### PR TITLE
Add bamlvalidationerrrors to http server

### DIFF
--- a/docs/docs/calling-baml/exceptions.mdx
+++ b/docs/docs/calling-baml/exceptions.mdx
@@ -31,12 +31,12 @@ Not available yet
 
 Base class for all BAML exceptions.  
 
-<ResponseField
-  name="message"
+<ParamField
+  path="message"
   type="string"
 >
   A human-readable error message.
-</ResponseField>
+</ParamField>
 
 ### BamlInvalidArgumentError
 
@@ -60,8 +60,8 @@ Subclass of `BamlClientError`.
 
 Raised when the HTTP request made by a client fails with a non-200 status code.
 
-<ResponseField
-  name="status_code"
+<ParamField
+  path="status_code"
   type="int"
 >
   The status code of the response.
@@ -76,7 +76,7 @@ Common status codes are:
 - 404: Not Found
 - 429: Too Many Requests
 - 500: Internal Server Error
-</ResponseField>
+</ParamField>
 
 ### BamlValidationError
 
@@ -84,9 +84,23 @@ Subclass of `BamlError`.
 
 Raised when BAML fails to parse a string from the LLM into the specified object.
 
-<ResponseField
-  name="raw_llm_response"
+<ParamField
+  path="raw_output"
   type="string"
 >
   The raw text from the LLM that failed to parse into the expected return type of a function.
-</ResponseField>
+</ParamField>
+
+<ParamField
+  path="message"
+  type="string"
+>
+  The parsing-related error message.
+</ParamField>
+
+<ParamField
+  path="prompt"
+  type="string"
+>
+  The original prompt that was sent to the LLM, formatted as a plain string. Images sent as base64-encoded strings are not serialized into this field.
+</ParamField>

--- a/docs/docs/calling-baml/set-env-vars.mdx
+++ b/docs/docs/calling-baml/set-env-vars.mdx
@@ -55,7 +55,7 @@ import os
 import dotenv
 
 dotenv.load_dotenv()
-reset_baml_env_vars(os.environ)
+reset_baml_env_vars(dict(os.environ))
 ```
 
 ```typescript TypeScript

