### PR TITLE
fix: show actionable errors for string[]? and map<...>? type validation

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -537,7 +537,15 @@ impl WithRepr<Field> for FieldWalker<'_> {
         Ok(Field {
             name: self.name().to_string(),
             r#type: Node {
-                elem: self.ast_field().expr.clone().ok_or(anyhow!(""))?.repr(db)?,
+                elem: self
+                    .ast_field()
+                    .expr
+                    .clone()
+                    .ok_or(anyhow!(
+                        "blowing up while resolving representation of field {}",
+                        self.name(),
+                    ))?
+                    .repr(db)?,
                 attributes: self.attributes(db),
             },
         })

--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -542,7 +542,7 @@ impl WithRepr<Field> for FieldWalker<'_> {
                     .expr
                     .clone()
                     .ok_or(anyhow!(
-                        "blowing up while resolving representation of field {}",
+                        "Internal error occurred while resolving repr of field {:?}",
                         self.name(),
                     ))?
                     .repr(db)?,

--- a/engine/baml-lib/baml/tests/validation_files/class/disallowed_types.baml
+++ b/engine/baml-lib/baml/tests/validation_files/class/disallowed_types.baml
@@ -1,0 +1,17 @@
+class DisallowedTypes {
+  p string[]?
+  q map<string, string>?
+}
+
+// error: Error validating: Lists are not allowed to be optional (please remove the ?)
+//   -->  class/disallowed_types.baml:2
+//    | 
+//  1 | class DisallowedTypes {
+//  2 |   p string[]?
+//    | 
+// error: Error validating: Maps are not allowed to be optional (please remove the ?)
+//   -->  class/disallowed_types.baml:3
+//    | 
+//  2 |   p string[]?
+//  3 |   q map<string, string>?
+//    | 

