### PR TITLE
Fix syntax error when user misses return type on functions

### DIFF
--- a/engine/baml-lib/baml/tests/validation_files/functions_v2/duplicate_names.baml
+++ b/engine/baml-lib/baml/tests/validation_files/functions_v2/duplicate_names.baml
@@ -14,6 +14,13 @@ function Bar(a: string, b: int | bool) -> int {
 //  5 | 
 //  6 | function Bar(a: string, b: int | bool) -> int {
 //    | 
+// error: Invalid syntax for function "Bar". Use:
+// function Bar(params...) -> ReturnType { ... }
+//   -->  functions_v2/duplicate_names.baml:1
+//    | 
+//    | 
+//  1 | function Bar {
+//    | 
 // error: Error validating: Unknown field `input` in function
 //   -->  functions_v2/duplicate_names.baml:2
 //    | 

--- a/engine/baml-lib/baml/tests/validation_files/functions_v2/invalid_no_return.baml
+++ b/engine/baml-lib/baml/tests/validation_files/functions_v2/invalid_no_return.baml
@@ -1,0 +1,12 @@
+function FooBar(arg: int) {
+  client "openai/gpt-3.5-turbo"
+  prompt #""#
+}
+
+// error: Invalid syntax for function "FooBar". Use:
+// function FooBar(params...) -> ReturnType { ... }
+//   -->  functions_v2/invalid_no_return.baml:1
+//    | 
+//    | 
+//  1 | function FooBar(arg: int) {
+//    | 

--- a/engine/baml-lib/diagnostics/src/error.rs
+++ b/engine/baml-lib/diagnostics/src/error.rs
@@ -260,6 +260,13 @@ impl DatamodelError {
         Self::new(msg, span)
     }
 
+    pub fn new_invalid_function_syntax_error(func_name: &str, span: Span) -> DatamodelError {
+        Self::new(
+            format!("Invalid syntax for function \"{func_name}\". Use:\nfunction {func_name}(params...) -> ReturnType {{ ... }}"),
+            span,
+        )
+    }
+
     pub fn new_duplicate_enum_value_error(
         enum_name: &str,
         value_name: &str,

--- a/engine/baml-lib/parser-database/src/types/mod.rs
+++ b/engine/baml-lib/parser-database/src/types/mod.rs
@@ -332,13 +332,22 @@ fn visit_function<'db>(idx: ValExpId, function: &'db ast::ValueExprBlock, ctx: &
         .iter()
         .map(|f| f.name().to_string())
         .collect::<HashSet<_>>();
-    let output_deps = function
-        .output()
-        .map(|output| output.field_type.flat_idns())
-        .unwrap_or_else(Vec::new)
-        .iter()
-        .map(|f| f.name().to_string())
-        .collect::<HashSet<_>>();
+
+    let output_deps = match function.output() {
+        Some(output) => output
+            .field_type
+            .flat_idns()
+            .iter()
+            .map(|f| f.name().to_string())
+            .collect::<HashSet<_>>(),
+        None => {
+            ctx.push_error(DatamodelError::new_invalid_function_syntax_error(
+                function.name(),
+                function.identifier().span().clone(),
+            ));
+            HashSet::new()
+        }
+    };
 
     let mut prompt = None;
     let mut client = None;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes syntax error by adding error handling for functions missing return types and updates tests to validate this behavior.
> 
>   - **Behavior**:
>     - Adds error handling for functions missing return types in `visit_function()` in `mod.rs`.
>     - New error message for invalid function syntax in `new_invalid_function_syntax_error()` in `error.rs`.
>   - **Tests**:
>     - Adds `invalid_no_return.baml` to test missing return type error.
>     - Updates `duplicate_names.baml` to include syntax error test.
>   - **Misc**:
>     - Refactors `visit_function()` to use `match` for output dependencies.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for d5838f6654510f18f1d0484b4e17ac1f163fbf65. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->