--- a/engine/baml-runtime/src/cli/serve/arg_validation.rs
+++ b/engine/baml-runtime/src/cli/serve/arg_validation.rs
@@ -12,9 +12,9 @@ impl BamlServeValidate for BamlValue {
         match &self {
           BamlValue::Media(m) => {
             match m.content {
-              BamlMediaContent::File(_) => Err(BamlError::InvalidArgument(
-                format!("BAML-over-HTTP only supports URLs and base64-encoded {} media (file is invalid)", m.media_type)
-              )),
+              BamlMediaContent::File(_) => Err(BamlError::InvalidArgument {
+                message: format!("BAML-over-HTTP only supports URLs and base64-encoded {} media (file is invalid)", m.media_type)
+              }),
               BamlMediaContent::Url(_) => Ok(()),
               BamlMediaContent::Base64(_) => Ok(()),
             }

--- a/engine/baml-runtime/src/cli/serve/error.rs
+++ b/engine/baml-runtime/src/cli/serve/error.rs
@@ -15,14 +15,22 @@ use super::json_response::Json;
 /// Variant names are deliberately redundant with the name of this enum: the variant
 /// names are what we show to users, so it's important that they're self-evident.
 #[derive(Debug, Serialize)]
-#[serde(tag = "error", content = "message", rename_all = "snake_case")]
+#[serde(tag = "error", rename_all = "snake_case")]
 pub enum BamlError {
-    InvalidArgument(String),
-    ClientError(String),
-    ValidationFailure(String),
+    #[serde(rename_all = "snake_case")]
+    InvalidArgument { message: String },
+    #[serde(rename_all = "snake_case")]
+    ClientError { message: String },
+    #[serde(rename_all = "snake_case")]
+    ValidationFailure {
+        prompt: String,
+        raw_output: String,
+        message: String,
+    },
     /// This is the only variant not documented at the aforementioned link:
     /// this is the catch-all for unclassified errors.
-    InternalError(String),
+    #[serde(rename_all = "snake_case")]
+    InternalError { message: String },
 }
 
 impl BamlError {
@@ -31,21 +39,27 @@ impl BamlError {
             match er {
                 ExposedError::ValidationError {
                     prompt,
-                    raw_response,
+                    raw_output,
                     message,
-                } => Self::ValidationFailure(format!("{:?}", err)),
+                } => Self::ValidationFailure {
+                    prompt: prompt.to_string(),
+                    raw_output: raw_output.to_string(),
+                    message: message.to_string(),
+                },
             }
         } else if let Some(er) = err.downcast_ref::<ScopeStack>() {
-            Self::InvalidArgument(format!("{:?}", er))
+            Self::InvalidArgument {
+                message: format!("{:?}", er),
+            }
         } else if let Some(er) = err.downcast_ref::<LLMResponse>() {
             match er {
-                LLMResponse::Success(_) => {
-                    Self::InternalError(format!("Unexpected error from BAML: {:?}", err))
-                }
+                LLMResponse::Success(_) => Self::InternalError {
+                    message: format!("Unexpected error from BAML: {:?}", err),
+                },
                 LLMResponse::LLMFailure(failed) => match &failed.code {
-                    crate::internal::llm_client::ErrorCode::Other(2) => Self::InternalError(
-                        format!("Something went wrong with the LLM client: {:?}", err),
-                    ),
+                    crate::internal::llm_client::ErrorCode::Other(2) => Self::InternalError {
+                        message: format!("Something went wrong with the LLM client: {:?}", err),
+                    },
                     crate::internal::llm_client::ErrorCode::Other(_)
                     | crate::internal::llm_client::ErrorCode::InvalidAuthentication
                     | crate::internal::llm_client::ErrorCode::NotSupported
@@ -53,19 +67,22 @@ impl BamlError {
                     | crate::internal::llm_client::ErrorCode::ServerError
                     | crate::internal::llm_client::ErrorCode::ServiceUnavailable
                     | crate::internal::llm_client::ErrorCode::UnsupportedResponse(_) => {
-                        Self::ClientError(format!("{:?}", err))
+                        Self::ClientError {
+                            message: format!("{:?}", err),
+                        }
                     }
                 },
-                LLMResponse::UserFailure(msg) => {
-                    Self::InvalidArgument(format!("Invalid argument: {}", msg))
-                }
-                LLMResponse::InternalFailure(_) => Self::InternalError(format!(
-                    "Something went wrong with the LLM client: {}",
-                    err
-                )),
+                LLMResponse::UserFailure(msg) => Self::InvalidArgument {
+                    message: format!("Invalid argument: {}", msg),
+                },
+                LLMResponse::InternalFailure(_) => Self::InternalError {
+                    message: format!("Something went wrong with the LLM client: {}", err),
+                },
             }
         } else {
-            Self::InternalError(format!("{:?}", err))
+            Self::InternalError {
+                message: format!("{:?}", err),
+            }
         }
     }
 }
@@ -74,10 +91,10 @@ impl IntoResponse for BamlError {
     fn into_response(self) -> Response {
         (
             match &self {
-                BamlError::InvalidArgument(_) => StatusCode::BAD_REQUEST,
-                BamlError::ClientError(_) => StatusCode::BAD_GATEWAY,
-                BamlError::ValidationFailure(_) => StatusCode::INTERNAL_SERVER_ERROR, // ??? - FIXME
-                BamlError::InternalError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+                BamlError::InvalidArgument { .. } => StatusCode::BAD_REQUEST,
+                BamlError::ClientError { .. } => StatusCode::BAD_GATEWAY,
+                BamlError::ValidationFailure { .. } => StatusCode::INTERNAL_SERVER_ERROR, // ??? - FIXME
+                BamlError::InternalError { .. } => StatusCode::INTERNAL_SERVER_ERROR,
             },
             Json(match serde_json::to_value(&self) {
                 Ok(serde_json::Value::Object(mut v)) => {

--- a/engine/baml-runtime/src/errors.rs
+++ b/engine/baml-runtime/src/errors.rs
@@ -2,7 +2,7 @@ pub enum ExposedError {
     /// Error in parsing post calling the LLM
     ValidationError {
         prompt: String,
-        raw_response: String,
+        raw_output: String,
         message: String,
     },
 }
@@ -14,13 +14,13 @@ impl std::fmt::Display for ExposedError {
         match self {
             ExposedError::ValidationError {
                 prompt,
-                raw_response,
+                raw_output,
                 message,
             } => {
                 write!(
                     f,
                     "Parsing error: {}\nPrompt: {}\nRaw Response: {}",
-                    message, prompt, raw_response
+                    message, prompt, raw_output
                 )
             }
         }

--- a/engine/baml-runtime/src/types/response.rs
+++ b/engine/baml-runtime/src/types/response.rs
@@ -110,7 +110,7 @@ impl FunctionResult {
                             LLMResponse::LLMFailure(err) => err.prompt.to_string(),
                             _ => "N/A".to_string(),
                         },
-                        raw_response: self
+                        raw_output: self
                             .llm_response()
                             .content()
                             .unwrap_or_default()

--- a/engine/language_client_python/src/errors.rs
+++ b/engine/language_client_python/src/errors.rs
@@ -115,7 +115,7 @@ impl BamlError {
             match er {
                 ExposedError::ValidationError {
                     prompt,
-                    raw_response,
+                    raw_output,
                     message,
                 } => {
                     // Assuming ValidationError has fields that correspond to prompt, message, and raw_output
@@ -124,7 +124,7 @@ impl BamlError {
                         raise_baml_validation_error(
                             prompt.clone(),
                             message.clone(),
-                            raw_response.clone(),
+                            raw_output.clone(),
                         )
                     })
                 }

--- a/engine/language_client_typescript/src/errors.rs
+++ b/engine/language_client_typescript/src/errors.rs
@@ -18,7 +18,7 @@ pub fn from_anyhow_error(err: anyhow::Error) -> napi::Error {
             ExposedError::ValidationError {
                 prompt,
                 message,
-                raw_response,
+                raw_output: raw_response,
             } => throw_baml_validation_error(prompt, raw_response, message),
         }
     } else if let Some(er) = err.downcast_ref::<ScopeStack>() {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance BAML error handling by introducing structured error responses and updating documentation and tests accordingly.
> 
>   - **Error Handling**:
>     - Update `BamlError` in `error.rs` to include structured fields for `InvalidArgument`, `ClientError`, `ValidationFailure`, and `InternalError`.
>     - Modify `from_anyhow` in `error.rs` to handle `ExposedError::ValidationError` with detailed fields.
>     - Update `arg_validation.rs` to use structured `BamlError` for media validation errors.
>   - **Documentation**:
>     - Change `ResponseField` to `ParamField` in `exceptions.mdx` for error documentation.
>     - Add detailed fields for `BamlValidationError` in `exceptions.mdx`.
>   - **Tests**:
>     - Add test `call_function_validation_error` in `test_cli.rs` to verify structured error response.
>   - **Miscellaneous**:
>     - Update `set-env-vars.mdx` to use `dict(os.environ)` in Python example.
>     - Rename `raw_response` to `raw_output` in `errors.rs` and related files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for a508957d8fa17d9e936c39ffc14bf553e8d88166. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->