### PR TITLE
Baml Classes come stable-sorted in the order you define fields

### DIFF
--- a/engine/baml-lib/baml-types/Cargo.toml
+++ b/engine/baml-lib/baml-types/Cargo.toml
@@ -37,6 +37,6 @@ features = [
 ]
 
 [features]
-default = []
+default = ["stable_sort"]
 stable_sort = ["indexmap"]
 mini-jinja = ["minijinja"]

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
@@ -37,11 +37,11 @@ impl TypeCoercer for Class {
         let mut optional_values = optional
             .iter()
             .map(|(f, ..)| (f.real_name().to_string(), None))
-            .collect::<HashMap<_, _>>();
+            .collect::<BamlMap<_, _>>();
         let mut required_values = required
             .iter()
             .map(|(f, ..)| (f.real_name().to_string(), None))
-            .collect::<HashMap<_, _>>();
+            .collect::<BamlMap<_, _>>();
         let mut flags = DeserializerConditions::new();
 
         let mut completed_cls = Vec::new();
@@ -254,8 +254,8 @@ impl TypeCoercer for Class {
 }
 
 fn update_map<'a>(
-    required_values: &'a mut HashMap<String, Option<Result<BamlValueWithFlags, ParsingError>>>,
-    optional_values: &'a mut HashMap<String, Option<Result<BamlValueWithFlags, ParsingError>>>,
+    required_values: &'a mut BamlMap<String, Option<Result<BamlValueWithFlags, ParsingError>>>,
+    optional_values: &'a mut BamlMap<String, Option<Result<BamlValueWithFlags, ParsingError>>>,
     (name, t, ..): &'a FieldValue,
     value: Result<BamlValueWithFlags, ParsingError>,
 ) {

--- a/engine/baml-lib/schema-ast/Cargo.toml
+++ b/engine/baml-lib/schema-ast/Cargo.toml
@@ -10,7 +10,7 @@ license-file.workspace = true
 internal-baml-diagnostics = { path = "../diagnostics" }
 baml-types = { path = "../baml-types" }
 log = "0.4.20"
-serde_json = "1.0"
+serde_json.workspace = true
 serde.workspace = true
 
 

--- a/engine/language_client_typescript/src/types/runtime_ctx_manager.rs
+++ b/engine/language_client_typescript/src/types/runtime_ctx_manager.rs
@@ -23,7 +23,7 @@ impl RuntimeContextManager {
             ));
         };
 
-        self.inner.upsert_tags(tags);
+        self.inner.upsert_tags(tags.into_iter().collect());
         Ok(())
     }
 

--- a/typescript/fiddle-frontend/app/_components/PosthogProvider.tsx
+++ b/typescript/fiddle-frontend/app/_components/PosthogProvider.tsx
@@ -3,7 +3,7 @@
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
 
-if (typeof window !== 'undefined') {
+if (typeof window !== 'undefined' && process.env.NODE_ENV === 'production') {
   posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
     api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
     capture_pageview: false, // Disable automatic pageview capture, as we capture manually

--- a/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/EventListener.tsx
@@ -18,7 +18,7 @@ const defaultEnvKeyValues: [string, string][] = (() => {
     console.log('Running in nextjs')
     const domain = window?.location?.origin || ''
     // Running in a Next.js environment, proxy to nextjs rewrite
-    return [['BOUNDARY_PROXY_URL', domain + '/anthropic/']]
+    return []
   } else {
     console.log('Not running in a Next.js environment, set default value')
     // Not running in a Next.js environment, set default value

--- a/typescript/playground-common/src/baml_wasm_web/test_uis/test_result.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/test_uis/test_result.tsx
@@ -86,26 +86,6 @@ const checkFilter = (filter: Set<FilterValues>, status: TestStatusType, test_sta
   return filter.has(status)
 }
 
-const asSortedJson = (parsed: any): any => {
-  if (Array.isArray(parsed)) {
-    return parsed.map(asSortedJson)
-  }
-  if (typeof parsed !== 'object') {
-    return parsed
-  }
-  if (parsed === null || parsed === undefined) {
-    return parsed
-  }
-
-  let sorted: Record<string, any> = {}
-  Object.keys(parsed)
-    .sort()
-    .forEach((key) => {
-      sorted[key] = parsed[key]
-    })
-  return sorted
-}
-
 const LLMTestResult: React.FC<{ test: WasmTestResponse; doneStatus: DoneTestStatusType; testLatency: number }> = ({
   test,
   doneStatus,
@@ -115,7 +95,7 @@ const LLMTestResult: React.FC<{ test: WasmTestResponse; doneStatus: DoneTestStat
   const llm_response = test.llm_response()
   const llm_failure = test.llm_failure()
   const parsed = test.parsed_response()
-  const sorted_parsed = parsed ? asSortedJson(JSON.parse(parsed)) : undefined
+  const sorted_parsed = parsed ? JSON.parse(parsed) : undefined
 
   const latencyMs = llm_response?.latency_ms ?? llm_failure?.latency_ms
   const client = llm_response?.client_name() ?? llm_failure?.client_name()
@@ -193,7 +173,7 @@ const LLMFunctionResult: React.FC<{ test: WasmFunctionResponse }> = ({ test }) =
   const llm_response = test.llm_response()
   const llm_failure = test.llm_failure()
   const parsed = test.parsed_response()
-  const sorted_parsed = parsed ? asSortedJson(JSON.parse(parsed)) : undefined
+  const sorted_parsed = parsed ? JSON.parse(parsed) : undefined
 
   const latencyMs = llm_response?.latency_ms ?? llm_failure?.latency_ms
   const client = llm_response?.client_name() ?? llm_failure?.client_name()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 237667d115e0b59e8c90fbeb61fbe8c442fd9f0c  | 
|--------|--------|

### Summary:
This PR ensures stable sorting of BAML classes by field definition order, updates environment configurations, and refines data handling across Rust and TypeScript modules.

**Key points**:
- Updated `BamlMap` usage in `coerce_class.rs` for stable sorting of fields.
- Enabled `stable_sort` feature in `baml-types` and `schema-ast` Cargo.toml.
- Modified `runtime_ctx_manager.rs` to handle tag upsertion correctly.
- Adjusted environment setup in `PosthogProvider.tsx` and `EventListener.tsx` for production checks and removal of default proxy URL.
- Simplified JSON parsing in `test_result.tsx` by removing custom sorting function.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->