### PR TITLE
Issue: removed vertex auth token printing

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
@@ -505,7 +505,6 @@ impl RequestBuilder for VertexClient {
 
                     // Extract and print the access token
                     if let Some(access_token) = res["access_token"].as_str() {
-                        println!("Access Token: {}", access_token);
                         access_token.to_string()
                     } else {
                         println!("Failed to get access token. Response: {:?}", res);


### PR DESCRIPTION
Bug: the vertex client printed the acquired access token on each attempt. Unsafe behavior.