### PR TITLE
Fix vertex citation data being optional

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
@@ -101,8 +101,8 @@ pub struct VertexAiSearch {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SafetySetting {
-    pub category: HarmCategory,
-    pub threshold: HarmBlockThreshold,
+    pub category: Option<HarmCategory>,
+    pub threshold: Option<HarmBlockThreshold>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
@@ -326,18 +326,19 @@ pub enum FinishReason {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct CitationMetadata {
-    pub citations: Vec<Citation>,
+    pub citations: Option<Vec<Citation>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Citation {
-    pub start_index: i32,
-    pub end_index: i32,
-    pub uri: String,
-    pub title: String,
-    pub license: String,
-    pub publication_date: Date,
+    pub start_index: Option<i32>,
+    pub end_index: Option<i32>,
+    pub uri: Option<String>,
+    // Their docs are incorrect, this is sometimes missing.
+    pub title: Option<String>,
+    pub license: Option<String>,
+    pub publication_date: Option<Date>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
@@ -101,9 +101,9 @@ pub struct VertexAiSearch {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SafetySetting {
-    pub category: HarmCategory,
-    pub threshold: HarmBlockThreshold,
-    pub method: HarmBlockMethod,
+    pub category: Option<HarmCategory>,
+    pub threshold: Option<HarmBlockThreshold>,
+    pub method: Option<HarmBlockMethod>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -178,8 +178,8 @@ pub enum BlockReason {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SafetyRating {
-    pub category: HarmCategory,
-    pub probability: HarmProbability,
+    pub category: Option<HarmCategory>,
+    pub probability: Option<HarmProbability>,
     pub probability_score: Option<f64>,
     pub severity: Option<HarmSeverity>,
     pub severity_score: Option<f64>,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> This PR makes citation and safety data optional in several structs to handle missing fields and updates a comment for documentation accuracy.
> 
>   - **Behavior**:
>     - `citations` in `CitationMetadata` is now `Option<Vec<Citation>>` to handle missing citation data.
>     - Fields in `Citation` (`start_index`, `end_index`, `uri`, `title`, `license`, `publication_date`) are now optional to accommodate missing data.
>     - `category` and `threshold` in `SafetySetting` in `google/types.rs` and `vertex/types.rs` are now optional.
>     - `method` in `SafetySetting` in `vertex/types.rs` is now optional.
>     - `category` and `probability` in `SafetyRating` in `vertex/types.rs` are now optional.
>   - **Misc**:
>     - Comment added to `title` in `Citation` noting incorrect documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7bc0f5179d7923ade89a85a6676f94d5c2753564. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->