### PR TITLE
Prefer case sensitive match over case insensitive

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
@@ -236,8 +236,11 @@ pub(super) fn coerce_bool(
                         target,
                         Some(value),
                         &[
-                            ("true", vec!["true".into()]),
-                            ("false", vec!["false".into()]),
+                            ("true", vec!["true".into(), "True".into(), "TRUE".into()]),
+                            (
+                                "false",
+                                vec!["false".into(), "False".into(), "FALSE".into()],
+                            ),
                         ],
                     ) {
                         Ok(val) => match val.value().as_str() {

--- a/engine/baml-lib/jsonish/src/tests/test_enum.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_enum.rs
@@ -96,6 +96,21 @@ test_deserializer!(
     "ONE"
 );
 
+test_deserializer!(
+    case_sensitive_non_ambiguous_match,
+    ENUM_FILE,
+    r#"TWO" is one of the correct answers."#,
+    FieldType::Enum("Category".to_string()),
+    "TWO"
+);
+
+test_failing_deserializer!(
+    case_insensitive_ambiguous_match,
+    ENUM_FILE,
+    r#"Two" is one of the correct answers."#,
+    FieldType::Enum("Category".to_string())
+);
+
 test_failing_deserializer!(
     from_string_with_extra_text_after_3,
     ENUM_FILE,


### PR DESCRIPTION
Related to #860, improves upon #1056.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `match_string` to prefer case-sensitive matches, update `coerce_bool` for case variations, and adjust tests accordingly.
> 
>   - **Behavior**:
>     - `match_string` in `match_string.rs` now prioritizes case-sensitive matches over case-insensitive ones.
>     - Handles punctuation by stripping it and retrying the match.
>     - `coerce_bool` in `coerce_primitive.rs` updated to handle different case variations of boolean strings.
>   - **Tests**:
>     - Added `case_sensitive_non_ambiguous_match` test in `test_enum.rs` for case-sensitive matching.
>     - Added `case_insensitive_ambiguous_match` failing test in `test_enum.rs` to ensure ambiguous matches are not incorrectly resolved.
>     - Updated existing tests in `test_enum.rs` to align with new matching logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 8fdc5b478b8021db3b4f2ca5c3f39ec58a8925d0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->