### PR TITLE
doc: updated dead vs-code-extension link

### DIFF
--- a/docs/docs/get-started/quickstart/python.mdx
+++ b/docs/docs/get-started/quickstart/python.mdx
@@ -2,7 +2,7 @@
 slug: docs/get-started/quickstart/python
 ---
 
-Here's a sample repository:
+Here's a sample repository: 
 https://github.com/BoundaryML/baml-examples/tree/main/python-fastapi-starter
 
 To set up BAML in python do the following:
@@ -24,22 +24,20 @@ To set up BAML in python do the following:
       }
       ```
       </Tip>
-
-### Install baml
-
+  
+  ### Install baml
         ```bash
         pip install baml-py
         ```
-
-### Add some starter code
-
+  
+  ### Add some starter code
       This will give you some starter BAML code in a `baml_src` directory.
 
       ```bash
       baml-cli init
       ```
-
-### Generate python code from .baml files
+  
+  ### Generate python code from .baml files
 
     This command will help you convert `.baml` files to `.py` files. Everytime you modify your `.baml` files,
     you must re-run this command, and regenerate the `baml_client` folder.
@@ -51,9 +49,8 @@ To set up BAML in python do the following:
     ```bash
     baml-cli generate
     ```
-
-### Use a baml function in python!
-
+  
+  ### Use a baml function in python!
     <Tip>If `baml_client` doesn't exist, make sure to run the previous step!</Tip>
 
     <CodeBlocks>
@@ -61,7 +58,7 @@ To set up BAML in python do the following:
     from baml_client.sync_client import b
     from baml_client.types import Resume
 
-    def example(raw_resume: str) -> Resume:
+    def example(raw_resume: str) -> Resume: 
       # BAML's internal parser guarantees ExtractResume
       # to be always return a Resume type
       response = b.ExtractResume(raw_resume)
@@ -71,7 +68,7 @@ To set up BAML in python do the following:
       stream = b.stream.ExtractResume(raw_resume)
       for msg in stream:
         print(msg) # This will be a PartialResume type
-
+      
       # This will be a Resume type
       final = stream.get_final_response()
 
@@ -82,7 +79,7 @@ To set up BAML in python do the following:
     from baml_client.async_client import b
     from baml_client.types import Resume
 
-    async def example(raw_resume: str) -> Resume:
+    async def example(raw_resume: str) -> Resume: 
       # BAML's internal parser guarantees ExtractResume
       # to be always return a Resume type
       response = await b.ExtractResume(raw_resume)
@@ -92,12 +89,12 @@ To set up BAML in python do the following:
       stream = b.stream.ExtractResume(raw_resume)
       async for msg in stream:
         print(msg) # This will be a PartialResume type
-
+      
       # This will be a Resume type
       final = stream.get_final_response()
 
       return final
     ```
     </CodeBlocks>
-
+  
 </Steps>

--- a/docs/docs/get-started/quickstart/python.mdx
+++ b/docs/docs/get-started/quickstart/python.mdx
@@ -2,14 +2,14 @@
 slug: docs/get-started/quickstart/python
 ---
 
-Here's a sample repository: 
+Here's a sample repository:
 https://github.com/BoundaryML/baml-examples/tree/main/python-fastapi-starter
 
 To set up BAML in python do the following:
 
 <Steps>
   ### Install BAML VSCode Extension
-      https://marketplace.visualstudio.com/items?itemName=boundary.BAML
+      https://marketplace.visualstudio.com/items?itemName=boundary.baml-extension
 
       - syntax highlighting
       - testing playground
