### PR TITLE
chore: move chatwoot to the bottom left, not bottom right

### DIFF
--- a/typescript/playground-common/src/lib/feedback_widget.ts
+++ b/typescript/playground-common/src/lib/feedback_widget.ts
@@ -72,6 +72,7 @@ const loadChatwoot = () => {
     s.parentNode.insertBefore(g, s)
     g.onload = function () {
       ;(window as any).chatwootSDK.run({
+        position: 'left',
         websiteToken: 'M4EXKvdb9NGgxqZzkTZfeFV7',
         baseUrl: BASE_URL,
       })


### PR DESCRIPTION
less likely to cover test results or the runtime version badge

https://github.com/orgs/chatwoot/discussions/2145