### PR TITLE
Add `hoisted_class_prefix` option in docs

### DIFF
--- a/fern/03-reference/baml/prompt-syntax/output-format.mdx
+++ b/fern/03-reference/baml/prompt-syntax/output-format.mdx
@@ -123,6 +123,67 @@ BAML renders it as `property: string or null` as we have observed some LLMs have
 You can always set it to ` | ` or something else for a specific model you use.
 </ParamField>
 
+<ParamField path="hoisted_class_prefix" type="string"> 
+Prefix of hoisted classes in the prompt. **Default: `<none>`**
+
+Recursive classes are hoisted in the prompt so that any class field can
+reference them using their name.
+
+**Recursive BAML Prompt Example**
+
+```baml
+class Node {
+  data int
+  next Node?
+}
+
+class LinkedList {
+  head Node?
+  len int
+}
+
+function BuildLinkedList(input: int[]) -> LinkedList {
+  prompt #"
+    Build a linked list from the input array of integers.
+
+    INPUT: {{ input }}
+
+    {{ ctx.output_format }}    
+  "#
+}
+```
+
+**Default `hoisted_class_prefix` (none)**
+
+```
+Node {
+  data: int,
+  next: Node or null
+}
+
+Answer in JSON using this schema:
+{
+  head: Node or null,
+  len: int
+}
+```
+
+**Custom Prefix: `hoisted_class_prefix="interface"`**
+
+```
+interface Node {
+  data: int,
+  next: Node or null
+}
+
+Answer in JSON using this schema:
+{
+  head: Node or null,
+  len: int
+}
+```
+</ParamField>
+
 ## Why BAML doesn't use JSON schema format in prompts
 BAML uses "type definitions" or "jsonish" format instead of the long-winded json-schema format.
 The tl;dr is that json schemas are


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for `hoisted_class_prefix` option in BAML prompt syntax reference, detailing default and custom prefix usage for hoisted classes.
> 
>   - **Documentation**:
>     - Adds `hoisted_class_prefix` option to `output-format.mdx`.
>     - Describes default behavior (no prefix) and custom prefix usage with examples.
>     - Explains how recursive classes are hoisted in prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f2716ad5df01fb4613ac6910d8f2ecefac895081. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->