### PR TITLE
Jump2def for vscode-extension

### DIFF
--- a/engine/baml-lib/baml-core/src/generate/ir/ir_helpers/mod.rs
+++ b/engine/baml-lib/baml-core/src/generate/ir/ir_helpers/mod.rs
@@ -2,8 +2,6 @@ mod error_utils;
 mod scope_diagnostics;
 mod to_baml_arg;
 
-
-
 use crate::{
     error_not_found, error_unsupported,
     ir::{
@@ -34,6 +32,8 @@ pub trait IRHelper {
     fn find_class(&self, class_name: &str) -> Result<ClassWalker<'_>>;
     fn find_function(&self, function_name: &str) -> Result<FunctionWalker<'_>>;
     fn find_client(&self, client_name: &str) -> Result<ClientWalker<'_>>;
+    fn find_retry_policy(&self, retry_policy_name: &str) -> Result<RetryPolicyWalker<'_>>;
+    fn find_template_string(&self, template_string_name: &str) -> Result<TemplateStringWalker<'_>>;
     fn find_test<'a>(
         &'a self,
         function: &'a FunctionWalker<'a>,
@@ -58,7 +58,7 @@ impl IRHelper for IntermediateRepr {
                 // Get best match.
                 let tests = function
                     .walk_tests()
-                    .map(|t| t.item.1.elem.name.clone())
+                    .map(|t| t.item.1.elem.name.as_str())
                     .collect::<Vec<_>>();
                 error_not_found!("test", test_name, &tests)
             }
@@ -118,9 +118,45 @@ impl IRHelper for IntermediateRepr {
                 // Get best match.
                 let clients = self
                     .walk_clients()
-                    .map(|c| c.elem().name.clone())
+                    .map(|c| c.elem().name.as_str())
                     .collect::<Vec<_>>();
                 error_not_found!("client", client_name, &clients)
+            }
+        }
+    }
+
+    // find_retry_policy
+    fn find_retry_policy(&self, retry_policy_name: &str) -> Result<RetryPolicyWalker<'_>> {
+        match self
+            .walk_retry_policies()
+            .find(|r| r.name() == retry_policy_name)
+        {
+            Some(r) => Ok(r),
+            None => {
+                // Get best match.
+                let retry_policies = self
+                    .walk_retry_policies()
+                    .map(|r| r.elem().name.0.as_str())
+                    .collect::<Vec<_>>();
+                error_not_found!("retry policy", retry_policy_name, &retry_policies)
+            }
+        }
+    }
+
+    // find_template_string
+    fn find_template_string(&self, template_string_name: &str) -> Result<TemplateStringWalker<'_>> {
+        match self
+            .walk_template_strings()
+            .find(|t| t.name() == template_string_name)
+        {
+            Some(t) => Ok(t),
+            None => {
+                // Get best match.
+                let template_strings = self
+                    .walk_template_strings()
+                    .map(|t| t.elem().name.as_str())
+                    .collect::<Vec<_>>(); // Ensure the collected type is owned
+                error_not_found!("template string", template_string_name, &template_strings)
             }
         }
     }

