### PR TITLE
more doc link fixes

### DIFF
--- a/fern/01-guide/06-prompt-engineering/hallucinations.mdx
+++ b/fern/01-guide/06-prompt-engineering/hallucinations.mdx
@@ -28,11 +28,11 @@ Let us know if you want more tips for processing images, we have some helper pro
 
 
 ### 2. Use reasoning or reflection prompting
-Read our [chain-of-thought guide](/01-guide/06-prompt-engineering/chain-of-thought) for more.
+Read our [chain-of-thought guide](/examples/prompt-engineering/chain-of-thought) for more.
 
 ### 3. Watch out for contradictions and word associations
 
-Each word you add into the prompt will cause it to associate it with something it saw before in its training data. This is why we have techniques like [symbol tuning](/01-guide/06-prompt-engineering/symbol-tuning) to help control this bias.
+Each word you add into the prompt will cause it to associate it with something it saw before in its training data. This is why we have techniques like [symbol tuning](/examples/prompt-engineering/symbol-tuning) to help control this bias.
 
 
 Let's say you have a prompt that says:

--- a/fern/01-guide/08-integrations/nextjs.mdx
+++ b/fern/01-guide/08-integrations/nextjs.mdx
@@ -20,6 +20,36 @@ You will need to use Server Actions, from the App Router, for this tutorial. You
 - Install the VSCode extension and Save a baml file to generate the client (or use `npx baml-cli generate`).
 
 
+### Update next.config.mjs
+
+@boundaryml/baml uses a native node addon to run the BAML functions. You need to tell NextJS to use the loader for these files.
+```JS
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverComponentsExternalPackages: ["@boundaryml/baml"],
+  },
+  webpack: (config, { dev, isServer, webpack, nextRuntime }) => {
+    config.module.rules.push({
+      test: /\.node$/,
+      use: [
+        {
+          loader: "nextjs-node-loader",
+          options: {
+            outputPath: config.output.path,
+          },
+        },
+      ],
+    });
+
+    return config;
+  },
+};
+
+export default nextConfig;
+```
+
+
 ### Create some helper utilities to stream BAML functions
 Let's add some helpers to export our baml functions as streamable server actions. See the last line in this file, where we export the `extractResume` function.
 

--- a/fern/01-guide/what-is-baml_src.mdx
+++ b/fern/01-guide/what-is-baml_src.mdx
@@ -13,4 +13,4 @@ Some things to note:
 1. All declarations within this directory are accessible across all files contained in the `baml_src` folder.
 2. You can have multiple files, and even nest subdirectories.
 
-You don't need to worry about including this directory when deploying your code. See: [Deploying](get-started/deploying/aws)
+You don't need to worry about including this directory when deploying your code. See: [Deploying](/guide/development/deploying/aws)

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -12,6 +12,10 @@
   /* font-weight: 600; */
 }
 
+.prose code {
+  background-color: #f8f8f8;
+}
+
 .fern-sidebar-link-container[data-state="active"] .fern-sidebar-link {
   font-weight: 600;
 }

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -375,14 +375,14 @@ navigation:
             path: 03-reference/baml/clients/providers/aws-bedrock.mdx
           - page: "Anthropic"
             path: 03-reference/baml/clients/providers/anthropic.mdx
-          - page: "Google AI Studio"
+          - page: "Google AI: Gemini"
             path: 03-reference/baml/clients/providers/google-ai.mdx
+          - page: "Google: Vertex"
+            path: 03-reference/baml/clients/providers/vertex.mdx
           - page: "OpenAI"
             path: 03-reference/baml/clients/providers/openai.mdx
           - page: "OpenAI from Azure"
             path: 03-reference/baml/clients/providers/azure.mdx
-          - page: "Vertex"
-            path: 03-reference/baml/clients/providers/vertex.mdx
           - page: "openai-generic"
             path: 03-reference/baml/clients/providers/openai-generic.mdx
           - page: "openai-generic: Groq"

