### PR TITLE
Allow nix for local development

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,16 @@
-PATH_add tools/
-PATH_add "$(brew --prefix llvm)/bin"
-
-# Use mise for tool versioning, e.g. Ruby
-eval "$(mise activate bash)" || echo "Please run 'brew install mise'"
-
 export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+
+# Use nix if nix-shell is available,
+# Otherwise, use mise and brew.
+if command -v nix-shell >/dev/null 2>&1; then
+    use nix
+    export PATH=$(pwd)/tools:$PATH
+else
+    PATH_add tools/
+    PATH_add "$(brew --prefix llvm)/bin"
+
+    # Use mise for tool versioning, e.g. Ruby
+    eval "$(mise activate bash)" || echo "Please run 'brew install mise'"
+    
+    export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+fi

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+let
+  pkgs = import <nixpkgs> {};
+in
+  pkgs.mkShell {
+    buildInputs = with pkgs; [ cargo rustc nodePackages.pnpm python3 poetry ];
+    shellHook = ''
+      export PROJECT_ROOT=/$(pwd)
+      export PATH=/$PROJECT_ROOT/tools:$PATH
+    '';
+  }


### PR DESCRIPTION
This adds a basic dev environment via nix-shell, and chooses between nix and mise for dev environment setup based on the presence of the `nix-shell` executable.