### PR TITLE
bug: Fixed panic during logging for splitting on UTF-8 strings.

### DIFF
--- a/engine/baml-runtime/src/tracing/mod.rs
+++ b/engine/baml-runtime/src/tracing/mod.rs
@@ -5,7 +5,7 @@ use crate::InnerTraceStats;
 use anyhow::{Context, Result};
 use baml_types::{BamlMap, BamlMediaType, BamlValue};
 use cfg_if::cfg_if;
-use colored::Colorize;
+use colored::{ColoredString, Colorize};
 use internal_baml_jinja::RenderedPrompt;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -58,17 +58,53 @@ pub trait Visualize {
     fn visualize(&self, max_chunk_size: usize) -> String;
 }
 
+fn log_str() -> ColoredString {
+    "...[log trimmed]...".yellow().dimmed()
+}
+
 pub fn truncate_string(s: &str, max_size: usize) -> String {
     if max_size > 0 && s.len() > max_size {
         let half_size = max_size / 2;
-        format!(
-            "{}{}{}",
-            &s[..half_size],
-            "...[log trimmed]...".yellow().dimmed(),
-            &s[s.len() - half_size..]
-        )
+        // We use UTF-8 aware char_indices to get the correct byte index (can't just do s[..half_size])
+        let start = s
+            .char_indices()
+            .take(half_size)
+            .map(|(i, _)| i)
+            .last()
+            .unwrap_or(0);
+        let end = s
+            .char_indices()
+            .rev()
+            .take(half_size)
+            .map(|(i, _)| i)
+            .last()
+            .unwrap_or(s.len());
+        format!("{}{}{}", &s[..start], log_str(), &s[end..])
     } else {
         s.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_string() {
+        assert_eq!(truncate_string("1234567890", 10), "1234567890".to_string());
+        assert_eq!(
+            truncate_string("12345678901", 10),
+            format!("1234{}78901", log_str())
+        );
+        assert_eq!(truncate_string("12345678901", 0), "12345678901".to_string());
+    }
+
+    #[test]
+    fn test_unicode_truncate_string() {
+        assert_eq!(
+            truncate_string(r#"👍👍👍👍👍👍👍"#, 4),
+            format!(r#"👍{}👍👍"#, log_str())
+        );
     }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix panic in `truncate_string()` by using UTF-8 aware slicing and add tests for ASCII and Unicode strings.
> 
>   - **Behavior**:
>     - Fix panic in `truncate_string()` in `mod.rs` by using UTF-8 aware `char_indices` for string slicing.
>     - Handles both ASCII and Unicode strings correctly.
>   - **Tests**:
>     - Add `test_truncate_string()` and `test_unicode_truncate_string()` in `mod.rs` to verify correct behavior for ASCII and Unicode strings.
>   - **Misc**:
>     - Refactor log string creation into `log_str()` function in `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0f474ed10479cd2cbd4ec9defe78e5d3854f4879. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->