### PR TITLE
 [BUMP:cli:0.4.0-canary.2] [BUMP:py_client:] [BUMP:vscode_ext:0.5.0-canary.4]

### DIFF
--- a/cli/.bumpversion.cfg
+++ b/cli/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0-canary.1
+current_version = 0.4.0-canary.2
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "gloo"
-version = "0.4.0-canary.1"
+version = "0.4.0-canary.2"
 dependencies = [
  "cc",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gloo"
-version = "0.4.0-canary.1"
+version = "0.4.0-canary.2"
 edition = "2021"
 build = "build.rs"
 

--- a/vscode-ext/.bumpversion.cfg
+++ b/vscode-ext/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0-canary.3
+current_version = 0.5.0-canary.4
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$


### PR DESCRIPTION
Automated flow to bump version [BUMP:cli:0.4.0-canary.2] [BUMP:py_client:] [BUMP:vscode_ext:0.5.0-canary.4]