### PR TITLE
Add a better `baml test` logging experience.

### DIFF
--- a/engine/baml-cli/src/test_command/mod.rs
+++ b/engine/baml-cli/src/test_command/mod.rs
@@ -171,7 +171,7 @@ pub fn run(
 
             if selected_tests.is_empty() {
                 if num_tests == 0 {
-                    return Err("No tests found".into());
+                    return Err("No tests declared".into());
                 }
                 return Err("No tests selected".into());
             }


### PR DESCRIPTION
* When tests fail due to IPC failures, we output an unexpected state errors for users to see.
* Only pipe stdout/stderr if we don't already print out the BAML trace error
