### PR TITLE
Add basic docs for literal types

### DIFF
--- a/docs/docs/snippets/supported-types.mdx
+++ b/docs/docs/snippets/supported-types.mdx
@@ -33,7 +33,7 @@ function ClassifyIssue(issue_description: string) -> "bug" | "enhancement" {
 See [Union(|)](#union-) for more details.
 
 <Info>
-  This feature was added in: v0.60.0.
+  This feature was added in: v0.61.0.
 </Info>
 
 ## Multimodal Types

--- a/docs/docs/snippets/supported-types.mdx
+++ b/docs/docs/snippets/supported-types.mdx
@@ -32,6 +32,10 @@ function ClassifyIssue(issue_description: string) -> "bug" | "enhancement" {
 
 See [Union(|)](#union-) for more details.
 
+<Info>
+  This feature was added in: v0.60.0.
+</Info>
+
 ## Multimodal Types
 See [calling a function with multimodal types](/docs/snippets/calling-baml/multi-modal)
 and [testing image inputs](/docs/snippets/test-cases#images)

--- a/docs/docs/snippets/supported-types.mdx
+++ b/docs/docs/snippets/supported-types.mdx
@@ -13,6 +13,25 @@ Here's a list of all the types that can be represented in BAML:
 * `string`
 * `null`
 
+## Literal Types
+
+The primitive types `string`, `int` and `bool` can be constrained to a specific value.
+For example, you can use literal values as return types:
+
+```rust
+function ClassifyIssue(issue_description: string) -> "bug" | "enhancement" {
+  client GPT4Turbo
+  prompt #"
+    {{ _.role("user")}}
+    Classify the issue based on the following description:
+    {{ issue_description }}
+    {{ ctx.output_format }}
+  "#
+}
+```
+
+See [Union(|)](#union-) for more details.
+
 ## Multimodal Types
 See [calling a function with multimodal types](/docs/snippets/calling-baml/multi-modal)
 and [testing image inputs](/docs/snippets/test-cases#images)
@@ -331,6 +350,23 @@ Optional[List[Union[Optional[int], List[str], MyClass]]]
 
 ```typescript TypeScript Equivalent
 ((number | null) | string[] | MyClass)[]
+```
+
+</CodeBlocks>
+
+### Example 5
+
+<CodeBlocks>
+```baml BAML
+"str" | 1 | false
+```
+
+```python Python Equivalent
+Union[Literal["str"], Literal[1], Literal[False]]
+```
+
+```typescript TypeScript Equivalent
+"str" | 1 | false
 ```
 
 </CodeBlocks>


### PR DESCRIPTION
Mention **Literal Types** in `supported-types` and add a couple examples.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add documentation for Literal Types in `supported-types.mdx`, including examples and references.
> 
>   - **Documentation**:
>     - Add section for **Literal Types** in `supported-types.mdx`.
>     - Include example of using literal values as return types in a function.
>     - Reference to Union type for more details.
>   - **Examples**:
>     - Add Example 5 demonstrating literal types in BAML, Python, and TypeScript equivalents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 109b715f09b0a1515b81542d88b598100265ee4e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->