### PR TITLE
feat: Add WYSIWYG UI (Swagger UI) to baml-cli dev

### DIFF
--- a/engine/baml-runtime/src/cli/serve/json_response.rs
+++ b/engine/baml-runtime/src/cli/serve/json_response.rs
@@ -1,14 +1,11 @@
 use axum::{
     http::{HeaderValue, StatusCode},
-    response::{
-        IntoResponse, Response,
-    },
+    response::{IntoResponse, Response},
 };
 use bytes::{BufMut, BytesMut};
 use http::header;
 use serde::Serialize;
-use std::{io::Write};
-
+use std::io::Write;
 
 pub(super) struct Json<T: Serialize>(pub T);
 

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -71,7 +71,7 @@ pub use internal_baml_core::ir::{scope_diagnostics, FieldType, IRHelper, TypeVal
 static TOKIO_SINGLETON: OnceLock<std::io::Result<Arc<tokio::runtime::Runtime>>> = OnceLock::new();
 
 pub struct BamlRuntime {
-    pub (crate) inner: InternalBamlRuntime,
+    pub(crate) inner: InternalBamlRuntime,
     tracer: Arc<BamlTracer>,
     env_vars: HashMap<String, String>,
     #[cfg(not(target_arch = "wasm32"))]

--- a/engine/baml-runtime/src/runtime/mod.rs
+++ b/engine/baml-runtime/src/runtime/mod.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use crate::internal::llm_client::{llm_provider::LLMProvider, retry_policy::CallablePolicy};
 
 pub struct InternalBamlRuntime {
-    pub (crate) ir: Arc<IntermediateRepr>,
+    pub(crate) ir: Arc<IntermediateRepr>,
     diagnostics: Diagnostics,
     clients: DashMap<String, Arc<LLMProvider>>,
     retry_policies: DashMap<String, CallablePolicy>,

--- a/engine/language_client_codegen/src/lib.rs
+++ b/engine/language_client_codegen/src/lib.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, path::PathBuf};
 use version_check::{check_version, GeneratorType, VersionCheckMode};
 
 mod dir_writer;
-mod openapi;
+pub mod openapi;
 mod python;
 mod ruby;
 mod typescript;

--- a/engine/language_client_codegen/src/openapi.rs
+++ b/engine/language_client_codegen/src/openapi.rs
@@ -60,7 +60,7 @@ impl LanguageFeatures for OpenApiLanguageFeatures {
     );
 }
 
-struct OpenApiSchema<'ir> {
+pub struct OpenApiSchema<'ir> {
     paths: Vec<OpenApiMethodDef<'ir>>,
     schemas: IndexMap<&'ir str, TypeSpecWithMeta>,
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds Swagger UI to BAML CLI for interactive API documentation with new routes and OpenAPI schema generation.
> 
>   - **Behavior**:
>     - Adds Swagger UI to BAML CLI with new routes `/docs` and `/openapi.json` in `mod.rs`.
>     - `docs_handler()` serves Swagger UI HTML page.
>     - `openapi_json_handler()` generates OpenAPI JSON from `OpenApiSchema`.
>   - **OpenAPI Schema**:
>     - Makes `OpenApiSchema` public in `openapi.rs`.
>     - Implements `TryFrom` for `OpenApiSchema` to convert from `IntermediateRepr`.
>   - **Misc**:
>     - Adjusts visibility of `internal_baml_codegen::openapi` module.
>     - Minor formatting changes in `json_response.rs` and `lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c542b11ea65ca1aea14646f743d91fb28d60015d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->