### PR TITLE
 [BUMP:cli:0.6.0-canary.1] [BUMP:py_client:0.8.0.dev1] [BUMP:vscode_ext:0.10.1]

### DIFF
--- a/clients/python/.bumpversion.cfg
+++ b/clients/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.0.dev0
+current_version = 0.8.0.dev1
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.(?P<pre>dev)(?P<prerelease>\d+))?$

--- a/clients/python/baml_version/__init__.py
+++ b/clients/python/baml_version/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8.0.dev0"
+__version__ = "0.8.0.dev1"

--- a/clients/python/baml_version/__main__.py
+++ b/clients/python/baml_version/__main__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.0.dev0"
+__version__ = "0.8.0.dev1"
 
 if __name__ == "__main__":
     print(__version__)

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "baml"
-version = "0.8.0.dev0"
+version = "0.8.0.dev1"
 description = ""
 authors = [ "Gloo <contact@trygloo.com>",]
 

--- a/engine/.bumpversion.cfg
+++ b/engine/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0-canary.0
+current_version = 0.6.0-canary.1
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "baml-lib",
  "base64 0.13.1",
@@ -164,7 +164,7 @@ dependencies = [
 
 [[package]]
 name = "baml-fmt"
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "baml-lib",
  "base64 0.13.1",
@@ -184,7 +184,7 @@ dependencies = [
 
 [[package]]
 name = "baml-lib"
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "base64 0.13.1",
  "dissimilar",
@@ -198,7 +198,7 @@ dependencies = [
 
 [[package]]
 name = "baml-schema-build"
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "baml-fmt",
  "wasm-bindgen",
@@ -893,7 +893,7 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "internal-baml-core"
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "base64 0.13.1",
  "chrono",
@@ -919,7 +919,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-diagnostics"
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "colored",
  "indoc",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-parser-database"
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "colored",
  "either",
@@ -951,7 +951,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-prompt-parser"
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "internal-baml-diagnostics",
  "internal-baml-schema-ast",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-schema-ast"
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 dependencies = [
  "either",
  "internal-baml-diagnostics",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,7 +14,7 @@ indoc = "2.0.1"
 
 # 
 [workspace.package]
-version = "0.6.0-canary.0"
+version = "0.6.0-canary.1"
 authors = ["Boundary <cntac@trygloo.com>"]
 
 description = "BAML Toolchain"

--- a/typescript/.bumpversion.cfg
+++ b/typescript/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 0.10.1
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$

--- a/typescript/vscode-ext/packages/package.json
+++ b/typescript/vscode-ext/packages/package.json
@@ -2,7 +2,7 @@
   "name": "baml",
   "displayName": "Baml",
   "description": "BAML is a DSL for AI applications.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "publisher": "Gloo",
   "repository": "https://github.com/GlooHQ/baml",
   "homepage": "https://www.boundaryml.com",


### PR DESCRIPTION
Automated flow to bump version [BUMP:cli:0.6.0-canary.1] [BUMP:py_client:0.8.0.dev1] [BUMP:vscode_ext:0.10.1]