### PR TITLE
bug-fix: Improve syntax highlighting for template strings

### DIFF
--- a/typescript/vscode-ext/packages/syntaxes/baml.tmLanguage.json
+++ b/typescript/vscode-ext/packages/syntaxes/baml.tmLanguage.json
@@ -78,13 +78,10 @@
       ]
     },
     "template_string_declaration": {
-      "begin": "(template_string)\\s+(\\w+)\\(([^)]*)\\)\\s+(#)(\")",
+      "begin": "(template_string)\\s+(\\w+)",
       "beginCaptures": {
         "1": { "name": "storage.type.declaration.function" },
-        "2": { "name": "entity.name.function" },
-        "3": { "name": "variable.parameter.function" },
-        "4": { "name": "string.quoted.block.baml" },
-        "5": { "name": "string.quoted.block.baml" }
+        "2": { "name": "entity.name.function" }
       },
       "end": "(\")(#)",
       "endCaptures": {
@@ -92,12 +89,7 @@
         "2": { "name": "string.quoted.block.baml" }
       },
       "name": "string.quoted.block.baml",
-      "patterns": [
-        {
-          "include": "source.baml-jinja"
-        },
-        { "include": "#block_attribute" }
-      ]
+      "patterns": [{ "include": "#comment" }, { "include": "#function_parameters" }, { "include": "#block_string" }]
     },
     "function_declaration": {
       "comment": "Function declaration",
@@ -583,6 +575,18 @@
           "include": "source.ts"
         }
       ]
+    },
+    "block_string": {
+      "begin": "(#(\"){1,3})",
+      "beginCaptures": {
+        "1": { "name": "string.quoted.block.baml.startquote" }
+      },
+      "end": "((\"){1,3}#)",
+      "endCaptures": {
+        "1": { "name": "string.quoted.block.baml.endquote" }
+      },
+      "contentName": "string.quoted.block.baml",
+      "patterns": [{ "include": "source.baml-jinja" }]
     },
     "block_string_pair": {
       "begin": "(\\w+)?\\s+(#(\"){1,3})",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves syntax highlighting for template strings in BAML by simplifying regex and adding a new block string pattern.
> 
>   - **Syntax Highlighting**:
>     - Simplified `begin` regex in `template_string_declaration` to `(template_string)\s+(\w+)`.
>     - Adjusted `beginCaptures` in `template_string_declaration` to remove unnecessary captures.
>     - Updated `patterns` in `template_string_declaration` to include `#comment`, `#function_parameters`, and `#block_string`.
>     - Added new `block_string` pattern to handle block strings with `#"` and `"#` delimiters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 95e6fadb91bd7c7af166d8f0d8e1580e85cfb1c9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->