### PR TITLE
Fixes for CURL

### DIFF
--- a/engine/baml-runtime/src/runtime_interface.rs
+++ b/engine/baml-runtime/src/runtime_interface.rs
@@ -136,6 +136,7 @@ pub trait InternalRuntimeInterface {
         node_index: Option<usize>,
     ) -> Result<(RenderedPrompt, OrchestrationScope)>;
 
+    #[warn(async_fn_in_trait)]
     async fn render_raw_curl(
         &self,
         function_name: &str,

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -994,14 +994,14 @@ impl WasmFunction {
                 RenderedPrompt::Chat(chat_messages) => chat_messages,
                 RenderedPrompt::Completion(_) => vec![], // or handle this case differently
             },
-            Err(e) => return Err(wasm_bindgen::JsError::new(format!("{:?}", e).as_str())),
+            Err(e) => return Err(wasm_bindgen::JsError::new(format!("{:#?}", e).as_str())),
         };
 
         rt.runtime
             .internal()
             .render_raw_curl(&self.name, &ctx, &final_prompt, stream, None)
             .await
-            .map_err(|e| wasm_bindgen::JsError::new(format!("{e:?}").as_str()))
+            .map_err(|e| wasm_bindgen::JsError::new(format!("{e:#?}").as_str()))
     }
 
     #[wasm_bindgen]

--- a/typescript/playground-common/src/baml_wasm_web/JotaiProvider.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/JotaiProvider.tsx
@@ -5,20 +5,15 @@ import { createJSONStorage } from 'jotai/utils'
 import type { SyncStorage } from 'jotai/vanilla/utils/atomWithStorage'
 import { DevTools } from 'jotai-devtools'
 import 'jotai-devtools/styles.css'
+import { vscode } from '../utils/vscode'
 
 export const atomStore = createStore()
 
-export const vscodeAPI = () => {
-  if (typeof acquireVsCodeApi === 'function') {
-    return acquireVsCodeApi()
-  }
-  return undefined
-}
 function setVSCodeState(state: any) {
-  vscodeAPI()?.setState(state)
+  vscode.setState(state)
 }
 function getLocalStorage() {
-  const state = vscodeAPI()?.getState() || { localStorage: {} }
+  const state = vscode.getState() || { localStorage: {} }
   return (state as any).localStorage
 }
 


### PR DESCRIPTION
* Remove vscode requirement and use VSCodeAPIWrapper to support prompt fiddle
* render_curl uses async method
* show errors when prompt fails to render while in curl mode
