### PR TITLE
Fix spans for JinjaExpressions + Improve syntax highlighting (lezer)

### DIFF
--- a/engine/baml-lib/schema-ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/schema-ast/src/parser/datamodel.pest
@@ -91,13 +91,16 @@ arguments_list = { "(" ~ (NEWLINE?) ~ expression? ~ ("," ~ (NEWLINE?) ~ expressi
 map_key   = { identifier | quoted_string_literal }
 map_entry = { (comment_block | empty_lines)* ~ map_key ~ (expression | ENTRY_CATCH_ALL)? ~ trailing_comment? }
 
-splitter         = _{ ("," ~ NEWLINE?) | NEWLINE }
-map_expression   =  { "{" ~ empty_lines? ~ (map_entry ~ (splitter ~ map_entry)*)? ~ (comment_block | empty_lines)* ~ "}" }
-array_expression =  { "[" ~ empty_lines? ~ ((expression | ARRAY_CATCH_ALL) ~ trailing_comment? ~ (splitter ~ (comment_block | empty_lines)* ~ (expression | ARRAY_CATCH_ALL) ~ trailing_comment?)*)? ~ (comment_block | empty_lines)* ~ splitter? ~ "]" }
-jinja_expression =  { "{{" ~ (!("}}" | "{{") ~ ANY)* ~ "}}" }
-expression       =  { jinja_expression | map_expression | array_expression | numeric_literal | string_literal | identifier }
-ARRAY_CATCH_ALL  =  { !"]" ~ CATCH_ALL }
-ENTRY_CATCH_ALL  =  { field_attribute | BLOCK_LEVEL_CATCH_ALL }
+splitter          = _{ ("," ~ NEWLINE?) | NEWLINE }
+map_expression    =  { "{" ~ empty_lines? ~ (map_entry ~ (splitter ~ map_entry)*)? ~ (comment_block | empty_lines)* ~ "}" }
+array_expression  =  { "[" ~ empty_lines? ~ ((expression | ARRAY_CATCH_ALL) ~ trailing_comment? ~ (splitter ~ (comment_block | empty_lines)* ~ (expression | ARRAY_CATCH_ALL) ~ trailing_comment?)*)? ~ (comment_block | empty_lines)* ~ splitter? ~ "]" }
+jinja_block_open  = _{ "{{" }
+jinja_block_close = _{ "}}" }
+jinja_body        =  { (!(jinja_block_open | jinja_block_close) ~ ANY)* }
+jinja_expression  =  { jinja_block_open ~ jinja_body ~ jinja_block_close }
+expression        =  { jinja_expression | map_expression | array_expression | numeric_literal | string_literal | identifier }
+ARRAY_CATCH_ALL   =  { !"]" ~ CATCH_ALL }
+ENTRY_CATCH_ALL   =  { field_attribute | BLOCK_LEVEL_CATCH_ALL }
 // ######################################
 // Literals / Values
 // ######################################

--- a/engine/baml-lib/schema-ast/src/parser/parse_expression.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_expression.rs
@@ -343,7 +343,7 @@ mod tests {
             .unwrap();
         let expr = parse_jinja_expression(pair, &mut diagnostics);
         match expr {
-            Expression::JinjaExpressionValue(JinjaExpression(s), _) => assert_eq!(s, " 1 + 1 "),
+            Expression::JinjaExpressionValue(JinjaExpression(s), _) => assert_eq!(s, "1 + 1"),
             _ => panic!("Expected JinjaExpression, got {:?}", expr),
         }
     }

--- a/engine/baml-lib/schema-ast/src/parser/parse_expression.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_expression.rs
@@ -3,8 +3,8 @@ use super::{
     parse_identifier::parse_identifier,
     Rule,
 };
-use baml_types::JinjaExpression;
 use crate::{assert_correct_parser, ast::*, unreachable_rule};
+use baml_types::JinjaExpression;
 use internal_baml_diagnostics::Diagnostics;
 
 pub(crate) fn parse_expression(
@@ -255,24 +255,41 @@ fn unescape_string(val: &str) -> String {
 /// therefor the backing string should be contain "\\n".
 pub fn parse_jinja_expression(token: Pair<'_>, diagnostics: &mut Diagnostics) -> Expression {
     assert_correct_parser!(token, Rule::jinja_expression);
-    let mut inner_text = String::new();
-    for c in token.as_str()[2..token.as_str().len() - 2].chars() {
-        match c {
-            // When encountering a single backslash, produce two backslashes.
-            '\\' => inner_text.push_str("\\\\"),
-            // Otherwise, just copy the character.
-            _ => inner_text.push(c),
-        }
+    let value = token
+        .into_inner()
+        .map(|token| match token.as_rule() {
+            Rule::jinja_body => {
+                let mut inner_text = String::new();
+                for c in token.as_str().chars() {
+                    match c {
+                        // When encountering a single backslash, produce two backslashes.
+                        '\\' => inner_text.push_str("\\\\"),
+                        // Otherwise, just copy the character.
+                        _ => inner_text.push(c),
+                    }
+                }
+                return Expression::JinjaExpressionValue(
+                    JinjaExpression(inner_text),
+                    diagnostics.span(token.as_span()),
+                );
+            }
+            _ => unreachable_rule!(token, Rule::jinja_expression),
+        })
+        .next();
+
+    if let Some(value) = value {
+        value
+    } else {
+        unreachable!("Encountered impossible jinja expression during parsing")
     }
-    Expression::JinjaExpressionValue(JinjaExpression(inner_text), diagnostics.span(token.as_span()))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::{BAMLParser, Rule};
-    use pest::{Parser, parses_to, consumes_to};
+    use super::*;
     use internal_baml_diagnostics::{Diagnostics, SourceFile};
+    use pest::{consumes_to, parses_to, Parser};
 
     #[test]
     fn array_trailing_comma() {
@@ -330,5 +347,4 @@ mod tests {
             _ => panic!("Expected JinjaExpression, got {:?}", expr),
         }
     }
-
 }

--- a/typescript/codemirror-lang-baml/src/index.ts
+++ b/typescript/codemirror-lang-baml/src/index.ts
@@ -20,7 +20,7 @@ import { parser } from './syntax.grammar'
 export const BAMLLanguage = LRLanguage.define({
   parser: parser.configure({
     wrap: parseMixed((node) => {
-      if (node.name !== 'PromptExprContents') {
+      if (node.name !== 'PromptExprContents' && node.name !== 'JinjaExpr') {
         return null
       }
 
@@ -101,6 +101,8 @@ export const BAMLLanguage = LRLanguage.define({
 const exampleCompletion = BAMLLanguage.data.of({
   autocomplete: [
     snippetCompletion('@alias(#"${one}"#)', { label: '@alias' }),
+    snippetCompletion('@assert({{ this }})', { label: '@assert' }),
+    snippetCompletion('@check(custom_check_name, {{ this }})', { label: '@check' }),
     snippetCompletion('@description(#"${}"#)', { label: '@description' }),
     snippetCompletion('class ${ClassName} {\n  ${property string}\n}', { label: 'class' }),
     snippetCompletion('enum ${EnumName} {\n  ${ONE}\n  ${TWO}\n}', { label: 'enum' }),

--- a/typescript/codemirror-lang-baml/src/syntax.grammar
+++ b/typescript/codemirror-lang-baml/src/syntax.grammar
@@ -66,7 +66,7 @@ TemplateStringDecl {
     NumericLiteral, QuotedString, UnquotedString, UnquotedAttributeValue
   }
   @precedence {
-    MapIdentifier, IdentifierDecl
+    MapIdentifier, IdentifierDecl, UnquotedAttributeValue
   }
 
   MapIdentifier { "map" }

--- a/typescript/codemirror-lang-baml/src/syntax.grammar
+++ b/typescript/codemirror-lang-baml/src/syntax.grammar
@@ -27,11 +27,11 @@ EnumDecl { "enum" IdentifierDecl "{" (BlockAttribute | EnumValueDecl)* "}" }
 EnumValueDecl { IdentifierDecl FieldAttribute* }
 
 FieldAttribute {
-  "@" IdentifierDecl AttributeValue
+  "@" IdentifierDecl (AttributeValue | AttributeValue2)
 }
 
 BlockAttribute {
-  "@@" IdentifierDecl AttributeValue
+  "@@" IdentifierDecl (AttributeValue | AttributeValue2)
 }
 
 FunctionDecl {
@@ -101,8 +101,9 @@ TemplateStringDecl {
 @skip {} {
   PromptExpr { '#"' PromptExprContents '"#'}
   PromptExprContents { (promptChar)* }
-  AttributeValue { '(' (QuotedString | UnquotedAttributeValue | PromptExprNonJinja)? ')' }
-  //AttributeValue2 { '(#"' (QuotedString |  )? '"#)' }
+  JinjaExpr { "{{" (promptChar)* "}}" }
+  AttributeValue { '(' (QuotedString | UnquotedAttributeValue | PromptExprNonJinja | JinjaExpr)? ')' }
+  AttributeValue2 { '(' IdentifierDecl (',' JinjaExpr)? ')' }
   PromptExprNonJinja { '#"' PromptExprContents '"#'}
 
 }

--- a/typescript/turbo.json
+++ b/typescript/turbo.json
@@ -11,12 +11,12 @@
     },
     "@gloo-ai/baml-schema-wasm-node#build": {
       "dependsOn": ["^build"],
-      "inputs": ["../../engine/**/*.rs", "../../engine/**/*.toml", "../../engine/**/*.j2"],
+      "inputs": ["../../engine/**/*.rs", "../../engine/**/*.toml", "../../engine/**/*.j2", "../../engine/**/*.pest"],
       "outputs": ["dist/**"]
     },
     "@gloo-ai/baml-schema-wasm-web#build": {
       "dependsOn": ["^build", "@gloo-ai/baml-schema-wasm-node#build"],
-      "inputs": ["../../engine/**/*.rs", "../../engine/**/*.toml", "../../engine/**/*.j2"],
+      "inputs": ["../../engine/**/*.rs", "../../engine/**/*.toml", "../../engine/**/*.j2", "../../engine/**/*.pest"],
       "outputs": ["dist/**"]
     },
     "@gloo-ai/web-panel#build": {


### PR DESCRIPTION
- Prior our spans were off by 2 due to including "{{"

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes Jinja expression span calculation and improves syntax highlighting in BAML language.
> 
>   - **Behavior**:
>     - Fixes span calculation for `jinja_expression` in `parse_jinja_expression()` in `parse_expression.rs` by separating Jinja block delimiters from the body.
>     - Updates syntax highlighting to include `JinjaExpr` in `index.ts` and `syntax.grammar`.
>   - **Parser**:
>     - Refactors `jinja_expression` in `datamodel.pest` to use `jinja_block_open`, `jinja_body`, and `jinja_block_close`.
>     - Modifies `parse_jinja_expression()` in `parse_expression.rs` to handle new Jinja expression structure.
>   - **Build**:
>     - Adds `.pest` files to build inputs in `turbo.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f198733a2a2759759f0a78efd7f2fd17f00ba8c7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->