### PR TITLE
Print out the stdout and stderr to console in case of a testing error

### DIFF
--- a/engine/baml-cli/src/test_command/run_test_with_forward.rs
+++ b/engine/baml-cli/src/test_command/run_test_with_forward.rs
@@ -143,9 +143,27 @@ async fn run_pytest_and_update_state(
                 // Pytest exits with 1 even if it ran fine but had some tests failing (we should suppress this via a pytest plugin) so we don't mark as failure on exit code 1
                 // But we could also get exit code 1 from other things like infisical CLI being absent, or python not being found.
                 let stderr_content = tokio::fs::read_to_string(&stderr_file_path).await?;
+                let stdout_content = tokio::fs::read_to_string(&stdout_file_path).await?;
                 if ![0, 1].contains(&code) {
-                    println!("{}",
-                        format!("Testing failed with exit code {}. Open the output logs below for more details", code).bright_red().bold()
+                    println!(
+                        "\n####### STDOUT Logs for this test ########\n{}",
+                        stdout_content
+                    );
+                    if !stderr_content.is_empty() {
+                        println!(
+                            "\n####### STDERR Logs for this test ########\n{}",
+                            stderr_content
+                        );
+                    }
+
+                    println!(
+                        "{}",
+                        format!(
+                            "Testing failed with exit code {}. Output logs were printed above this line.",
+                            code
+                        )
+                        .bright_red()
+                        .bold()
                     );
                     println!(
                         "\n{}\n{}",

--- a/engine/baml-cli/src/test_command/run_test_with_watcher.rs
+++ b/engine/baml-cli/src/test_command/run_test_with_watcher.rs
@@ -141,16 +141,24 @@ async fn run_pytest_and_update_state(
     if let Some(code) = output.status.code() {
         // Open the stderr file and check if it has any content
         let stderr_content = tokio::fs::read_to_string(&stderr_file_path).await?;
+        let stdout_content = tokio::fs::read_to_string(&stdout_file_path).await?;
         // Pytest exits with 1 even if it ran fine but had some tests failing (we should suppress this via a pytest plugin) so we dont mark as failure
         // But we could also get exit code 1 from other things like infisical CLI being absent, or python not being found.
         // so check the stderr for any other issues.
         if ![0, 1].contains(&code) {
+            println!("\n####### STDOUT Logs ########\n{}", stdout_content);
+            if !stderr_content.is_empty() {
+                println!("\n####### STDERR Logs ########\n{}", stderr_content);
+            }
+
             println!(
                 "{}",
                 format!(
-                    "Testing failed with exit code {}. Open the output logs below for more details\n",
-                    code,
+                    "Testing failed with exit code {}. Output logs were printed above this line.",
+                    code
                 )
+                .bright_red()
+                .bold()
             );
             println!(
                 "{}\n{}",


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->
| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit c816aa0cfbc4d684b2faabf4c12e3d4bdedc92b5.  | 
|--------|--------|

### Summary:
This PR enhances the `run_pytest_and_update_state` function to print stdout and stderr content to the console when a test fails, providing more detailed failure information.

**Key points**:
- Modified `run_pytest_and_update_state` function in `/engine/baml-cli/src/test_command/run_test_with_forward.rs` and `/engine/baml-cli/src/test_command/run_test_with_watcher.rs`.
- Added code to read stdout and stderr content from files.
- Printed stdout and stderr content to console when test fails.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
