### PR TITLE
Revert "feat: add a WYSIWYG UI (Swagger UI) to `baml-cli dev` (#1011)"

### DIFF
--- a/engine/baml-runtime/src/cli/serve/json_response.rs
+++ b/engine/baml-runtime/src/cli/serve/json_response.rs
@@ -1,11 +1,14 @@
 use axum::{
     http::{HeaderValue, StatusCode},
-    response::{IntoResponse, Response},
+    response::{
+        IntoResponse, Response,
+    },
 };
 use bytes::{BufMut, BytesMut};
 use http::header;
 use serde::Serialize;
-use std::io::Write;
+use std::{io::Write};
+
 
 pub(super) struct Json<T: Serialize>(pub T);
 

--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -4,7 +4,6 @@ mod json_response;
 mod ping;
 use error::BamlError;
 use indexmap::IndexMap;
-use internal_baml_codegen::GeneratorArgs;
 use json_response::Json;
 
 use anyhow::{Context, Result};
@@ -15,15 +14,15 @@ use axum::{
     middleware::Next,
     response::{
         sse::{Event, KeepAlive, Sse},
-        Html, IntoResponse, Response,
+        IntoResponse, Response,
     },
-    routing::{any, get, post},
+    routing::{any, post},
 };
 use axum_extra::{
     headers::{self, authorization::Basic, Authorization, Header},
     TypedHeader,
 };
-use baml_types::{BamlValue, GeneratorDefaultClientMode};
+use baml_types::BamlValue;
 use core::pin::Pin;
 use futures::Stream;
 use serde::{Deserialize, Serialize};
@@ -36,7 +35,6 @@ use crate::{
     client_registry::ClientRegistry, errors::ExposedError, internal::llm_client::LLMResponse,
     BamlRuntime, FunctionResult, RuntimeContextManager,
 };
-use internal_baml_codegen::openapi::OpenApiSchema;
 
 #[derive(clap::Args, Clone, Debug)]
 pub struct ServeArgs {
@@ -298,14 +296,6 @@ impl Server {
             "/stream/:msg",
             post(move |b_fn, b_args| s.clone().baml_stream_axum2(b_fn, b_args)),
         );
-        let s = self.clone();
-        let app = app.route("/docs", get(move || s.clone().docs_handler()));
-
-        let s = self.clone();
-        let app = app.route(
-            "/openapi.json",
-            get(move || s.clone().openapi_json_handler()),
-        );
 
         let service = axum::serve(
             tcp_listener,
@@ -556,76 +546,6 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
             }
         }
         self.baml_stream(path, body, b_options)
