### PR TITLE
coerce floats and ints with commas and other special cases

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
@@ -316,6 +316,9 @@ mod tests {
             ("Increase of 5% and a profit of $1,000", None),
             ("Loss of -€500 and a gain of 1,200.50", None),
             ("Targets: 2,000 units and €3.000,75 revenue", None),
+            // trailing periods and commas
+            ("12,111,123.", Some(12111123.0)),
+            ("12,111,123,", Some(12111123.0)),
         ];
 
         for &(input, expected) in &test_cases {

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
@@ -114,6 +114,10 @@ fn coerce_int(
                     Ok(BamlValueWithFlags::Int(
                         ((frac.round() as i64), Flag::FloatToInt(frac)).into(),
                     ))
+                } else if let Some(frac) = float_from_comma_separated(s) {
+                    Ok(BamlValueWithFlags::Int(
+                        ((frac.round() as i64), Flag::FloatToInt(frac)).into(),
+                    ))
                 } else {
                     Err(ctx.error_unexpected_type(target, value))
                 }
@@ -142,6 +146,203 @@ fn float_from_maybe_fraction(value: &str) -> Option<f64> {
     } else {
         None
     }
+}
+
+fn float_from_comma_separated(value: &str) -> Option<f64> {
+    let trimmed = value.trim();
+
+    // Return None if the input is empty or contains only whitespace
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Define a set of currency symbols to ignore
+    let currency_symbols = [
+        '$', '€', '£', '¥', '₹', '₽', '₩', '₪', '₫', '₴', '₦', '₱', '฿', '₵', '₲', '₡', '₺', '₼',
+        '₸', '₿',
+    ];
+
+    // Remove currency symbols from the string
+    let without_currency: String = trimmed
+        .chars()
+        .filter(|c| !currency_symbols.contains(c))
+        .collect();
+
+    // Replace any non-breaking spaces or other Unicode spaces with nothing
+    let normalized: String = without_currency
+        .chars()
+        .filter(|c| !c.is_whitespace())
+        .collect();
+
+    // Return None if the normalized string is empty
+    if normalized.is_empty() {
+        return None;
+    }
+
+    // Early rejection of inputs with disallowed characters
+    if normalized
+        .chars()
+        .any(|c| !c.is_ascii_digit() && c != ',' && c != '.' && c != '-' && c != '+')
+    {
+        return None;
+    }
+
+    // Get an iterator over the characters
+    let mut chars = normalized.chars();
+
+    // Attempt to get the first character
+    let first_char = match chars.next() {
+        Some(c) => c,
+        None => return None,
+    };
+
+    // Check for multiple signs
+    if (first_char == '+' || first_char == '-')
+        && match chars.clone().next() {
+            Some(c) => c == '+' || c == '-',
+            None => false,
+        }
+    {
+        return None;
+    }
+
+    // Split the string into sign and rest
+    let rest = if first_char == '+' || first_char == '-' {
+        chars.as_str()
+    } else {
+        normalized.as_str()
+    };
+    let sign = if first_char == '+' || first_char == '-' {
+        first_char.to_string()
+    } else {
+        "".to_string()
+    };
+
+    // Return None if rest is empty after removing sign and currency symbols
+    if rest.is_empty() {
+        return None;
+    }
+
+    // Count occurrences of ',' and '.'
+    let comma_count = rest.matches(',').count();
+    let dot_count = rest.matches('.').count();
+
+    // Determine decimal and thousands separators
+    let (decimal_sep, thousands_sep) = if rest.contains('.') && rest.contains(',') {
+        // Both '.' and ',' present
+        match (rest.rfind(','), rest.rfind('.')) {
+            (Some(comma_pos), Some(dot_pos)) => {
+                if comma_pos > dot_pos {
+                    // ',' occurs after '.', so ',' is decimal separator
+                    (Some(','), Some('.'))
+                } else {
+                    // '.' occurs after ',', so '.' is decimal separator
+                    (Some('.'), Some(','))
+                }
+            }
+            _ => (None, None),
+        }
+    } else if rest.contains('.') {
+        if dot_count == 1 {
+            if let Some(dot_pos) = rest.rfind('.') {
+                // Check if the dot is within the last three characters
+                if dot_pos > rest.len().saturating_sub(4) {
+                    // Dot is near the end, likely a decimal separator
+                    (Some('.'), None)
+                } else {
+                    // Dot is not near the end, treat as thousands separator
+                    (None, Some('.'))
+                }
+            } else {
+                // Should not reach here, default to treating as thousands separator
+                (None, Some('.'))
+            }
+        } else {
+            // Multiple dots, assume dots are thousands separators
+            (None, Some('.'))
+        }
+    } else if rest.contains(',') {
+        if comma_count == 1 {
+            if let Some(comma_pos) = rest.rfind(',') {
+                // Check if the comma is within the last three characters
+                if comma_pos > rest.len().saturating_sub(4) {
+                    // Comma is near the end, likely a decimal separator
+                    (Some(','), None)
+                } else {
+                    // Comma is not near the end, treat as thousands separator
+                    (None, Some(','))
+                }
+            } else {
+                // Should not reach here, default to treating as thousands separator
+                (None, Some(','))
+            }
+        } else {
+            // Multiple commas, assume commas are thousands separators
+            (None, Some(','))
+        }
+    } else {
+        // No separators
+        (None, None)
+    };
+
+    // Split rest into integer and fractional parts
+    let (integer_part, fractional_part) = if let Some(decimal) = decimal_sep {
+        let parts: Vec<&str> = rest.split(decimal).collect();
+        if parts.len() != 2 {
+            return None; // Invalid decimal format
+        }
+        (parts[0], parts[1])
+    } else {
+        (rest, "")
+    };
+
+    // Validate and clean the integer part
+    let integer_digits = if let Some(thousands) = thousands_sep {
+        let groups: Vec<&str> = integer_part.split(thousands).collect();
+
+        // Validate grouping
+        if groups.is_empty() || groups[0].is_empty() {
+            return None;
+        }
+
+        if groups[0].len() > 3 {
+            return None; // First group can't have more than 3 digits
+        }
+
+        for group in &groups[1..] {
+            if group.len() != 3 {
+                return None; // Subsequent groups must have exactly 3 digits
+            }
+        }
+
+        // Reconstruct integer part without thousands separators
+        groups.join("")
+    } else {
+        integer_part.to_string()
+    };
+
+    // Validate that integer and fractional parts contain only digits
+    if !integer_digits.chars().all(|c| c.is_ascii_digit())
+        || !fractional_part.chars().all(|c| c.is_ascii_digit())
+    {
+        return None;
+    }
+
+    // Reconstruct the cleaned number
+    let mut cleaned = sign;
+    cleaned.push_str(&integer_digits);
+    if !fractional_part.is_empty() {
+        cleaned.push('.');
+        cleaned.push_str(fractional_part);
+    }
+
+    // Ensure there are no remaining separators
+    if cleaned.matches(',').count() > 0 || cleaned.matches('.').count() > 1 {
+        return None;
+    }
+
+    // Parse the cleaned string into f64
+    cleaned.parse::<f64>().ok()
 }
 
 fn coerce_float(
@@ -173,6 +374,8 @@ fn coerce_float(
                 } else if let Ok(n) = s.parse::<u64>() {
                     Ok(BamlValueWithFlags::Float((n as f64).into()))
                 } else if let Some(frac) = float_from_maybe_fraction(s) {
+                    Ok(BamlValueWithFlags::Float(frac.into()))
+                } else if let Some(frac) = float_from_comma_separated(s) {
                     Ok(BamlValueWithFlags::Float(frac.into()))
                 } else {
                     Err(ctx.error_unexpected_type(target, value))
@@ -224,5 +427,129 @@ fn coerce_bool(
         }
     } else {
         Err(ctx.error_unexpected_null(target))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_float_from_comma_separated() {
+        let test_cases = vec![
+            // Valid German format (comma as decimal separator)
+            ("3,14", Some(3.14)),
+            ("1.234,56", Some(1234.56)),
+            ("1.234.567,89", Some(1234567.89)),
+            // Valid US format (comma as thousands separator)
+            ("3,000", Some(3000.0)),
+            ("3,100.00", Some(3100.00)),
+            ("1,234.56", Some(1234.56)),
+            ("1,234,567.89", Some(1234567.89)),
+            // No separators
+            ("314", Some(314.0)),
+            // Invalid formats
+            ("3,abc", None),
+            ("1,234,567,89", None),
+            ("1.234.567.89", None),
+            ("", None),
+            (",", None),
+            (".", None),
+            ("1234,56.78", None), // Mixed separators not following conventions
+            ("1,23,4", None),     // Incorrect thousands separators
+            ("1.23.4", None),     // Incorrect thousands separators
+            // Additional Edge Cases
+            ("12,345.67", Some(12345.67)),     // Valid US
+            ("12,345.6789", Some(12345.6789)), // Valid US
+            ("12.345,67", Some(12345.67)),     // Valid German
+            ("12,111.123", Some(12111.123)),   // Valid German
+            // big number
+            ("10,000,000.1234", Some(10000000.1234)),
+            ("100,000,000.1234", Some(100000000.1234)),
+            ("1,000,000.1234", Some(1000000.1234)),
+            ("1234567", Some(1234567.0)), // Large number without separators
+            ("1,2345.67", None),          // Incorrect thousands separators
+            ("1.2345,67", None),          // Incorrect thousands separators
+            ("1,234.5.67", None),         // Multiple decimal separators
+            ("1.234,5,67", None),         // Multiple decimal separators
+            ("1,234,56.78", None),        // Mixed separators with incorrect grouping
+            ("1.234.56,78", None),        // Mixed separators with incorrect grouping
+            ("1,234", Some(1234.0)),      // US format without decimal
+            ("1.234", Some(1234.0)),      // German format without decimal
+            ("-1,234.56", Some(-1234.56)), // Negative number in US format
+            ("   1,234.56   ", Some(1234.56)), // Leading and trailing spaces
+            ("1 234,56", Some(1234.56)),  // Embedded space should be rejected
+            ("1,,234.56", None),          // Consecutive thousands separators
+            ("123,456,789,012,345.67", Some(123456789012345.67)), // Very large number
+            // currencies
+            // Valid US format without decimal places
+            ("$1,234", Some(1234.0)),
+            ("€1,234,567", Some(1234567.0)),
+            ("£1.234", Some(1234.0)),
+            ("¥1.234.567", Some(1234567.0)),
+            // Valid German format with decimal places
+            ("€1.234,56", Some(1234.56)),
+            ("$1.234.567,89", Some(1234567.89)),
+            // Valid US format with decimal places
+            ("$1,234.56", Some(1234.56)),
+            ("€1,234,567.89", Some(1234567.89)),
+            // Currency symbols at the end
+            ("1,234$", Some(1234.0)),
+            ("1.234€", Some(1234.0)),
+            ("1,234.56£", Some(1234.56)),
+            ("1.234,56¥", Some(1234.56)),
+            // Currency symbols with spaces
+            ("$ 1,234.56", Some(1234.56)),
+            ("1,234.56 €", Some(1234.56)),
+            // No separators
+            ("$314", Some(314.0)),
+            // Negative numbers with currency symbols
+            ("-$1,234.56", Some(-1234.56)),
+            ("-€1.234,56", Some(-1234.56)),
+            // Leading and trailing spaces with currency symbols
+            ("   $1,234.56   ", Some(1234.56)),
+            ("€   1.234,56   ", Some(1234.56)),
+            // Invalid formats (should still be rejected)
+            ("$1.23.456", None),
+            ("€1,23,456", None),
+            ("£1.234.567.890", Some(1234567890.0)),
+            // Only currency symbols
+            ("$", None),
+            ("€", None),
+            ("£", None),
+            // Currency symbols with invalid numbers
+            ("$abc", None),
+            ("€1,2a3", None),
+            ("£-1.23.45", None),
+            // Multiple currency symbols
+            ("$$1,234.56", Some(1234.56)),
+            ("€€1.234,56", Some(1234.56)),
+            ("$€1,234.56", Some(1234.56)),
+            // Currency symbols in the middle of the number
+            ("1,$234.56", Some(1234.56)),
+            ("1€234,56", Some(1234.56)),
+            // Valid numbers with different currency symbols
+            ("₹1,234.56", Some(1234.56)),
+            ("₽1.234,56", Some(1234.56)),
+            ("1,234.56₩", Some(1234.56)),
+            // Valid numbers with positive sign and currency symbols
+            ("+$1,234.56", Some(1234.56)),
+            ("+€1.234,56", Some(1234.56)),
+            // Edge cases with only currency symbols and signs
+            ("+$", None),
+            ("-€", None),
+            // Large numbers with currency symbols
+            ("$9,999,999,999", Some(9999999999.0)),
+            ("€9.999.999.999", Some(9999999999.0)),
+        ];
+
+        for &(input, expected) in &test_cases {
+            let result = float_from_comma_separated(input);
+            assert_eq!(
+                result, expected,
+                "Failed to parse '{}'. Expected {:?}, got {:?}",
+                input, expected, result
+            );
+        }
     }
 }

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
@@ -341,7 +341,6 @@ fn float_from_comma_separated(value: &str) -> Option<f64> {
         return None;
     }
 
-    // Parse the cleaned string into f64
     cleaned.parse::<f64>().ok()
 }
 

