### PR TITLE
[BUGFIX] Parser should require a space between class keyword and class name

### DIFF
--- a/engine/baml-lib/schema-ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/schema-ast/src/parser/datamodel.pest
@@ -5,8 +5,7 @@ schema = {
 // ######################################
 // Unified Block for Class and Enum
 // ######################################
-type_expression_keyword  = { ENUM_KEYWORD | CLASS_KEYWORD | identifier }
-type_expression_block    = { type_expression_keyword ~ identifier ~ named_argument_list? ~ BLOCK_OPEN ~ type_expression_contents ~ BLOCK_CLOSE }
+type_expression_block    = { identifier ~ identifier ~ named_argument_list? ~ BLOCK_OPEN ~ type_expression_contents ~ BLOCK_CLOSE }
 type_expression_contents = {
     (type_expression | block_attribute | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)*
 }
@@ -174,8 +173,6 @@ BLOCK_LEVEL_CATCH_ALL = { !BLOCK_CLOSE ~ CATCH_ALL }
 CATCH_ALL             = { (!NEWLINE ~ ANY)+ ~ NEWLINE? }
 
 TYPE_KEYWORD         = { "type" }
-ENUM_KEYWORD         = { "enum" }
-CLASS_KEYWORD        = { "class" }
 FUNCTION_KEYWORD     = { "function" }
 TEMPLATE_KEYWORD     = { "template_string" | "string_template" }
 TEST_KEYWORD         = { "test" }

--- a/shell.nix
+++ b/shell.nix
@@ -13,8 +13,15 @@ let
     dependencies = [];
   };
 
+  appleDeps = with pkgs.darwin.apple_sdk.frameworks; [
+    CoreServices
+    SystemConfiguration
+    pkgs.libiconv-darwin
+  ];
+
 in
   pkgs.mkShell {
+
     buildInputs = with pkgs; [
       cargo
       rustc
@@ -23,7 +30,16 @@ in
       poetry
       rust-analyzer
       fern
-    ];
+      ruby
+    ] ++ (if pkgs.stdenv.isDarwin then appleDeps else []);
+
+    LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
+    BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin
+      then
+        "-I${pkgs.llvmPackages_18.libclang.lib}/lib/clang/18/headers "
+      else
+        "-isystem ${pkgs.llvmPackages_18.libclang.lib}/lib/clang/18/include -isystem ${pkgs.glibc.dev}/include";
+
     shellHook = ''
       export PROJECT_ROOT=/$(pwd)
       export PATH=/$PROJECT_ROOT/tools:$PATH


### PR DESCRIPTION
BAML's pest parser accepts the following BAML code, despite the lack of a space between `class` and `Foo`:

```
classFoo {
  name string
}
```

This PR changes the pest grammar to force a whitespace between the keyword (i.e. `class` or `enum`) and the name of the class or enum (i.e.`Foo`), and adds a regression test.

The grammar changes remove `type_expression_keyword` ( `type_expression_keyword = { ENUM_KEYWORD | CLASS_KEYWORD | identifier } `), and instead uses a simple `identifier` to capture the block type.

We could probably alternatively fix this by parsing `type_expression_block` with some combination of atomic rules and `type_expression_keyword ~ WHITESPACE+ ~ identifier ...`. However our existing rules interact in subtle ways making it hard to find a working solution here. It is arguably better to remove `type_expression_keyword` anyway, in the spirit of doing less validation in pest and more in Rust.

## Testing done
 - [x] Unit tests
 - [ ] Integ tests
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes BAML parser to require whitespace between `class`/`enum` keywords and names, updates grammar and parser logic, and adds regression test.
> 
>   - **Behavior**:
>     - Enforces mandatory whitespace between `class`/`enum` keywords and names in `datamodel.pest`.
>     - Removes `type_expression_keyword` rule, using `identifier` instead.
>     - Adds regression test in `parse_type_expression_block.rs` to ensure whitespace is required.
>   - **Parser Logic**:
>     - Updates `parse_type_expression_block()` to handle two `identifier` rules for block type and name.
>   - **Shell Environment**:
>     - Updates `shell.nix` to include `appleDeps` for macOS builds and adjusts `BINDGEN_EXTRA_CLANG_ARGS`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 74e1535fbcfdd5ff3e310440bd796c7704efdb27. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->