### PR TITLE
windows unc fixes

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "console",
  "dialoguer",
  "dissimilar",
+ "dunce",
  "either",
  "env_logger",
  "expect-test",
@@ -515,6 +516,12 @@ name = "dissimilar"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86e3bdc80eee6e16b2b6b0f87fbc98c04bee3455e35174c0de1a125d0688c632"
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "either"

--- a/engine/baml-cli/Cargo.toml
+++ b/engine/baml-cli/Cargo.toml
@@ -32,6 +32,7 @@ tempfile = "3.10.1"
 uuid = { version = "1.7.0", features = ["v4"] }
 anyhow.workspace = true
 json_comments = "0.2.2"
+dunce = "1.0.4"
 
 [dev-dependencies]
 base64 = "0.13.0"

--- a/engine/baml-cli/src/builder/dir_utils.rs
+++ b/engine/baml-cli/src/builder/dir_utils.rs
@@ -1,5 +1,5 @@
 use std::path::{Component, PathBuf};
-
+use dunce::canonicalize;
 use baml_lib::{parse_configuration, Configuration, Diagnostics};
 
 use crate::errors::CliError;
@@ -29,7 +29,7 @@ pub(crate) fn get_baml_src(baml_dir: &Option<String>) -> Result<PathBuf, CliErro
             }
         },
     };
-    let abs_src_dir = src_dir.canonicalize();
+    let abs_src_dir = canonicalize(src_dir.clone());
 
     if let Err(_) = abs_src_dir {
         return Err(format!("Directory not found {}", src_dir.to_string_lossy()).into());
@@ -52,7 +52,7 @@ pub(crate) fn get_src_dir(
     };
     let config = parse_configuration(&baml_dir, main_baml, &main_baml_contents)?;
 
-    let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+    let cwd = canonicalize(std::env::current_dir().unwrap()).unwrap();
 
     Ok((relative_path(cwd, baml_dir), config))
 }

--- a/engine/baml-cli/src/init_command/baml_src.rs
+++ b/engine/baml-cli/src/init_command/baml_src.rs
@@ -1,5 +1,6 @@
 /// File to convert types to baml code.
 use std::path::PathBuf;
+use dunce::canonicalize;
 
 use crate::errors::CliError;
 
@@ -77,7 +78,7 @@ impl WithLoader<Vec<LanguageConfig>> for LanguageConfig {
         project_root: &PathBuf,
         writer: &mut Writer,
     ) -> Result<Vec<LanguageConfig>, CliError> {
-        let project_root_str = match project_root.canonicalize() {
+        let project_root_str = match canonicalize(project_root) {
             Ok(p) => p,
             Err(_) => project_root.clone(),
         };

--- a/engine/baml-cli/src/test_command/mod.rs
+++ b/engine/baml-cli/src/test_command/mod.rs
@@ -1,5 +1,6 @@
 use colored::*;
 use std::{path::PathBuf, str::FromStr};
+use dunce::canonicalize;
 
 use baml_lib::{internal_baml_schema_ast::ast::WithName, Configuration, ValidatedSchema};
 
@@ -213,7 +214,7 @@ pub fn run(
                 )
             );
 
-            let test_dir = generator.output_path.canonicalize().map_err(|e| {
+            let test_dir = canonicalize(generator.output_path.clone()).map_err(|e| {
                 format!(
                     "Directory Error: {}: {}",
                     generator.output_path.display(),

--- a/engine/baml-cli/src/update_client.rs
+++ b/engine/baml-cli/src/update_client.rs
@@ -1,4 +1,5 @@
 use colored::Colorize;
+use dunce::canonicalize;
 
 use crate::{builder::get_src_dir, errors::CliError, shell::build_shell_command};
 
@@ -6,7 +7,7 @@ pub fn update_client(baml_dir: &Option<String>) -> Result<(), CliError> {
     let (_, (config, mut diagnostics)) = get_src_dir(baml_dir)?;
     diagnostics.to_result()?;
 
-    let cwd = std::env::current_dir().unwrap().canonicalize().unwrap();
+    let cwd = canonicalize(std::env::current_dir().unwrap()).unwrap();
 
     let errors: Vec<_> = config
         .generators
@@ -30,7 +31,7 @@ pub fn update_client(baml_dir: &Option<String>) -> Result<(), CliError> {
 
             // Get the project_root relative to cwd.
             let project_root = cwd.join(&gen.project_root);
-            let project_root = project_root.canonicalize().map_err(|e| {
+            let project_root = canonicalize(project_root).map_err(|e| {
                 CliError::StringError(format!(
                     "{}\nDirectory error: {}:\n{}",
                     "Failed!".red(),
@@ -48,7 +49,7 @@ pub fn update_client(baml_dir: &Option<String>) -> Result<(), CliError> {
                     if !e.status.success() {
                         Err(CliError::StringError(format!(
                             "{}{}{}",
-                            "Failed to add/update baml dependency!".normal().red(),
+                            "Failed to add/update baml dependency to the project! Try re-running the install command manually or run `baml update-client`".normal().red(),
                             match String::from_utf8_lossy(&e.stdout) {
                                 s if s.is_empty() => "".into(),
                                 s => format!("\n{}", s.trim()),

--- a/engine/baml-cli/src/version_command.rs
+++ b/engine/baml-cli/src/version_command.rs
@@ -2,6 +2,7 @@ use crate::{builder::get_src_dir, shell::build_shell_command, update::UPDATE_CHA
 use crate::{errors::CliError, OutputType};
 
 use colored::Colorize;
+use dunce::canonicalize;
 
 use regex::Regex;
 
@@ -235,9 +236,9 @@ pub fn get_client_version(
     // NOTE(sam): no idea why this has to start in the cwd; this is copied from update_client.rs
     // according to vbv@ this had to be done for _some_ reason, so just preserving it as closely as i can
     // per aaron@ there's some Windows slash MacOS funniness going on here
-    let cwd = std::env::current_dir()?.canonicalize()?;
+    let cwd = canonicalize(std::env::current_dir()?)?;
     let project_root = cwd.join(project_root);
-    let project_root = project_root.canonicalize().map_err(|e| {
+    let project_root = canonicalize(project_root.clone()).map_err(|e| {
         CliError::StringError(format!(
             "{}\nDirectory error: {}:\n{}",
             "Failed!".red(),
@@ -334,7 +335,7 @@ pub fn check_for_updates(baml_dir_override: &Option<String>) -> Result<CheckedVe
 
                     ret.generators.push(GeneratorVersion {
                         name: gen.name,
-                        dir: gen.project_root.canonicalize()?,
+                        dir: canonicalize(gen.project_root)?,
                         language: gen.language.as_str().to_string(),
                         current_version: Some(current_version),
                         latest_version,
@@ -345,7 +346,7 @@ pub fn check_for_updates(baml_dir_override: &Option<String>) -> Result<CheckedVe
                     log::warn!("Failed to get version for {}: {}", gen.name, e);
                     ret.generators.push(GeneratorVersion {
                         name: gen.name,
-                        dir: gen.project_root.canonicalize()?,
+                        dir: canonicalize(gen.project_root)?,
                         language: gen.language.as_str().to_string(),
                         current_version: None,
                         latest_version,


### PR DESCRIPTION
- Use more robust canonicalize() on windows

https://github.com/rust-lang/cc-rs/issues/169

Basically, fs::canonicalize adds a prefix to the path which makes it a UNC path, and CMD doesnt work with these paths. This dunce::canonicalize returns a non-UNC path.
