### PR TITLE
fix: add musl to the ts release artifacts

### DIFF
--- a/engine/language_client_typescript/package.json
+++ b/engine/language_client_typescript/package.json
@@ -39,9 +39,11 @@
       "aarch64-apple-darwin",
       "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-linux-musl",
       "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc",
-      "x86_64-unknown-linux-gnu"
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl"
     ]
   },
   "engines": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add musl target support to TypeScript package in `package.json`.
> 
>   - **Behavior**:
>     - Added `aarch64-unknown-linux-musl` and `x86_64-unknown-linux-musl` to `napi.targets` in `package.json` to support musl-based systems.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f08ca9838504d4691948d4c86c3531f2be01320d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->