### PR TITLE
 Fixed playground function swapping based on click 

### DIFF
--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -849,12 +849,18 @@ impl WasmRuntime {
     }
 
     #[wasm_bindgen]
-    pub fn get_function_at_position(&self, cursorIdx: usize) -> Option<WasmFunction> {
+    pub fn get_function_at_position(
+        &self,
+        fileName: &str,
+        cursorIdx: usize,
+    ) -> Option<WasmFunction> {
         let functions = self.list_functions();
 
         for function in functions {
             let span = function.span.clone(); // Clone the span
-            if ((span.start + 1)..=(span.end + 1)).contains(&cursorIdx) {
+            if span.file_path == fileName
+                && ((span.start + 1)..=(span.end + 1)).contains(&cursorIdx)
+            {
                 return Some(function);
             }
         }

--- a/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
@@ -1,4 +1,5 @@
 import 'react18-json-view/src/style.css'
+// import * as vscode from 'vscode'
 
 import { VSCodeButton } from '@vscode/webview-ui-toolkit/react'
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
@@ -136,36 +137,40 @@ export const selectedTestCaseAtom = atom(
   },
 )
 
-const updateCursorAtom = atom(null, (get, set, cursor: { fileText: string; line: number; column: number }) => {
-  const selectedProject = get(selectedProjectAtom)
-  if (selectedProject === null) {
-    return
-  }
-
-  const project = get(projectFamilyAtom(selectedProject))
-  const runtime = get(selectedRuntimeAtom)
-
-  if (runtime && project) {
-    //need logic to convert line and column to index value
-    let cursorIdx = 0
-    const fileContent = cursor.fileText
-    const lines = fileContent.split('\n')
-    let charCount = 0
-
-    for (let i = 0; i < cursor.line; i++) {
-      charCount += lines[i].length + 1 // +1 for the newline character
+const updateCursorAtom = atom(
+  null,
+  (get, set, cursor: { fileName: string; fileText: string; line: number; column: number }) => {
+    const selectedProject = get(selectedProjectAtom)
+    if (selectedProject === null) {
+      return
     }
 
-    charCount += cursor.column
-    cursorIdx = charCount
+    const project = get(projectFamilyAtom(selectedProject))
+    const runtime = get(selectedRuntimeAtom)
 
-    const selectedFunc = runtime.get_function_at_position(cursorIdx)
+    if (runtime && project) {
+      //need logic to convert line and column to index value
+      let cursorIdx = 0
+      const fileName = cursor.fileName
+      const fileContent = cursor.fileText
+      const lines = fileContent.split('\n')
+      let charCount = 0
 
-    if (selectedFunc) {
-      set(selectedFunctionAtom, selectedFunc.name)
+      for (let i = 0; i < cursor.line; i++) {
+        charCount += lines[i].length + 1 // +1 for the newline character
+      }
+
+      charCount += cursor.column
+      cursorIdx = charCount
+
+      const selectedFunc = runtime.get_function_at_position(fileName, cursorIdx)
+
+      if (selectedFunc) {
+        set(selectedFunctionAtom, selectedFunc.name)
+      }
     }
-  }
-})
+  },
+)
 
 const removeProjectAtom = atom(null, (get, set, root_path: string) => {
   set(projectFilesAtom(root_path), {})
@@ -501,7 +506,7 @@ export const EventListener: React.FC<{ children: React.ReactNode }> = ({ childre
         | {
             command: 'update_cursor'
             content: {
-              cursor: { fileText: string; line: number; column: number }
+              cursor: { fileName: string; fileText: string; line: number; column: number }
             }
           }
       >,

--- a/typescript/vscode-ext/packages/vscode/src/extension.ts
+++ b/typescript/vscode-ext/packages/vscode/src/extension.ts
@@ -199,13 +199,15 @@ export function activate(context: vscode.ExtensionContext) {
   // Add cursor movement listener
   vscode.window.onDidChangeTextEditorSelection((event) => {
     const position = event.selections[0].active
-    console.log(`Cursor moved to line ${position.line + 1}, character ${position.character}`)
+
     const editor = vscode.window.activeTextEditor
     if (editor) {
+      const name = editor.document.fileName
       const text = editor.document.getText()
 
       WebPanelView.currentPanel?.postMessage('update_cursor', {
         cursor: {
+          fileName: name,
           fileText: text,
           line: position.line + 1,
           column: position.character,


### PR DESCRIPTION
Previously wasn't restricted to functions in the same file. Was matching with any function whose span the cursor fell into, not just the ones in the same file whose span it fell under.