--- a/engine/baml-lib/jsonish/src/tests/test_basics.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_basics.rs
@@ -65,6 +65,14 @@ test_deserializer!(
     12111.123
 );
 
+test_deserializer!(
+    test_float_comma_german2,
+    EMPTY_FILE,
+    "12.11.",
+    FieldType::float(),
+    12.11
+);
+
 test_deserializer!(test_float_1, EMPTY_FILE, "1/5", FieldType::float(), 0.2);
 
 test_deserializer!(

--- a/engine/baml-lib/jsonish/src/tests/test_basics.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_basics.rs
@@ -57,13 +57,14 @@ test_deserializer!(
     12111.123
 );
 
-test_deserializer!(
-    test_float_comma_german,
-    EMPTY_FILE,
-    "12.111,123",
-    FieldType::float(),
-    12111.123
-);
+// uncomment when we support european formatting.
+// test_deserializer!(
+//     test_float_comma_german,
+//     EMPTY_FILE,
+//     "12.111,123",
+//     FieldType::float(),
+
+// );
 
 test_deserializer!(
     test_float_comma_german2,

--- a/engine/baml-lib/jsonish/src/tests/test_basics.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_basics.rs
@@ -27,7 +27,7 @@ test_deserializer!(
 );
 
 test_deserializer!(test_number, EMPTY_FILE, "12111", FieldType::int(), 12111);
-
+test_deserializer!(test_number_2, EMPTY_FILE, "12,111", FieldType::int(), 12111);
 test_deserializer!(
     test_string,
     EMPTY_FILE,
@@ -45,6 +45,22 @@ test_deserializer!(
     test_float,
     EMPTY_FILE,
     "12111.123",
+    FieldType::float(),
+    12111.123
+);
+
+test_deserializer!(
+    test_float_comma_us,
+    EMPTY_FILE,
+    "12,111.123",
+    FieldType::float(),
+    12111.123
+);
+
+test_deserializer!(
+    test_float_comma_german,
+    EMPTY_FILE,
+    "12.111,123",
     FieldType::float(),
     12111.123
 );

--- a/engine/baml-lib/jsonish/src/tests/test_lists.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_lists.rs
@@ -43,3 +43,82 @@ test_deserializer!(
     FieldType::List(FieldType::Class("Foo".to_string()).into()),
     [{"a": 1, "b": "hello"}, {"a": 2, "b": "world"}]
 );
+
+test_deserializer!(
+  test_class_list,
+  r#"
+    class ListClass {
+      date string
+      description string
+      transaction_amount float
+      transaction_type string
+    }
+    "#,
+  r#"
+    [
+    {
+      "date": "01/01",
+      "description": "Transaction 1",
+      "transaction_amount": -100.00,
+      "transaction_type": "Withdrawal"
+    },
+    {
+      "date": "01/02",
+      "description": "Transaction 2",
+      "transaction_amount": -2,000.00,
+      "transaction_type": "Withdrawal"
+    },
+    {
+      "date": "01/03",
+      "description": "Transaction 3",
+      "transaction_amount": -300.00,
+      "transaction_type": "Withdrawal"
+    },
+    {
+      "date": "01/04",
+      "description": "Transaction 4",
+      "transaction_amount": -4,000.00,
+      "transaction_type": "Withdrawal"
+    },
+    {
+      "date": "01/05",
+      "description": "Transaction 5",
+      "transaction_amount": -5,000.00,
+      "transaction_type": "Withdrawal"
+    }
+  ]
+    "#,
+  FieldType::List(FieldType::Class("ListClass".to_string()).into()),
+  [
+      {
+        "date": "01/01",
+        "description": "Transaction 1",
+        "transaction_amount": -100.00,
+        "transaction_type": "Withdrawal"
+      },
+      {
+        "date": "01/02",
+        "description": "Transaction 2",
+        "transaction_amount": -2000.00,
+        "transaction_type": "Withdrawal"
+      },
+      {
+        "date": "01/03",
+        "description": "Transaction 3",
+        "transaction_amount": -300.00,
+        "transaction_type": "Withdrawal"
+      },
+      {
+        "date": "01/04",
+        "description": "Transaction 4",
+        "transaction_amount": -4000.00,
+        "transaction_type": "Withdrawal"
+      },
+      {
+        "date": "01/05",
+        "description": "Transaction 5",
+        "transaction_amount": -5000.00,
+        "transaction_type": "Withdrawal"
+      }
+    ]
+);

--- a/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
+++ b/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
@@ -13,7 +13,6 @@ use crate::{
     RuntimeContext,
 };
 
-// TODO: need the FieldType
 pub fn render_output_format(
     ir: &IntermediateRepr,
     ctx: &RuntimeContext,
@@ -343,29 +342,33 @@ fn relevant_data_models<'a>(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-    use crate::BamlRuntime;
     use super::*;
+    use crate::BamlRuntime;
+    use std::collections::HashMap;
 
     #[test]
     fn skipped_variants_are_not_rendered() {
-        let files = vec![("test-file.baml",r#"
+        let files = vec![(
+            "test-file.baml",
+            r#"
           enum Foo {
             Bar
             Baz @skip
-          }"#
-        )].into_iter().collect();
+          }"#,
+        )]
+        .into_iter()
+        .collect();
         let env_vars: HashMap<&str, &str> = HashMap::new();
         let baml_runtime = BamlRuntime::from_file_content(".", &files, env_vars).unwrap();
         let ctx_manager = baml_runtime.create_ctx_manager(BamlValue::Null, None);
         let ctx: RuntimeContext = ctx_manager.create_ctx(None, None).unwrap();
 
         let field_type = FieldType::Enum("Foo".to_string());
-        let render_output = render_output_format( baml_runtime.inner.ir.as_ref(), &ctx, &field_type ).unwrap();
+        let render_output =
+            render_output_format(baml_runtime.inner.ir.as_ref(), &ctx, &field_type).unwrap();
 
         let foo_enum = render_output.find_enum("Foo").unwrap();
-        assert_eq!(foo_enum.values[0].0.real_name(),  "Bar".to_string());
+        assert_eq!(foo_enum.values[0].0.real_name(), "Bar".to_string());
         assert_eq!(foo_enum.values.len(), 1);
     }
-
 }

--- a/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
+++ b/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
@@ -13,6 +13,7 @@ use crate::{
     RuntimeContext,
 };
 
+// TODO: need the FieldType
 pub fn render_output_format(
     ir: &IntermediateRepr,
     ctx: &RuntimeContext,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance deserialization to handle numbers with commas and currency symbols, adding tests for validation in `coerce_primitive.rs`, `test_basics.rs`, and `test_lists.rs`.
> 
>   - **Behavior**:
>     - Enhance `coerce_int` and `coerce_float` in `coerce_primitive.rs` to handle numbers with commas and currency symbols.
>     - Introduce `float_from_comma_separated` to parse numbers with commas as decimal or thousand separators.
>   - **Tests**:
>     - Add `test_float_from_comma_separated` in `coerce_primitive.rs` to validate parsing of numbers with commas and currency symbols.
>     - Add tests in `test_basics.rs` and `test_lists.rs` for deserializing numbers with commas.
>   - **Misc**:
>     - Add a TODO comment in `render_output_format.rs` indicating a need for `FieldType`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f299c5e6d5ac173f12eff983bc036a9a92608def. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->