--- a/fern/pages/changelog.mdx
+++ b/fern/pages/changelog.mdx
@@ -5,6 +5,57 @@ title: Changelog
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 
+
+## [0.65.0](https://github.com/boundaryml/baml/compare/0.64.0..0.65.0) - 2024-10-31
+
+### Documentation
+
+- **New Documentation Structure**: Introduced version 3 of the documentation, enhancing clarity and organization. ([#1118](https://github.com/boundaryml/baml/commit/bab2767414172dd632437a57631c4cee04910518))
+
+
+### Bug Fixes
+
+- **Python Type Handling**: Moved Python Checked and Check types into `baml_client` for better type management. ([#1122](https://github.com/boundaryml/baml/commit/0ccf473fd821d25d431bbf4341c4e837967104bf))
+- **Literal Input Type Checking**: Fixed an issue where literal inputs were not being type-checked correctly. ([#1121](https://github.com/boundaryml/baml/commit/aa5dc85026a175216b5caae6320d09a1fcd35752))
+
+
+## [0.64.0](https://github.com/boundaryml/baml/compare/0.63.0..0.64.0) - 2024-10-29
+
+### Bug Fixes
+- **Playground Stability:** Prevented crashes in the playground due to malformed vertex credentials ([#1107](https://github.com/boundaryml/baml/commit/e665346fbc84a9b969a979cfdf1c70d530201e93)) - _Samuel Lijin_
+- **Union Handling:** Addressed an issue with union types in the schema ([#1096](https://github.com/boundaryml/baml/commit/cb5ce7623d3e95464fb5e5152c4d2339458caa26)) - _Greg Hale_
+- **WASM Function Signatures:** Resolved stack overflow when computing WASM function signatures ([#1100](https://github.com/boundaryml/baml/commit/aa736ed2d7386cae78421c22d5669c73d8921085)) - _aaronvg_
+- **VSCode Extension:** Fixed crashes in the VSCode extension that caused the output panel to open unexpectedly ([#1103](https://github.com/boundaryml/baml/commit/cb5a266bc68f15483f3ec3fa0f4edbc8d176287a)) - _hellovai_
+- **Static Analysis Improvements:** Enhanced static analysis on Jinja expressions and `regex_match` functions ([#1102](https://github.com/boundaryml/baml/commit/7ca8136ffbc690877091627415941674f6f14b2f), [#1104](https://github.com/boundaryml/baml/commit/83ddb1cfe81c9b5f6ae620c331c4eefe512c78bd)) - _hellovai_
+- **Codegen Enhancements:** Fixed code generation for Python boolean literals and updated integration tests ([#1099](https://github.com/boundaryml/baml/commit/635976238fd9246bfb8764875358a36b4ec6a7f5)) - _Antonio Sarosi_
+- **Enum Handling:** Improved substring alias handling for enums ([#1098](https://github.com/boundaryml/baml/commit/0c5cbd4ae03d2bc836ee4b61a7df638855bb72ca)) - _Miguel Cárdenas_
+- **Syntax Highlighting:** Refined span calculations for Jinja expressions and improved VSCode syntax highlighting with Lezer ([#1110](https://github.com/boundaryml/baml/commit/a53072f5fe9fe83a0accb36e43a06550602a3c65)) - _hellovai_
+- **Ruby Support:** Fixed literal boolean tests for Ruby ([#1109](https://github.com/boundaryml/baml/commit/23e590b0b2fdb51f80e7eced769baabd12b3be22)) - _Antonio Sarosi_
+
+### Features
+- **Constraint Support:** Added the ability to define constraints using Jinja expressions ([#1006](https://github.com/boundaryml/baml/commit/d794f28b4f8830b1a40cd08043ecdc562938d36e)) - _Greg Hale_
+- **VSCode & Fiddle UI:** Introduced a new "Intro to Checks" UI for easier onboarding ([#1106](https://github.com/boundaryml/baml/commit/11efa5e97f8e9b8f385b7fb0e823f5ff2bc4c314)) - _Samuel Lijin_
+- **Dev Container Configurations:** Added Dev Container configurations for streamlined development environments ([#1112](https://github.com/boundaryml/baml/commit/5790393d7ad320e9e257c09e461c9bc39310a834)) - _Antonio Sarosi_
+
+### Documentation
+- **Constraints Documentation:** Published new documentation for defining constraints in BAML ([#1113](https://github.com/boundaryml/baml/commit/6332021a59661d3931934adc2afbf4f99f6f4bee)) - _Greg Hale_
+- **Dynamic Types Linking:** Added cross-links to dynamic types documentation for easier navigation ([#1116](https://github.com/boundaryml/baml/commit/8ce0a539d74d05438e8047e4e02022ddd7121e21)) - _Greg Hale_
+
+### Miscellaneous
+- **Code Quality:** Improved style and fixed typos in the codebase ([#1115](https://github.com/boundaryml/baml/commit/4c3970a6e6ce998a784e682f4c218ba2a69cf86a)) - _Greg Hale_
+- **Parsing Stability:** Added logic to prevent assertions from parsing errors and ensured checks no longer affect parsing ([#1101](https://github.com/boundaryml/baml/commit/5ec89c92ab14622afddc3ce348c5b981b4840492)) - _hellovai_
+- **Version Bump:** Bumped version to 0.64.0 ([#1114](https://github.com/boundaryml/baml/commit/90d3c17ba67bc1467ee5973ff6cf257069e265b9), [#ff7e152](https://github.com/boundaryml/baml/commit/ff7e152510395bab1d38afa60211226070d12cc2)) - _Vaibhav Gupta_
+
+
+## [0.63.0](https://github.com/boundaryml/baml/compare/0.62.0..0.63.0) - 2024-10-23
+
+### Bug Fixes
+- Fix dynamic enums which already are defined in BAML (#1080) - ([22d0f1c](https://github.com/boundaryml/baml/commit/22d0f1cff3428c2cd58ea78c50c4fc7ea39c8d0c)) - hellovai
+
+### Features
+- Updated clients.baml to use the latest sonnet model (#1081) - ([71df0b7](https://github.com/boundaryml/baml/commit/71df0b7b627ba218d581d2c21be01fea4e4993c1)) - aaronvg
+- Improved clients.baml generated via baml init (#1089) - ([682dd66](https://github.com/boundaryml/baml/commit/682dd66f4adab8c4fad13bfe32a3fc0268d8b511)) - hellovai
+
 <hr/>
 ## [0.62.0](https://github.com/boundaryml/baml/compare/0.61.1..0.62.0) - 2024-10-21
 

--- a/fern/pages/welcome.mdx
+++ b/fern/pages/welcome.mdx
@@ -44,7 +44,7 @@ With BAML you can build reliable Agents, Chatbots with RAG, extract data from PD
   <Card
     title="Reference"
     icon="fa-regular fa-code"
-    href="/learn/sdks/introduction/overview"
+    href="/ref"
   >
     Language docs on all BAML syntax. Quickly learn syntax with simple examples and code snippets.
   </Card>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes documentation links, updates Next.js configuration, and adds changelog entries.
> 
>   - **Documentation Links**:
>     - Fixed links in `hallucinations.mdx` for `chain-of-thought` and `symbol tuning`.
>     - Updated link in `what-is-baml_src.mdx` for `Deploying`.
>   - **Configuration**:
>     - Added `next.config.mjs` configuration for `@boundaryml/baml` in `nextjs.mdx`.
>   - **Styles**:
>     - Added background color for `.prose code` in `styles.css`.
>   - **Navigation**:
>     - Updated `docs.yml` to reflect changes in documentation structure.
>   - **Changelog**:
>     - Added entries for versions `0.65.0`, `0.64.0`, and `0.63.0` in `changelog.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 3f59d3a516a2b35ccc941d1a6a154056e9f503cf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->