### PR TITLE
Hover to show definition works 

### DIFF
--- a/engine/baml-lib/diagnostics/src/span.rs
+++ b/engine/baml-lib/diagnostics/src/span.rs
@@ -41,6 +41,8 @@ impl Span {
         let mut start = None;
         let mut end = None;
 
+        log::info!("Start: {}, End: {}", self.start, self.end);
+
         for (idx, c) in contents.chars().enumerate() {
             if idx == self.start {
                 start = Some((line, column));

--- a/engine/baml-lib/schema-ast/src/parser/parse_config.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_config.rs
@@ -61,18 +61,11 @@ pub(crate) fn parse_config_block(
             _ => parsing_catch_all(&current, "client"),
         }
     }
-    log::info!("Rebuilt");
 
     let span = match kw {
-        Some(name) => {
-            log::info!("Name: {}", name);
-
-            log::info!("Length of name: {}", name.len());
-            diagnostics.span(pair_span)
-        }
+        Some(name) => diagnostics.span(pair_span),
         _ => unreachable!("Encountered impossible model declaration during parsing"),
     };
-    log::info!("Span: {:?}", span);
 
     match (kw, name, template_args) {
         (Some("printer"), _, None) => Err(DatamodelError::new_validation_error(

--- a/engine/baml-lib/schema-ast/src/parser/parse_config.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_config.rs
@@ -61,11 +61,18 @@ pub(crate) fn parse_config_block(
             _ => parsing_catch_all(&current, "client"),
         }
     }
+    log::info!("Rebuilt");
 
     let span = match kw {
-        Some(name) => diagnostics.span(pair_span.get(0..(name.len())).unwrap()),
+        Some(name) => {
+            log::info!("Name: {}", name);
+
+            log::info!("Length of name: {}", name.len());
+            diagnostics.span(pair_span)
+        }
         _ => unreachable!("Encountered impossible model declaration during parsing"),
     };
+    log::info!("Span: {:?}", span);
 
     match (kw, name, template_args) {
         (Some("printer"), _, None) => Err(DatamodelError::new_validation_error(

--- a/engine/baml-schema-wasm/src/runtime_wasm.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm.rs
@@ -711,6 +711,7 @@ test TestName {{
 
         if let Ok(walker) = runtime.find_enum(symbol) {
             let elem = walker.span().unwrap();
+            log::info!("Found enum: {:?}", elem);
 
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
             return Some(SymbolLocation {
@@ -723,6 +724,8 @@ test TestName {{
         }
         if let Ok(walker) = runtime.find_class(symbol) {
             let elem = walker.span().unwrap();
+            log::info!("Found class: {:?}", elem);
+
             let uri_str = elem.file.path().to_string(); // Store the String in a variable
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
             return Some(SymbolLocation {
@@ -736,6 +739,8 @@ test TestName {{
 
         if let Ok(walker) = runtime.find_function(symbol) {
             let elem = walker.span().unwrap();
+            log::info!("Found function: {:?}", elem);
+
             let uri_str = elem.file.path().to_string(); // Store the String in a variable
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
             return Some(SymbolLocation {
@@ -749,8 +754,11 @@ test TestName {{
 
         if let Ok(walker) = runtime.find_client(symbol) {
             let elem = walker.span().unwrap();
+            log::info!("Found client: {:?}", elem);
+
             let uri_str = elem.file.path().to_string(); // Store the String in a variable
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
+
             return Some(SymbolLocation {
                 uri: elem.file.path().to_string(), // Use the variable here
                 start_line: s_line,
@@ -762,6 +770,8 @@ test TestName {{
 
         if let Ok(walker) = runtime.find_retry_policy(symbol) {
             let elem = walker.span().unwrap();
+            log::info!("Found retry policy: {:?}", elem);
+
             let uri_str = elem.file.path().to_string(); // Store the String in a variable
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
             return Some(SymbolLocation {

--- a/engine/baml-schema-wasm/src/runtime_wasm.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm.rs
@@ -706,12 +706,10 @@ test TestName {{
 
     #[wasm_bindgen]
     pub fn searchForSymbol(&self, symbol: &str) -> Option<SymbolLocation> {
-        log::info!("Searching for symbol: {}", symbol);
         let runtime = self.runtime.internal().ir();
 
         if let Ok(walker) = runtime.find_enum(symbol) {
             let elem = walker.span().unwrap();
-            log::info!("Found enum: {:?}", elem);
 
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
             return Some(SymbolLocation {
@@ -724,7 +722,6 @@ test TestName {{
         }
         if let Ok(walker) = runtime.find_class(symbol) {
             let elem = walker.span().unwrap();
-            log::info!("Found class: {:?}", elem);
 
             let uri_str = elem.file.path().to_string(); // Store the String in a variable
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
@@ -739,7 +736,6 @@ test TestName {{
 
         if let Ok(walker) = runtime.find_function(symbol) {
             let elem = walker.span().unwrap();
-            log::info!("Found function: {:?}", elem);
 
             let uri_str = elem.file.path().to_string(); // Store the String in a variable
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
@@ -754,7 +750,6 @@ test TestName {{
 
         if let Ok(walker) = runtime.find_client(symbol) {
             let elem = walker.span().unwrap();
-            log::info!("Found client: {:?}", elem);
 
             let uri_str = elem.file.path().to_string(); // Store the String in a variable
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
@@ -770,7 +765,6 @@ test TestName {{
 
         if let Ok(walker) = runtime.find_retry_policy(symbol) {
             let elem = walker.span().unwrap();
-            log::info!("Found retry policy: {:?}", elem);
 
             let uri_str = elem.file.path().to_string(); // Store the String in a variable
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
@@ -785,7 +779,6 @@ test TestName {{
 
         if let Ok(walker) = runtime.find_template_string(symbol) {
             let elem = walker.span().unwrap();
-            log::info!("Found template string: {:?}", elem);
             let uri_str = elem.file.path().to_string(); // Store the String in a variable
             let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
             return Some(SymbolLocation {

--- a/typescript/playground-common/src/shared/TestSnippet.tsx
+++ b/typescript/playground-common/src/shared/TestSnippet.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@/components/ui/input'
+import { Input } from '../components/ui/input'
 import { selectedFunctionAtom } from '../baml_wasm_web/EventListener'
 import { useAtomValue } from 'jotai'
 import { Textarea } from '../components/ui/textarea'

--- a/typescript/vscode-ext/packages/language-server/src/lib/MessageHandler.ts
+++ b/typescript/vscode-ext/packages/language-server/src/lib/MessageHandler.ts
@@ -79,21 +79,21 @@ export function handleDefinitionRequest(
 
   const lines = convertDocumentTextToTrimmedLineArray(document)
   let result = lines.join('\n');
-  console.log(result)
+  
   const newDoc =  TextDocument.create(document.uri, document.languageId, document.version, result);
   const word = getWordAtPosition(newDoc, position)
-  console.log('handleDefinitionRequest')
+  
   if (word === '') {
-    console.log('word is empty')
+    
     return
   }
   console.log('word is not empty')
-  console.log(word)
+
 
   // TODO: Do block level definitions
   const match = fileCache.define(word)
   
-  console.log(match)
+  
   if (match) {
     return [
       {

--- a/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
+++ b/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
@@ -99,11 +99,7 @@ class Project {
   }
 
   get_file(file_path: string) {
-    // const filePath = this.files.files().find((f) => f.startsWith(file_path || ''));
-    // if (!filePath) {
-    //   return null;
-    // }
-    // console.log(`Filepath: ${filePath}`)
+
     // Read the file content
     const fileContent = readFileSync(file_path, 'utf8');
   
@@ -166,7 +162,7 @@ class Project {
     }
 
     const match = this.runtime().searchForSymbol(cleaned_word)
-    console.log("handle hover request")
+    
     //need to get the content of the range specified by match's start and end lines and characters
     if (match) {
       const hoverCont: { language: string; value: string }[] = []
@@ -401,11 +397,10 @@ class BamlProjectManager {
   }
 
   getProjectById(id: URI): Project {
-    console.log("Getting project by id")
-    console.log(`rebuild changed ${id.toString()} -> ${uriToRootPath(id)}`)
-    const project = this.get_project(uriToRootPath(id));
-    console.log("got project id")
-    return project;
+
+    
+    
+    return this.get_project(uriToRootPath(id));
   }
 
 

--- a/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
+++ b/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
@@ -176,15 +176,14 @@ class Project {
         end: { line: match.end_line, character: match.end_character }
       }
       
-      console.log(`Match URI: ${JSON.stringify(match.uri)}`)
+      
       const hoverDoc = this.get_file(match.uri)
 
       if (hoverDoc) {
-        console.log(`URI: ${hoverDoc.uri}`)
-        console.log(`Hover range: ${JSON.stringify(range)}`)
+
 
         const hoverText = hoverDoc.getText(range)
-        console.log(`Hover text: ${hoverText}`)
+        
         hoverCont.push({ language: 'baml', value: hoverText })
       
         return {contents: hoverCont}

--- a/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
+++ b/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
@@ -1,10 +1,13 @@
 import BamlWasm, { type WasmDiagnosticError } from '@gloo-ai/baml-schema-wasm-node'
 import { readFile } from 'fs/promises'
-import { type Diagnostic, DiagnosticSeverity, Position, LocationLink } from 'vscode-languageserver'
+import { type Diagnostic, DiagnosticSeverity, Position, LocationLink, Hover } from 'vscode-languageserver'
 import { TextDocument } from 'vscode-languageserver-textdocument' 
+import { readFileSync } from 'fs';
+
 import type { URI } from 'vscode-uri'
 import { findTopLevelParent, gatherFiles } from '../file/fileUtils'
 import { getWordAtPosition, convertDocumentTextToTrimmedLineArray, trimLine } from './ast'
+
 
 
 type Notify = (
@@ -95,6 +98,21 @@ class Project {
     this.current_runtime = undefined
   }
 
+  get_file(file_path: string) {
+    // const filePath = this.files.files().find((f) => f.startsWith(file_path || ''));
+    // if (!filePath) {
+    //   return null;
+    // }
+    // console.log(`Filepath: ${filePath}`)
+    // Read the file content
+    const fileContent = readFileSync(file_path, 'utf8');
+  
+    // Create a TextDocument
+    const doc = TextDocument.create(file_path, 'plaintext', 1, fileContent);
+  
+    return doc;
+  }
+
   upsert_file(file_path: string, content: string | undefined) {
     this.files.update_file(file_path, content)
     if (this.current_runtime) {
@@ -105,16 +123,11 @@ class Project {
   }
 
   handleDefinitionRequest(doc: TextDocument, position: Position): LocationLink[] {
-  
-  
-  
-    
+      
     const word = getWordAtPosition(doc, position)
     
     //clean non-alphanumeric characters besides underscores and periods
     const cleaned_word = trimLine(word)
-    
-
     if (cleaned_word === '') {
       
       return []
@@ -123,9 +136,6 @@ class Project {
     // Search for the symbol in the runtime
     const match = this.runtime().searchForSymbol(cleaned_word)
 
-    
-    
-    
     // If we found a match, return the location
     if (match) {
       return [
@@ -146,6 +156,43 @@ class Project {
     
     
     return [];
+  }
+
+  handleHoverRequest(doc: TextDocument, position: Position): Hover {
+    const word = getWordAtPosition(doc, position)
+    const cleaned_word = trimLine(word)
+    if (cleaned_word === '') {
+      return { contents: [] }
+    }
+
+    const match = this.runtime().searchForSymbol(cleaned_word)
+    console.log("handle hover request")
+    //need to get the content of the range specified by match's start and end lines and characters
+    if (match) {
+      const hoverCont: { language: string; value: string }[] = []
+
+      const range = {
+        start: { line: match.start_line, character: match.start_character },
+        end: { line: match.end_line, character: match.end_character }
+      }
+      
+      console.log(`Match URI: ${JSON.stringify(match.uri)}`)
+      const hoverDoc = this.get_file(match.uri)
+
+      if (hoverDoc) {
+        console.log(`URI: ${hoverDoc.uri}`)
+        console.log(`Hover range: ${JSON.stringify(range)}`)
+
+        const hoverText = hoverDoc.getText(range)
+        console.log(`Hover text: ${hoverText}`)
+        hoverCont.push({ language: 'baml', value: hoverText })
+      
+        return {contents: hoverCont}
+      }
+
+    }
+
+    return { contents: [] }
   }
 
   // list_functions(): BamlWasm.WasmFunction[] {

--- a/typescript/vscode-ext/packages/language-server/src/server.ts
+++ b/typescript/vscode-ext/packages/language-server/src/server.ts
@@ -358,6 +358,7 @@ export function startServer(options?: LSOptions): void {
         return proj.handleDefinitionRequest(doc, params.position)
       }
     }
+    return undefined
   })
 
   // connection.onCompletion((params: CompletionParams) => {
@@ -373,7 +374,6 @@ export function startServer(options?: LSOptions): void {
   // })
 
   connection.onHover((params: HoverParams) => {
-    // return undefined
     const doc = getDocument(params.textDocument.uri)
     if (doc) {
       const proj = bamlProjectManager.getProjectById(URI.parse(doc.uri))

--- a/typescript/vscode-ext/packages/language-server/src/server.ts
+++ b/typescript/vscode-ext/packages/language-server/src/server.ts
@@ -348,23 +348,15 @@ export function startServer(options?: LSOptions): void {
   }
 
   connection.onDefinition((params: DeclarationParams) => {
-    
-    
-    
-    //accesses document from uri
     const doc = getDocument(params.textDocument.uri)
-    
-    if (doc) {
-      
-      //accesses project from uri via bamlProjectManager
-      const proj = bamlProjectManager.getProjectById((URI.parse(doc.uri)))
-      if (proj) {
 
+    if (doc) {
+      //accesses project from uri via bamlProjectManager
+      const proj = bamlProjectManager.getProjectById(URI.parse(doc.uri))
+      if (proj) {
         //returns the definition of reference within the project
         return proj.handleDefinitionRequest(doc, params.position)
-
-      } 
-  
+      }
     }
   })
 
@@ -381,14 +373,16 @@ export function startServer(options?: LSOptions): void {
   // })
 
   connection.onHover((params: HoverParams) => {
+    // return undefined
+    const doc = getDocument(params.textDocument.uri)
+    if (doc) {
+      const proj = bamlProjectManager.getProjectById(URI.parse(doc.uri))
+
+      if (proj) {
+        return proj.handleHoverRequest(doc, params.position)
+      }
+    }
     return undefined
-    // const doc = getDocument(params.textDocument.uri)
-    // if (doc) {
-    //   const db = bamlCache.getFileCache(doc)
-    //   if (db) {
-    //     return MessageHandler.handleHoverRequest(db, doc, params)
-    //   }
-    // }
   })
 
   connection.onCodeLens((params: CodeLensParams) => {


### PR DESCRIPTION
Adjusted span setting for parse.config data types, which affects all definition linking.
Hover works. Only note is that origins also show their definitions, which may be a small annoyance in the future but punted for now.