@@ -24,20 +24,22 @@ To set up BAML in python do the following:
       }
       ```
       </Tip>
-  
-  ### Install baml
+
+### Install baml
+
         ```bash
         pip install baml-py
         ```
-  
-  ### Add some starter code
+
+### Add some starter code
+
       This will give you some starter BAML code in a `baml_src` directory.
 
       ```bash
       baml-cli init
       ```
-  
-  ### Generate python code from .baml files
+
+### Generate python code from .baml files
 
     This command will help you convert `.baml` files to `.py` files. Everytime you modify your `.baml` files,
     you must re-run this command, and regenerate the `baml_client` folder.
@@ -49,8 +51,9 @@ To set up BAML in python do the following:
     ```bash
     baml-cli generate
     ```
-  
-  ### Use a baml function in python!
+
+### Use a baml function in python!
+
     <Tip>If `baml_client` doesn't exist, make sure to run the previous step!</Tip>
 
     <CodeBlocks>
@@ -58,7 +61,7 @@ To set up BAML in python do the following:
     from baml_client.sync_client import b
     from baml_client.types import Resume
 
-    def example(raw_resume: str) -> Resume: 
+    def example(raw_resume: str) -> Resume:
       # BAML's internal parser guarantees ExtractResume
       # to be always return a Resume type
       response = b.ExtractResume(raw_resume)
@@ -68,7 +71,7 @@ To set up BAML in python do the following:
       stream = b.stream.ExtractResume(raw_resume)
       for msg in stream:
         print(msg) # This will be a PartialResume type
-      
+
       # This will be a Resume type
       final = stream.get_final_response()
 
@@ -79,7 +82,7 @@ To set up BAML in python do the following:
     from baml_client.async_client import b
     from baml_client.types import Resume
 
-    async def example(raw_resume: str) -> Resume: 
+    async def example(raw_resume: str) -> Resume:
       # BAML's internal parser guarantees ExtractResume
       # to be always return a Resume type
       response = await b.ExtractResume(raw_resume)
@@ -89,12 +92,12 @@ To set up BAML in python do the following:
       stream = b.stream.ExtractResume(raw_resume)
       async for msg in stream:
         print(msg) # This will be a PartialResume type
-      
+
       # This will be a Resume type
       final = stream.get_final_response()
 
       return final
     ```
     </CodeBlocks>
-  
+
 </Steps>

--- a/docs/docs/get-started/quickstart/ruby.mdx
+++ b/docs/docs/get-started/quickstart/ruby.mdx
@@ -8,28 +8,28 @@ To set up BAML in ruby do the following:
 
 <Steps>
   ### Install BAML VSCode Extension
-      https://marketplace.visualstudio.com/items?itemName=boundary.BAML
+      https://marketplace.visualstudio.com/items?itemName=boundary.baml-extension
 
       - syntax highlighting
       - testing playground
       - prompt previews
 
-  
-  ### Install baml
+### Install baml
+
         ```bash
         bundle init
         bundle add baml sorbet-runtime
         ```
-  
-  ### Add some starter code
+
+### Add some starter code
+
       This will give you some starter BAML code in a `baml_src` directory.
 
       ```bash
       bundle exec baml-cli init
       ```
 
-  
-  ### Generate python code from .baml files
+### Generate python code from .baml files
 
     This command will help you convert `.baml` files to `.rb` files. Everytime you modify your `.baml` files,
     you must re-run this command, and regenerate the `baml_client` folder.
@@ -42,8 +42,8 @@ To set up BAML in ruby do the following:
     bundle exec baml-cli generate
     ```
 
-  
-  ### Use a baml function in Ruby!
+### Use a baml function in Ruby!
+
     <Tip>If `baml_client` doesn't exist, make sure to run the previous step!</Tip>
 
     ```ruby main.rb
@@ -73,5 +73,4 @@ To set up BAML in ruby do the following:
     example_stream 'Grace Hopper created COBOL'
     ```
 
-  
 </Steps>

--- a/docs/docs/get-started/quickstart/ruby.mdx
+++ b/docs/docs/get-started/quickstart/ruby.mdx
@@ -14,22 +14,22 @@ To set up BAML in ruby do the following:
       - testing playground
       - prompt previews
 
-### Install baml
-
+  
+  ### Install baml
         ```bash
         bundle init
         bundle add baml sorbet-runtime
         ```
-
-### Add some starter code
-
+  
+  ### Add some starter code
       This will give you some starter BAML code in a `baml_src` directory.
 
       ```bash
       bundle exec baml-cli init
       ```
 
-### Generate python code from .baml files
+  
+  ### Generate python code from .baml files
 
     This command will help you convert `.baml` files to `.rb` files. Everytime you modify your `.baml` files,
     you must re-run this command, and regenerate the `baml_client` folder.
@@ -42,8 +42,8 @@ To set up BAML in ruby do the following:
     bundle exec baml-cli generate
     ```
 
-### Use a baml function in Ruby!
-
+  
+  ### Use a baml function in Ruby!
     <Tip>If `baml_client` doesn't exist, make sure to run the previous step!</Tip>
 
     ```ruby main.rb
@@ -73,4 +73,5 @@ To set up BAML in ruby do the following:
     example_stream 'Grace Hopper created COBOL'
     ```
 
+  
 </Steps>

--- a/docs/docs/get-started/quickstart/typescript.mdx
+++ b/docs/docs/get-started/quickstart/typescript.mdx
@@ -2,25 +2,26 @@
 slug: docs/get-started/quickstart/typescript
 ---
 
