### PR TITLE
Disable eslint during promptfiddle build

### DIFF
--- a/typescript/fiddle-frontend/next.config.mjs
+++ b/typescript/fiddle-frontend/next.config.mjs
@@ -2,6 +2,9 @@
 const nextConfig = {
   transpilePackages: ['jotai-devtools', '@baml/playground-common', '@gloo-ai/baml-schema-wasm-web', '@baml/common'],
   productionBrowserSourceMaps: true,
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
   webpack(config, { isServer, dev }) {
     config.experiments = {
       ...config.experiments,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable ESLint during builds in `next.config.mjs`.
> 
>   - **Build Configuration**:
>     - Disable ESLint during builds in `next.config.mjs` by setting `eslint.ignoreDuringBuilds` to `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 208a3c28c9ee16e88411a8208f70f83c15bb25b5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->