### PR TITLE
[syntax] Allow lists to contain trailing comma

### DIFF
--- a/engine/baml-lib/schema-ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/schema-ast/src/parser/datamodel.pest
@@ -93,7 +93,7 @@ map_entry = { (comment_block | empty_lines)* ~ map_key ~ (expression | ENTRY_CAT
 
 splitter         = _{ ("," ~ NEWLINE?) | NEWLINE }
 map_expression   =  { "{" ~ empty_lines? ~ (map_entry ~ (splitter ~ map_entry)*)? ~ (comment_block | empty_lines)* ~ "}" }
-array_expression =  { "[" ~ empty_lines? ~ ((expression | ARRAY_CATCH_ALL) ~ trailing_comment? ~ (splitter ~ (comment_block | empty_lines)* ~ (expression | ARRAY_CATCH_ALL) ~ trailing_comment?)*)? ~ (comment_block | empty_lines)* ~ "]" }
+array_expression =  { "[" ~ empty_lines? ~ ((expression | ARRAY_CATCH_ALL) ~ trailing_comment? ~ (splitter ~ (comment_block | empty_lines)* ~ (expression | ARRAY_CATCH_ALL) ~ trailing_comment?)*)? ~ (comment_block | empty_lines)* ~ splitter? ~ "]" }
 expression       =  { map_expression | array_expression | numeric_literal | string_literal | identifier }
 ARRAY_CATCH_ALL  =  { !"]" ~ CATCH_ALL }
 ENTRY_CATCH_ALL  =  { field_attribute | BLOCK_LEVEL_CATCH_ALL }

--- a/engine/baml-lib/schema-ast/src/parser/parse_expression.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_expression.rs
@@ -236,3 +236,50 @@ fn unescape_string(val: &str) -> String {
 
     result
 }
+
+#[cfg(test)]
+mod tests {
+    use super::super::{BAMLParser, Rule};
+    use pest::{parses_to, consumes_to};
+
+    #[test]
+    fn array_trailing_comma() {
+
+        parses_to!{
+            parser: BAMLParser,
+            input: "[1,2],",
+            rule: Rule::expression,
+            tokens: [expression(0, 5,[
+                array_expression(0, 5,[
+                expression(1,2,[numeric_literal(1,2)]),
+                expression(3,4,[numeric_literal(3,4)]),
+            ])])]
+        };
+
+        parses_to!{
+            parser: BAMLParser,
+            input: r##"[#"foo"#, #"bar"#]"##,
+            rule: Rule::expression,
+            tokens: [expression(0, 18, [
+                array_expression(0, 18, [
+                    expression(1,8,[
+                        string_literal(1,8,[
+                            raw_string_literal(1,8,[
+                                raw_string_literal_content_1(3,6)
+                            ])
+                        ])
+                    ]),
+                    expression(10,17,[
+                        string_literal(10,17,[
+                            raw_string_literal(10,17,[
+                                raw_string_literal_content_1(12,15)
+                            ])
+                        ])
+                    ]),
+                ])
+            ])]
+        };
+
+    }
+
+}

--- a/engine/baml-lib/schema-ast/src/parser/parse_schema.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_schema.rs
@@ -239,7 +239,6 @@ mod tests {
         let source = SourceFile::new_static(root_path.into(), input);
 
         let result = parse_schema(&root_path.into(), &source).unwrap();
-        dbg!(&result.0);
         assert_eq!(result.1.errors().len(), 0);
     }
 }

--- a/engine/baml-lib/schema-ast/src/parser/parse_schema.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_schema.rs
@@ -201,6 +201,47 @@ mod tests {
             _ => panic!("Expected a model declaration"),
         }
     }
+
+    #[test]
+    fn test_example() {
+        let input = r##"
+          function EvaluateCaption(imgs: image[], captions: string[]) -> string {
+            client GPTo4
+            prompt #"
+              Evaluate the quality of the captions for the images.
+
+              {{ imgs }}
+              {{ captions }}
+            "#
+          }
+
+          test EvaluateCaptionTest {
+            functions [EvaluateCaption]
+            args {
+              image [{
+                file ../../files/images/restaurant.png
+              },{
+                file ../../files/images/bear.png
+              }]
+              captions [
+                #"
+                  A bear walking next to a rabbit in the woods.
+                "#,
+                #"
+                  A restaurant full of diners.
+                "#,
+              ]
+            }
+          }
+        "##;
+
+        let root_path = "example_file.baml";
+        let source = SourceFile::new_static(root_path.into(), input);
+
+        let result = parse_schema(&root_path.into(), &source).unwrap();
+        dbg!(&result.0);
+        assert_eq!(result.1.errors().len(), 0);
+    }
 }
 
 fn get_expected_from_error(positives: &[Rule]) -> String {


### PR DESCRIPTION
Prior to this change, an expression `[1,2,]` would fail to parse.

This PR updates the pest grammar to allow lists to contain trailing commas.

The new tests in this PR fail if you revert the change to the pest grammar, and pass with the updated grammar.

I also tested this change in baml_runtime, by updating an existing example to take a list of strings as a parameter, and supplying a list with a trailing comma in a test-case. This test fails prior to the grammar update and passes after. I did not check the baml_runtime test in to the codebase.