### PR TITLE
Add unstable_internal_repr on FunctionResult in python

### DIFF
--- a/engine/baml-lib/jinja-runtime/src/lib.rs
+++ b/engine/baml-lib/jinja-runtime/src/lib.rs
@@ -289,7 +289,7 @@ impl ImageBase64 {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize)]
 pub enum RenderedPrompt {
     Completion(String),
     Chat(Vec<RenderedChatMessage>),

--- a/engine/baml-runtime/src/internal/llm_client/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/mod.rs
@@ -84,7 +84,7 @@ pub struct RetryLLMResponse {
     pub failed: Vec<LLMResponse>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum LLMResponse {
     /// BAML was able to successfully make the HTTP request and got a 2xx
     /// response from the model provider
@@ -148,7 +148,7 @@ impl LLMResponse {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct LLMErrorResponse {
     pub client: String,
     pub model: Option<String>,
@@ -162,7 +162,7 @@ pub struct LLMErrorResponse {
     pub code: ErrorCode,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum ErrorCode {
     InvalidAuthentication, // 401
     NotSupported,          // 403
@@ -225,7 +225,7 @@ impl ErrorCode {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct LLMCompleteResponse {
     pub client: String,
     pub model: String,

--- a/engine/baml-runtime/src/internal/llm_client/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/mod.rs
@@ -154,6 +154,7 @@ pub struct LLMErrorResponse {
     pub model: Option<String>,
     pub prompt: RenderedPrompt,
     pub request_options: HashMap<String, serde_json::Value>,
+    #[cfg_attr(target_arch = "wasm32", serde(skip_serializing))]
     pub start_time: web_time::SystemTime,
     pub latency: web_time::Duration,
 
@@ -232,6 +233,7 @@ pub struct LLMCompleteResponse {
     pub prompt: RenderedPrompt,
     pub request_options: HashMap<String, serde_json::Value>,
     pub content: String,
+    #[cfg_attr(target_arch = "wasm32", serde(skip_serializing))]
     pub start_time: web_time::SystemTime,
     pub latency: web_time::Duration,
     pub metadata: LLMCompleteResponseMetadata,

--- a/engine/language_client_python/python_src/baml_py/baml_py.pyi
+++ b/engine/language_client_python/python_src/baml_py/baml_py.pyi
@@ -19,6 +19,14 @@ class FunctionResult:
     def is_ok(self) -> bool: ...
     def cast_to(self, enum_module: Any, class_module: Any) -> Any: ...
 
+    # This is a debug function that returns the internal representation of the response
+    # This is not to be relied upon and is subject to change
+    # Usage:
+    #   result = await runtime.call_function(...)
+    #   val = json.loads(result.unstable_internal_repr())
+    #   print(val)
+    def unstable_internal_repr(self) -> str: ...
+
 class FunctionResultStream:
     """The result of a BAML function stream.
 

--- a/engine/language_client_python/src/types/function_results.rs
+++ b/engine/language_client_python/src/types/function_results.rs
@@ -20,6 +20,12 @@ impl FunctionResult {
         self.inner.parsed_content().is_ok()
     }
 
+    /// This is a debug function that returns the internal representation of the response
+    /// This is not to be relied upon and is subject to change
+    fn unstable_internal_repr(&self) -> String {
+        serde_json::json!(self.inner.llm_response()).to_string()
+    }
+
     // Cast the parsed value to a specific type
     // the module is the module that the type is defined in
     fn cast_to(


### PR DESCRIPTION
This exposes the very last web request with some stats. Retries and such are not available.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add `unstable_internal_repr` method to `FunctionResult` for debugging and serialize related Rust structs.
> 
>   - **Functionality**:
>     - Add `unstable_internal_repr()` method to `FunctionResult` in `baml_py.pyi` and `function_results.rs` for debugging internal response representation.
>   - **Serialization**:
>     - Add `Serialize` derive to `RenderedPrompt` in `lib.rs`.
>     - Add `Serialize` derive to `LLMResponse`, `LLMErrorResponse`, `ErrorCode`, and `LLMCompleteResponse` in `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0d85cd974732fd1f0a994f25a58ba43d3a9a2b78. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->