### PR TITLE
vscode: check for updates on the hour

### DIFF
--- a/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
+++ b/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
@@ -134,7 +134,6 @@ const sleep = (time: number) => {
   })
 }
 
-let bamlOutputChannel: OutputChannel | null = null
 const activateClient = (
   context: ExtensionContext,
   serverOptions: ServerOptions,
@@ -142,11 +141,8 @@ const activateClient = (
 ) => {
   // Create the language client
   client = createLanguageServer(serverOptions, clientOptions)
-  window.showInformationMessage('client activating')
-  console.log('client activating')
 
   client.onReady().then(() => {
-    window.showInformationMessage('client onReady')
     client.onNotification('baml/showLanguageServerOutput', () => {
       // need to append line for the show to work for some reason.
       // dont delete this.
@@ -347,7 +343,6 @@ const plugin: BamlVSCodePlugin = {
     )
 
     activateClient(context, serverOptions, clientOptions)
-    console.log('hugga humma choo choo activated')
 
     if (!isDebugOrTest) {
       // eslint-disable-next-line

--- a/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
+++ b/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
@@ -18,7 +18,7 @@ const packageJson = require('../../../package.json') // eslint-disable-line
 let client: LanguageClient
 let serverModule: string
 let telemetry: TelemetryReporter
-let intervalTimers: NodeJS.Timer[] = [];
+let intervalTimers: NodeJS.Timer[] = []
 
 const isDebugMode = () => process.env.VSCODE_DEBUG_MODE === 'true'
 const isE2ETestOnPullRequest = () => process.env.PRISMA_USE_LOCAL_LS === 'true'
@@ -49,7 +49,7 @@ const getLatestVersion = async () => {
   return { cli, py_client }
 }
 
-const getCheckForUpdates = async ({showIfNoUpdates}: {showIfNoUpdates: boolean}) => {
+const getCheckForUpdates = async ({ showIfNoUpdates }: { showIfNoUpdates: boolean }) => {
   try {
     const [versions, localVersion] = await Promise.allSettled([getLatestVersion(), cliVersion()])
 
@@ -105,7 +105,7 @@ const getCheckForUpdates = async ({showIfNoUpdates}: {showIfNoUpdates: boolean})
       }
     }
   } catch (e) {
-    console.error('Failed to check for updates', e);
+    console.error('Failed to check for updates', e)
   }
 }
 
@@ -142,11 +142,11 @@ const activateClient = (
 ) => {
   // Create the language client
   client = createLanguageServer(serverOptions, clientOptions)
-  window.showInformationMessage("client activating");
-  console.log("client activating");
+  window.showInformationMessage('client activating')
+  console.log('client activating')
 
   client.onReady().then(() => {
-    window.showInformationMessage("client onReady");
+    window.showInformationMessage('client onReady')
     client.onNotification('baml/showLanguageServerOutput', () => {
       // need to append line for the show to work for some reason.
       // dont delete this.
@@ -210,7 +210,7 @@ const activateClient = (
       try {
         BamlDB.set(rootPath, db)
         glooLens.setDB(rootPath, db)
-        console.log('set_database');
+        console.log('set_database')
         WebPanelView.currentPanel?.postMessage('setDb', Array.from(BamlDB.entries()))
       } catch (e) {
         console.log('Error setting database', e)
@@ -224,12 +224,14 @@ const activateClient = (
 
     // this will fail otherwise in dev mode if the config where the baml path is hasnt been picked up yet. TODO: pass the config to the server to avoid this.
     // Immediately check for updates on extension activation
-    void getCheckForUpdates({showIfNoUpdates: false});
+    void getCheckForUpdates({ showIfNoUpdates: false })
     // And check again once every hour
-    intervalTimers.push(setInterval(async () => {
-      console.log(`checking for updates ${new Date()}`)
-      await getCheckForUpdates({showIfNoUpdates: false});
-    }, 5 * 1000 /* 1h in milliseconds: min/hr * secs/min * ms/sec */));
+    intervalTimers.push(
+      setInterval(async () => {
+        console.log(`checking for updates ${new Date()}`)
+        await getCheckForUpdates({ showIfNoUpdates: false })
+      }, 5 * 1000 /* 1h in milliseconds: min/hr * secs/min * ms/sec */),
+    )
   })
 
   const disposable = client.start()
@@ -287,7 +289,6 @@ const plugin: BamlVSCodePlugin = {
         transport: TransportKind.ipc,
         options: debugOptions,
       },
-
     }
 
     // Options to control the language client
@@ -302,7 +303,7 @@ const plugin: BamlVSCodePlugin = {
       ],
       synchronize: {
         fileEvents: workspace.createFileSystemWatcher('**/baml_src/**/*.{baml,json}'),
-      }
+      },
     }
 
     context.subscriptions.push(
@@ -312,7 +313,7 @@ const plugin: BamlVSCodePlugin = {
       }),
 
       commands.registerCommand('baml.checkForUpdates', async () => {
-        getCheckForUpdates({showIfNoUpdates: true}).catch((e) => {
+        getCheckForUpdates({ showIfNoUpdates: true }).catch((e) => {
           console.error('Failed to check for updates', e)
         })
       }),
@@ -357,7 +358,7 @@ const plugin: BamlVSCodePlugin = {
       telemetry = new TelemetryReporter(extensionId, extensionVersion)
 
       context.subscriptions.push(telemetry)
-      await telemetry.initialize();
+      await telemetry.initialize()
 
       if (extensionId === 'Gloo.baml-insider') {
         // checkForOtherExtension()
@@ -376,12 +377,12 @@ const plugin: BamlVSCodePlugin = {
     }
 
     while (intervalTimers.length > 0) {
-      clearInterval(intervalTimers.pop());
+      clearInterval(intervalTimers.pop())
     }
 
     return client.stop()
   },
 }
 
-export { telemetry };
+export { telemetry }
 export default plugin

--- a/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
+++ b/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
@@ -357,6 +357,13 @@ const plugin: BamlVSCodePlugin = {
     }
 
     checkForMinimalColorTheme()
+
+    // Immediately check for updates on extension activation
+    void commands.executeCommand('baml.checkForUpdates');
+    // And check again once every hour
+    setInterval(() => {
+      void commands.executeCommand('baml.checkForUpdates');
+    }, 60 * 60 * 1000 /* 1h in milliseconds: min/hr * secs/min * ms/sec */);
   },
   deactivate: async () => {
     if (!client) {


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit c70a3b373cb2346a0df9a1eba0ebacb74d59b53e.  | 
|--------|--------|

### Summary:
This PR modifies the `BamlVSCodePlugin` to check for updates immediately upon extension activation and then every hour thereafter, with corresponding updates to the `getCheckForUpdates`, `activateClient`, and `deactivate` functions.

**Key points**:
- Modified `activate` function in `BamlVSCodePlugin` to check for updates on activation and every hour thereafter.
- Updated `getCheckForUpdates` function to accept an object with a `showIfNoUpdates` property.
- Updated `activateClient` function to immediately check for updates on extension activation and set an interval to check for updates every hour.
- Updated `deactivate` function to clear any interval timers when the extension is deactivated.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
