### PR TITLE
Fix language server crash relying on node crypto

### DIFF
--- a/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
@@ -548,6 +548,7 @@ export const EventListener: React.FC<{ children: React.ReactNode }> = ({ childre
           break
 
         case 'port_number':
+          console.log('Setting port number', content.port)
           setEnvKeyValueStorage((prev) => {
             let keyExists = false
             const updated: [string, string][] = prev.map(([key, value]) => {

--- a/typescript/vscode-ext/packages/language-server/src/server.ts
+++ b/typescript/vscode-ext/packages/language-server/src/server.ts
@@ -37,7 +37,6 @@ import { z } from 'zod'
 // import { getVersion, getEnginesVersion } from './lib/wasm/internals'
 import BamlProjectManager from './lib/baml_project_manager'
 import type { LSOptions, LSSettings } from './lib/types'
-;(globalThis as any).crypto = require('node:crypto').webcrypto
 
 const packageJson = require('../../package.json') // eslint-disable-line
 function getConnection(options?: LSOptions): Connection {

--- a/typescript/vscode-ext/packages/package.json
+++ b/typescript/vscode-ext/packages/package.json
@@ -2,7 +2,7 @@
   "name": "baml-extension",
   "displayName": "Baml",
   "description": "BAML is a DSL for AI applications.",
-  "version": "0.36.1",
+  "version": "0.36.2",
   "publisher": "Boundary",
   "repository": "https://github.com/BoundaryML/baml",
   "homepage": "https://www.boundaryml.com",

--- a/typescript/vscode-ext/packages/package.json
+++ b/typescript/vscode-ext/packages/package.json
@@ -2,7 +2,7 @@
   "name": "baml-extension",
   "displayName": "Baml",
   "description": "BAML is a DSL for AI applications.",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "publisher": "Boundary",
   "repository": "https://github.com/BoundaryML/baml",
   "homepage": "https://www.boundaryml.com",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 900d14e08218b1426eadce72c6f0f798621ab584  | 
|--------|--------|

### Summary:
This PR addresses crashes by removing the assignment of Node's `crypto` module to `globalThis.crypto` in the language server and updates the package version.

**Key points**:
- Removed global assignment of `crypto` to `node:crypto`'s `webcrypto` in `server.ts`.
- Removed assignment of Node's `crypto` module to `globalThis.crypto` in `server.ts`.
- Updated package version in `package.json` from `0.36.0` to `0.36.1`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!-- ELLIPSIS_HIDDEN -->