### PR TITLE
Fix test case issue with including " and \n and other special characters.

### DIFF
--- a/engine/baml-lib/baml-core/src/generate/generate_python_client/template.rs
+++ b/engine/baml-lib/baml-core/src/generate/generate_python_client/template.rs
@@ -130,7 +130,7 @@ fn use_partial(
         }
         HSTemplate::MultiArgTestSnippet => {
             register_partial_file!(reg, "tests", "multi_arg_snippet");
-            f.add_import("json", "loads");
+            f.add_import("json", "dumps");
             f.add_import("..__do_not_import.generated_baml_client", "baml");
             f.add_import("baml_lib._impl.deserializer", "Deserializer");
             String::from("multi_arg_snippet")

--- a/engine/baml-lib/baml-core/src/generate/generate_python_client/templates/tests/multi_arg_snippet.hb
+++ b/engine/baml-lib/baml-core/src/generate/generate_python_client/templates/tests/multi_arg_snippet.hb
@@ -1,11 +1,9 @@
 @baml.{{function_name}}.test
 async def test_{{test_case_name}}({{function_name}}Impl: I{{function_name}}):
-    case = loads("""\
-{{{test_case_input}}}\
-""")
+    case = {{{test_case_input}}}
     {{#each test_case_types}}
     deserializer_{{this.name}} = Deserializer[{{this.type}}]({{this.type}}) # type: ignore
-    {{this.name}} = deserializer_{{this.name}}.from_string(case["{{this.name}}"])
+    {{this.name}} = deserializer_{{this.name}}.from_string(dumps(case["{{this.name}}"]))
     {{/each}}
     await {{function_name}}Impl(
         {{#each test_case_types}}

--- a/engine/baml-lib/baml-core/src/generate/generate_python_client/templates/tests/single_arg_snippet.hb
+++ b/engine/baml-lib/baml-core/src/generate/generate_python_client/templates/tests/single_arg_snippet.hb
@@ -1,9 +1,8 @@
 @baml.{{function_name}}.test
 async def test_{{test_case_name}}({{function_name}}Impl: I{{function_name}}):
+    content = dumps({{{test_case_input}}})
     deserializer = Deserializer[{{test_case_type}}]({{test_case_type}}) # type: ignore
-    param = deserializer.from_string("""\
-{{{test_case_input}}}\
-""")
+    param = deserializer.from_string(content)
     await {{function_name}}Impl(param)
 
 

--- a/engine/baml-lib/schema-ast/src/parser/parse_test.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_test.rs
@@ -12,7 +12,6 @@ use serde_json::Value;
 #[derive(Deserialize, Debug)]
 #[serde(untagged)] // This allows for different shapes of JSON
 enum Input {
-    StringInput(String),
     ObjectInput(Value), // Use serde_json::Value for a generic JSON object
 }
 
@@ -20,7 +19,6 @@ impl Input {
     // Method to get the string representation of the input
     fn to_string(&self) -> String {
         match self {
-            Input::StringInput(s) => s.clone(),
             Input::ObjectInput(obj) => serde_json::to_string(obj).unwrap_or_default(),
         }
     }
@@ -164,7 +162,7 @@ pub(crate) fn parse_test_from_json(
     let span = Span::new(source.clone(), 0, end_range);
     let content = Expression::RawStringValue(RawString::new(
         test_input,
-        Span::new(source.clone(), 0, end_range),
+        span.clone(),
         Some(("json".into(), Span::empty(source.clone()))),
     ));
     let test_case = ConfigBlockProperty {


### PR DESCRIPTION
Currently this is still quite hacky, we should do something more robust and actually validate the json at compile time in BAML rather than what we are doing today which is evaluating it at runtime.