-Here's a sample repository: 
+Here's a sample repository:
 https://github.com/BoundaryML/baml-examples/tree/main/nextjs-starter
 
 To set up BAML in typescript do the following:
 
 <Steps>
   ### Install BAML VSCode Extension
-      https://marketplace.visualstudio.com/items?itemName=boundary.BAML
+      https://marketplace.visualstudio.com/items?itemName=boundary.baml-extension
 
       - syntax highlighting
       - testing playground
       - prompt previews
-  
-  ### Install baml
+
+### Install baml
+
       <CodeBlocks>
         ```bash npm
         npm install @boundaryml/baml
         ```
-        
+
         ```bash pnpm
         pnpm add @boundaryml/baml
         ```
@@ -29,14 +30,15 @@ To set up BAML in typescript do the following:
         yarn add @boundaryml/baml
         ```
     </CodeBlocks>
-  
-  ### Add some starter code
+
+### Add some starter code
+
       This will give you some starter BAML code in a `baml_src` directory.
       <CodeBlocks>
         ```bash npm
         npx baml-cli init
         ```
-        
+
         ```bash pnpm
         pnpx baml-cli init
         ```
@@ -45,8 +47,8 @@ To set up BAML in typescript do the following:
         yarn baml-cli init
         ```
     </CodeBlocks>
-  
-  ### Update your package.json
+
+### Update your package.json
 
     This command will help you convert `.baml` files to `.ts` files. Everytime you modify your `.baml` files,
     you must re-run this command, and regenerate the `baml_client` folder.
@@ -65,8 +67,9 @@ To set up BAML in typescript do the following:
       }
     }
     ```
-  
-  ### Use a baml function in typescript!
+
+### Use a baml function in typescript!
+
     <Tip>If `baml_client` doesn't exist, make sure to run `npm run baml-generate`</Tip>
 
     ```typescript index.ts
@@ -90,5 +93,5 @@ To set up BAML in typescript do the following:
       return await stream.get_final_response();
     }
     ```
-  
+
 </Steps>

--- a/docs/docs/get-started/quickstart/typescript.mdx
+++ b/docs/docs/get-started/quickstart/typescript.mdx
@@ -2,7 +2,7 @@
 slug: docs/get-started/quickstart/typescript
 ---
 
-Here's a sample repository:
+Here's a sample repository: 
 https://github.com/BoundaryML/baml-examples/tree/main/nextjs-starter
 
 To set up BAML in typescript do the following:
@@ -14,14 +14,13 @@ To set up BAML in typescript do the following:
       - syntax highlighting
       - testing playground
       - prompt previews
-
-### Install baml
-
+  
+  ### Install baml
       <CodeBlocks>
         ```bash npm
         npm install @boundaryml/baml
         ```
-
+        
         ```bash pnpm
         pnpm add @boundaryml/baml
         ```
@@ -30,15 +29,14 @@ To set up BAML in typescript do the following:
         yarn add @boundaryml/baml
         ```
     </CodeBlocks>
-
-### Add some starter code
-
+  
+  ### Add some starter code
       This will give you some starter BAML code in a `baml_src` directory.
       <CodeBlocks>
         ```bash npm
         npx baml-cli init
         ```
-
+        
         ```bash pnpm
         pnpx baml-cli init
         ```
@@ -47,8 +45,8 @@ To set up BAML in typescript do the following:
         yarn baml-cli init
         ```
     </CodeBlocks>
-
-### Update your package.json
+  
+  ### Update your package.json
 
     This command will help you convert `.baml` files to `.ts` files. Everytime you modify your `.baml` files,
     you must re-run this command, and regenerate the `baml_client` folder.
@@ -67,9 +65,8 @@ To set up BAML in typescript do the following:
       }
     }
     ```
-
-### Use a baml function in typescript!
-
+  
+  ### Use a baml function in typescript!
     <Tip>If `baml_client` doesn't exist, make sure to run `npm run baml-generate`</Tip>
 
     ```typescript index.ts
@@ -93,5 +90,5 @@ To set up BAML in typescript do the following:
       return await stream.get_final_response();
     }
     ```
-
+  
 </Steps>


### PR DESCRIPTION
Upon setting up baml, I happened to notice outdated links to the VS-code extension (as I followed those dead links myself).

For example in the [python docs](https://github.com/BoundaryML/baml/blob/canary/docs/docs/get-started/quickstart/python.mdx), the old link ending `https://marketplace.visualstudio.com/items?itemName=boundary.BAML`  is used instead of `https://marketplace.visualstudio.com/items?itemName=Boundary.baml-extension`. 

