### PR TITLE
Fixed end of function swapping bug

### DIFF
--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -28,7 +28,6 @@ use anyhow::Result;
 
 use baml_types::BamlMap;
 use baml_types::BamlValue;
-// use cli::LanguageClientType;
 use indexmap::IndexMap;
 use internal_baml_core::configuration::GeneratorOutputType;
 use runtime::InternalBamlRuntime;

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -28,7 +28,7 @@ use anyhow::Result;
 
 use baml_types::BamlMap;
 use baml_types::BamlValue;
-use cli::LanguageClientType;
+// use cli::LanguageClientType;
 use indexmap::IndexMap;
 use internal_baml_core::configuration::GeneratorOutputType;
 use runtime::InternalBamlRuntime;

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -879,19 +879,13 @@ impl WasmRuntime {
         cursor_idx: usize,
     ) -> Option<WasmFunction> {
         let functions = self.list_functions();
-        log::info!("Cursor index is {:#?}", cursor_idx);
+
         for function in functions {
             let span = function.span.clone(); // Clone the span
 
             if span.file_path == file_name
                 && ((span.start + 1)..=(span.end + 1)).contains(&cursor_idx)
             {
-                log::info!(
-                    "Function is {:#?} and Span is {:#?} to {:#?}",
-                    function.name,
-                    span.start,
-                    span.end
-                );
                 return Some(function);
             }
         }

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -659,7 +659,7 @@ impl WasmRuntime {
                 }),
                 None => false,
             })
-
+    }
 
     #[wasm_bindgen]
     pub fn list_functions(&self) -> Vec<WasmFunction> {
@@ -875,16 +875,23 @@ impl WasmRuntime {
     #[wasm_bindgen]
     pub fn get_function_at_position(
         &self,
-        fileName: &str,
-        cursorIdx: usize,
+        file_name: &str,
+        cursor_idx: usize,
     ) -> Option<WasmFunction> {
         let functions = self.list_functions();
-
+        log::info!("Cursor index is {:#?}", cursor_idx);
         for function in functions {
             let span = function.span.clone(); // Clone the span
-            if span.file_path == fileName
-                && ((span.start + 1)..=(span.end + 1)).contains(&cursorIdx)
+
+            if span.file_path == file_name
+                && ((span.start + 1)..=(span.end + 1)).contains(&cursor_idx)
             {
+                log::info!(
+                    "Function is {:#?} and Span is {:#?} to {:#?}",
+                    function.name,
+                    span.start,
+                    span.end
+                );
                 return Some(function);
             }
         }

--- a/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
@@ -147,26 +147,24 @@ const updateCursorAtom = atom(
       return
     }
 
+    console.log(`Line: ${cursor.line}, Column: ${cursor.column}`)
     const project = get(projectFamilyAtom(selectedProject))
     const runtime = get(selectedRuntimeAtom)
 
     if (runtime && project) {
-      //need logic to convert line and column to index value
-      let cursorIdx = 0
       const fileName = cursor.fileName
       const fileContent = cursor.fileText
       const lines = fileContent.split('\n')
-      let charCount = 0
 
-      for (let i = 0; i < cursor.line; i++) {
-        charCount += lines[i].length + 1 // +1 for the newline character
+      let cursorIdx = 0
+      for (let i = 0; i < cursor.line - 1; i++) {
+        cursorIdx += lines[i].length + 1 // +1 for the newline character
       }
 
-      charCount += cursor.column
-      cursorIdx = charCount
+      cursorIdx += cursor.column
 
+      console.log(`Cursor position: ${cursorIdx}`)
       const selectedFunc = runtime.get_function_at_position(fileName, cursorIdx)
-
       if (selectedFunc) {
         set(selectedFunctionAtom, selectedFunc.name)
       }

--- a/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
@@ -147,7 +147,6 @@ const updateCursorAtom = atom(
       return
     }
 
-    console.log(`Line: ${cursor.line}, Column: ${cursor.column}`)
     const project = get(projectFamilyAtom(selectedProject))
     const runtime = get(selectedRuntimeAtom)
 
@@ -163,7 +162,6 @@ const updateCursorAtom = atom(
 
       cursorIdx += cursor.column
 
-      console.log(`Cursor position: ${cursorIdx}`)
       const selectedFunc = runtime.get_function_at_position(fileName, cursorIdx)
       if (selectedFunc) {
         set(selectedFunctionAtom, selectedFunc.name)

--- a/typescript/vscode-ext/packages/vscode/src/extension.ts
+++ b/typescript/vscode-ext/packages/vscode/src/extension.ts
@@ -216,14 +216,14 @@ export function activate(context: vscode.ExtensionContext) {
       const text = editor.document.getText()
 
       // TODO: buggy when used with multiple functions, needs a fix.
-      // WebPanelView.currentPanel?.postMessage('update_cursor', {
-      //   cursor: {
-      //     fileName: name,
-      //     fileText: text,
-      //     line: position.line + 1,
-      //     column: position.character,
-      //   },
-      // })
+      WebPanelView.currentPanel?.postMessage('update_cursor', {
+        cursor: {
+          fileName: name,
+          fileText: text,
+          line: position.line + 1,
+          column: position.character,
+        },
+      })
     }
   })
 


### PR DESCRIPTION
Previously, cursor index was being incorrectly calculated, causing clicks near the end of functions to cause switching to other functions.
Now: fixed cursor index calculation, issue is resolved.