### PR TITLE
Improved parser for unions.

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
@@ -159,7 +159,8 @@ impl TypeCoercer for Class {
                             }
                             // If we're missing a field, thats ok!
                             None => Some(BamlValueWithFlags::Null(
-                                DeserializerConditions::new().with_flag(Flag::DefaultFromNoValue),
+                                DeserializerConditions::new()
+                                    .with_flag(Flag::OptionalDefaultFromNoValue),
                             )),
                         };
 

--- a/engine/baml-lib/jsonish/src/tests/test_unions.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_unions.rs
@@ -70,3 +70,180 @@ test_deserializer!(
     "data": null
   }
 );
+
+const CUSTOMER_FILE2: &str = r###"
+enum AssistantType {
+  ETF @alias("ETFAssistantAPI")
+  Stock @alias("StockAssistantAPI")
+}
+
+class AssistantAPI {
+  action AssistantType
+  instruction string @description("Detailed instructions for the assistants API to be able to process the request")
+  user_message string @description("The message to keep the user informed")
+
+  @@description(#"
+    Used for 
+  "#)
+}
+
+enum AskClarificationAction {
+  ASK_CLARIFICATION @alias("AskClarificationAPI")
+}
+
+class AskClarificationAPI {
+  action AskClarificationAction
+  question string @description("The clarification question to ask the user")
+}
+
+enum RespondToUserAction {
+  RESPOND_TO_USER @alias("RespondToUserAPI")
+}
+
+class RespondToUserAPI {
+  action RespondToUserAction
+  sections UI[]
+}
+
+class Message {
+  role string
+  message string
+}
+
+
+
+enum UIType {
+  CompanyBadge @description("Company badge UI type")
+  Markdown @description("Markdown text UI type")
+  NumericalSlider @description("Numerical slider UI type")
+  BarGraph @description("Bar graph UI type")
+  ScatterPlot @description("Scatter plot UI type")
+}
+
+class MarkdownContent {
+  text string
+}
+
+class CompanyBadgeContent {
+  name string
+  symbol string
+  logo_url string
+}
+
+class NumericalSliderContent {
+  title string
+  min float
+  max float
+  value float
+}
+
+class TabContent {
+  title string
+  content string
+}
+
+class GraphDataPoint {
+  name string
+  expected float
+  reported float
+}
+
+class ScatterDataPoint {
+  x string
+  y float
+}
+
+class ScatterPlotContent {
+  expected ScatterDataPoint[]
+  reported ScatterDataPoint[]
+}
+
+class UIContent {
+  richText MarkdownContent?
+  companyBadge CompanyBadgeContent?
+  numericalSlider NumericalSliderContent?
+  barGraph GraphDataPoint[] | null
+  scatterPlot ScatterPlotContent?
+  foo string?
+}
+
+class UI {
+  section_title string
+  type UIType[] @alias(types)
+  content UIContent
+}
+
+"###;
+
+test_deserializer!(
+  test_union3,
+  CUSTOMER_FILE2,
+  r####"```json
+{
+  "action": "RespondToUserAPI",
+  "sections": [
+    {
+      "section_title": "NVIDIA Corporation (NVDA) Latest Earnings Summary",
+      "types": ["CompanyBadge", "Markdown", "BarGraph"],
+      "content": {
+        "companyBadge": {
+          "name": "NVIDIA Corporation",
+          "symbol": "NVDA",
+          "logo_url": "https://upload.wikimedia.org/wikipedia/en/thumb/2/21/Nvidia_logo.svg/1920px-Nvidia_logo.svg.png"
+        },
+        "richText": {
+          "text": "### Key Metrics for the Latest Earnings Report (2024-08-28)\n\n- **Earnings Per Share (EPS):** $0.68\n- **Estimated EPS:** $0.64\n- **Revenue:** $30.04 billion\n- **Estimated Revenue:** $28.74 billion\n\n#### Notable Highlights\n- NVIDIA exceeded both EPS and revenue estimates for the quarter ending July 28, 2024.\n- The company continues to show strong growth in its data center and gaming segments."
+        },
+        "barGraph": [
+          {
+            "name": "Earnings Per Share (EPS)",
+            "expected": 0.64,
+            "reported": 0.68
+          },
+          {
+            "name": "Revenue (in billions)",
+            "expected": 28.74,
+            "reported": 30.04
+          }
+        ]
+      }
+    }
+  ]
+}
+```"####,
+  FieldType::union(vec![FieldType::class("RespondToUserAPI"), FieldType::class("AskClarificationAPI"), FieldType::class("AssistantAPI").as_list()]),
+  {
+    "action": "RESPOND_TO_USER",
+    "sections": [
+      {
+        "section_title": "NVIDIA Corporation (NVDA) Latest Earnings Summary",
+        "type": ["CompanyBadge", "Markdown", "BarGraph"],
+        "content": {
+          "companyBadge": {
+            "name": "NVIDIA Corporation",
+            "symbol": "NVDA",
+            "logo_url": "https://upload.wikimedia.org/wikipedia/en/thumb/2/21/Nvidia_logo.svg/1920px-Nvidia_logo.svg.png"
+          },
+          "richText": {
+            "text": "### Key Metrics for the Latest Earnings Report (2024-08-28)\n\n- **Earnings Per Share (EPS):** $0.68\n- **Estimated EPS:** $0.64\n- **Revenue:** $30.04 billion\n- **Estimated Revenue:** $28.74 billion\n\n#### Notable Highlights\n- NVIDIA exceeded both EPS and revenue estimates for the quarter ending July 28, 2024.\n- The company continues to show strong growth in its data center and gaming segments."
+          },
+          "scatterPlot": null,
+          "numericalSlider": null,
+          "barGraph": [
+            {
+              "name": "Earnings Per Share (EPS)",
+              "expected": 0.64,
+              "reported": 0.68
+            },
+            {
+              "name": "Revenue (in billions)",
+              "expected": 28.74,
+              "reported": 30.04
+            }
+          ],
+          "foo": null
+        }
+      }
+    ]
+  }
+);


### PR DESCRIPTION
Currently:

(A | B | C[]) will often come back as C even if A or B is present due to the fact that an empty [] has a very low cost. we can attach a higher cost to throwing away objects that are not matching yourself, but do match others.

For now the solution is simply to devalue default matches as low-quality results. e.g. [] will always match worse than some poor match of A or B.

[ { ... } ] will not be devalued (only empty lists)
