### PR TITLE
fix: restore one-workspace-per-folder

### DIFF
--- a/root.code-workspace
+++ b/root.code-workspace
@@ -1,7 +1,31 @@
 {
   "folders": [
     {
-      "path": "."
+      "path": ".baml"
+    },
+    {
+      "path": ".github"
+    },
+    {
+      "path": "docs"
+    },
+    {
+      "path": "engine"
+    },
+    {
+      "path": "fiddle"
+    },
+    {
+      "path": "integ-tests"
+    },
+    {
+      "path": "release"
+    },
+    {
+      "path": "tools"
+    },
+    {
+      "path": "typescript"
     }
   ],
   "settings": {


### PR DESCRIPTION
This allows setting one Python env per workspace
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 81b75c5b5cc37175074a52e953eac16a4f29faa4  | 
|--------|--------|

### Summary:
Updated `root.code-workspace` to support individual settings for multiple folders, enabling specific Python environments per workspace.

**Key points**:
- Updated `root.code-workspace` to include multiple folders.
- Allows setting individual Python environments per workspace.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->