### PR TITLE
Adding various stability fixes

### DIFF
--- a/engine/baml-runtime/src/cli/init.rs
+++ b/engine/baml-runtime/src/cli/init.rs
@@ -50,7 +50,7 @@ impl InitArgs {
 // your choice. You can have multiple generators if you use multiple languages.
 // Just ensure that the output_dir is different for each generator.
 generator target {{
-    // Valid values: "typescript", "python-pydantic", "ruby"
+    // Valid values: "python/pydantic", "typescript", "ruby/sorbet"
     output_type "{}"
     // Where the generated code will be saved (relative to baml_src/)
     output_dir "../"

--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/properties/azure.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/properties/azure.rs
@@ -98,6 +98,10 @@ pub fn resolve_properties(
         }
     };
 
+    properties
+        .entry("max_tokens".into())
+        .or_insert_with(|| 4096.into());
+
     Ok(PostRequestProperities {
         default_role,
         base_url,

--- a/engine/baml-runtime/src/type_builder/mod.rs
+++ b/engine/baml-runtime/src/type_builder/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use baml_types::{BamlValue, FieldType};
@@ -94,7 +93,7 @@ impl ClassBuilder {
 }
 
 pub struct EnumBuilder {
-    values: Arc<Mutex<HashMap<String, Arc<Mutex<EnumValueBuilder>>>>>,
+    values: Arc<Mutex<IndexMap<String, Arc<Mutex<EnumValueBuilder>>>>>,
     meta: MetaData,
 }
 impl_meta!(EnumBuilder);

--- a/integ-tests/python/README.md
+++ b/integ-tests/python/README.md
@@ -7,4 +7,3 @@ env -u CONDA_PREFIX poetry run maturin develop --manifest-path ../../engine/lang
 
 BAML_LOG=baml_events infisical run --env=dev -- poetry run pytest app/test_functions.py -s
 ```
-

--- a/integ-tests/python/test_functions.py
+++ b/integ-tests/python/test_functions.py
@@ -449,7 +449,7 @@ async def test_stream_dynamic_class_output():
     tb = TypeBuilder()
     tb.DynamicOutput.add_property("hair_color", tb.string())
     print(tb.DynamicOutput.list_properties())
-    for prop in tb.DynamicOutput.list_properties():
+    for prop, _ in tb.DynamicOutput.list_properties():
         print(f"Property: {prop}")
 
     stream = b.stream.MyFunc(


### PR DESCRIPTION
* Dynamic enums are now ordered in the order of insertion
* ruby -> ruby/sorbet in the generator
* Default max_tokens for azure ->  4096
