### PR TITLE
set pool timeout for all clients

### DIFF
--- a/engine/baml-runtime/src/request/mod.rs
+++ b/engine/baml-runtime/src/request/mod.rs
@@ -34,7 +34,7 @@ pub(crate) fn create_tracing_client() -> Result<reqwest::Client> {
         } else {
             let cb = builder()
                 // Wait up to 30s to send traces to the backend
-                .read_timeout(Duration::from_secs(30))
+                .read_timeout(Duration::from_secs(30));
 
         }
     }

--- a/engine/baml-runtime/src/request/mod.rs
+++ b/engine/baml-runtime/src/request/mod.rs
@@ -14,6 +14,11 @@ fn builder() -> reqwest::ClientBuilder {
                 .connect_timeout(Duration::from_secs(10))
                 .danger_accept_invalid_certs(danger_accept_invalid_certs)
                 .http2_keep_alive_interval(Some(Duration::from_secs(10)))
+                // We don't want to keep idle connections around due to sometimes
+                // causing a stall in the connection pool across FFI boundaries
+                // https://github.com/seanmonstar/reqwest/issues/600
+                .pool_max_idle_per_host(0)
+
         }
     }
 }
@@ -30,10 +35,7 @@ pub(crate) fn create_tracing_client() -> Result<reqwest::Client> {
             let cb = builder()
                 // Wait up to 30s to send traces to the backend
                 .read_timeout(Duration::from_secs(30))
-                // We don't want to keep idle connections around due to sometimes
-                // causing a stall in the connection pool across FFI boundaries
-                // https://github.com/seanmonstar/reqwest/issues/600
-                .pool_max_idle_per_host(0);
+
         }
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set `pool_max_idle_per_host(0)` in `builder()` to prevent idle connections from stalling, removing it from `create_tracing_client()`.
> 
>   - **Behavior**:
>     - Set `pool_max_idle_per_host(0)` in `builder()` in `mod.rs` to prevent idle connections from stalling the connection pool.
>     - Removed `pool_max_idle_per_host(0)` from `create_tracing_client()` as it is now set globally in `builder()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 953bc8ce1c85fe34b67c200b4589069ef7c1ad86. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->