### PR TITLE
feat: add tests to check that baml version --check works

### DIFF
--- a/engine/.docker/python-tests/conda/script.sh
+++ b/engine/.docker/python-tests/conda/script.sh
@@ -25,3 +25,6 @@ conda run -n base python -m baml_version || echo "Base environment should not ha
 baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stderr.log
 
 conda run -n envbaml python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
+
+check_for_updates="$(baml version --check --output json)"
+[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"

--- a/engine/.docker/python-tests/conda/script.sh
+++ b/engine/.docker/python-tests/conda/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 conda init
 . /root/.bashrc > /dev/null
@@ -26,5 +26,4 @@ baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stde
 
 conda run -n envbaml python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
 
-check_for_updates="$(baml version --check --output json)"
-[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"
+# TODO - add test for 'baml version --check' here

--- a/engine/.docker/python-tests/poetry/script.sh
+++ b/engine/.docker/python-tests/poetry/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Exit on error
 set -e
@@ -15,5 +15,10 @@ baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stde
 
 poetry run python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
 
-check_for_updates="$(baml version --check --output json)"
-[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"
+baml version --check --output json >$CAPTURE_DIR/baml_version_check.json
+python3 <<EOF
+import json, sys
+checked_versions = json.load(open('$CAPTURE_DIR/baml_version_check.json'))
+print(checked_versions)
+assert all([g['current_version'][0].isdigit() for g in checked_versions['generators']]), "baml cli failed to parse package_version_command"
+EOF

--- a/engine/.docker/python-tests/poetry/script.sh
+++ b/engine/.docker/python-tests/poetry/script.sh
@@ -14,3 +14,6 @@ poetry run python -m baml_version
 baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stderr.log
 
 poetry run python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
+
+check_for_updates="$(baml version --check --output json)"
+[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"

--- a/engine/.docker/python-tests/python/script.sh
+++ b/engine/.docker/python-tests/python/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Exit on error
 set -e
@@ -12,5 +12,10 @@ baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stde
 
 python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
 
-check_for_updates="$(baml version --check --output json)"
-[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"
+baml version --check --output json >$CAPTURE_DIR/baml_version_check.json
+python3 <<EOF
+import json, sys
+checked_versions = json.load(open('$CAPTURE_DIR/baml_version_check.json'))
+print(checked_versions)
+assert all([g['current_version'][0].isdigit() for g in checked_versions['generators']]), "baml cli failed to parse package_version_command"
+EOF

--- a/engine/.docker/python-tests/python/script.sh
+++ b/engine/.docker/python-tests/python/script.sh
@@ -11,3 +11,6 @@ baml init -n
 baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stderr.log
 
 python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
+
+check_for_updates="$(baml version --check --output json)"
+[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"

--- a/engine/.docker/python-tests/python3/script.sh
+++ b/engine/.docker/python-tests/python3/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Exit on error
 set -e
@@ -12,5 +12,10 @@ baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stde
 
 python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
 
-check_for_updates="$(baml version --check --output json)"
-[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"
+baml version --check --output json >$CAPTURE_DIR/baml_version_check.json
+python3 <<EOF
+import json, sys
+checked_versions = json.load(open('$CAPTURE_DIR/baml_version_check.json'))
+print(checked_versions)
+assert all([g['current_version'][0].isdigit() for g in checked_versions['generators']]), "baml cli failed to parse package_version_command"
+EOF

--- a/engine/.docker/python-tests/python3/script.sh
+++ b/engine/.docker/python-tests/python3/script.sh
@@ -11,3 +11,6 @@ baml init -n
 baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stderr.log
 
 python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
+
+check_for_updates="$(baml version --check --output json)"
+[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"

--- a/engine/.docker/python-tests/virtualenv/script.sh
+++ b/engine/.docker/python-tests/virtualenv/script.sh
@@ -15,3 +15,6 @@ deactivate
 baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stderr.log
 
 . venv/bin/activate && python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
+
+check_for_updates="$(baml version --check --output json)"
+[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"

--- a/engine/.docker/python-tests/virtualenv/script.sh
+++ b/engine/.docker/python-tests/virtualenv/script.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Exit on error
 set -e
@@ -16,5 +16,10 @@ baml test run > $CAPTURE_DIR/baml_test_stdout.log 2> $CAPTURE_DIR/baml_test_stde
 
 . venv/bin/activate && python -m baml_example_app > $CAPTURE_DIR/baml_example_stdout.log 2> $CAPTURE_DIR/baml_example_stderr.log
 
-check_for_updates="$(baml version --check --output json)"
-[[ $(echo "$check_for_updates" | jq '.generators.[].current_version') =~ '[0-9].*' ]] || echo "Failed to resolve current client version"
+baml version --check --output json >$CAPTURE_DIR/baml_version_check.json
+python3 <<EOF
+import json, sys
+checked_versions = json.load(open('$CAPTURE_DIR/baml_version_check.json'))
+print(checked_versions)
+assert all([g['current_version'][0].isdigit() for g in checked_versions['generators']]), "baml cli failed to parse package_version_command"
+EOF

--- a/engine/baml-cli/src/init_command/py.rs
+++ b/engine/baml-cli/src/init_command/py.rs
@@ -113,7 +113,7 @@ impl WithLanguage for PackageManager {
             PackageManager::Pip3(_) => "pip3 show baml".into(),
             PackageManager::Poetry => "poetry show baml".into(),
             PackageManager::Venv(path) => format!(". {}/bin/activate && pip show baml", path),
-            PackageManager::Conda(name) => format!("conda list -n {}", name),
+            PackageManager::Conda(name) => format!("conda list -n {} baml", name),
         }
     }
 }

--- a/engine/baml-cli/src/version_command.rs
+++ b/engine/baml-cli/src/version_command.rs
@@ -84,9 +84,17 @@ pub fn get_client_version(
             Ok(String::from_utf8(e.stdout)?)
         })?;
 
-    let version_line_re = Regex::new(r#"(?i)\b(?:version)\b"#).map_err(|e| {
-        CliError::StringError(format!("{} Error: {}", "Failed!".red(), e.to_string()))
-    })?;
+    let version_line_re = if package_version_command.starts_with("conda") {
+        // conda's version output has "baml" in the same line
+        Regex::new(r#"(?i)\b(?:baml)\b"#).map_err(|e| {
+            CliError::StringError(format!("{} Error: {}", "Failed!".red(), e.to_string()))
+        })?
+    } else {
+        // for other python package managers, they have "version" in the same line
+        Regex::new(r#"(?i)\b(?:version)\b"#).map_err(|e| {
+            CliError::StringError(format!("{} Error: {}", "Failed!".red(), e.to_string()))
+        })?
+    };
 
     let Some(version_line) = output.lines().find(|line| version_line_re.is_match(line)) else {
         return Err(CliError::StringError(format!(


### PR DESCRIPTION
also partially fix the conda package_version_command, although it still doesn't work- see [slack thread] for more details

[slack thread]: https://gloo-global.slack.com/archives/C03KV1PJ6EM/p1709174240544919?thread_ts=1709168531.306309&cid=C03KV1PJ6EM