### PR TITLE
Revert .json loading in tsconfig and use require

### DIFF
--- a/typescript/vscode-ext/packages/vscode/package.json
+++ b/typescript/vscode-ext/packages/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "baml-client",
   "displayName": "Baml - Insider - Client",
   "description": "This is the Insider Build of the Baml VS Code extension (only use it if you are also using the dev version of the CLI).",
-  "version": "0.62.0",
+  "version": "1.1.0",
   "publisher": "Gloo",
   "repository": "https://github.com/BoundaryML/baml",
   "homepage": "https://boundaryml.com",

--- a/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
+++ b/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
@@ -16,7 +16,7 @@ import type { BamlVSCodePlugin } from '../types'
 import { URI } from 'vscode-uri'
 import StatusBarPanel from '../../panels/StatusBarPanel'
 
-import packageJson from '../../../package.json'
+const packageJson = require('../../../../package.json') // eslint-disable-line
 
 const BamlConfig = z.optional(
   z.object({

--- a/typescript/vscode-ext/packages/vscode/tsconfig.json
+++ b/typescript/vscode-ext/packages/vscode/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
-    "resolveJsonModule": true,
     "module": "commonjs",
     "noUnusedLocals": false,
     "target": "es6",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reverts JSON loading in `index.ts` to use `require` and updates version in `package.json` to `1.1.0`.
> 
>   - **Behavior**:
>     - Reverts JSON loading method in `index.ts` from ES6 `import` to CommonJS `require` for `package.json`.
>     - Updates version in `package.json` from `0.62.0` to `1.1.0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for a26e891fe9dd3d06d1ad8b9b6f19d789352f5fd8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->