### PR TITLE
 [BUMP:cli:0.3.0-canary.0] [BUMP:py_client:1.2.0+canary.0] [BUMP:vscode_ext:0.4.0-canary.0]

### DIFF
--- a/cli/.bumpversion.cfg
+++ b/cli/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.5-canary.0
+current_version = 0.3.0-canary.0
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$
@@ -15,3 +15,5 @@ values =
 	release
 
 [bumpversion:file:Cargo.toml]
+
+[bumpversion:file:Cargo.lock]

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "gloo"
-version = "0.2.5-canary.0"
+version = "0.3.0-canary.0"
 dependencies = [
  "cc",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gloo"
-version = "0.2.5-canary.0"
+version = "0.3.0-canary.0"
 edition = "2021"
 build = "build.rs"
 

--- a/clients/python/.bumpversion.cfg
+++ b/clients/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.24+canary.0
+current_version = 1.2.0+canary.0
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\+(?P<pre>canary)\.(?P<prerelease>\d+))?$

--- a/clients/python/gloo_py/__init__.py
+++ b/clients/python/gloo_py/__init__.py
@@ -7,7 +7,7 @@ from gloo_internal.tracer import trace, update_trace_tags
 from gloo_internal.llm_client import LLMClient, OpenAILLMClient
 
 
-__version__ = "1.1.24+canary.0"
+__version__ = "1.2.0+canary.0"
 
 __all__ = [
     "CodeVariant",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gloo-lib"
-version = "1.1.24+canary.0"
+version = "1.2.0+canary.0"
 description = ""
 authors = [ "Gloo <contact@trygloo.com>",]
 [[tool.poetry.packages]]

--- a/release/version-bump.sh
+++ b/release/version-bump.sh
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+set -e
+
+VALID_VERSIONS=("none" "prerelease" "pre" "patch" "minor" "major")
+
+for COMPONENT in "CLI" "Python Client" "VSCode Extension"; do
+  while true; do
+    echo "Enter the version type for ${COMPONENT} [none, prerelease, pre, patch, minor, major] (none):"
+    read VERSION_TYPE
+    if [[ -z "${VERSION_TYPE}" ]]; then
+      VERSION_TYPE="none"
+    fi
+    
+    if [[ " ${VALID_VERSIONS[@]} " =~ " ${VERSION_TYPE} " ]]; then
+      if [[ "${COMPONENT}" == "CLI" ]]; then
+        CLI=${VERSION_TYPE}
+      elif [[ "${COMPONENT}" == "Python Client" ]]; then
+        CLIENT_PYTHON=${VERSION_TYPE}
+      else
+        VSCODE_EXT=${VERSION_TYPE}
+      fi
+      break
+    else
+      echo "Invalid version type. Please enter a valid version type."
+    fi
+  done
+done
+
+if [ "$CLI" != "none" ] || [ "$CLIENT_PYTHON" != "none" ] || [ "$VSCODE_EXT" != "none" ]
+then
+  TIMESTAMP=$(date +%s%3N)
+  git checkout -b ${USER}/bump-version/${TIMESTAMP}
+  
+  if [ "$CLI" != "none" ]
+  then
+    pushd cli
+    VERSION=$(bumpversion --allow-dirty $CLI --list | grep new_version | cut -d '=' -f 2) || exit 1
+    COMMIT_MSG="${COMMIT_MSG} [BUMP:cli:${VERSION}]"
+    popd
+  fi
+  
+  if [ "$CLIENT_PYTHON" != "none" ]
+  then
+    pushd clients/python
+    VERSION=$(bumpversion --allow-dirty $CLIENT_PYTHON --list | grep new_version | cut -d '=' -f 2) || exit 1
+    COMMIT_MSG="${COMMIT_MSG} [BUMP:py_client:${VERSION}]"
+    popd
+  fi
+  
+  if [ "$VSCODE_EXT" != "none" ]
+  then
+    pushd vscode-ext
+    VERSION=$(bumpversion --allow-dirty $VSCODE_EXT --list | grep new_version | cut -d '=' -f 2) || exit 1
+    COMMIT_MSG="${COMMIT_MSG} [BUMP:vscode_ext:${VERSION}]"
+    popd
+  fi
+  
+  git commit -am "${COMMIT_MSG}"
+  gh pr create --title "${COMMIT_MSG}" --body "Automated flow to bump version${COMMIT_MSG}"
+fi

--- a/vscode-ext/.bumpversion.cfg
+++ b/vscode-ext/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.3.6-canary.0
+current_version = 0.4.0-canary.0
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$

--- a/vscode-ext/package.json
+++ b/vscode-ext/package.json
@@ -2,7 +2,7 @@
   "name": "gloo",
   "displayName": "Gloo",
   "description": "Gloo intellisense",
-  "version": "0.3.6-canary.0",
+  "version": "0.4.0-canary.0",
   "publisher": "Gloo",
   "repository": "https://github.com/GlooHQ/gloo-lang",
   "homepage": "https://trygloo.com",


### PR DESCRIPTION
Automated flow to bump version [BUMP:cli:0.3.0-canary.0] [BUMP:py_client:1.2.0+canary.0] [BUMP:vscode_ext:0.4.0-canary.0]