### PR TITLE
only pop up env var dialog if there are some env vars required

### DIFF
--- a/typescript/playground-common/src/shared/SettingsDialog.tsx
+++ b/typescript/playground-common/src/shared/SettingsDialog.tsx
@@ -112,6 +112,7 @@ const requiredButUnsetAtom = atom((get) => {
   )
 })
 
+
 const requiredAndSetCountAtom = atom((get) => {
   const envvars = get(envvarsAtom)
   return get(runtimeRequiredEnvVarsAtom).filter((k) =>
@@ -181,18 +182,24 @@ export const ShowSettingsButton: React.FC<{ iconClassName: string }> = ({ iconCl
   const setShowSettings = useSetAtom(showSettingsAtom)
   const requiredButUnset = useAtomValue(requiredButUnsetAtom)
   const requiredAndSetCount = useAtomValue(requiredAndSetCountAtom)
+  const requiredEnvVars = useAtomValue(runtimeRequiredEnvVarsAtom)
   const requiredButUnsetCount = requiredButUnset.length
+  useEffect(() => {
+    if ((window as any).next?.version) {
+      // dont run in nextjs
+      return
+    }
+    if (requiredAndSetCount === 0 && requiredEnvVars.length > 0) {
+      // no env vars have been set at all pop up the dialog
+      setShowSettings(true)
+    }
+  }, [requiredAndSetCount, requiredEnvVars, setShowSettings])
+
   if ((window as any).next?.version) {
     // dont run in nextjs
     return null
   }
 
-  useEffect(() => {
-    if (requiredAndSetCount === 0) {
-      // no env vars have been set at all pop up the dialog
-      setShowSettings(true)
-    }
-  }, [requiredAndSetCount])
 
   const button = (
     <Button
@@ -263,7 +270,7 @@ export const SettingsDialog: React.FC = () => {
               <>
                 <p className='text-xs italic text-vscode-descriptionForeground'>
                   You can get these from{' '}
-                  <a className='text-blue-400 underline' target='_blank' href='https://app.boundaryml.com'>
+                  <a className='text-blue-400 underline' target='_blank' href='https://app.boundaryml.com' rel="noreferrer">
                     Boundary Studio
                   </a>
                 </p>

--- a/typescript/playground-common/src/shared/SettingsDialog.tsx
+++ b/typescript/playground-common/src/shared/SettingsDialog.tsx
@@ -112,7 +112,6 @@ const requiredButUnsetAtom = atom((get) => {
   )
 })
 
-
 const requiredAndSetCountAtom = atom((get) => {
   const envvars = get(envvarsAtom)
   return get(runtimeRequiredEnvVarsAtom).filter((k) =>
@@ -200,7 +199,6 @@ export const ShowSettingsButton: React.FC<{ iconClassName: string }> = ({ iconCl
     return null
   }
 
-
   const button = (
     <Button
       className='relative px-2 py-1 bg-transparent h-fit text-vscode-editor-foreground hover:text-vscode-button-foreground hover:bg-vscode-button-hoverBackground'
@@ -270,7 +268,12 @@ export const SettingsDialog: React.FC = () => {
               <>
                 <p className='text-xs italic text-vscode-descriptionForeground'>
                   You can get these from{' '}
-                  <a className='text-blue-400 underline' target='_blank' href='https://app.boundaryml.com' rel="noreferrer">
+                  <a
+                    className='text-blue-400 underline'
+                    target='_blank'
+                    href='https://app.boundaryml.com'
+                    rel='noreferrer'
+                  >
                     Boundary Studio
                   </a>
                 </p>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `ShowSettingsButton` in `SettingsDialog.tsx` to check `requiredEnvVars` before showing the dialog and add `rel="noreferrer"` to an anchor tag.
> 
>   - **Behavior**:
>     - Modify `ShowSettingsButton` in `SettingsDialog.tsx` to check `requiredEnvVars` before showing the settings dialog if no env vars are set.
>     - Add `rel="noreferrer"` to anchor tag in `SettingsDialog.tsx` for security.
>   - **Misc**:
>     - Minor formatting change (extra newline) in `SettingsDialog.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for b73012ae6454860b927f7198711f0672af0a6a02. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->