### PR TITLE
fix: serde-serialize can trigger package cycle detection

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -4779,8 +4779,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -97,7 +97,7 @@ reqwest = { version = "0.12.5", features = ["stream", "json"] }
 send_wrapper = { version = "0.6.0", features = ["futures"] }
 serde-wasm-bindgen = "0.6.5"
 uuid = { version = "1.8.0", features = ["v4", "serde", "js"] }
-wasm-bindgen = { version = "^0.2.74", features = ["serde-serialize"] }
+wasm-bindgen = "^0.2.74"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3.69", features = [
   "Headers",

--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -97,6 +97,8 @@ reqwest = { version = "0.12.5", features = ["stream", "json"] }
 send_wrapper = { version = "0.6.0", features = ["futures"] }
 serde-wasm-bindgen = "0.6.5"
 uuid = { version = "1.8.0", features = ["v4", "serde", "js"] }
+# WARNING: Do not add serde-serialize feature to wasm-bindgen.
+# It may produce a dependency cycle in projects that use wasm and import baml.
 wasm-bindgen = "^0.2.74"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3.69", features = [


### PR DESCRIPTION
I'm getting this error when loading the Rust project from an external source that uses wasm

```
package:   /Users/nijaar/shinkai/develop/shinkai-node/shinkai-libs/shinkai-baml/Cargo.toml
workspace: /Users/nijaar/shinkai/develop/shinkai-node/Cargo.toml
    Updating crates.io index
    Updating git repository https://github.com/BoundaryML/baml.git
error: cyclic package dependency: package getrandom v0.2.15 depends on itself. Cycle:
package getrandom v0.2.15
    ... which satisfies dependency getrandom = "^0.2.0" of package const-random-macro v0.1.16
    ... which satisfies dependency const-random-macro = "^0.1.16" of package const-random v0.1.18
    ... which satisfies dependency const-random = "^0.1.17" of package ahash v0.8.11
    ... which satisfies dependency ahash = "^0.8.7" of package hashbrown v0.14.5
    ... which satisfies dependency hashbrown = "^0.14.1" of package indexmap v2.5.0
    ... which satisfies dependency indexmap = "^2.2.3" of package serde_json v1.0.128
    ... which satisfies dependency serde_json = "^1.0" of package wasm-bindgen v0.2.93
    ... which satisfies dependency wasm-bindgen = "^0.2.93" of package js-sys v0.3.70
    ... which satisfies dependency js-sys = "^0.3" of package getrandom v0.2.15
    ... which satisfies dependency getrandom = "^0.2" of package rand_core v0.6.4
    ... which satisfies dependency rand_core = "^0.6" of package crypto-common v0.1.6
    ... which satisfies dependency crypto-common = "^0.1.4" of package aead v0.5.2
```

I created another Rust project that uses baml and it wasn't hitting the issue, so it seems that for some reason projects that also use wasm trigger the issue.

it seems to be a very common issue

https://github.com/tkaitchuck/aHash/issues/95
https://github.com/rustwasm/gloo/pull/239

![image](https://github.com/user-attachments/assets/7b268d4d-67f8-48ab-9d03-ef60ebc4f181)

the tldr is that the feature `serde-serializer` seems to be the culprit (deprecated). it's recommended to move to use `serde_wasm_bindgen` which baml already uses! so the fix seems to be just removing the feature.

From my limited experience of the project and to try to make sure that the wasm build still compiles and works, i actually compiled it myself and tested it in a nodejs project, and it continues to work.

Then I imported this branch to the other project and it worked without hitting the dependency cycle issue.