### PR TITLE
Fix build

### DIFF
--- a/engine/.cargo/config.toml
+++ b/engine/.cargo/config.toml
@@ -4,6 +4,6 @@ rustflags = ["--cfg", "tracing_unstable"]
 
 # https://github.com/rust-lang/cargo/issues/8607
 [target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=-crt-static"]
+rustflags = ["-C", "target-feature=-crt-static", "--cfg", "tracing_unstable"]
 [target.aarch64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=-crt-static"]
+rustflags = ["-C", "target-feature=-crt-static", "--cfg", "tracing_unstable"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `--cfg tracing_unstable` to `rustflags` for specific targets in `engine/.cargo/config.toml`.
> 
>   - **Build Configuration**:
>     - Add `--cfg tracing_unstable` to `rustflags` for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets in `engine/.cargo/config.toml` to enable unstable tracing features.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 2a1b373c1144e69778fe840adb2ef8418b13ed80. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->