### PR TITLE
Fix infinite redirect on docs

### DIFF
--- a/fern/01-guide/08-integrations/nextjs.mdx
+++ b/fern/01-guide/08-integrations/nextjs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Next.js Integration
-slug: docs/baml-nextjs/baml-nextjs
+
 ---
 
 BAML can be used with Vercel's AI SDK to stream BAML functions to your UI.

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -668,7 +668,7 @@ redirects:
   - source: "/docs/calling-baml/multi-modal"
     destination: "/guide/baml-basics/multi-modal"
   - source: "/docs/baml-nextjs/baml-nextjs"
-    destination: "/docs/baml-nextjs/baml-nextjs"
+    destination: "/guides/installation-language/next-js"
   - source: "/docs/observability/overview"
     destination: "/guide/observability/tracking-usage"
   - source: "/docs/observability/tracing-tagging"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes infinite redirect by correcting the redirect path in `docs.yml`.
> 
>   - **Redirect Fix**:
>     - Corrects redirect in `docs.yml` from `/docs/baml-nextjs/baml-nextjs` to `/guides/installation-language/next-js` to fix infinite redirect issue.
>   - **Misc**:
>     - Removes `slug` from `nextjs.mdx` front matter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 4f1266f1ab5dfc5ab4eb1c5917cdad8256fd87d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->