### PR TITLE
Type Attributes

### DIFF
--- a/engine/baml-lib/diagnostics/src/span.rs
+++ b/engine/baml-lib/diagnostics/src/span.rs
@@ -64,6 +64,13 @@ impl Span {
             _ => ((0, 0), (0, 0)),
         }
     }
+
+    /// Create a fake span. Useful when generating test data that requires
+    /// spans but doesn't check spans.
+    pub fn fake() -> Span {
+        let fake_source = ("fake-file.baml".into(), "fake contents").into();
+        Span::empty(fake_source)
+    }
 }
 
 impl From<(SourceFile, pest::Span<'_>)> for Span {

--- a/engine/baml-lib/parser-database/src/context/mod.rs
+++ b/engine/baml-lib/parser-database/src/context/mod.rs
@@ -83,8 +83,6 @@ impl<'db> Context<'db> {
     ///
     /// - When you are done validating an attribute, you must call `discard_arguments()` or
     ///   `validate_visited_arguments()`. Otherwise, Context will helpfully panic.
-    /// - When you are done validating an attribute set, you must call
-    ///   `validate_visited_attributes()`. Otherwise, Context will helpfully panic.
     pub(super) fn visit_attributes(&mut self, ast_attributes: ast::AttributeContainer) {
         if self.attributes.attributes.is_some() || !self.attributes.unused_attributes.is_empty() {
             panic!(

--- a/engine/baml-lib/schema-ast/src/ast/argument.rs
+++ b/engine/baml-lib/schema-ast/src/ast/argument.rs
@@ -56,6 +56,12 @@ pub struct Argument {
     pub span: Span,
 }
 
+impl Argument {
+    pub fn assert_eq_up_to_span(&self, other: &Argument) {
+        assert_eq!(self.to_string(), other.to_string())
+    }
+}
+
 impl Display for Argument {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         Display::fmt(&self.value, f)

--- a/engine/baml-lib/schema-ast/src/ast/attribute.rs
+++ b/engine/baml-lib/schema-ast/src/ast/attribute.rs
@@ -19,6 +19,10 @@ pub struct Attribute {
     ///         ^^^^^^^^^^^^^^^^^^^^^^^^
     /// ```
     pub arguments: ArgumentsList,
+    /// Whether the Attribute was closely associated to a type, via parentheses.
+    /// This flag protects attributes from being lifted away from a union variant
+    /// up to the level of the union.
+    pub parenthesized: bool,
     /// The AST span of the node.
     pub span: Span,
 }
@@ -27,6 +31,19 @@ impl Attribute {
     /// Try to find the argument and return its span.
     pub fn span_for_argument(&self, argument: ArguementId) -> Span {
         self.arguments[argument].span.clone()
+    }
+
+    pub fn assert_eq_up_to_span(&self, other: &Attribute) {
+        assert_eq!(self.name.to_string(), other.name.to_string());
+        assert_eq!(self.parenthesized, other.parenthesized);
+        self
+            .arguments
+            .iter()
+            .zip(other.arguments.iter())
+            .for_each(|(arg1, arg2)| {
+                assert_eq!(arg1.0, arg2.0);
+                arg1.1.assert_eq_up_to_span(arg2.1);
+            })
     }
 }
 

--- a/engine/baml-lib/schema-ast/src/ast/expression.rs
+++ b/engine/baml-lib/schema-ast/src/ast/expression.rs
@@ -136,7 +136,7 @@ impl RawString {
 
     pub fn assert_eq_up_to_span(&self, other: &RawString) {
         assert_eq!(self.inner_value, other.inner_value);
-        assert_eq!(self.raw_value, other.inner_value);
+        assert_eq!(self.raw_value, other.raw_value);
         assert_eq!(self.language, other.language);
         assert_eq!(self.indent, other.indent);
     }

--- a/engine/baml-lib/schema-ast/src/ast/identifier.rs
+++ b/engine/baml-lib/schema-ast/src/ast/identifier.rs
@@ -1,5 +1,3 @@
-use baml_types::{BamlMediaType, TypeValue};
-
 use super::{Span, WithName, WithSpan};
 use std::fmt::Display;
 
@@ -65,6 +63,22 @@ impl Identifier {
             Identifier::Ref(_, _) => false,
 
             Identifier::Invalid(_, _) => false,
+        }
+    }
+
+    pub fn assert_eq_up_to_span(&self, other: &Identifier) {
+        use Identifier::*;
+        match (self, other) {
+            (ENV(e1,_), ENV(e2, _)) => assert_eq!(e1, e2),
+            (ENV(_,_), _) => panic!("Mismatched identifiers: {:?}, {:?}", self, other),
+            (Local(l1,_), Local(l2,_)) => assert_eq!(l1, l2),
+            (Local(_,_), _) => panic!("Mismatched identifiers: {:?}, {:?}", self, other),
+            (Ref(r1,_), Ref(r2,_)) => assert_eq!(r1, r2),
+            (Ref(_,_), _) => panic!("Mismatched identifiers: {:?}, {:?}", self, other),
+            (Identifier::String(s1,_), Identifier::String(s2,_)) => assert_eq!(s1,s2),
+            (Identifier::String(_,_), _) => panic!("Mismatched identifiers: {:?}, {:?}", self, other),
+            (Invalid(i1,_), Invalid(i2,_)) => assert_eq!(i1,i2),
+            (Invalid(_,_), _) => panic!("Mismatched identifiers: {:?}, {:?}", self, other),
         }
     }
 }

--- a/engine/baml-lib/schema-ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/schema-ast/src/parser/datamodel.pest
@@ -13,7 +13,7 @@ type_expression          = {
     identifier ~ field_type_chain? ~ (NEWLINE? ~ (field_attribute | trailing_comment))* ~ NEWLINE?
 }
 
-field_operator       = { "|" | "&" }
+field_operator       = { "|" }
 field_type_chain     = { field_type_with_attr ~ (field_operator ~ field_type_with_attr)* }
 field_type_with_attr = { field_type ~ (NEWLINE? ~ (field_attribute | trailing_comment))* }
 
@@ -21,7 +21,7 @@ field_type_with_attr = { field_type ~ (NEWLINE? ~ (field_attribute | trailing_co
 // Unified Block for Function, Test, Client, Generator
 // ######################################
 value_expression_keyword  = { FUNCTION_KEYWORD | TEST_KEYWORD | CLIENT_KEYWORD | RETRY_POLICY_KEYWORD | GENERATOR_KEYWORD }
-value_expression_block    = { value_expression_keyword ~ identifier ~ named_argument_list? ~ ARROW? ~ field_type? ~ SPACER_TEXT ~ BLOCK_OPEN ~ value_expression_contents ~ BLOCK_CLOSE }
+value_expression_block    = { value_expression_keyword ~ identifier ~ named_argument_list? ~ ARROW? ~ field_type_chain? ~ SPACER_TEXT ~ BLOCK_OPEN ~ value_expression_contents ~ BLOCK_CLOSE }
 value_expression_contents = {
     (value_expression | comment_block | empty_lines | BLOCK_LEVEL_CATCH_ALL)*
 }
@@ -37,7 +37,7 @@ assignment           = { "=" }
 template_declaration = { TEMPLATE_KEYWORD ~ identifier ~ assignment? ~ named_argument_list? ~ raw_string_literal }
 
 colon          = { ":" }
-named_argument = { identifier ~ ((":" ~ field_type) | colon)? }
+named_argument = { identifier ~ ((":" ~ field_type_chain) | colon)? }
 // Be forgiving and allow trailing comma
 named_argument_list = { openParan ~ SPACER_TEXT ~ named_argument? ~ ("," ~ SPACER_TEXT ~ named_argument)* ~ ","? ~ SPACER_TEXT ~ closeParan }
 
@@ -61,8 +61,8 @@ map = { "map" ~ "<" ~ field_type ~ "," ~ field_type ~ ">" }
 
 openParan  = { "(" }
 closeParan = { ")" }
-group      = { openParan ~ field_type ~ closeParan }
-tuple      = { openParan ~ field_type ~ ("," ~ field_type)+ ~ closeParan }
+group      = { openParan ~ field_type ~ (field_attribute)* ~ closeParan }
+tuple      = { openParan ~ field_type_with_attr ~ ("," ~ field_type_with_attr)+ ~ closeParan }
 
 base_type_without_array = { map | identifier | group | tuple }
 

--- a/engine/baml-lib/schema-ast/src/parser/helpers.rs
+++ b/engine/baml-lib/schema-ast/src/parser/helpers.rs
@@ -51,3 +51,26 @@ macro_rules! unreachable_rule {
         )
     };
 }
+
+#[macro_export]
+macro_rules! test_parse_baml_type {
+    ( source: $source:expr, target: $target:expr, $(,)* ) => {
+        use crate::parser::{BAMLParser, Rule};
+        use internal_baml_diagnostics::{Diagnostics, SourceFile};
+        use pest::Parser;
+
+        let root_path = "test_file.baml";
+        let source = SourceFile::new_static(root_path.into(), $source);
+        let mut diagnostics = Diagnostics::new(root_path.into());
+        diagnostics.set_source(&source);
+
+        let parsed = BAMLParser::parse(Rule::field_type_chain, $source)
+            .expect("Pest parsing should succeed")
+            .next()
+            .unwrap();
+        let type_ =
+            parse_field_type_chain(parsed, &mut diagnostics).expect("Type parsing should succeed");
+
+        type_.assert_eq_up_to_span(&$target);
+    };
+}

--- a/engine/baml-lib/schema-ast/src/parser/parse_attribute.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_attribute.rs
@@ -7,6 +7,7 @@ use crate::{assert_correct_parser, ast::*, parser::parse_arguments::parse_argume
 
 pub(crate) fn parse_attribute(
     pair: Pair<'_>,
+    parenthesized: bool,
     diagnostics: &mut internal_baml_diagnostics::Diagnostics,
 ) -> Attribute {
     assert_correct_parser!(pair, Rule::block_attribute, Rule::field_attribute);
@@ -29,6 +30,7 @@ pub(crate) fn parse_attribute(
         Some(name) => Attribute {
             name,
             arguments,
+            parenthesized,
             span,
         },
         // This is suspicious, can probably cause a panic

--- a/engine/baml-lib/schema-ast/src/parser/parse_named_args_list.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_named_args_list.rs
@@ -1,7 +1,8 @@
 use internal_baml_diagnostics::Diagnostics;
 
 use super::{
-    helpers::parsing_catch_all, parse_identifier::parse_identifier, parse_types::parse_field_type,
+    helpers::parsing_catch_all, parse_field::parse_field_type_chain,
+    parse_identifier::parse_identifier,
 };
 use crate::{
     assert_correct_parser,
@@ -46,7 +47,7 @@ pub(crate) fn parse_named_argument_list(
                     name = Some(parse_identifier(arg, diagnostics));
                 }
                 Rule::colon => {}
-                Rule::field_type => {
+                Rule::field_type | Rule::field_type_chain => {
                     r#type = Some(parse_function_arg(arg, diagnostics)?);
                 }
                 _ => parsing_catch_all(arg, "named_argument_list"),
@@ -80,13 +81,13 @@ pub fn parse_function_arg(
     diagnostics: &mut Diagnostics,
 ) -> Result<BlockArg, DatamodelError> {
     assert!(
-        pair.as_rule() == Rule::field_type,
+        [Rule::field_type, Rule::field_type_chain].contains(&pair.as_rule()),
         "parse_function_arg called on the wrong rule: {:?}",
         pair.as_rule()
     );
     let span = diagnostics.span(pair.as_span());
 
-    match parse_field_type(pair, diagnostics) {
+    match parse_field_type_chain(pair, diagnostics) {
         Some(ftype) => Ok(BlockArg {
             span,
             field_type: ftype,

--- a/engine/baml-lib/schema-ast/src/parser/parse_types.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_types.rs
@@ -13,12 +13,12 @@ pub fn parse_field_type(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option
 
     let mut arity = FieldArity::Required;
     let mut ftype = None;
+    let mut attributes = Vec::new();
 
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::union => {
                 let result = parse_union(current, diagnostics);
-
                 ftype = result;
             }
             Rule::non_union => {
@@ -26,9 +26,10 @@ pub fn parse_field_type(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option
 
                 ftype = result;
             }
-            Rule::optional_token => {
-                arity = FieldArity::Optional;
+            Rule::field_attribute => {
+                attributes.push(parse_attribute(current, false, diagnostics));
             }
+            Rule::optional_token => arity = FieldArity::Optional,
             _ => {
                 unreachable_rule!(current, Rule::field_type)
             }
@@ -44,8 +45,7 @@ pub fn parse_field_type(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option
             }
         }
         None => {
-            log::error!("Ftype should always be defined");
-            None
+            unreachable!("Ftype should always be defined")
         }
     }
 }
@@ -73,11 +73,13 @@ fn parse_union(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<FieldTyp
         }
     }
 
-    match types.len() {
+    let mut union = match types.len() {
         0 => unreachable!("A union must have atleast 1 type"),
         1 => Some(types[0].to_owned()),
         _ => Some(FieldType::Union(FieldArity::Required, types, span, None)),
-    }
+    };
+    union.as_mut().map(|ft| reassociate_union_attributes(ft));
+    union
 }
 
 fn parse_base_type_with_attr(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<FieldType> {
@@ -90,7 +92,7 @@ fn parse_base_type_with_attr(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> O
                 base_type = parse_base_type(current, diagnostics);
             }
             Rule::field_attribute => {
-                let att = parse_attribute(current, diagnostics);
+                let att = parse_attribute(current, false, diagnostics);
                 attributes.push(att);
             }
             _ => unreachable_rule!(current, Rule::base_type_with_attr),
@@ -99,7 +101,7 @@ fn parse_base_type_with_attr(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> O
 
     match base_type {
         Some(mut ft) => {
-            ft.set_attributes(attributes);
+            ft.extend_attributes(attributes);
             Some(ft)
         }
         None => None,
@@ -163,7 +165,7 @@ fn parse_parenthesized_type(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Op
         match current.as_rule() {
             Rule::openParan | Rule::closeParan => continue,
             Rule::field_type_with_attr => {
-                return parse_field_type_with_attr(current, diagnostics);
+                return parse_field_type_with_attr(current, true, diagnostics);
             }
             _ => unreachable_rule!(current, Rule::parenthesized_type),
         }
@@ -230,18 +232,27 @@ fn parse_map(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<FieldType>
 
 fn parse_group(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<FieldType> {
     assert_correct_parser!(pair, Rule::group);
+    let mut attributes = Vec::new();
+    let mut field_type = None;
 
     for current in pair.into_inner() {
         match current.as_rule() {
             Rule::openParan | Rule::closeParan => continue,
             Rule::field_type => {
-                return parse_field_type(current, diagnostics);
+                field_type = parse_field_type(current, diagnostics);
+            }
+            Rule::field_attribute => {
+                let attr = parse_attribute(current, true, diagnostics);
+                attributes.push(attr);
             }
             _ => unreachable_rule!(current, Rule::group),
         }
     }
 
-    unreachable!("impossible group parsing");
+    field_type
+        .as_mut()
+        .map(|ft| ft.extend_attributes(attributes));
+    field_type
 }
 
 fn parse_tuple(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<FieldType> {
@@ -255,6 +266,11 @@ fn parse_tuple(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<FieldTyp
         match current.as_rule() {
             Rule::openParan | Rule::closeParan => continue,
 
+            Rule::field_type_with_attr => {
+                if let Some(f) = parse_field_type_with_attr(current, false, diagnostics) {
+                    fields.push(f)
+                }
+            }
             Rule::field_type => {
                 if let Some(f) = parse_field_type(current, diagnostics) {
                     fields.push(f)
@@ -268,5 +284,67 @@ fn parse_tuple(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<FieldTyp
         0 => None,
         1 => Some(fields[0].to_owned()),
         _ => Some(FieldType::Tuple(FieldArity::Required, fields, span, None)),
+    }
+}
+
+/// For the last variant of a Union, remove the attributes from that variant
+/// and attach them to the union, unless the attribute was tagged with the
+/// `parenthesized` field.
+///
+/// This is done because `field_foo int | string @description("d")`
+/// is naturally parsed as a field with a union whose secord variant has
+/// a description. But the correct BAML interpretation is a union with a
+/// description.
+pub fn reassociate_union_attributes(field_type: &mut FieldType) {
+    match field_type {
+        FieldType::Union(_arity, ref mut variants, _, _) => {
+            if let Some(last_variant) = variants.last_mut() {
+                let last_variant_attributes = last_variant.attributes().to_owned();
+                let (attrs_for_variant, attrs_for_union): (Vec<Attribute>, Vec<Attribute>) =
+                    last_variant_attributes
+                        .into_iter()
+                        .partition(|attr| attr.parenthesized);
+                last_variant.set_attributes(attrs_for_variant);
+                field_type.extend_attributes(attrs_for_union);
+            }
+        }
+        _ => {
+            panic!("Unexpected: `reassociate_union_attributes` should only be called when parsing a union.");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{BAMLParser, Rule};
+    use pest::{consumes_to, parses_to};
+
+    #[test]
+    fn type_attributes() {
+        parses_to! {
+            parser: BAMLParser,
+            input: r#"int @description("hi")"#,
+            rule: Rule::type_expression,
+            tokens: [type_expression(0,22,[
+                identifier(0,3, [
+                    single_word(0, 3)
+                ]),
+                field_attribute(4,22,[
+                    identifier(5,16,[
+                        single_word(5,16)
+                    ]),
+                    arguments_list(16, 22, [
+                        expression(17,21, [
+                            string_literal(17,21,[
+                                quoted_string_literal(17,21,[
+                                  quoted_string_content(18,20)
+                                ])
+                            ])
+                        ])
+                    ])
+                ])
+              ])
+            ]
+        }
     }
 }

--- a/engine/baml-lib/schema-ast/src/parser/parse_value_expression_block.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_value_expression_block.rs
@@ -42,7 +42,7 @@ pub(crate) fn parse_value_expression_block(
                 Ok(arg) => input = Some(arg),
                 Err(err) => diagnostics.push_error(err),
             },
-            Rule::field_type => match parse_function_arg(current, diagnostics) {
+            Rule::field_type | Rule::field_type_chain => match parse_function_arg(current, diagnostics) {
                 Ok(arg) => output = Some(arg),
                 Err(err) => diagnostics.push_error(err),
             },

--- a/integ-tests/python/README.md
+++ b/integ-tests/python/README.md
@@ -5,5 +5,5 @@ infisical run --env=dev -- poetry run pytest app/test_functions.py
 
 env -u CONDA_PREFIX poetry run maturin develop --manifest-path ../../engine/language_client_python/Cargo.toml && poetry run baml-cli generate --from ../baml_src
 
-BAML_LOG=baml_events infisical run --env=test -- poetry run pytest app/test_functions.py -s
+BAML_LOG=baml_events infisical run --env=test -- poetry run pytest tests/test_functions.py -s
 ```

--- a/shell.nix
+++ b/shell.nix
@@ -1,7 +1,8 @@
 let
-  pkgs = import <nixpkgs> {};
+  pkgs = import <nixpkgs> { };
 
-  nodeEnv = pkgs.callPackage <nixpkgs/pkgs/development/node-packages/node-env.nix> {};
+  nodeEnv =
+    pkgs.callPackage <nixpkgs/pkgs/development/node-packages/node-env.nix> { };
   fern = nodeEnv.buildNodePackage rec {
     name = "fern-api";
     packageName = "fern-api";
@@ -10,7 +11,7 @@ let
       url = "https://registry.npmjs.org/fern-api/-/fern-api-${version}.tgz";
       sha256 = "sha256-jaKXJsvgjRPpm2ojB6a2hkEAmk7NrfcTA28MLl3VjHg=";
     };
-    dependencies = [];
+    dependencies = [ ];
   };
 
   appleDeps = with pkgs.darwin.apple_sdk.frameworks; [
@@ -19,11 +20,12 @@ let
     pkgs.libiconv-darwin
   ];
 
-in
-  pkgs.mkShell {
+in pkgs.mkShell {
 
-    buildInputs = with pkgs; [
+  buildInputs = with pkgs;
+    [
       cargo
+      cargo-watch
       rustc
       rustfmt
       maturin
@@ -33,17 +35,17 @@ in
       rust-analyzer
       fern
       ruby
-    ] ++ (if pkgs.stdenv.isDarwin then appleDeps else []);
+      nixfmt-classic
+    ] ++ (if pkgs.stdenv.isDarwin then appleDeps else [ ]);
 
-    LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
-    BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin
-      then
-        "-I${pkgs.llvmPackages_18.libclang.lib}/lib/clang/18/headers "
-      else
-        "-isystem ${pkgs.llvmPackages_18.libclang.lib}/lib/clang/18/include -isystem ${pkgs.glibc.dev}/include";
+  LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
+  BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin then
+    "-I${pkgs.llvmPackages_18.libclang.lib}/lib/clang/18/headers "
+  else
+    "-isystem ${pkgs.llvmPackages_18.libclang.lib}/lib/clang/18/include -isystem ${pkgs.glibc.dev}/include";
 
-    shellHook = ''
-      export PROJECT_ROOT=/$(pwd)
-      export PATH=/$PROJECT_ROOT/tools:$PATH
-    '';
-  }
+  shellHook = ''
+    export PROJECT_ROOT=/$(pwd)
+    export PATH=/$PROJECT_ROOT/tools:$PATH
+  '';
+}


### PR DESCRIPTION
This PR makes it possible to add attributes to types in more contexts.

 - Function parameters can have attributes
 - Function return types can have attributes
 - Shuffling attributes between union variants and the top-level union is handled more explicitly
 - We have new unit tests for attributes attached to components of compound types, e.g. union variants with and without parentheses

## Testing done
 - [x] unit tests
 - [x] python integ-tests
 - [ ] TS integ-tests
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable attributes on function parameters and return types, refine union attribute handling, and add related tests.
> 
>   - **Behavior**:
>     - Allow attributes on function parameters and return types.
>     - Explicit handling of attribute shuffling between union variants and top-level union.
>     - New unit tests for attributes on compound types, including union variants.
>   - **Parsing**:
>     - Update `datamodel.pest` to support attributes in `field_type_chain` and `field_type_with_attr`.
>     - Modify `parse_field.rs` and `parse_types.rs` to handle new attribute contexts.
>     - Add `reassociate_union_attributes()` in `parse_types.rs` for union attribute handling.
>   - **Misc**:
>     - Add `fake()` method to `Span` in `span.rs` for testing.
>     - Update `README.md` in `integ-tests/python` to fix test command path.
>     - Minor formatting changes in `shell.nix`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for daccdab760f86eb323f1bb6480d120f2f4f44854. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->