### PR TITLE
 [BUMP:cli:0.4.0-canary.3] [BUMP:py_client:1.3.0.dev4] [BUMP:vscode_ext:0.5.0-canary.5]

### DIFF
--- a/cli/.bumpversion.cfg
+++ b/cli/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0-canary.2
+current_version = 0.4.0-canary.3
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "gloo"
-version = "0.4.0-canary.2"
+version = "0.4.0-canary.3"
 dependencies = [
  "cc",
  "clap",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gloo"
-version = "0.4.0-canary.2"
+version = "0.4.0-canary.3"
 edition = "2021"
 build = "build.rs"
 

--- a/clients/python/.bumpversion.cfg
+++ b/clients/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.3.0.dev3
+current_version = 1.3.0.dev4
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.(?P<pre>dev)(?P<prerelease>\d+))?$

--- a/clients/python/gloo_py/__init__.py
+++ b/clients/python/gloo_py/__init__.py
@@ -7,7 +7,7 @@ from gloo_internal.tracer import trace, update_trace_tags
 from gloo_internal.llm_client import LLMClient, OpenAILLMClient
 
 
-__version__ = "1.3.0.dev3"
+__version__ = "1.3.0.dev4"
 
 __all__ = [
     "CodeVariant",

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gloo-lib"
-version = "1.3.0.dev3"
+version = "1.3.0.dev4"
 description = ""
 authors = [ "Gloo <contact@trygloo.com>",]
 [[tool.poetry.packages]]

--- a/vscode-ext/.bumpversion.cfg
+++ b/vscode-ext/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.0-canary.4
+current_version = 0.5.0-canary.5
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$


### PR DESCRIPTION
Automated flow to bump version [BUMP:cli:0.4.0-canary.3] [BUMP:py_client:1.3.0.dev4] [BUMP:vscode_ext:0.5.0-canary.5]