### PR TITLE
Add links to DynamicTypes from intro pages

### DIFF
--- a/docs/docs/snippets/supported-types.mdx
+++ b/docs/docs/snippets/supported-types.mdx
@@ -255,6 +255,9 @@ enum Name {
 }
 ```
 
+If you need to add new variants, because they need to be loaded from a file or fetched dynamically
+from a database, you can do this with [Dynamic Types](/docs/calling-baml/dynamic-types).
+
 ### class
 
 **See also:** [Class](/docs/snippets/class)
@@ -272,6 +275,9 @@ class Car {
   year int @description("Year of manufacture")
 }
 ```
+
+If you need to add fields to a class because some properties of your class are only
+known at runtime, you can do this with [Dynamic Types](/docs/calling-baml/dynamic-types).
 
 ### Optional (?)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds links to Dynamic Types documentation in `supported-types.mdx` for `enum` and `class` sections.
> 
>   - **Documentation**:
>     - Adds links to [Dynamic Types](/docs/calling-baml/dynamic-types) in `supported-types.mdx` under `enum` and `class` sections.
>     - Provides guidance for adding new variants to `enum` and fields to `class` dynamically.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 1119858469291e1691d43334a2c42304143a139f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->