### PR TITLE
chore: Correct Promptfiddle link and back to top button

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ To rebuild the playground UI:
 2. `pnpm build`
 3. Close and open the playground in your “Debug mode VSCode window”
 
-## Testing [prompfiddle.com](http://prompfiddle.com)
+## Testing [promptfiddle.com](http://promptfiddle.com)
 
 This is useful if you want to iterate faster on the Extension UI, since it supports hot-reloading.
 

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ HQ in Seattle, WA
 
 P.S. We're hiring for software engineers. [Email us](founders@boundaryml.com) or reach out on [discord](https://discord.gg/ENtBB6kkXH)!
 
-<div align="left" align-items: left;">
+<div align="left" style="align-items: left;">
         <a href="#top">
             <img src="https://img.shields.io/badge/Back%20to%20Top-000000?style=for-the-badge&logo=github&logoColor=white" alt="Back to Top">
         </a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-<a href="https://boundaryml.com?utm_source=github" target="_blank" rel="noopener noreferrer" id="top">
+<a href="https://boundaryml.com?utm_source=github" target="_blank" rel="noopener noreferrer">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/assets/baml-lamb-white.png">
-    <img src="docs/assets/baml-lamb-white.png" height="64">
+    <img src="docs/assets/baml-lamb-white.png" height="64" id="top">
   </picture>
   
 </a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://boundaryml.com?utm_source=github" target="_blank" rel="noopener noreferrer">
+<a href="https://boundaryml.com?utm_source=github" target="_blank" rel="noopener noreferrer" id="top">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/assets/baml-lamb-white.png">
     <img src="docs/assets/baml-lamb-white.png" height="64">
@@ -341,3 +341,9 @@ Made with ❤️ by Boundary
 HQ in Seattle, WA
 
 P.S. We're hiring for software engineers. [Email us](founders@boundaryml.com) or reach out on [discord](https://discord.gg/ENtBB6kkXH)!
+
+<div align="left" align-items: left;">
+        <a href="#top">
+            <img src="https://img.shields.io/badge/Back%20to%20Top-000000?style=for-the-badge&logo=github&logoColor=white" alt="Back to Top">
+        </a>
+</div>


### PR DESCRIPTION
Corrected Prompt fiddle link and added back to top button for easy accessibility
![image](https://github.com/user-attachments/assets/9cc5b4fe-63f5-4610-8890-f0f693ed603a)

now fixed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects a link in `CONTRIBUTING.md` and adds a "Back to Top" button in `README.md`.
> 
>   - **Documentation**:
>     - Corrected link from `prompfiddle.com` to `promptfiddle.com` in `CONTRIBUTING.md`.
>   - **UI Enhancements**:
>     - Added "Back to Top" button in `README.md` for easier navigation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for dcb7e1e4e11b69ff86232ea620998a14f93f6282. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->