--- a/engine/baml-lib/baml-core/src/generate/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/generate/ir/repr.rs
@@ -194,7 +194,7 @@ pub struct NodeAttributes {
 
     // Spans
     #[serde(skip)]
-    span: Option<ast::Span>,
+    pub span: Option<ast::Span>,
 }
 
 impl NodeAttributes {
@@ -477,6 +477,7 @@ impl WithRepr<Expression> for ast::Expression {
 type TemplateStringId = String;
 
 #[derive(serde::Serialize, Debug)]
+
 pub struct TemplateString {
     pub name: TemplateStringId,
     pub params: Vec<Field>,
@@ -484,6 +485,14 @@ pub struct TemplateString {
 }
 
 impl WithRepr<TemplateString> for TemplateStringWalker<'_> {
+    fn attributes(&self, _: &ParserDatabase) -> NodeAttributes {
+        NodeAttributes {
+            meta: Default::default(),
+            overrides: Default::default(),
+            span: Some(self.span().clone()),
+        }
+    }
+
     fn repr(&self, _db: &ParserDatabase) -> Result<TemplateString> {
         Ok(TemplateString {
             name: self.name().to_string(),
@@ -949,6 +958,14 @@ fn process_field(
 }
 
 impl WithRepr<Function> for FunctionWalker<'_> {
+    fn attributes(&self, _: &ParserDatabase) -> NodeAttributes {
+        NodeAttributes {
+            meta: Default::default(),
+            overrides: Default::default(),
+            span: Some(self.span().clone()),
+        }
+    }
+
     fn repr(&self, db: &ParserDatabase) -> Result<Function> {
         if self.is_old_function() {
             Ok(Function::V1(self.repr(db)?))

--- a/engine/baml-lib/baml-core/src/generate/ir/walker.rs
+++ b/engine/baml-lib/baml-core/src/generate/ir/walker.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use baml_types::BamlValue;
 use indexmap::IndexMap;
+
 use internal_baml_parser_database::RetryPolicyStrategy;
 
 use std::collections::HashMap;
@@ -89,6 +90,10 @@ impl<'a> Walker<'a, &'a Function> {
     ) -> either::Either<&'a repr::FunctionArgs, &'a Vec<(String, repr::FieldType)>> {
         self.item.elem.inputs()
     }
+
+    pub fn span(&self) -> Option<&crate::Span> {
+        self.item.attributes.span.as_ref()
+    }
 }
 
 impl<'a> Walker<'a, &'a Enum> {
@@ -105,6 +110,10 @@ impl<'a> Walker<'a, &'a Enum> {
 
     pub fn elem(&self) -> &'a repr::Enum {
         &self.item.elem
+    }
+
+    pub fn span(&self) -> Option<&crate::Span> {
+        self.item.attributes.span.as_ref()
     }
 }
 
@@ -279,6 +288,10 @@ impl<'a> Walker<'a, &'a Class> {
     pub fn elem(&self) -> &'a repr::Class {
         &self.item.elem
     }
+
+    pub fn span(&self) -> Option<&crate::Span> {
+        self.item.attributes.span.as_ref()
+    }
 }
 
 impl<'a> Walker<'a, &'a Client> {
@@ -292,6 +305,10 @@ impl<'a> Walker<'a, &'a Client> {
 
     pub fn retry_policy(&self) -> &Option<String> {
         &self.elem().retry_policy_id
+    }
+
+    pub fn span(&self) -> Option<&crate::Span> {
+        self.item.attributes.span.as_ref()
     }
 }
 
@@ -311,6 +328,10 @@ impl<'a> Walker<'a, &'a RetryPolicy> {
     pub fn strategy(&self) -> &RetryPolicyStrategy {
         &self.elem().strategy
     }
+
+    pub fn span(&self) -> Option<&crate::Span> {
+        self.item.attributes.span.as_ref()
+    }
 }
 
 impl<'a> Walker<'a, &'a TemplateString> {
@@ -328,6 +349,10 @@ impl<'a> Walker<'a, &'a TemplateString> {
 
     pub fn template(&self) -> &str {
         &self.elem().content
+    }
+
+    pub fn span(&self) -> Option<&crate::Span> {
+        self.item.attributes.span.as_ref()
     }
 }
 
@@ -350,5 +375,9 @@ impl<'a> Walker<'a, &'a Field> {
             |v| v.as_string_value(env_values),
         )?;
         Ok(vec![val])
+    }
+
+    pub fn span(&self) -> Option<&crate::Span> {
+        self.item.attributes.span.as_ref()
     }
 }

--- a/engine/baml-lib/diagnostics/src/span.rs
+++ b/engine/baml-lib/diagnostics/src/span.rs
@@ -60,6 +60,7 @@ impl Span {
 
         match (start, end) {
             (Some(start), Some(end)) => (start, end),
+            (Some(start), None) => (start, (line, column)),
             _ => ((0, 0), (0, 0)),
         }
     }

--- a/engine/baml-lib/parser-database/src/walkers/template_string.rs
+++ b/engine/baml-lib/parser-database/src/walkers/template_string.rs
@@ -1,6 +1,6 @@
 use either::Either;
 use internal_baml_jinja::{PredefinedTypes, Type};
-use internal_baml_schema_ast::ast::{self, FunctionArgs, WithIdentifier, WithName};
+use internal_baml_schema_ast::ast::{self, FunctionArgs, Span, WithIdentifier, WithName, WithSpan};
 
 use crate::types::TemplateStringProperties;
 
@@ -51,5 +51,11 @@ impl<'db> TemplateStringWalker<'db> {
 impl WithIdentifier for TemplateStringWalker<'_> {
     fn identifier(&self) -> &ast::Identifier {
         self.ast_node().identifier()
+    }
+}
+
+impl<'a> WithSpan for TemplateStringWalker<'a> {
+    fn span(&self) -> &Span {
+        self.ast_node().span()
     }
 }

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -52,7 +52,7 @@ pub(crate) use internal_baml_jinja::{ChatMessagePart, RenderedPrompt};
 pub(crate) use runtime_interface::InternalRuntimeInterface;
 
 pub use internal_baml_core::internal_baml_diagnostics::Diagnostics as DiagnosticsError;
