### PR TITLE
feat: teach vscode/fiddle to explain when we drop information

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
@@ -222,23 +222,6 @@ impl TypeCoercer for Class {
             }
             log::trace!("----");
 
-            let unparsed_required_fields = required_values
-                .iter()
-                .filter_map(|(k, v)| match v {
-                    Some(Ok(_)) => None,
-                    Some(Err(e)) => Some((k.clone(), e.to_string())),
-                    None => None,
-                })
-                .collect::<Vec<_>>();
-            let missing_required_fields = required_values
-                .iter()
-                .filter_map(|(k, v)| match v {
-                    Some(Ok(_)) => None,
-                    Some(Err(e)) => None,
-                    None => Some(k.clone()),
-                })
-                .collect::<Vec<_>>();
-
             let unparsed_or_missing = required_values
                 .iter()
                 .filter_map(|(k, v)| match v {
@@ -248,21 +231,11 @@ impl TypeCoercer for Class {
                 })
                 .collect::<Vec<_>>();
 
-            // if !missing_required_fields.is_empty() || !unparsed_required_fields.is_empty() {
             if !unparsed_or_missing.is_empty() {
                 if completed_cls.is_empty() {
                     return Err(ctx.error_missing_required_field(unparsed_or_missing, value));
                 }
             } else {
-                let merged_errors = required_values
-                    .iter()
-                    .filter_map(|(_k, v)| v.clone())
-                    .filter_map(|v| match v {
-                        Ok(_) => None,
-                        Err(e) => Some(e.to_string()),
-                    })
-                    .collect::<Vec<_>>();
-
                 let valid_fields = required_values
                     .iter()
                     .filter_map(|(k, v)| match v.to_owned() {

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
@@ -187,10 +187,16 @@ pub struct ParsingError {
 
 impl std::fmt::Display for ParsingError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.scope.is_empty() {
-            return write!(f, "Error parsing '<root>': {}", self.reason);
-        }
-        write!(f, "{}: {}", self.scope.join("."), self.reason)?;
+        write!(
+            f,
+            "{}: {}",
+            if self.scope.is_empty() {
+                "<root>".to_string()
+            } else {
+                self.scope.join(".")
+            },
+            self.reason
+        )?;
         for cause in &self.causes {
             write!(f, "\n  - {}", format!("{}", cause).replace("\n", "\n  "))?;
         }

--- a/engine/baml-lib/jsonish/src/deserializer/deserialize_flags.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/deserialize_flags.rs
@@ -49,6 +49,95 @@ pub struct DeserializerConditions {
     pub(super) flags: Vec<Flag>,
 }
 
+impl DeserializerConditions {
+    pub fn explanation(&self) -> Option<String> {
+        let flags = self
+            .flags
+            .iter()
+            .filter_map(|c| match c {
+                // Flag::ObjectFromMarkdown(_) => None,
+                // Flag::ObjectFromFixedJson(_) => Some(format!("Object from fixed JSON")),
+                // Flag::ArrayItemParseError(idx, e) => {
+                //     Some(format!("Error parsing item {} in array: {}", idx, e))
+                // }
+                // Flag::DefaultButHadUnparseableValue(e) => {
+                //     Some(format!("Default but had unparseable value {e}"))
+                // }
+                // Flag::ObjectToString(_) => Some(format!("Object to string")),
+                // Flag::ObjectToPrimitive(_) => Some(format!("Object to primitive")),
+                // Flag::ObjectToMap(_) => Some(format!("Object to map")),
+                // Flag::ExtraKey(_, _) => None,
+                // Flag::StrippedNonAlphaNumeric(_) => Some(format!("Stripped non-alphanumeric")),
+                // Flag::SubstringMatch(_) => Some(format!("Substring match")),
+                // Flag::SingleToArray => Some(format!("Single to array")),
+                // Flag::MapKeyParseError(idx, e) => {
+                //     Some(format!("Error parsing key {} in map: {}", idx, e))
+                // }
+                // Flag::MapValueParseError(key, e) => Some(format!(
+                //     "Error parsing value for key '{}' in map: {}",
+                //     key, e
+                // )),
+                // Flag::JsonToString(_) => Some(format!("JSON to string")),
+                // Flag::ImpliedKey(_) => Some(format!("Implied key")),
+                // Flag::InferedObject(_) => Some(format!("Inferred object")),
+                // Flag::FirstMatch(idx, _) => Some(format!("First match at index {}", idx)),
+                // Flag::EnumOneFromMany(matches) => {
+                //     Some(format!("Enum one from many with {} matches", matches.len()))
+                // }
+                // Flag::DefaultFromNoValue => Some(format!("Default from no value")),
+                // Flag::DefaultButHadValue(_) => Some(format!("Default but had value")),
+                // Flag::OptionalDefaultFromNoValue => Some(format!("Optional default from no value")),
+                // Flag::StringToBool(_) => Some(format!("String to bool")),
+                // Flag::StringToNull(_) => Some(format!("String to null")),
+                // Flag::StringToChar(_) => Some(format!("String to char")),
+                // Flag::FloatToInt(_) => Some(format!("Float to int")),
+                // Flag::NoFields(_) => Some(format!("No fields")),
+                Flag::ObjectFromMarkdown(_) => None,
+                Flag::ObjectFromFixedJson(_) => None,
+                Flag::ArrayItemParseError(idx, e) => {
+                    Some(format!("Error parsing item {} in array: {}", idx, e))
+                }
+                Flag::DefaultButHadUnparseableValue(e) => {
+                    Some(format!("Default but had unparseable value {e}"))
+                }
+                Flag::ObjectToString(_) => None,
+                Flag::ObjectToPrimitive(_) => None,
+                Flag::ObjectToMap(_) => None,
+                Flag::ExtraKey(_, _) => None,
+                Flag::StrippedNonAlphaNumeric(_) => None,
+                Flag::SubstringMatch(_) => None,
+                Flag::SingleToArray => None,
+                Flag::MapKeyParseError(idx, e) => {
+                    Some(format!("Error parsing key {} in map: {}", idx, e))
+                }
+                Flag::MapValueParseError(key, e) => Some(format!(
+                    "Error parsing value for key '{}' in map: {}",
+                    key, e
+                )),
+                Flag::JsonToString(_) => None,
+                Flag::ImpliedKey(_) => None,
+                Flag::InferedObject(_) => None,
+                Flag::FirstMatch(_idx, _) => None,
+                Flag::EnumOneFromMany(_matches) => None,
+                Flag::DefaultFromNoValue => None,
+                Flag::DefaultButHadValue(_) => None,
+                Flag::OptionalDefaultFromNoValue => None,
+                Flag::StringToBool(_) => None,
+                Flag::StringToNull(_) => None,
+                Flag::StringToChar(_) => None,
+                Flag::FloatToInt(_) => None,
+                Flag::NoFields(_) => None,
+            })
+            .map(|s| format!("<flag>{}</flag>", s))
+            .collect::<Vec<_>>();
+
+        match flags.len() {
+            0 => None,
+            _ => Some(flags.join("; ")),
+        }
+    }
+}
+
 impl std::fmt::Debug for DeserializerConditions {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         std::fmt::Display::fmt(self, f)

--- a/engine/baml-lib/jsonish/src/deserializer/deserialize_flags.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/deserialize_flags.rs
@@ -56,7 +56,7 @@ impl DeserializerConditions {
             .filter_map(|c| match c {
                 Flag::ObjectFromMarkdown(_) => None,
                 Flag::ObjectFromFixedJson(_) => None,
-                Flag::ArrayItemParseError(idx, e) => {
+                Flag::ArrayItemParseError(_idx, e) => {
                     // TODO: should idx be recorded?
                     Some(e.clone())
                 }
@@ -67,11 +67,11 @@ impl DeserializerConditions {
                 Flag::StrippedNonAlphaNumeric(_) => None,
                 Flag::SubstringMatch(_) => None,
                 Flag::SingleToArray => None,
-                Flag::MapKeyParseError(idx, e) => {
+                Flag::MapKeyParseError(_idx, e) => {
                     // Some(format!("Error parsing key {} in map: {}", idx, e))
                     Some(e.clone())
                 }
-                Flag::MapValueParseError(key, e) => {
+                Flag::MapValueParseError(_key, e) => {
                     // Some(format!( "Error parsing value for key '{}' in map: {}", key, e))
                     Some(e.clone())
                 }
@@ -91,7 +91,6 @@ impl DeserializerConditions {
                 Flag::UnionMatch(_idx, _) => None,
                 Flag::DefaultButHadUnparseableValue(e) => Some(e.clone()),
             })
-            // .map(|s| format!("<flag>{}</flag>", s))
             .collect::<Vec<_>>()
     }
 }

--- a/engine/baml-lib/jsonish/src/deserializer/deserialize_flags.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/deserialize_flags.rs
@@ -50,55 +50,15 @@ pub struct DeserializerConditions {
 }
 
 impl DeserializerConditions {
-    pub fn explanation(&self) -> Option<String> {
-        let flags = self
-            .flags
+    pub fn explanation(&self) -> Vec<ParsingError> {
+        self.flags
             .iter()
             .filter_map(|c| match c {
-                // Flag::ObjectFromMarkdown(_) => None,
-                // Flag::ObjectFromFixedJson(_) => Some(format!("Object from fixed JSON")),
-                // Flag::ArrayItemParseError(idx, e) => {
-                //     Some(format!("Error parsing item {} in array: {}", idx, e))
-                // }
-                // Flag::DefaultButHadUnparseableValue(e) => {
-                //     Some(format!("Default but had unparseable value {e}"))
-                // }
-                // Flag::ObjectToString(_) => Some(format!("Object to string")),
-                // Flag::ObjectToPrimitive(_) => Some(format!("Object to primitive")),
-                // Flag::ObjectToMap(_) => Some(format!("Object to map")),
-                // Flag::ExtraKey(_, _) => None,
-                // Flag::StrippedNonAlphaNumeric(_) => Some(format!("Stripped non-alphanumeric")),
-                // Flag::SubstringMatch(_) => Some(format!("Substring match")),
-                // Flag::SingleToArray => Some(format!("Single to array")),
-                // Flag::MapKeyParseError(idx, e) => {
-                //     Some(format!("Error parsing key {} in map: {}", idx, e))
-                // }
-                // Flag::MapValueParseError(key, e) => Some(format!(
-                //     "Error parsing value for key '{}' in map: {}",
-                //     key, e
-                // )),
-                // Flag::JsonToString(_) => Some(format!("JSON to string")),
-                // Flag::ImpliedKey(_) => Some(format!("Implied key")),
-                // Flag::InferedObject(_) => Some(format!("Inferred object")),
-                // Flag::FirstMatch(idx, _) => Some(format!("First match at index {}", idx)),
-                // Flag::EnumOneFromMany(matches) => {
-                //     Some(format!("Enum one from many with {} matches", matches.len()))
-                // }
-                // Flag::DefaultFromNoValue => Some(format!("Default from no value")),
-                // Flag::DefaultButHadValue(_) => Some(format!("Default but had value")),
-                // Flag::OptionalDefaultFromNoValue => Some(format!("Optional default from no value")),
-                // Flag::StringToBool(_) => Some(format!("String to bool")),
-                // Flag::StringToNull(_) => Some(format!("String to null")),
-                // Flag::StringToChar(_) => Some(format!("String to char")),
-                // Flag::FloatToInt(_) => Some(format!("Float to int")),
-                // Flag::NoFields(_) => Some(format!("No fields")),
                 Flag::ObjectFromMarkdown(_) => None,
                 Flag::ObjectFromFixedJson(_) => None,
                 Flag::ArrayItemParseError(idx, e) => {
-                    Some(format!("Error parsing item {} in array: {}", idx, e))
-                }
-                Flag::DefaultButHadUnparseableValue(e) => {
-                    Some(format!("Default but had unparseable value {e}"))
+                    // TODO: should idx be recorded?
+                    Some(e.clone())
                 }
                 Flag::ObjectToString(_) => None,
                 Flag::ObjectToPrimitive(_) => None,
@@ -108,12 +68,13 @@ impl DeserializerConditions {
                 Flag::SubstringMatch(_) => None,
                 Flag::SingleToArray => None,
                 Flag::MapKeyParseError(idx, e) => {
-                    Some(format!("Error parsing key {} in map: {}", idx, e))
+                    // Some(format!("Error parsing key {} in map: {}", idx, e))
+                    Some(e.clone())
                 }
-                Flag::MapValueParseError(key, e) => Some(format!(
-                    "Error parsing value for key '{}' in map: {}",
-                    key, e
-                )),
+                Flag::MapValueParseError(key, e) => {
+                    // Some(format!( "Error parsing value for key '{}' in map: {}", key, e))
+                    Some(e.clone())
+                }
                 Flag::JsonToString(_) => None,
                 Flag::ImpliedKey(_) => None,
                 Flag::InferedObject(_) => None,
@@ -127,14 +88,11 @@ impl DeserializerConditions {
                 Flag::StringToChar(_) => None,
                 Flag::FloatToInt(_) => None,
                 Flag::NoFields(_) => None,
+                Flag::UnionMatch(_idx, _) => None,
+                Flag::DefaultButHadUnparseableValue(e) => Some(e.clone()),
             })
-            .map(|s| format!("<flag>{}</flag>", s))
-            .collect::<Vec<_>>();
-
-        match flags.len() {
-            0 => None,
-            _ => Some(flags.join("; ")),
-        }
+            // .map(|s| format!("<flag>{}</flag>", s))
+            .collect::<Vec<_>>()
     }
 }
 

--- a/engine/baml-lib/jsonish/src/deserializer/score.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/score.rs
@@ -24,7 +24,7 @@ impl WithScore for BamlValueWithFlags {
                 s.score() + 10 * kv.iter().map(|(_, v)| v.score()).sum::<i32>()
             }
             BamlValueWithFlags::Null(s) => s.score(),
-            BamlValueWithFlags::Image(s) => s.score(),
+            BamlValueWithFlags::Media(s) => s.score(),
         }
     }
 }

--- a/engine/baml-lib/jsonish/src/deserializer/types.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/types.rs
@@ -73,17 +73,6 @@ impl BamlValueWithFlags {
     }
 }
 
-struct ParseExplanation {
-    scope: Vec<String>,
-    explanation: String,
-}
-
-impl std::fmt::Display for ParseExplanation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} - {}", self.scope.join("."), self.explanation)
-    }
-}
-
 trait ParsingErrorToUiJson {
     fn to_ui_json(&self) -> serde_json::Value;
 }
@@ -91,7 +80,11 @@ trait ParsingErrorToUiJson {
 impl ParsingErrorToUiJson for ParsingError {
     fn to_ui_json(&self) -> serde_json::Value {
         json!({
-            self.scope.join("."): self.reason,
+            if self.scope.is_empty() {
+                "<root>".to_string()
+            } else {
+                self.scope.join(".")
+            }: self.reason,
             "causes": self.causes.iter().map(|c| c.to_ui_json()).collect::<Vec<_>>(),
         })
     }

--- a/engine/baml-runtime/src/types/runtime_context.rs
+++ b/engine/baml-runtime/src/types/runtime_context.rs
@@ -45,7 +45,7 @@ cfg_if::cfg_if!(
         pub type BamlSrcReader = Option<Box<dyn Fn(&str) -> core::pin::Pin<Box<dyn Future<Output = Result<Vec<u8>>>>>>>;
     } else {
         use futures::future::BoxFuture;
-        pub type BamlSrcReader = Option<Box<fn(&str) -> BoxFuture<'static, Result<Vec<u8>>>>>;
+        pub type BamlSrcReader = Option<Box<dyn Fn(&str) -> BoxFuture<'static, Result<Vec<u8>>>>>;
     }
 );
 

--- a/engine/baml-runtime/src/types/runtime_context.rs
+++ b/engine/baml-runtime/src/types/runtime_context.rs
@@ -45,7 +45,7 @@ cfg_if::cfg_if!(
         pub type BamlSrcReader = Option<Box<dyn Fn(&str) -> core::pin::Pin<Box<dyn Future<Output = Result<Vec<u8>>>>>>>;
     } else {
         use futures::future::BoxFuture;
-        pub type BamlSrcReader = Option<Box<dyn Fn(&str) -> BoxFuture<'static, Result<Vec<u8>>>>>;
+        pub type BamlSrcReader = Option<Box<fn(&str) -> BoxFuture<'static, Result<Vec<u8>>>>>;
     }
 );
 

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -401,6 +401,7 @@ pub struct WasmParsedTestResponse {
     #[wasm_bindgen(readonly)]
     pub value: String,
     #[wasm_bindgen(readonly)]
+    /// JSON-string of the explanation, if there were any ParsingErrors
     pub explanation: Option<String>,
 }
 
@@ -518,7 +519,6 @@ impl WasmTestResponse {
             .parsed_content()?;
         Ok(WasmParsedTestResponse {
             value: serde_json::to_string(&BamlValue::from(parsed_response))?,
-            // explanation: format!("{}", parsed_response.explanation()),
             explanation: {
                 let j = parsed_response.explanation_json();
                 if j.is_empty() {
@@ -1507,15 +1507,6 @@ impl WasmFunction {
         let (test_response, span) = rt
             .run_test(&function_name, &test_name, &ctx, Some(cb))
             .await;
-
-        log::debug!(
-            "Test response contains: {:?}",
-            test_response
-                .as_ref()
-                .unwrap()
-                .function_response
-                .parsed_content()
-        );
 
         Ok(WasmTestResponse {
             test_response,

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -401,7 +401,7 @@ pub struct WasmParsedTestResponse {
     #[wasm_bindgen(readonly)]
     pub value: String,
     #[wasm_bindgen(readonly)]
-    pub explanation: String,
+    pub explanation: Option<String>,
 }
 
 #[wasm_bindgen]
@@ -518,7 +518,15 @@ impl WasmTestResponse {
             .parsed_content()?;
         Ok(WasmParsedTestResponse {
             value: serde_json::to_string(&BamlValue::from(parsed_response))?,
-            explanation: format!("{}", parsed_response.explanation(),),
+            // explanation: format!("{}", parsed_response.explanation()),
+            explanation: {
+                let j = parsed_response.explanation_json();
+                if j.is_empty() {
+                    None
+                } else {
+                    Some(serde_json::to_string(&j)?)
+                }
+            },
         })
     }
 

--- a/typescript/playground-common/src/baml_wasm_web/test_uis/test_result.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/test_uis/test_result.tsx
@@ -163,7 +163,7 @@ const ParsedTestResult: React.FC<{ doneStatus: string; parsed?: WasmParsedTestRe
                 if (parsed?.explanation) {
                   return 'Click to show parsing explanation'
                 }
-                return 'No parsing explanation available'
+                return 'Parsing succeeded'
               })()}
             </TooltipContent>
           </Tooltip>

--- a/typescript/playground-common/src/baml_wasm_web/test_uis/test_result.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/test_uis/test_result.tsx
@@ -19,11 +19,12 @@ import {
   type WasmTestCase,
   type TestStatus,
   type WasmTestResponse,
+  type WasmParsedTestResponse,
   WasmFunctionResponse,
 } from '@gloo-ai/baml-schema-wasm-web/baml_schema_build'
 import JsonView from 'react18-json-view'
 import clsx from 'clsx'
-import { Check, Copy, FilterIcon, Link2Icon, PlayIcon, PlusIcon } from 'lucide-react'
+import { Check, Copy, FilterIcon, InfoIcon, Link2Icon, PlayIcon, PlusIcon } from 'lucide-react'
 import { currentClientsAtom, selectedFunctionAtom, selectedTestCaseAtom } from '../EventListener'
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog'
 import FunctionTestSnippet from '../../shared/TestSnippet'
@@ -110,23 +111,88 @@ const checkFilter = (filter: Set<FilterValues>, status: TestStatusType, test_sta
   return filter.has(status)
 }
 
+const copyToClipboard = (text: string, setCopied: React.Dispatch<React.SetStateAction<boolean>>) => {
+  navigator.clipboard.writeText(text)
+  setCopied(true)
+  setTimeout(() => setCopied(false), 2000)
+}
+
+const ParsedTestResult: React.FC<{ doneStatus: string; parsed?: WasmParsedTestResponse; failure?: string }> = ({
+  doneStatus,
+  parsed,
+  failure,
+}) => {
+  const [copiedParsed, setCopiedParsed] = useState(false)
+  const [showExplanation, setShowExplanation] = useState(true)
+
+  const sorted_parsed = parsed ? JSON.parse(parsed.value) : undefined
+
+  if (doneStatus === 'parse_failed' || parsed !== undefined) {
+    return (
+      <div className='flex relative flex-col'>
+        <div className='flex flex-row '>
+          Parsed LLM Response
+          <Button
+            variant='ghost'
+            size='icon'
+            className='inline h-2 w-2 pl-1'
+            onClick={() => setShowExplanation(!showExplanation)}
+            aria-label='Toggle information'
+          >
+            <InfoIcon className='h-4 w-4' />
+          </Button>
+        </div>
+        <div className='relative px-1 py-2'>
+          {showExplanation && parsed ? (
+            <>
+              <div className='text-xs whitespace-pre-wrap'>Showing explanation:</div>
+              <pre className='text-xs whitespace-pre-wrap'>{parsed.explanation}</pre>
+            </>
+          ) : (
+            <>
+              {failure && <pre className='text-xs whitespace-pre-wrap text-vscode-errorForeground'>{failure}</pre>}
+              {parsed !== undefined && (
+                <>
+                  <JsonView
+                    enableClipboard={false}
+                    className='bg-[#1E1E1E] px-1 py-1 rounded-sm'
+                    theme='a11y'
+                    collapseStringsAfterLength={200}
+                    matchesURL
+                    src={sorted_parsed}
+                  />
+                  <div className='flex absolute right-2 top-3 items-center'>
+                    <button
+                      className='text-vscode-descriptionForeground hover:text-vscode-foreground'
+                      onClick={() => copyToClipboard(JSON.stringify(sorted_parsed, null, 2), setCopiedParsed)}
+                    >
+                      {copiedParsed ? <Check size={16} /> : <Copy size={16} />}
+                    </button>
+                    {copiedParsed && <span className='ml-1 text-xs text-vscode-foreground'>Copied</span>}
+                  </div>
+                </>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    )
+  } else {
+    return <></>
+  }
+}
+
 const LLMTestResult: React.FC<{ test: WasmTestResponse; doneStatus: DoneTestStatusType; testLatency: number }> = ({
   test,
   doneStatus,
   testLatency,
 }) => {
   const [copiedRaw, setCopiedRaw] = useState(false)
-  const [copiedParsed, setCopiedParsed] = useState(false)
-  const copyToClipboard = (text: string, setCopied: React.Dispatch<React.SetStateAction<boolean>>) => {
-    navigator.clipboard.writeText(text)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
+
   const failure = test.failure_message()
   const llm_response = test.llm_response()
   const llm_failure = test.llm_failure()
   const parsed = test.parsed_response()
-  const sorted_parsed = parsed ? JSON.parse(parsed) : undefined
 
   const latencyMs = llm_response?.latency_ms ?? llm_failure?.latency_ms
   const client = llm_response?.client_name() ?? llm_failure?.client_name()
@@ -170,8 +236,8 @@ const LLMTestResult: React.FC<{ test: WasmTestResponse; doneStatus: DoneTestStat
           <div className='grid grid-cols-2 gap-2'>
             <div className='flex flex-col'>
               {llm_response?.output_tokens === undefined
-                ? 'Raw LLM Response:'
-                : `Raw LLM Response (${llm_response?.output_tokens} tokens):`}
+                ? 'Raw LLM Response'
+                : `Raw LLM Response (${llm_response?.output_tokens} tokens)`}
               <div className='px-1 py-2'>
                 {llm_response && (
                   <pre className='px-1 py-2 whitespace-pre-wrap rounded-sm bg-vscode-input-background max-h-[300px] overflow-y-auto relative pr-2'>
@@ -208,35 +274,7 @@ const LLMTestResult: React.FC<{ test: WasmTestResponse; doneStatus: DoneTestStat
                 )}
               </div>
             </div>
-            {(doneStatus === 'parse_failed' || parsed !== undefined) && (
-              <div className='flex relative flex-col'>
-                Parsed LLM Response:
-                <div className='relative px-1 py-2'>
-                  {failure && <pre className='text-xs whitespace-pre-wrap text-vscode-errorForeground'>{failure}</pre>}
-                  {parsed !== undefined && (
-                    <>
-                      <JsonView
-                        enableClipboard={false}
-                        className='bg-[#1E1E1E] px-1 py-1 rounded-sm'
-                        theme='a11y'
-                        collapseStringsAfterLength={200}
-                        matchesURL
-                        src={sorted_parsed}
-                      />
-                      <div className='flex absolute right-2 top-3 items-center'>
-                        <button
-                          className='text-vscode-descriptionForeground hover:text-vscode-foreground'
-                          onClick={() => copyToClipboard(JSON.stringify(sorted_parsed, null, 2), setCopiedParsed)}
-                        >
-                          {copiedParsed ? <Check size={16} /> : <Copy size={16} />}
-                        </button>
-                        {copiedParsed && <span className='ml-1 text-xs text-vscode-foreground'>Copied</span>}
-                      </div>
-                    </>
-                  )}
-                </div>
-              </div>
-            )}
+            <ParsedTestResult doneStatus={doneStatus} parsed={parsed} failure={failure} />
           </div>
         </div>
       )}

--- a/typescript/playground-common/src/baml_wasm_web/test_uis/test_result.tsx
+++ b/typescript/playground-common/src/baml_wasm_web/test_uis/test_result.tsx
@@ -123,7 +123,7 @@ const ParsedTestResult: React.FC<{ doneStatus: string; parsed?: WasmParsedTestRe
   failure,
 }) => {
   const [copiedParsed, setCopiedParsed] = useState(false)
-  const [showExplanation, setShowExplanation] = useState(true)
+  const [showExplanation, setShowExplanation] = useState(false)
 
   const sorted_parsed = parsed ? JSON.parse(parsed.value) : undefined
 
@@ -132,21 +132,62 @@ const ParsedTestResult: React.FC<{ doneStatus: string; parsed?: WasmParsedTestRe
       <div className='flex relative flex-col'>
         <div className='flex flex-row '>
           Parsed LLM Response
-          <Button
-            variant='ghost'
-            size='icon'
-            className='inline h-2 w-2 pl-1'
-            onClick={() => setShowExplanation(!showExplanation)}
-            aria-label='Toggle information'
-          >
-            <InfoIcon className='h-4 w-4' />
-          </Button>
+          <Tooltip delayDuration={100}>
+            <TooltipTrigger asChild>
+              <Button
+                variant='ghost'
+                size='icon'
+                className='inline h-2 w-2 pl-1'
+                onClick={() => {
+                  if (parsed?.explanation) {
+                    setShowExplanation(!showExplanation)
+                  }
+                }}
+                aria-label='Toggle information'
+              >
+                {showExplanation ? (
+                  <div className='text-xs text-white whitespace-prewrap'>
+                    <InfoIcon className='h-4 w-4 inline-block align-top' />
+                    &nbsp;Showing Explanation
+                  </div>
+                ) : (
+                  <InfoIcon className='h-4 w-4' />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {(() => {
+                if (showExplanation) {
+                  return 'Showing parsing explanation. Click to show the parsed response.'
+                }
+                if (parsed?.explanation) {
+                  return 'Click to show parsing explanation'
+                }
+                return 'No parsing explanation available'
+              })()}
+            </TooltipContent>
+          </Tooltip>
         </div>
         <div className='relative px-1 py-2'>
-          {showExplanation && parsed ? (
+          {showExplanation && parsed && parsed.explanation ? (
             <>
-              <div className='text-xs whitespace-pre-wrap'>Showing explanation:</div>
-              <pre className='text-xs whitespace-pre-wrap'>{parsed.explanation}</pre>
+              <JsonView
+                enableClipboard={false}
+                className='bg-[#1E1E1E] px-1 py-1 rounded-sm'
+                theme='a11y'
+                collapseStringsAfterLength={200}
+                matchesURL
+                src={JSON.parse(parsed.explanation)}
+              />
+              <div className='flex absolute right-2 top-3 items-center'>
+                <button
+                  className='text-vscode-descriptionForeground hover:text-vscode-foreground'
+                  onClick={() => copyToClipboard(JSON.stringify(sorted_parsed, null, 2), setCopiedParsed)}
+                >
+                  {copiedParsed ? <Check size={16} /> : <Copy size={16} />}
+                </button>
+                {copiedParsed && <span className='ml-1 text-xs text-vscode-foreground'>Copied</span>}
+              </div>
             </>
           ) : (
             <>


### PR DESCRIPTION
when there's an explanation to be shown, the information icon is clickable and toggles showing the explanation:

![image](https://github.com/user-attachments/assets/50338f22-f18f-4364-9160-a25f5e9e7ee9)

if there's no explanation, the information icon tooltip just shows "parsing succeeded" and clicking it does nothing

![image](https://github.com/user-attachments/assets/b0a7d1bc-e957-4db3-842b-17c4c045c007)
