### PR TITLE
bugfix: Fix parser so that we are able to correctly detect sequences of empty strings.

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
@@ -136,7 +136,7 @@ impl ParsingContext<'_> {
             scope: self.scope.clone(),
             causes: missing
                 .into_iter()
-                .map(|(k)| ParsingError {
+                .map(|k| ParsingError {
                     scope: self.scope.clone(),
                     reason: format!("Missing required field: {}", k),
                     causes: vec![],

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -574,12 +574,10 @@ impl JsonParseState {
             }
             '"' => {
                 // Peek if next 2 characters are also quotes
-                let is_triple_quoted = match next.peek() {
-                    Some((_, '"')) => match next.peek() {
-                        Some((_, '"')) => true,
-                        _ => false,
-                    },
-                    _ => false,
+                let is_triple_quoted = {
+                    next.next_if(|&(_, c)| c == '"')
+                        .and_then(|_| next.next_if(|&(_, c)| c == '"'))
+                        .is_some()
                 };
 
                 if is_triple_quoted {

--- a/engine/baml-lib/jsonish/src/tests/test_class.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_class.rs
@@ -1152,11 +1152,52 @@ test_partial_deserializer!(
   {"big": {"a": 11, "b": 12.0}, "big_nums": [{"a": 22, "b": null}], "another": null}
 );
 
-
 test_partial_deserializer!(
   test_big_object_start_big_into_list2,
   BIG_OBJECT_STREAM_TEST,
   r#"json```{"big": {"a": 11, "b": 12.2}, "big_nums": [{"a": 22, "b": 33}, {"a": 1, "b": 2.2}], "another": {"a": 45, "b": 0.1"#,
   FieldType::Class("CompoundBigNumbers".to_string()),
   {"big": {"a": 11, "b": 12.2}, "big_nums": [{"a": 22, "b": 33.0}, {"a": 1, "b": 2.2}], "another": {"a": 45, "b": null}}
+);
+
+test_deserializer!(
+  test_empty_string_value,
+  r#"
+  class Foo {
+    a string
+  }
+  "#,
+  r#"{"a": ""}"#,
+  FieldType::Class("Foo".to_string()),
+  {"a": ""}
+);
+
+test_deserializer!(
+  test_empty_string_value_1,
+  r#"
+  class Foo {
+    a string
+  }
+  "#,
+  r#"{a: ""}"#,
+  FieldType::Class("Foo".to_string()),
+  {"a": ""}
+);
+
+test_deserializer!(
+  test_empty_string_value_2,
+  r#"
+  class Foo {
+    a string
+    b string
+    res string[]
+  }
+  "#,
+  r#"{
+    a: "",
+    b: "",
+    res: []
+  }"#,
+  FieldType::Class("Foo".to_string()),
+  {"a": "", "b": "", "res": []}
 );


### PR DESCRIPTION
* Added unit tests to prevent regressions

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes JSON parser to correctly detect sequences of empty strings and adds unit tests to prevent regressions.
> 
>   - **Behavior**:
>     - Fixes detection of triple-quoted strings in `JsonParseState` in `json_parse_state.rs` by using `next.next_if()` for peeking.
>     - Adds unit tests in `test_class.rs` to verify handling of empty string sequences.
>   - **Misc**:
>     - Removes unnecessary tuple destructuring in `mod.rs` in `coercer` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 99039368ce031d8ef64a72e5a74c615183c84848. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->