### PR TITLE
 [BUMP:cli:0.18.0-canary.1] [BUMP:py_client:0.19.0.dev1] [BUMP:vscode_ext:0.28.1]

### DIFF
--- a/clients/python/.bumpversion.cfg
+++ b/clients/python/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.19.0.dev0
+current_version = 0.19.0.dev1
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:\.(?P<pre>dev)(?P<prerelease>\d+))?$

--- a/clients/python/baml_version/__init__.py
+++ b/clients/python/baml_version/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.19.0.dev0"
+__version__ = "0.19.0.dev1"

--- a/clients/python/baml_version/__main__.py
+++ b/clients/python/baml_version/__main__.py
@@ -1,4 +1,4 @@
-__version__ = "0.19.0.dev0"
+__version__ = "0.19.0.dev1"
 
 if __name__ == "__main__":
     print(__version__)

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "baml"
-version = "0.19.0.dev0"
+version = "0.19.0.dev1"
 description = ""
 authors = ["Boundary <contact@boundaryml.com>"]
 

--- a/engine/.bumpversion.cfg
+++ b/engine/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.18.0-canary.0
+current_version = 0.18.0-canary.1
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(?:-(?P<pre>canary)\.(?P<prerelease>\d+))?$

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -138,7 +138,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "anyhow",
  "baml-lib",
@@ -173,7 +173,7 @@ dependencies = [
 
 [[package]]
 name = "baml-ffi"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "baml-fmt"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "anyhow",
  "baml-lib",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "baml-lib"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "base64 0.13.1",
  "dissimilar",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "baml-schema-build"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "baml-fmt",
  "wasm-bindgen",
@@ -1014,7 +1014,7 @@ checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
 
 [[package]]
 name = "internal-baml-core"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -1045,7 +1045,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-diagnostics"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "colored",
  "indoc",
@@ -1056,7 +1056,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-jinja"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "anyhow",
  "env_logger 0.11.3",
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-parser-database"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "colored",
  "either",
@@ -1091,7 +1091,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-prompt-parser"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "internal-baml-diagnostics",
  "internal-baml-schema-ast",
@@ -1103,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-schema-ast"
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 dependencies = [
  "either",
  "internal-baml-diagnostics",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -16,7 +16,7 @@ indexmap = { version = "2.1.0", features = ["serde"] }
 indoc = "2.0.1"
 
 [workspace.package]
-version = "0.18.0-canary.0"
+version = "0.18.0-canary.1"
 authors = ["Boundary <contact@boundaryml.com>"]
 
 description = "BAML Toolchain"

--- a/engine/baml-core-ffi/package.json
+++ b/engine/baml-core-ffi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaryml/baml-core-ffi",
-  "version": "0.18.0-canary.0",
+  "version": "0.18.0-canary.1",
   "description": "Template project for writing node package with napi-rs",
   "main": "index.js",
   "repository": {

--- a/typescript/.bumpversion.cfg
+++ b/typescript/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.28.0
+current_version = 0.28.1
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)$

--- a/typescript/vscode-ext/packages/package.json
+++ b/typescript/vscode-ext/packages/package.json
@@ -2,7 +2,7 @@
   "name": "baml",
   "displayName": "Baml",
   "description": "BAML is a DSL for AI applications.",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "publisher": "Gloo",
   "repository": "https://github.com/BoundaryML/baml",
   "homepage": "https://www.boundaryml.com",


### PR DESCRIPTION
Automated flow to bump version [BUMP:cli:0.18.0-canary.1] [BUMP:py_client:0.19.0.dev1] [BUMP:vscode_ext:0.28.1]