### PR TITLE
Constraints cause a runtime bug when functions are unioned with media types

### DIFF
--- a/engine/baml-lib/jinja-runtime/src/lib.rs
+++ b/engine/baml-lib/jinja-runtime/src/lib.rs
@@ -3,8 +3,8 @@ use colored::*;
 mod chat_message_part;
 
 mod output_format;
-use internal_baml_core::ir::repr::IntermediateRepr;
 use internal_baml_core::ir::jinja_helpers::get_env;
+use internal_baml_core::ir::repr::IntermediateRepr;
 pub use output_format::types;
 mod baml_value_to_jinja_value;
 
@@ -435,7 +435,6 @@ pub fn render_prompt(
         }
     }
 }
-
 
 #[cfg(test)]
 mod render_tests {
@@ -1977,5 +1976,4 @@ mod render_tests {
 
     //     Ok(())
     // }
-
 }


### PR DESCRIPTION
The bug appears to be a bad propagation of attributes on `media | string`

Repro:
cd ./engine/baml-runtime/tests
cargo test --features internal -- internal_tests::test_with_image_union --exact --show-output

Bug:
```
Error: receipt: Failed to evaluate assert: Could not unify Media with Union([Primitive(Media(Image)), Primitive(String)])
```
