### PR TITLE
syntax highlight vscode

### DIFF
--- a/typescript/vscode-ext/packages/syntaxes/baml.tmLanguage.json
+++ b/typescript/vscode-ext/packages/syntaxes/baml.tmLanguage.json
@@ -326,6 +326,33 @@
     "block_attribute": {
       "patterns": [
         {
+          "begin": "(@{1,2}(?:check|assert))\\(([^,]+)?\\s*,\\s*()",
+          "beginCaptures": {
+            "1": { "name": "entity.name.function.attribute" },
+            "2": { "name": "variable.parameter.checkName" },
+            "3": { "name": "punctuation.definition.template-expression.begin" }
+          },
+          "end": "()\\)",
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.template-expression.end" }
+          },
+          "contentName": "string.quoted.block.thing",
+          "patterns": [{ "include": "source.baml-jinja" }]
+        },
+        {
+          "begin": "(@{1,2}assert)\\(",
+          "beginCaptures": {
+            "1": { "name": "entity.name.function.attribute.assert" },
+            "2": { "name": "punctuation.definition.template-expression.begin" }
+          },
+          "end": "()\\)",
+          "endCaptures": {
+            "1": { "name": "punctuation.definition.template-expression.end" }
+          },
+          "contentName": "string.quoted.block.thing",
+          "patterns": [{ "include": "source.baml-jinja" }]
+        },
+        {
           "begin": "(@{1,2}\\w+)\\(#\"",
           "beginCaptures": {
             "1": { "name": "entity.name.function.attribute" }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add syntax highlighting for `@check` and `@assert` attributes in BAML files for VSCode.
> 
>   - **Syntax Highlighting**:
>     - Add new patterns for `@check` and `@assert` attributes in `baml.tmLanguage.json`.
>     - Handles both single and double `@` prefixes.
>     - Captures function names and parameters for these attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 962c428b7600d35d9e4d979f861878c6f9a48484. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->