-    }
-
-    /// Serve an HTML page that loads swagger-ui from local static files.
-    /// This page will in turn fetch `/openapi.json`, and use the results
-    /// to build interactive documentation.
-    async fn docs_handler(self: Arc<Self>) -> Response {
-        let page = r#"
-<html>
-    <head>
-        <title>
-            BAML Function Docs
-        </title>
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.14/swagger-ui.css" integrity="sha512-MvYROlKG3cDBPskMQgPmkNgZh85LIf68y7SZ34TIppaIHQz1M/3S/yYqzIfufdKDJjzB9Qu1BV63SZjimJkPvw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-        <script language="javascript">
-
-            window.onload = function() {
-              //<editor-fold desc="Changeable Configuration Block">
-
-              // the following lines will be replaced by docker/configurator, when it runs in a docker-container
-              window.ui = SwaggerUIBundle({
-                url: "/openapi.json",
-                dom_id: '#swagger-ui',
-                deepLinking: true,
-                presets: [
-                  SwaggerUIBundle.presets.apis,
-                  SwaggerUIStandalonePreset
-                ],
-                plugins: [
-                  SwaggerUIBundle.plugins.DownloadUrl
-                ],
-                layout: "StandaloneLayout"
-              });
-
-              //</editor-fold>
-            };
-        </script>
-    </head>
-    <body>
-        <div id="swagger-ui"></div>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.14/swagger-ui-bundle.js" integrity="sha512-mVvFSCxt0sK0FeL8C7n8BcHh10quzdwfxQbjRaw9pRdKNNep3YQusJS5e2/q4GYt4Ma5yWXSJraoQzXPgZd2EQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/5.17.14/swagger-ui-standalone-preset.js" integrity="sha512-DgicCd4AI/d7/OdgaHqES3hA+xJ289Kb5NmMEegbN8w/Dxn5mvvqr9szOR6TQC+wjTTMeqPscKE4vj6bmAQn6g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-        <script src="./swagger-initializer.js" charset="UTF-8"> </script>
-    </body>
-</html>
-"#;
-        Html(page.to_string()).into_response()
-    }
-
-    /// Render the openapi spec. This endpoint is used by the swagger ui.
-    async fn openapi_json_handler(self: Arc<Self>) -> Result<String, BamlError> {
-        let locked = self.b.read().await;
-        let fake_generator = GeneratorArgs::new(
-            "fake_directory",
-            "fake_directory",
-            Vec::new(),
-            "fake-version".to_string(),
-            true,
-            GeneratorDefaultClientMode::Sync,
-            Vec::new(),
-        ).map_err(|_| BamlError::InternalError{ message: "Failed to make placeholder generator".to_string()})?;
-        let schema: OpenApiSchema = (locked.inner.ir.as_ref(), &fake_generator)
-            .try_into()
-            .map_err(|e| {
-                log::warn!("Failed to generate openapi schema: {}", e);
-                BamlError::InternalError{ message: format!("Failed to generate openapi schema")}
-            })?;
-        serde_json::to_string(&schema).map_err(|e| {
-            log::warn!("Failed to serialize openapi schema: {}", e);
-            BamlError::InternalError{ message: format!("Failed to serialize openapi schema") }
-        })
     }
 }
 

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -71,7 +71,7 @@ pub use internal_baml_core::ir::{scope_diagnostics, FieldType, IRHelper, TypeVal
 static TOKIO_SINGLETON: OnceLock<std::io::Result<Arc<tokio::runtime::Runtime>>> = OnceLock::new();
 
 pub struct BamlRuntime {
-    pub(crate) inner: InternalBamlRuntime,
+    pub (crate) inner: InternalBamlRuntime,
     tracer: Arc<BamlTracer>,
     env_vars: HashMap<String, String>,
     #[cfg(not(target_arch = "wasm32"))]

--- a/engine/baml-runtime/src/runtime/mod.rs
+++ b/engine/baml-runtime/src/runtime/mod.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use crate::internal::llm_client::{llm_provider::LLMProvider, retry_policy::CallablePolicy};
 
 pub struct InternalBamlRuntime {
-    pub(crate) ir: Arc<IntermediateRepr>,
+    pub (crate) ir: Arc<IntermediateRepr>,
     diagnostics: Diagnostics,
     clients: DashMap<String, Arc<LLMProvider>>,
     retry_policies: DashMap<String, CallablePolicy>,

--- a/engine/language_client_codegen/src/lib.rs
+++ b/engine/language_client_codegen/src/lib.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 use version_check::{check_version, GeneratorType, VersionCheckMode};
 
 mod dir_writer;
-pub mod openapi;
+mod openapi;
 mod python;
 mod ruby;
 mod typescript;

--- a/engine/language_client_codegen/src/openapi.rs
+++ b/engine/language_client_codegen/src/openapi.rs
@@ -60,7 +60,7 @@ impl LanguageFeatures for OpenApiLanguageFeatures {
     );
 }
 
-pub struct OpenApiSchema<'ir> {
+struct OpenApiSchema<'ir> {
     paths: Vec<OpenApiMethodDef<'ir>>,
     schemas: IndexMap<&'ir str, TypeSpecWithMeta>,
 }


### PR DESCRIPTION
This reverts commit fe9dde4f3a7ff0503fd13087da50e4da9d97c3a0.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Revert addition of Swagger UI to `baml-cli dev`, removing related routes and OpenAPI schema generation.
> 
>   - **Revert Swagger UI**:
>     - Remove `/docs` and `/openapi.json` routes in `mod.rs`.
>     - Delete `docs_handler()` and `openapi_json_handler()` in `mod.rs`.
>     - Remove `OpenApiSchema` and related code in `openapi.rs`.
>   - **Code Cleanup**:
>     - Remove `internal_baml_codegen::GeneratorArgs` and `OpenApiSchema` imports in `mod.rs`.
>     - Change `pub mod openapi` to `mod openapi` in `lib.rs`.
>     - Adjust `pub(crate)` visibility in `lib.rs` and `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 513c402f3a074c5cb79df13436a1f49086e104b1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->