-pub use internal_baml_core::ir::{FieldType, TypeValue};
+pub use internal_baml_core::ir::{FieldType, IRHelper, TypeValue};
 
 pub struct BamlRuntime {
     inner: InternalBamlRuntime,

--- a/typescript/vscode-ext/packages/language-server/src/lib/MessageHandler.ts
+++ b/typescript/vscode-ext/packages/language-server/src/lib/MessageHandler.ts
@@ -20,7 +20,7 @@ import {
   type TextEdit,
   type WorkspaceEdit,
 } from 'vscode-languageserver'
-import type { TextDocument } from 'vscode-languageserver-textdocument'
+import { TextDocument } from 'vscode-languageserver-textdocument'
 import { URI } from 'vscode-uri'
 import type { FileCache } from '../file/fileCache'
 import { fullDocumentRange } from './ast'
@@ -78,15 +78,22 @@ export function handleDefinitionRequest(
   const position = params.position
 
   const lines = convertDocumentTextToTrimmedLineArray(document)
-  const word = getWordAtPosition(document, position)
-
+  let result = lines.join('\n');
+  console.log(result)
+  const newDoc =  TextDocument.create(document.uri, document.languageId, document.version, result);
+  const word = getWordAtPosition(newDoc, position)
+  console.log('handleDefinitionRequest')
   if (word === '') {
+    console.log('word is empty')
     return
   }
+  console.log('word is not empty')
+  console.log(word)
 
   // TODO: Do block level definitions
   const match = fileCache.define(word)
-
+  
+  console.log(match)
   if (match) {
     return [
       {

--- a/typescript/vscode-ext/packages/language-server/src/lib/ast/index.ts
+++ b/typescript/vscode-ext/packages/language-server/src/lib/ast/index.ts
@@ -8,3 +8,7 @@ export function convertDocumentTextToTrimmedLineArray(document: TextDocument): s
     .fill(0)
     .map((_, i) => getCurrentLine(document, i).trim())
 }
+
+export function trimLine(line: string): string {
+  return line.trim().replace(/[^a-zA-Z0-9_.]/g, '');
+}

--- a/typescript/vscode-ext/packages/language-server/src/server.ts
+++ b/typescript/vscode-ext/packages/language-server/src/server.ts
@@ -365,15 +365,6 @@ export function startServer(options?: LSOptions): void {
 
       } 
   
-
-      
-      else if (doc.languageId === 'python') {
-        const db = bamlCache.lastBamlDir?.cache
-        
-        if (db) {
-          return MessageHandler.handleDefinitionRequest(db, doc, params)
-        }
-      }
     }
   })
 

--- a/typescript/vscode-ext/packages/language-server/src/server.ts
+++ b/typescript/vscode-ext/packages/language-server/src/server.ts
@@ -348,20 +348,33 @@ export function startServer(options?: LSOptions): void {
   }
 
   connection.onDefinition((params: DeclarationParams) => {
-    return undefined
-    // const doc = getDocument(params.textDocument.uri)
-    // if (doc) {
-    //   const db = bamlCache.getFileCache(doc)
-    //   if (db) {
-    //     return MessageHandler.handleDefinitionRequest(db, doc, params)
-    //   } else if (doc.languageId === 'python') {
-    //     const db = bamlCache.lastBamlDir?.cache
-    //     console.log(` python: ${doc.uri} files: ${db?.getDocuments().length}`)
-    //     if (db) {
-    //       return MessageHandler.handleDefinitionRequest(db, doc, params)
-    //     }
-    //   }
-    // }
+    
+    
+    
+    //accesses document from uri
+    const doc = getDocument(params.textDocument.uri)
+    
+    if (doc) {
+      
+      //accesses project from uri via bamlProjectManager
+      const proj = bamlProjectManager.getProjectById((URI.parse(doc.uri)))
+      if (proj) {
+
+        //returns the definition of reference within the project
+        return proj.handleDefinitionRequest(doc, params.position)
+
+      } 
+  
+
+      
+      else if (doc.languageId === 'python') {
+        const db = bamlCache.lastBamlDir?.cache
+        
+        if (db) {
+          return MessageHandler.handleDefinitionRequest(db, doc, params)
+        }
+      }
+    }
   })
 
   // connection.onCompletion((params: CompletionParams) => {
@@ -399,7 +412,7 @@ export function startServer(options?: LSOptions): void {
     // bamlCache.addDocument(document)
     // // Dont debounce this! We need to give VSCode the most up to date info.
     // // VSCode will actually do adaptive debouncing for us https://github.com/microsoft/vscode/issues/106267
-    // validateTextDocument(document)
+    // // validateTextDocument(document)
 
     // const db = bamlCache.getParserDatabase(document)
     // const docFsPath = URI.parse(document.uri).fsPath


### PR DESCRIPTION
Supports enums, classes, functions, clients, retry policies, and template strings.
Adjusted span logic for some symbols, but mainly added functionality to bamlProjectManager, called from TS.