### PR TITLE
Make it possible to generate code better in structures with snippets

### DIFF
--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_collection.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_collection.rs
@@ -10,6 +10,7 @@ pub enum JsonCollection {
     QuotedString(String),
     TripleQuotedString(String),
     SingleQuotedString(String),
+    BacktickString(String),
     // Handles numbers, booleans, null, and unquoted strings
     UnquotedString(String),
     // Starting with // or #
@@ -25,6 +26,7 @@ impl JsonCollection {
             JsonCollection::Array(_) => "Array",
             JsonCollection::QuotedString(_) => "String",
             JsonCollection::SingleQuotedString(_) => "String",
+            JsonCollection::BacktickString(_) => "String",
             JsonCollection::TripleQuotedString(_) => "TripleQuotedString",
             JsonCollection::UnquotedString(_) => "UnquotedString",
             JsonCollection::TrailingComment(_) => "Comment",
@@ -49,6 +51,7 @@ impl From<JsonCollection> for Option<Value> {
             JsonCollection::QuotedString(s) => Value::String(s),
             JsonCollection::TripleQuotedString(s) => Value::String(s),
             JsonCollection::SingleQuotedString(s) => Value::String(s),
+            JsonCollection::BacktickString(s) => Value::String(s),
             JsonCollection::UnquotedString(s) => {
                 let s = s.trim();
                 if s == "true" {

--- a/engine/baml-lib/jsonish/src/tests/mod.rs
+++ b/engine/baml-lib/jsonish/src/tests/mod.rs
@@ -7,6 +7,7 @@ pub mod macros;
 mod test_basics;
 mod test_class;
 mod test_class_2;
+mod test_code;
 mod test_constraints;
 mod test_enum;
 mod test_lists;

--- a/engine/baml-lib/jsonish/src/tests/test_code.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_code.rs
@@ -1,0 +1,359 @@
+// examples of code the LLM may generate that we need to fix
+
+use super::*;
+
+const BAML_FILE: &str = r#"
+class Test {
+    type "code"
+    code string
+}
+"#;
+
+test_deserializer!(
+    backticks,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": `print("Hello, world!")`
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+);
+
+test_deserializer!(
+    single_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": 'print("Hello, world!")'
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+);
+
+test_deserializer!(
+    double_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+);
+
+test_deserializer!(
+    unquoted_string,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+);
+
+test_deserializer!(
+    triple_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": """print("Hello, world!")"""
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+);
+
+// Now super degenerate cases
+
+test_deserializer!(
+    unescaped_newline_double_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!
+Goodbye, world!\")"
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\nGoodbye, world!\")"
+    }
+);
+
+// Test case for unescaped newline in backticks
+test_deserializer!(
+    unescaped_newline_backticks,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": `print("Hello, world!
+Goodbye, world!")`
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\nGoodbye, world!\")"
+    }
+);
+
+// Test case for unescaped newline in single quotes
+test_deserializer!(
+    unescaped_newline_single_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": 'print("Hello, world!
+Goodbye, world!")'
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\nGoodbye, world!\")"
+    }
+);
+
+// Test case for unescaped newline in triple quotes
+test_deserializer!(
+    unescaped_newline_triple_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": """print("Hello, world!
+Goodbye, world!")"""
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\nGoodbye, world!\")"
+    }
+);
+
+// Test case for unescaped double quotes in double quotes
+test_deserializer!(
+    unescaped_double_quotes_in_double_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": "print("Hello, world!")"
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+);
+
+// Test case for unescaped double quotes in backticks
+test_deserializer!(
+    unescaped_double_quotes_in_backticks,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": `print("Hello, world!")`
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+);
+
+// Test case for unescaped single quotes in single quotes
+test_deserializer!(
+    unescaped_single_quotes_in_single_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": 'print('Hello, world!')'
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print('Hello, world!')"
+    }
+);
+
+// Test case for unescaped double quotes in triple quotes
+test_deserializer!(
+    unescaped_double_quotes_in_triple_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": """print("Hello, world!")"""
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+);
+
+// Test case for unescaped single quotes in triple quotes
+// TODO: THIS PARSES INCORRECTLY! Rare case, but should be fixed
+// if a customer complains about it.
+// https://github.com/BoundaryML/baml/issues/1145
+test_deserializer!(
+    unescaped_single_quotes_in_triple_quotes,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": """print("""Hello, world!""")"""
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print("
+    }
+);
+
+test_deserializer!(
+    unescaped_backticks_in_backticks,
+    BAML_FILE,
+    r#"
+    {
+      "type": "code",
+      "code": `console.log(`Hello, world!`)`
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "console.log(`Hello, world!`)"
+    }
+);
+
+test_deserializer!(
+    large_backticks,
+    BAML_FILE,
+    r#"
+  {
+    "type": "code",
+  "code": `import { query } from './_generated/server';
+import { v } from 'convex/values';
+
+export default query(async (ctx) => {
+  const posts = await ctx.db
+    .query('posts')
+    .order('desc')
+    .collect();
+
+  const postsWithDetails = await Promise.all(
+    posts.map(async (post) => {
+      // Fetch author information
+      const author = await ctx.db.get(post.authorId);
+      if (!author) {
+        throw new Error('Author not found');
+      }
+
+      // Count upvotes
+      const upvotes = await ctx.db
+        .query('upvotes')
+        .filter((q) => q.eq(q.field('postId'), post._id))
+        .collect();
+
+      return {
+        id: post._id.toString(),
+        title: post.title,
+        content: post.content,
+        author: {
+          id: author._id.toString(),
+          name: author.name,
+        },
+        upvoteCount: upvotes.length,
+        createdAt: post._creationTime.toString(),
+      };
+    })
+  );
+
+  return postsWithDetails;
+})`
+  }
+  "#,
+  FieldType::class("Test"),
+  {
+    "type": "code",
+    "code": r#"import { query } from './_generated/server';
+import { v } from 'convex/values';
+
+export default query(async (ctx) => {
+  const posts = await ctx.db
+    .query('posts')
+    .order('desc')
+    .collect();
+
+  const postsWithDetails = await Promise.all(
+    posts.map(async (post) => {
+      // Fetch author information
+      const author = await ctx.db.get(post.authorId);
+      if (!author) {
+        throw new Error('Author not found');
+      }
+
+      // Count upvotes
+      const upvotes = await ctx.db
+        .query('upvotes')
+        .filter((q) => q.eq(q.field('postId'), post._id))
+        .collect();
+
+      return {
+        id: post._id.toString(),
+        title: post.title,
+        content: post.content,
+        author: {
+          id: author._id.toString(),
+          name: author.name,
+        },
+        upvoteCount: upvotes.length,
+        createdAt: post._creationTime.toString(),
+      };
+    })
+  );
+
+  return postsWithDetails;
+})"#
+  }
+);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for backtick strings in JSON parser and include comprehensive test cases for various string formats.
> 
>   - **Behavior**:
>     - Add `BacktickString` variant to `JsonCollection` in `json_collection.rs`.
>     - Update `JsonParseState` in `json_parse_state.rs` to handle `BacktickString` during parsing.
>   - **Tests**:
>     - Add `test_code.rs` with test cases for `BacktickString`, including handling of unescaped newlines and quotes.
>     - Ensure existing string formats (single, double, triple quotes) are tested for similar cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c98e049c7944d1cd8b35a2fadd542576db2ee3ba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->