### PR TITLE
 [BUMP:cli:0.1.1-canary.4] [BUMP:vscode_ext:0.2.0-canary.4]

### DIFF
--- a/engine/.bumpversion.cfg
+++ b/engine/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1-canary.3
+current_version = 0.1.1-canary.4
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 dependencies = [
  "baml-lib",
  "base64 0.13.1",
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "baml-fmt"
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 dependencies = [
  "baml-lib",
  "base64 0.13.1",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "baml-lib"
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 dependencies = [
  "base64 0.13.1",
  "dissimilar",
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "baml-schema-build"
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 dependencies = [
  "baml-fmt",
  "wasm-bindgen",
@@ -832,7 +832,7 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "internal-baml-core"
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -857,7 +857,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-diagnostics"
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 dependencies = [
  "colored",
  "indoc",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-parser-database"
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 dependencies = [
  "colored",
  "either",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-prompt-parser"
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 dependencies = [
  "internal-baml-diagnostics",
  "log",
@@ -900,7 +900,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-schema-ast"
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 dependencies = [
  "either",
  "internal-baml-diagnostics",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -15,7 +15,7 @@ libc = "=0.2.149" # Temporarily pin this to 0.2.149 until 0.2.150 is patched
 
 # 
 [workspace.package]
-version = "0.1.1-canary.3"
+version = "0.1.1-canary.4"
 authors = ["Gloo <contact@trygloo.com>"]
 
 description = "BAiML Toolchain"

--- a/typescript/.bumpversion.cfg
+++ b/typescript/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0-canary.3
+current_version = 0.2.0-canary.4
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$


### PR DESCRIPTION
Automated flow to bump version [BUMP:cli:0.1.1-canary.4] [BUMP:vscode_ext:0.2.0-canary.4]