### PR TITLE
Improve SAP for triple quoted strings along with unions

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/types.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/types.rs
@@ -333,7 +333,7 @@ impl BamlValueWithFlags {
         }
     }
 
-    fn r#type(&self) -> String {
+    pub(super) fn r#type(&self) -> String {
         match self {
             BamlValueWithFlags::String(_) => "String".to_string(),
             BamlValueWithFlags::Int(_) => "Int".to_string(),

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_collection.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_collection.rs
@@ -8,6 +8,7 @@ pub enum JsonCollection {
     Object(Vec<String>, Vec<Value>),
     Array(Vec<Value>),
     QuotedString(String),
+    TripleQuotedString(String),
     SingleQuotedString(String),
     // Handles numbers, booleans, null, and unquoted strings
     UnquotedString(String),
@@ -24,6 +25,7 @@ impl JsonCollection {
             JsonCollection::Array(_) => "Array",
             JsonCollection::QuotedString(_) => "String",
             JsonCollection::SingleQuotedString(_) => "String",
+            JsonCollection::TripleQuotedString(_) => "TripleQuotedString",
             JsonCollection::UnquotedString(_) => "UnquotedString",
             JsonCollection::TrailingComment(_) => "Comment",
             JsonCollection::BlockComment(_) => "Comment",
@@ -45,6 +47,7 @@ impl From<JsonCollection> for Option<Value> {
             }
             JsonCollection::Array(values) => Value::Array(values),
             JsonCollection::QuotedString(s) => Value::String(s),
+            JsonCollection::TripleQuotedString(s) => Value::String(s),
             JsonCollection::SingleQuotedString(s) => Value::String(s),
             JsonCollection::UnquotedString(s) => {
                 let s = s.trim();

--- a/engine/baml-lib/jsonish/src/jsonish/parser/mod.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/mod.rs
@@ -26,15 +26,20 @@ impl Default for ParseOptions {
     }
 }
 
-enum ParsingMode {
+pub(super) enum ParsingMode {
     JsonMarkdown,
+    JsonMarkdownString,
     AllJsonObjects,
 }
 
 impl ParseOptions {
-    pub fn next_from_mode(&self, curr_mode: ParsingMode) -> Self {
+    pub(super) fn next_from_mode(&self, curr_mode: ParsingMode) -> Self {
         let mut new = self.clone();
         match curr_mode {
+            ParsingMode::JsonMarkdownString => {
+                new.allow_markdown_json = false;
+                new.allow_as_string = true;
+            }
             ParsingMode::JsonMarkdown => {
                 new.allow_markdown_json = false;
                 new.allow_as_string = false;

--- a/engine/baml-lib/jsonish/src/tests/test_basics.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_basics.rs
@@ -828,11 +828,108 @@ repleta de monstros e perigos!"""
     {
       "id": "CH1_02",
       "English": "Arcadia is a vast land, with monsters and dangers!",
-      "Portuguese": "\"\"Arcadia é uma terra vasta,\n\nrepleta de monstros e perigos!\"\""
+      "Portuguese": "Arcadia é uma terra vasta,\n\nrepleta de monstros e perigos!"
     },
     {
       "id": "CH1_03",
       "English": "Find him {player_name}. Find him and save Arcadia. Jonathan will save us all. It is the only way.",
       "Portuguese": null
     }]
+);
+
+const SIDD_BAML: &str = r#"
+class Headings {
+    headings Heading[]
+}
+class Heading {
+    heading string
+    python_function_code string
+    description string
+}
+"#;
+
+test_deserializer!(
+  test_sidd,
+  SIDD_BAML,
+  r#"
+<thinking>
+To create a personalized catalogue for the customer, I need to analyze both the properties available and the customer's requirements. The customer is looking for an apartment that is 970.0 sq.ft. and costs Rs. 27,030,000.00. However, none of the listed properties match these specifications perfectly.
+
+1. **Analyze the Properties**: I'll look at the properties provided to identify common themes, features, or unique selling points that can inspire creative headings.
+2. **Consider Customer Requirements**: While the customer has specific requirements, the task is to create headings that are creative and interesting, not strictly based on those requirements.
+3. **Generate Creative Headings**: I will brainstorm seven catchy headings that can be used to categorize the properties in a way that highlights their best features or unique aspects.
+
+Next, I will generate the headings and their corresponding Python functions to categorize the properties.
+</thinking>
+
+<reflection>
+I have considered the properties and the customer's requirements. The next step is to formulate creative headings that reflect the unique aspects of the properties without being overly focused on the customer's specific requirements. I will ensure that each heading is distinct and engaging.
+</reflection>
+
+<thinking>
+Here are the seven creative headings along with their descriptions and Python functions:
+
+1. **Urban Oasis**
+   - This heading captures properties that offer a serene living experience amidst the bustling city life.
+   - Python function:
+   ```python
+   def is_urban_oasis(property):
+       return 'Large Green Area' in property['amenities'] or 'Garden' in property['amenities']
+   ```
+
+   Now, I will compile these into the required format.
+</thinking>
+
+{
+  "headings": [
+    {
+      "heading": "Urban Oasis",
+      "python_function_code": """def is_urban_oasis(property):
+       return 'Large Green Area' in property['amenities'] or 'Garden' in property['amenities']""",
+      "description": "Properties that offer a serene living experience amidst the bustling city life."
+    }
+  ]
+}
+  "#.trim(),
+  baml_types::FieldType::Class("Headings".into()),
+
+  {
+    "headings": [
+      {
+        "heading": "Urban Oasis",
+        "python_function_code": r#"def is_urban_oasis(property):
+       return 'Large Green Area' in property['amenities'] or 'Garden' in property['amenities']"#,
+        "description": "Properties that offer a serene living experience amidst the bustling city life."
+      }
+    ]
+  }
+);
+
+test_deserializer!(
+  test_injected_triple_quoted_string,
+  SIDD_BAML,
+  r#"
+{
+  "headings": [
+    {
+      "heading": "Urban Oasis",
+      "python_function_code": """def is_urban_oasis(property):
+       return 'Large Green Area' in property['amenities'] or 'Garden' in property['amenities']""",
+      "description": "Properties that offer a serene living experience amidst the bustling city life."
+    }
+  ]
+}
+  "#.trim(),
+  baml_types::FieldType::Class("Headings".into()),
+
+  {
+    "headings": [
+      {
+        "heading": "Urban Oasis",
+        "python_function_code": r#"def is_urban_oasis(property):
+       return 'Large Green Area' in property['amenities'] or 'Garden' in property['amenities']"#,
+        "description": "Properties that offer a serene living experience amidst the bustling city life."
+      }
+    ]
+  }
 );

--- a/engine/baml-lib/jsonish/src/tests/test_basics.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_basics.rs
@@ -784,3 +784,55 @@ JSON Output:
       "Portuguese": "Encontre-o {player_name}. Encontre-o e salve Arcadia. Jonathan nos salvará a todos. É a única maneira."
     }]
 );
+
+test_deserializer!(
+  test_localization2,
+  r#"
+  class Test {
+    id string
+    English string
+    Portuguese string?
+  }
+  "#,
+  r#"
+To effectively localize these strings for a Portuguese-speaking audience, I will focus on maintaining the original tone and meaning while ensuring that the translations sound natural and culturally appropriate. For the game title "Arcadian Atlas," I will keep it unchanged as it is a proper noun and likely a branded term within the game. For the other strings, I will adapt them to resonate with Portuguese players, using idiomatic expressions if necessary and ensuring that the sense of adventure and urgency is conveyed.
+
+For the string with the placeholder {player_name}, I will ensure that the placeholder is kept intact and that the surrounding text is grammatically correct and flows naturally in Portuguese. The name "Jonathan" will remain unchanged as it is a proper noun and recognizable in Portuguese.
+
+
+[
+  {
+    id: "CH1_Welcome",
+    English: "Welcome to Arcadian Atlas",
+    Portuguese: "Bem-vindo ao Arcadian Atlas"
+  },
+  {
+    id: "CH1_02",
+    English: "Arcadia is a vast land, with monsters and dangers!",
+    Portuguese: """Arcadia é uma terra vasta,
+
+repleta de monstros e perigos!"""
+  },
+  {
+    id: "CH1_03",
+    English: "Find him {player_name}. Find him and save Arcadia. Jonathan will save us all. It is the only way.",
+  }
+]
+  "#.trim(),
+  FieldType::class("Test").as_list(),
+  [{
+      "id": "CH1_Welcome",
+      "English": "Welcome to Arcadian Atlas",
+      "Portuguese": "Bem-vindo ao Arcadian Atlas"
+    },
+    {
+      "id": "CH1_02",
+      "English": "Arcadia is a vast land, with monsters and dangers!",
+      "Portuguese": "\"\"Arcadia é uma terra vasta,\n\nrepleta de monstros e perigos!\"\""
+    },
+    {
+      "id": "CH1_03",
+      "English": "Find him {player_name}. Find him and save Arcadia. Jonathan will save us all. It is the only way.",
+      "Portuguese": null
+    }]
+);


### PR DESCRIPTION
Added new unit tests to SAP tests for codeblocks which don't contain JSON but later have JSON that isn't in a code-block.

Added unit tests for optional fields being parsed correctly.

SAP now handles `"""<string>"""` values as well now. In the future we can also handle `'''<string>'''` values as well with similar logic.