### PR TITLE
Fix test cases

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
@@ -41,6 +41,7 @@ pub trait IRHelper {
         &'a self,
         function: &'a FunctionWalker<'a>,
         params: &BamlMap<String, BamlValue>,
+        allow_implicit_cast_to_string: bool,
     ) -> Result<BamlValue>;
 }
 
@@ -163,6 +164,7 @@ impl IRHelper for IntermediateRepr {
         &'a self,
         function: &'a FunctionWalker<'a>,
         params: &BamlMap<String, BamlValue>,
+        allow_implicit_cast_to_string: bool,
     ) -> Result<BamlValue> {
         let function_params = match function.inputs() {
             either::Either::Left(_) => {
@@ -182,9 +184,13 @@ impl IRHelper for IntermediateRepr {
         for (param_name, param_type) in function_params {
             scope.push(param_name.to_string());
             if let Some(param_value) = params.get(param_name.as_str()) {
-                if let Some(baml_arg) =
-                    to_baml_arg::validate_arg(self, param_type, param_value, &mut scope)
-                {
+                if let Some(baml_arg) = to_baml_arg::validate_arg(
+                    self,
+                    param_type,
+                    param_value,
+                    &mut scope,
+                    allow_implicit_cast_to_string,
+                ) {
                     baml_arg_map.insert(param_name.to_string(), baml_arg);
                 }
             } else {

--- a/engine/baml-runtime/src/runtime/runtime_interface.rs
+++ b/engine/baml-runtime/src/runtime/runtime_interface.rs
@@ -123,7 +123,7 @@ impl InternalRuntimeInterface for InternalBamlRuntime {
         node_index: Option<usize>,
     ) -> Result<(RenderedPrompt, OrchestrationScope)> {
         let func = self.get_function(function_name, ctx)?;
-        let baml_args = self.ir().check_function_params(&func, params)?;
+        let baml_args = self.ir().check_function_params(&func, params, false)?;
 
         let renderer = PromptRenderer::from_function(&func, &self.ir(), ctx)?;
         let client_name = renderer.client_name().to_string();
@@ -193,7 +193,9 @@ impl InternalRuntimeInterface for InternalBamlRuntime {
                         errors
                     ));
                 }
-                Ok(params)
+
+                let baml_args = self.ir().check_function_params(&func, &params, true)?;
+                Ok(baml_args.as_map_owned().unwrap())
             }
             Err(e) => return Err(anyhow::anyhow!("Unable to resolve test params: {:?}", e)),
         }
@@ -296,7 +298,7 @@ impl RuntimeInterface for InternalBamlRuntime {
         ctx: RuntimeContext,
     ) -> Result<crate::FunctionResult> {
         let func = self.get_function(&function_name, &ctx)?;
-        let baml_args = self.ir().check_function_params(&func, &params)?;
+        let baml_args = self.ir().check_function_params(&func, &params, false)?;
 
         let renderer = PromptRenderer::from_function(&func, self.ir(), &ctx)?;
         let client_name = renderer.client_name().to_string();
@@ -325,7 +327,7 @@ impl RuntimeInterface for InternalBamlRuntime {
         let orchestrator = self.orchestration_graph(&client_name, &ctx)?;
         let Some(baml_args) = self
             .ir
-            .check_function_params(&func, &params)?
+            .check_function_params(&func, &params, false)?
             .as_map_owned()
         else {
             anyhow::bail!("Expected parameters to be a map for: {}", function_name);


### PR DESCRIPTION
* BAML test cases that are bools or ints need to allow for casting to string

example:
args {
  foo 1
}

could work for foo: string or foo: int
