### PR TITLE
 [BUMP:cli:0.1.1-canary.2] [BUMP:vscode_ext:0.2.0-canary.1]

### DIFF
--- a/engine/.bumpversion.cfg
+++ b/engine/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1-canary.1
+current_version = 0.1.1-canary.2
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 dependencies = [
  "baml-lib",
  "base64 0.13.1",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "baml-fmt"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 dependencies = [
  "baml-lib",
  "base64 0.13.1",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "baml-lib"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 dependencies = [
  "base64 0.13.1",
  "dissimilar",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "baml-schema-build"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 dependencies = [
  "baml-fmt",
  "wasm-bindgen",
@@ -832,7 +832,7 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "internal-baml-core"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-diagnostics"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 dependencies = [
  "colored",
  "indoc",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-parser-database"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 dependencies = [
  "colored",
  "either",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-prompt-parser"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 dependencies = [
  "internal-baml-diagnostics",
  "log",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-schema-ast"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 dependencies = [
  "either",
  "internal-baml-diagnostics",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,7 +14,7 @@ indoc = "2.0.1"
 
 # 
 [workspace.package]
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 authors = ["Gloo <contact@trygloo.com>"]
 license = "Apache-2.0"
 description = "BAiML Toolchain"

--- a/engine/baml-cli/Cargo.toml
+++ b/engine/baml-cli/Cargo.toml
@@ -8,7 +8,7 @@ licence = "Apache-2.0"
 licence-file.workspace = true
 
 [dependencies]
-baml-lib = { path = "../baml-lib/baml", version = "0.1.1-canary.1", features = ["use-pyo3"]}
+baml-lib = { path = "../baml-lib/baml", version = "0.1.1-canary.2", features = ["use-pyo3"]}
 check-latest = "1.0.2"
 clap = { version = "4.4.6", features = ["derive"] }
 colored = "2.0.4"

--- a/engine/baml-fmt/Cargo.toml
+++ b/engine/baml-fmt/Cargo.toml
@@ -36,4 +36,4 @@ vendored-openssl = []
 use-pyo3 = ["baml-lib/use-pyo3"]
 
 [target.'cfg(feature = "use-pyo3")'.dependencies]
-baml-lib = { path = "../baml-lib/baml", version = "0.1.1-canary.1", features = ["use-pyo3"] }
+baml-lib = { path = "../baml-lib/baml", version = "0.1.1-canary.2", features = ["use-pyo3"] }

--- a/engine/baml-lib/baml-core/Cargo.toml
+++ b/engine/baml-lib/baml-core/Cargo.toml
@@ -8,10 +8,10 @@ licence = "Apache-2.0"
 licence-file.workspace = true
 
 [dependencies]
-internal-baml-diagnostics = { path = "../diagnostics", version = "0.1.1-canary.1" }
-internal-baml-schema-ast = { path = "../schema-ast", version = "0.1.1-canary.1" }
-internal-baml-parser-database = { path = "../parser-database", version = "0.1.1-canary.1" }
-internal-baml-prompt-parser = { path = "../prompt-parser", version = "0.1.1-canary.1" }
+internal-baml-diagnostics = { path = "../diagnostics", version = "0.1.1-canary.2" }
+internal-baml-schema-ast = { path = "../schema-ast", version = "0.1.1-canary.2" }
+internal-baml-parser-database = { path = "../parser-database", version = "0.1.1-canary.2" }
+internal-baml-prompt-parser = { path = "../prompt-parser", version = "0.1.1-canary.2" }
 serde.workspace = true
 serde_json.workspace = true
 enumflags2 = "0.7"
@@ -36,4 +36,4 @@ either = "1.8.1"
 use-pyo3 = ["internal-baml-parser-database/use-pyo3"]
 
 [target.'cfg(feature = "use-pyo3")'.dependencies]
-internal-baml-parser-database = { path = "../parser-database", version = "0.1.1-canary.1", features = ["use-pyo3"] }
+internal-baml-parser-database = { path = "../parser-database", version = "0.1.1-canary.2", features = ["use-pyo3"] }

--- a/engine/baml-lib/parser-database/Cargo.toml
+++ b/engine/baml-lib/parser-database/Cargo.toml
@@ -8,9 +8,9 @@ licence = "Apache-2.0"
 licence-file.workspace = true
 
 [dependencies]
-internal-baml-diagnostics = { path = "../diagnostics", version = "0.1.1-canary.1" }
-internal-baml-schema-ast = { path = "../schema-ast", version = "0.1.1-canary.1" }
-internal-baml-prompt-parser = { path = "../prompt-parser", version = "0.1.1-canary.1" }
+internal-baml-diagnostics = { path = "../diagnostics", version = "0.1.1-canary.2" }
+internal-baml-schema-ast = { path = "../schema-ast", version = "0.1.1-canary.2" }
+internal-baml-prompt-parser = { path = "../prompt-parser", version = "0.1.1-canary.2" }
 
 either = "1.6.1"
 enumflags2 = "0.7"

--- a/engine/baml-lib/prompt-parser/Cargo.toml
+++ b/engine/baml-lib/prompt-parser/Cargo.toml
@@ -7,7 +7,7 @@ description.workspace = true
 licence-file.workspace = true
 
 [dependencies]
-internal-baml-diagnostics = { path = "../diagnostics", version = "0.1.1-canary.1" }
+internal-baml-diagnostics = { path = "../diagnostics", version = "0.1.1-canary.2" }
 log = "0.4.20"
 
 pest = "2.1.3"

--- a/engine/baml-lib/schema-ast/Cargo.toml
+++ b/engine/baml-lib/schema-ast/Cargo.toml
@@ -7,7 +7,7 @@ description.workspace = true
 licence-file.workspace = true
 
 [dependencies]
-internal-baml-diagnostics = { path = "../diagnostics", version = "0.1.1-canary.1" }
+internal-baml-diagnostics = { path = "../diagnostics", version = "0.1.1-canary.2" }
 log = "0.4.20"
 
 pest = "2.1.3"

--- a/engine/baml-schema-wasm/Cargo.toml
+++ b/engine/baml-schema-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "baml-schema-build"
-version = "0.1.1-canary.1"
+version = "0.1.1-canary.2"
 edition = "2021"
 
 [lib]

--- a/typescript/.bumpversion.cfg
+++ b/typescript/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0-canary.0
+current_version = 0.2.0-canary.1
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$


### PR DESCRIPTION
Automated flow to bump version [BUMP:cli:0.1.1-canary.2] [BUMP:vscode_ext:0.2.0-canary.1]