### PR TITLE
fix: make anthropic work in fiddle/vscode

### DIFF
--- a/typescript/fiddle-proxy/server.js
+++ b/typescript/fiddle-proxy/server.js
@@ -63,8 +63,6 @@ app.use(
       const originalUrl = req.headers['baml-original-url']
 
       if (typeof originalUrl === 'string') {
-        delete req.headers['baml-original-url']
-        delete req.headers['origin']
         return originalUrl
       } else {
         throw new Error('baml-original-url header is missing or invalid')
@@ -89,6 +87,7 @@ app.use(
           for (const [header, value] of Object.entries(headers)) {
             proxyReq.setHeader(header, value)
           }
+          proxyReq.removeHeader('origin')
         } catch (err) {
           // This is not console.warn because it's not important
           console.log('baml-original-url is not parsable', err)

--- a/typescript/fiddle-proxy/server.js
+++ b/typescript/fiddle-proxy/server.js
@@ -63,6 +63,8 @@ app.use(
       const originalUrl = req.headers['baml-original-url']
 
       if (typeof originalUrl === 'string') {
+        delete req.headers['baml-original-url']
+        delete req.headers['origin']
         return originalUrl
       } else {
         throw new Error('baml-original-url header is missing or invalid')

--- a/typescript/vscode-ext/packages/vscode/src/extension.ts
+++ b/typescript/vscode-ext/packages/vscode/src/extension.ts
@@ -200,14 +200,12 @@ export function activate(context: vscode.ExtensionContext) {
         return path
       },
       router: (req) => {
-        console.log('proxy middleware', req)
         // Extract the original target URL from the custom header
         let originalUrl = req.headers['baml-original-url']
         if (typeof originalUrl === 'string') {
+          // For some reason, Node doesn't like deleting headers in the proxyReq function.
           delete req.headers['baml-original-url']
           delete req.headers['origin']
-
-          // req.headers['origin'] = `http://localhost:${port}`
 
           // Ensure the URL does not end with a slash
           if (originalUrl.endsWith('/')) {
@@ -220,20 +218,6 @@ export function activate(context: vscode.ExtensionContext) {
       },
       logger: console,
       on: {
-        proxyReq: (proxyReq, req, res) => {
-          console.log('proxying request', { proxyReq, req, res })
-          // Handle OPTIONS requests
-          if (req.method === 'OPTIONS') {
-            res.statusCode = 204
-            res.setHeader('Access-Control-Allow-Origin', '*')
-            res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, PATCH, OPTIONS')
-            res.setHeader('Access-Control-Allow-Headers', '*')
-            res.end()
-          }
-
-          // Delete the "origin" header from the outgoing request
-          // proxyReq.removeHeader('origin')
-        },
         proxyRes: (proxyRes, req, res) => {
           console.log('proxying response', { proxyRes, req, res })
           proxyRes.headers['Access-Control-Allow-Origin'] = '*'

--- a/typescript/vscode-ext/packages/vscode/src/extension.ts
+++ b/typescript/vscode-ext/packages/vscode/src/extension.ts
@@ -218,8 +218,10 @@ export function activate(context: vscode.ExtensionContext) {
       },
       logger: console,
       on: {
+        proxyReq: (proxyReq, req, res) => {
+          console.debug('Proxying an LLM request (to bypass CORS)', { proxyReq, req, res })
+        },
         proxyRes: (proxyRes, req, res) => {
-          console.log('proxying response', { proxyRes, req, res })
           proxyRes.headers['Access-Control-Allow-Origin'] = '*'
         },
         error: (error) => {


### PR DESCRIPTION
Anthropic now reacts to the `Origin` header being set, and reacts to such requests complaining about CORS issues.

To get around this without magically injecting the Anthropic headers, just delete the `origin` header.