### PR TITLE
Fix baml_log_json logs for py, ruby, and TS

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -895,6 +895,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1060,6 +1061,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -4010,6 +4012,7 @@ dependencies = [
  "serde_json",
  "serde_magnus",
  "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/engine/language_client_python/Cargo.toml
+++ b/engine/language_client_python/Cargo.toml
@@ -46,6 +46,7 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio = { version = "1", features = ["full"] }
+tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter","valuable"] }
 
 [build-dependencies]
 pyo3-build-config = "0.21.2"

--- a/engine/language_client_ruby/ext/ruby_ffi/Cargo.toml
+++ b/engine/language_client_ruby/ext/ruby_ffi/Cargo.toml
@@ -31,6 +31,7 @@ serde.workspace = true
 serde_json.workspace = true
 serde_magnus = { git = "https://github.com/BoundaryML/serde-magnus.git", branch = "sam/magnus-0.7.1" }
 tokio = { version = "1", features = ["full"] }
+tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter","valuable"] }
 
 [dev-dependencies.magnus]
 version = "0.7.1"

--- a/engine/language_client_typescript/Cargo.toml
+++ b/engine/language_client_typescript/Cargo.toml
@@ -33,6 +33,7 @@ napi-derive = "2"
 serde.workspace = true
 serde_json.workspace = true
 tokio = { version = "1", features = ["full"] }
+tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter","valuable"] }
 
 [build-dependencies]
 napi-build = "2.1.3"

--- a/engine/language_client_typescript/src/lib.rs
+++ b/engine/language_client_typescript/src/lib.rs
@@ -7,6 +7,7 @@ mod runtime;
 mod types;
 
 pub(crate) use runtime::BamlRuntime;
+use tracing_subscriber::{self, EnvFilter};
 
 #[napi(js_name = "invoke_runtime_cli")]
 pub fn run_cli(env: Env, params: Vec<String>) -> napi::Result<JsUndefined> {
@@ -21,11 +22,34 @@ pub fn run_cli(env: Env, params: Vec<String>) -> napi::Result<JsUndefined> {
 
 #[napi::module_init]
 fn module_init() {
-    if let Err(e) = env_logger::try_init_from_env(
-        env_logger::Env::new()
-            .filter("BAML_LOG")
-            .write_style("BAML_LOG_STYLE"),
-    ) {
-        eprintln!("Failed to initialize BAML logger: {:#}", e);
+    // Check if JSON logging is enabled
+    let use_json = match std::env::var("BAML_LOG_JSON") {
+        Ok(val) => val.trim().eq_ignore_ascii_case("true") || val.trim() == "1",
+        Err(_) => false,
     };
+
+    if use_json {
+        // JSON formatting
+        tracing_subscriber::fmt()
+            .with_target(false)
+            .with_file(false)
+            .with_line_number(false)
+            .json()
+            .with_env_filter(
+                EnvFilter::try_from_env("BAML_LOG").unwrap_or_else(|_| EnvFilter::new("info")),
+            )
+            .flatten_event(true)
+            .with_current_span(false)
+            .with_span_list(false)
+            .init();
+    } else {
+        // Regular formatting
+        if let Err(e) = env_logger::try_init_from_env(
+            env_logger::Env::new()
+                .filter("BAML_LOG")
+                .write_style("BAML_LOG_STYLE"),
+        ) {
+            eprintln!("Failed to initialize BAML logger: {:#}", e);
+        }
+    }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds JSON logging support for Python, Ruby, and TypeScript language clients using `tracing-subscriber`, controlled by the `BAML_LOG_JSON` environment variable.
> 
>   - **Behavior**:
>     - Adds JSON logging support for Python, Ruby, and TypeScript language clients by using `tracing-subscriber`.
>     - Checks `BAML_LOG_JSON` environment variable to determine if JSON logging is enabled.
>     - If JSON logging is enabled, configures `tracing-subscriber` with JSON formatting and environment filter.
>     - If JSON logging is not enabled, falls back to `env_logger` for regular logging.
>   - **Dependencies**:
>     - Adds `tracing-subscriber` to `Cargo.toml` for Python, Ruby, and TypeScript language clients.
>   - **Files**:
>     - Updates `lib.rs` in `language_client_python`, `language_client_ruby/ext/ruby_ffi`, and `language_client_typescript` to implement the logging changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 86ad7070553b77c3a12048b3ba641591585dc09e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->