--- a/engine/baml-lib/baml/tests/validation_tests.rs
+++ b/engine/baml-lib/baml/tests/validation_tests.rs
@@ -24,7 +24,7 @@ fn parse_schema_fail_on_diagnostics(file: impl Into<SourceFile>) -> Result<(), S
     match (schema.diagnostics.warnings(), schema.diagnostics.errors()) {
         ([], []) => {
             match IntermediateRepr::from_parser_database(&schema.db, schema.configuration) {
-                Ok(ir) => Ok(()),
+                Ok(_ir) => Ok(()),
                 Err(e) => Err(format!("{:?}", e.context("Error while converting AST to IR (did you mean to add a step to AST validation?)")))
             }
         }

--- a/engine/baml-lib/baml/tests/validation_tests.rs
+++ b/engine/baml-lib/baml/tests/validation_tests.rs
@@ -1,6 +1,7 @@
 mod panic_with_diff;
 
-use baml_lib::{SourceFile, ValidatedSchema};
+use baml_lib::SourceFile;
+use internal_baml_core::ir::repr::IntermediateRepr;
 
 use std::sync::Once;
 
@@ -15,15 +16,18 @@ use strip_ansi_escapes::strip_str;
 const TESTS_ROOT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/validation_files");
 
 /// Parse and analyze a Prisma schema, returning Err if there are any diagnostics (warnings or errors).
-fn parse_schema_fail_on_diagnostics(
-    file: impl Into<SourceFile>,
-) -> Result<ValidatedSchema, String> {
+fn parse_schema_fail_on_diagnostics(file: impl Into<SourceFile>) -> Result<(), String> {
     let path = PathBuf::from("./unknown");
     let file = file.into();
     let schema = baml_lib::validate(&path, vec![file]);
 
     match (schema.diagnostics.warnings(), schema.diagnostics.errors()) {
-        ([], []) => Ok(schema),
+        ([], []) => {
+            match IntermediateRepr::from_parser_database(&schema.db, schema.configuration) {
+                Ok(ir) => Ok(()),
+                Err(e) => Err(format!("{:?}", e.context("Error while converting AST to IR (did you mean to add a step to AST validation?)")))
+            }
+        }
         (warnings, errors) => {
             let mut message: Vec<u8> = Vec::new();
 

--- a/engine/baml-lib/schema-ast/src/ast/field.rs
+++ b/engine/baml-lib/schema-ast/src/ast/field.rs
@@ -180,11 +180,11 @@ impl FieldType {
                 attributes.to_owned(),
             )),
             FieldType::Map(_, span, _) => Err(DatamodelError::new_validation_error(
-                "Dictionaries can not be optional",
+                "Maps are not allowed to be optional (please remove the ?)",
                 span.clone(),
             )),
             FieldType::List(_, _, span, _) => Err(DatamodelError::new_validation_error(
-                "Lists can not be optional",
+                "Lists are not allowed to be optional (please remove the ?)",
                 span.clone(),
             )),
         }

--- a/engine/baml-lib/schema-ast/src/parser/parse_field.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_field.rs
@@ -74,7 +74,6 @@ pub(crate) fn parse_type_expr(
     let mut field_type = None;
     let mut comment: Option<Comment> = block_comment.and_then(parse_comment_block);
 
-    dbg!(&pair);
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::identifier => name = Some(parse_identifier(current, diagnostics)),
@@ -82,7 +81,6 @@ pub(crate) fn parse_type_expr(
                 comment = merge_comments(comment, parse_trailing_comment(current));
             }
             Rule::field_type_chain => {
-                // dbg!(&is_enum);
                 if !is_enum {
                     field_type = parse_field_type_chain(current, diagnostics);
                 }
@@ -91,12 +89,6 @@ pub(crate) fn parse_type_expr(
             _ => parsing_catch_all(current, "field"),
         }
     }
-
-    log::debug!(
-        "parse_type_expr: name: {:#?}, field_type: {:#?}",
-        name,
-        field_type
-    );
 
     match (name, field_type) {
         (Some(name), Some(field_type)) => Ok(Field {
@@ -135,12 +127,10 @@ fn parse_field_type_chain(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Opti
     let mut types = Vec::new();
     let mut operators = Vec::new();
 
-    // dbg!(&pair);
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::field_type_with_attr => {
                 if let Some(field_type) = parse_field_type_with_attr(current, diagnostics) {
-                    // dbg!(&field_type);
                     types.push(field_type);
                 }
             }
@@ -161,7 +151,6 @@ pub(crate) fn parse_field_type_with_attr(
     let mut field_attributes = Vec::new();
 
     for current in pair.into_inner() {
-        // dbg!(&current);
         match current.as_rule() {
             Rule::field_type => field_type = parse_field_type(current, diagnostics),
             Rule::field_attribute => field_attributes.push(parse_attribute(current, diagnostics)),

--- a/engine/baml-lib/schema-ast/src/parser/parse_field.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_field.rs
@@ -74,6 +74,7 @@ pub(crate) fn parse_type_expr(
     let mut field_type = None;
     let mut comment: Option<Comment> = block_comment.and_then(parse_comment_block);
 
+    // dbg!(&pair);
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::identifier => name = Some(parse_identifier(current, diagnostics)),
@@ -81,6 +82,7 @@ pub(crate) fn parse_type_expr(
                 comment = merge_comments(comment, parse_trailing_comment(current));
             }
             Rule::field_type_chain => {
+                // dbg!(&is_enum);
                 if !is_enum {
                     field_type = parse_field_type_chain(current, diagnostics);
                 }
@@ -89,6 +91,12 @@ pub(crate) fn parse_type_expr(
             _ => parsing_catch_all(current, "field"),
         }
     }
+
+    log::debug!(
+        "parse_type_expr: name: {:#?}, field_type: {:#?}",
+        name,
+        field_type
+    );
 
     match (name, field_type) {
         (Some(name), Some(field_type)) => Ok(Field {
@@ -127,10 +135,12 @@ fn parse_field_type_chain(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Opti
     let mut types = Vec::new();
     let mut operators = Vec::new();
 
+    // dbg!(&pair);
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::field_type_with_attr => {
                 if let Some(field_type) = parse_field_type_with_attr(current, diagnostics) {
+                    // dbg!(&field_type);
                     types.push(field_type);
                 }
             }
@@ -151,11 +161,10 @@ pub(crate) fn parse_field_type_with_attr(
     let mut field_attributes = Vec::new();
 
     for current in pair.into_inner() {
+        // dbg!(&current);
         match current.as_rule() {
             Rule::field_type => field_type = parse_field_type(current, diagnostics),
-            Rule::field_type_with_attr => {}
             Rule::field_attribute => field_attributes.push(parse_attribute(current, diagnostics)),
-            Rule::trailing_comment => {}
             _ => {
                 parsing_catch_all(current, "field_type_with_attr!");
             }

--- a/engine/baml-lib/schema-ast/src/parser/parse_field.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_field.rs
@@ -74,7 +74,7 @@ pub(crate) fn parse_type_expr(
     let mut field_type = None;
     let mut comment: Option<Comment> = block_comment.and_then(parse_comment_block);
 
-    // dbg!(&pair);
+    dbg!(&pair);
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::identifier => name = Some(parse_identifier(current, diagnostics)),

--- a/engine/baml-lib/schema-ast/src/parser/parse_type_expression_block.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_type_expression_block.rs
@@ -27,17 +27,12 @@ pub(crate) fn parse_type_expression_block(
     let mut input = None;
 
     for current in pair.into_inner() {
-        
-
         match current.as_rule() {
-            Rule::type_expression_keyword => {
-                match current.as_str() {
-                    "class" => sub_type = Some(SubType::Class.clone()),
-                    "enum" => sub_type = Some(SubType::Enum.clone()),
-                    _ => sub_type = Some(SubType::Other(current.as_str().to_string())),
-                }
-
-            }
+            Rule::type_expression_keyword => match current.as_str() {
+                "class" => sub_type = Some(SubType::Class.clone()),
+                "enum" => sub_type = Some(SubType::Enum.clone()),
+                _ => sub_type = Some(SubType::Other(current.as_str().to_string())),
+            },
 
             Rule::BLOCK_OPEN | Rule::BLOCK_CLOSE => {}
             Rule::identifier => name = Some(parse_identifier(current, diagnostics)),
@@ -49,14 +44,11 @@ pub(crate) fn parse_type_expression_block(
                 let mut pending_field_comment: Option<Pair<'_>> = None;
 
                 for item in current.into_inner() {
-                    
-
                     match item.as_rule() {
                         Rule::block_attribute => {
                             attributes.push(parse_attribute(item, diagnostics));
                         }
                         Rule::type_expression =>{
-                            
                             match parse_type_expr(
                                     &name,
                                     sub_type.clone().map(|st| match st {
@@ -90,12 +82,10 @@ pub(crate) fn parse_type_expression_block(
                 }
             }
 
-            _ => {
-                parsing_catch_all(current, "type_expression")
-            }
+            _ => parsing_catch_all(current, "type_expression"),
         }
     }
-  
+
     match name {
         Some(name) => TypeExpressionBlock {
             name,

--- a/engine/baml-lib/schema-ast/src/parser/parse_types.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_types.rs
@@ -16,8 +16,7 @@ pub fn parse_field_type(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option
     let mut arity = FieldArity::Required;
     let mut ftype = None;
 
-    for (i, current) in pair.into_inner().enumerate() {
-        // dbg!((i, &current));
+    for current in pair.into_inner() {
         match current.as_rule() {
             Rule::union => {
                 let result = parse_union(current, diagnostics);

--- a/root.code-workspace
+++ b/root.code-workspace
@@ -80,7 +80,7 @@
       "titleBar.activeForeground": "#FFFBFB"
     },
     "biome.lspBin": "typescript/node_modules/@biomejs/biome/bin/biome",
-    "terminal.integrated.scrollback": 1000000
+    "terminal.integrated.scrollback": 1e6
     
   },
   "extensions": {

--- a/root.code-workspace
+++ b/root.code-workspace
@@ -79,7 +79,8 @@
       "titleBar.activeBackground": "#8B0002",
       "titleBar.activeForeground": "#FFFBFB"
     },
-    "biome.lspBin": "typescript/node_modules/@biomejs/biome/bin/biome"
+    "biome.lspBin": "typescript/node_modules/@biomejs/biome/bin/biome",
+    "terminal.integrated.scrollback": 1000000
     
   },
   "extensions": {


### PR DESCRIPTION
Today, if users define a field of type `string[]?` or `map<string, string>?` in their BAML, the BAML compiler/runtime crashes with zero error message for the user.

At a minimum, we need to produce an actionable error so the user knows how to make their BAML valid; but really we need to push this type validation to post-parse validation, instead of doing the validation at parse time.