### PR TITLE
feat: use better default for openapi/rust client

### DIFF
--- a/engine/baml-runtime/src/cli/init.rs
+++ b/engine/baml-runtime/src/cli/init.rs
@@ -149,7 +149,7 @@ fn generate_main_baml_content(
             "{cmd} --additional-properties gemName=baml_client",
         ),
         Some("rust") => format!(
-            "{cmd} --additional-properties packageName=baml-client",
+            "{cmd} --additional-properties packageName=baml-client,avoidBoxedModels=true",
         ),
         _ => cmd,
     };


### PR DESCRIPTION
The OpenAPI-generated Rust client by default wraps types in `Box<T>`, which can get annoying pretty fast, in everything from `.into()` or `Box::new` on object construction to having to do `.as_ref()` on every `match` construct.

Setting `avoidBoxedModels=true` makes this behavior much more sane.