### PR TITLE
Add more test cases for unquoted strings in objects

### DIFF
--- a/engine/baml-lib/jsonish/src/tests/test_class.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_class.rs
@@ -1201,3 +1201,27 @@ test_deserializer!(
   FieldType::Class("Foo".to_string()),
   {"a": "", "b": "", "res": []}
 );
+
+test_deserializer!(
+  test_string_field_with_spaces,
+  r#"
+  class Foo {
+    a string
+    b string
+    res string[]
+  }
+  "#,
+  r#"{
+    a: Hi friends!,
+    b: hey world lets do something kinda cool
+    so that we can test this out,
+    res: [hello,
+     world]
+  }"#,
+  FieldType::Class("Foo".to_string()),
+  {
+    "a": "Hi friends!",
+    "b": "hey world lets do something kinda cool\n    so that we can test this out",
+    "res": ["hello", "world"]
+  }
+);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add test case for handling unquoted strings with spaces in JSON-like objects in `test_class.rs`.
> 
>   - **Tests**:
>     - Add `test_string_field_with_spaces` in `test_class.rs` to handle unquoted strings with spaces in JSON-like objects.
>     - Validates deserialization of strings with spaces and newline characters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for abeceb6b1cda09a8876954748b46b29906ad6662. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->