### PR TITLE
chore: clean up cargo.toml warnings

### DIFF
--- a/.github/workflows/build-ruby-release.reusable.yaml
+++ b/.github/workflows/build-ruby-release.reusable.yaml
@@ -36,6 +36,7 @@ jobs:
           # - platform: x86-mingw-ucrt
 
     runs-on: ubuntu-latest
+    name: ${{ matrix._.platform }}
     defaults:
       run:
         working-directory: engine/language_client_ruby

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -3,7 +3,7 @@ name: Release language_client_typescript
 on:
   workflow_call: {}
   push:
-    branches: [sam/alpine-builds]
+    branches: [sam/alpine-warnings]
 
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -68,7 +68,7 @@ jobs:
               echo "$PWD/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
             node_build: pnpm build:napi-release --target aarch64-unknown-linux-musl --use-napi-cross
 
-    name: Build ${{ matrix._.target }}
+    name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.host }}
     container: ${{ matrix._.container }}
     steps:

--- a/engine/language_client_typescript/Cargo.toml
+++ b/engine/language_client_typescript/Cargo.toml
@@ -7,12 +7,6 @@ version = "0.0.1"
 name = "baml"
 crate-type = ["cdylib"]
 
-[target.x86_64-unknown-linux-musl]
-linker = "x86_64-linux-musl-gcc"
-
-[target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-musl-gcc"
-
 [dependencies]
 anyhow.workspace = true
 baml-types = { path = "../baml-lib/baml-types" }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Cleaned up `Cargo.toml` warnings by removing target-specific configurations and updated GitHub Actions workflow naming and branch specifications.
> 
>   - **Cargo.toml**:
>     - Removed `[target.x86_64-unknown-linux-musl]` and `[target.aarch64-unknown-linux-musl]` sections.
>   - **GitHub Actions**:
>     - In `build-ruby-release.reusable.yaml`, added `name: ${{ matrix._.platform }}` for job naming.
>     - In `build-typescript-release.reusable.yaml`, changed branch from `sam/alpine-builds` to `sam/alpine-warnings` and adjusted job name to `name: ${{ matrix._.target }}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c9103a73eaf561ae6886526c7056737606ac081c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->