### PR TITLE
Make substring match algorithm case insensitive

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
@@ -223,12 +223,12 @@ pub(super) fn coerce_bool(
     if let Some(value) = value {
         match value {
             crate::jsonish::Value::Boolean(b) => Ok(BamlValueWithFlags::Bool((*b).into())),
-            crate::jsonish::Value::String(s) => match s.as_str() {
+            crate::jsonish::Value::String(s) => match s.to_lowercase().as_str() {
                 "true" => Ok(BamlValueWithFlags::Bool(
                     (true, Flag::StringToBool(s.clone())).into(),
                 )),
                 "false" => Ok(BamlValueWithFlags::Bool(
-                    (true, Flag::StringToBool(s.clone())).into(),
+                    (false, Flag::StringToBool(s.clone())).into(),
                 )),
                 _ => {
                     match super::match_string::match_string(
@@ -255,7 +255,7 @@ pub(super) fn coerce_bool(
             },
             crate::jsonish::Value::Array(items) => {
                 coerce_array_to_singular(ctx, target, &items.iter().collect::<Vec<_>>(), &|value| {
-                    coerce_float(ctx, target, Some(value))
+                    coerce_bool(ctx, target, Some(value))
                 })
             }
             _ => Err(ctx.error_unexpected_type(target, value)),

--- a/engine/baml-lib/jsonish/src/tests/test_basics.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_basics.rs
@@ -49,10 +49,41 @@ test_deserializer!(
     [true]
 );
 
+test_deserializer!(
+    test_bool_wrapped_mismatched_case,
+    EMPTY_FILE,
+    "The answer is True",
+    FieldType::bool().as_list(),
+    [true]
+);
+
+test_deserializer!(
+    test_bool_wrapped_mismatched_case_preceded_by_text,
+    EMPTY_FILE,
+    "The tax return you provided has section for dependents.\n\nAnswer: **True**",
+    FieldType::bool(),
+    true
+);
+
+test_deserializer!(
+    test_bool_mismatched_case_followed_by_text,
+    EMPTY_FILE,
+    r#"False.\n\nThe statement "2 + 2 = 5" is mathematically incorrect. The correct sum of 2 + 2 is 4, not 5."#,
+    FieldType::bool(),
+    false
+);
+
 test_failing_deserializer!(
     test_ambiguous_bool,
     EMPTY_FILE,
     "The answer is true or false",
+    FieldType::bool()
+);
+
+test_failing_deserializer!(
+    test_elaborate_ambiguous_bool,
+    EMPTY_FILE,
+    r#"False. The statement "2 + 2 = 5" is not accurate according to basic arithmetic. In standard arithmetic, the sum of 2 and 2 is equal to 4, not 5. Therefore, the statement does not hold true."#,
     FieldType::bool()
 );
 

--- a/engine/baml-lib/jsonish/src/tests/test_enum.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_enum.rs
@@ -8,6 +8,14 @@ TWO
 }
 "#;
 
+const PASCAL_CASE_ENUM_FILE: &str = r#"
+// Enums
+enum PascalCaseCategory {
+One
+Two
+}
+"#;
+
 test_deserializer!(
     test_enum,
     ENUM_FILE,
@@ -54,6 +62,30 @@ test_deserializer!(
     r#""ONE: The description of k1""#,
     FieldType::Enum("Category".to_string()),
     "ONE"
+);
+
+test_deserializer!(
+    from_string_and_case_mismatch,
+    ENUM_FILE,
+    "The answer is One",
+    FieldType::Enum("Category".to_string()),
+    "ONE"
+);
+
+test_deserializer!(
+    from_string_and_case_mismatch_wrapped,
+    ENUM_FILE,
+    "**one** is the answer",
+    FieldType::Enum("Category".to_string()),
+    "ONE"
+);
+
+test_deserializer!(
+    from_string_and_case_mismatch_upper,
+    PASCAL_CASE_ENUM_FILE,
+    "**ONE** is the answer",
+    FieldType::Enum("PascalCaseCategory".to_string()),
+    "One"
 );
 
 test_deserializer!(

--- a/engine/baml-lib/jsonish/src/tests/test_literals.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_literals.rs
@@ -83,9 +83,25 @@ test_deserializer!(
 );
 
 test_deserializer!(
+    test_literal_string_preceded_by_extra_text_case_mismatch,
+    EMPTY_FILE,
+    "The answer is Two",
+    FieldType::Literal(LiteralValue::String("TWO".into())),
+    "TWO"
+);
+
+test_deserializer!(
     test_literal_string_followed_by_extra_text,
     EMPTY_FILE,
     "TWO is the answer",
+    FieldType::Literal(LiteralValue::String("TWO".into())),
+    "TWO"
+);
+
+test_deserializer!(
+    test_literal_string_followed_by_extra_text_case_mismatch,
+    EMPTY_FILE,
+    "Two is the answer",
     FieldType::Literal(LiteralValue::String("TWO".into())),
     "TWO"
 );
@@ -99,11 +115,37 @@ test_deserializer!(
 );
 
 test_deserializer!(
+    test_literal_string_with_quotes_preceded_by_extra_text_case_mismatch,
+    EMPTY_FILE,
+    r#"The answer is "two""#,
+    FieldType::Literal(LiteralValue::String("TWO".into())),
+    "TWO"
+);
+
+test_deserializer!(
     test_literal_string_with_quotes_followed_by_extra_text,
     EMPTY_FILE,
     r#""TWO" is the answer"#,
     FieldType::Literal(LiteralValue::String("TWO".into())),
     "TWO"
+);
+
+test_deserializer!(
+    test_literal_string_with_quotes_followed_by_extra_text_case_mismatch,
+    EMPTY_FILE,
+    r#""Two" is the answer"#,
+    FieldType::Literal(LiteralValue::String("TWO".into())),
+    "TWO"
+);
+
+test_deserializer!(
+    test_literal_string_case_mismatch_upper,
+    EMPTY_FILE,
+    // Came up with this example unintentioanlly but this causes ambiguity
+    // issues with unions ("two" | "one"), see the TODO at the end of this file.
+    r#"The ansewr "TWO" is the correct one"#,
+    FieldType::Literal(LiteralValue::String("two".into())),
+    "two"
 );
 
 test_deserializer!(


### PR DESCRIPTION
Fixes #860 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make substring match algorithm case insensitive and update tests for boolean, enum, and literal string matches.
> 
>   - **Behavior**:
>     - Make substring match algorithm case insensitive by converting strings to lowercase in `coerce_primitive.rs` and `match_string.rs`.
>     - Fix boolean coercion in `coerce_bool()` to handle case-insensitive matches for "true" and "false".
>   - **Tests**:
>     - Add tests in `test_basics.rs` for case-insensitive boolean matches and handling of text around boolean values.
>     - Add tests in `test_enum.rs` for case-insensitive enum matches and handling of text around enum values.
>     - Add tests in `test_literals.rs` for case-insensitive literal string matches and handling of text around literal values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ef5be3cd683203442afb6e511ac9a60acdd3f18d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->