### PR TITLE
0.37.0 release

### DIFF
--- a/engine/language_client_python/pyproject.toml
+++ b/engine/language_client_python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "baml-py"
-version = "0.36.0"
+version = "0.37.0"
 description = "BAML python bindings (pyproject.toml)"
 readme = "README.md"
 authors = [["Boundary", "contact@boundaryml.com"]]

--- a/engine/language_client_typescript/package.json
+++ b/engine/language_client_typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaryml/baml",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "BAML typescript bindings (package.json)",
   "repository": {
     "type": "git",

--- a/typescript/vscode-ext/packages/package.json
+++ b/typescript/vscode-ext/packages/package.json
@@ -2,7 +2,7 @@
   "name": "baml-extension",
   "displayName": "Baml",
   "description": "BAML is a DSL for AI applications.",
-  "version": "0.36.2",
+  "version": "0.37.0",
   "publisher": "Boundary",
   "repository": "https://github.com/BoundaryML/baml",
   "homepage": "https://www.boundaryml.com",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 469fdb288b2297f664d7033b91752663228ea32d  | 
|--------|--------|

### Summary:
This PR updates the version numbers for the Python and TypeScript language clients, and the VSCode extension to `0.37.0`.

**Key points**:
- Updated `pyproject.toml` in `engine/language_client_python` to version `0.37.0`
- Updated `package.json` in `engine/language_client_typescript` to version `0.37.0`
- Updated `package.json` in `typescript/vscode-ext/packages` to version `0.37.0`


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->