### PR TITLE
Make render messages dynamic and use `hoisted_class_prefix` instead of `"schema"`

### DIFF
--- a/fern/03-reference/baml/prompt-syntax/output-format.mdx
+++ b/fern/03-reference/baml/prompt-syntax/output-format.mdx
@@ -123,6 +123,67 @@ BAML renders it as `property: string or null` as we have observed some LLMs have
 You can always set it to ` | ` or something else for a specific model you use.
 </ParamField>
 
+<ParamField path="hoisted_class_prefix" type="string"> 
+Prefix of hoisted classes in the prompt. **Default: `<none>`**
+
+Recursive classes are hoisted in the prompt so that any class field can
+reference them using their name.
+
+**Recursive BAML Prompt Example**
+
+```baml
+class Node {
+  data int
+  next Node?
+}
+
+class LinkedList {
+  head Node?
+  len int
+}
+
+function BuildLinkedList(input: int[]) -> LinkedList {
+  prompt #"
+    Build a linked list from the input array of integers.
+
+    INPUT: {{ input }}
+
+    {{ ctx.output_format }}    
+  "#
+}
+```
+
+**Default `hoisted_class_prefix` (none)**
+
+```
+Node {
+  data: int,
+  next: Node or null
+}
+
+Answer in JSON using this schema:
+{
+  head: Node or null,
+  len: int
+}
+```
+
+**Custom Prefix: `hoisted_class_prefix="interface"`**
+
+```
+interface Node {
+  data: int,
+  next: Node or null
+}
+
+Answer in JSON using this schema:
+{
+  head: Node or null,
+  len: int
+}
+```
+</ParamField>
+
 ## Why BAML doesn't use JSON schema format in prompts
 BAML uses "type definitions" or "jsonish" format instead of the long-winded json-schema format.
 The tl;dr is that json schemas are


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `hoisted_class_prefix` to `RenderOptions` for customizable hoisted class prefixes in rendered messages.
> 
>   - **Behavior**:
>     - `RenderOptions` in `types.rs` now supports `hoisted_class_prefix` to customize prefix for hoisted classes.
>     - Default prefix for hoisted classes changed from "schema" to user-defined or "interface".
>     - Updated rendering logic in `OutputFormatContent` to use `hoisted_class_prefix`.
>   - **Documentation**:
>     - Added `hoisted_class_prefix` parameter to `output-format.mdx` with examples.
>   - **Tests**:
>     - Added tests in `types.rs` to verify `hoisted_class_prefix` functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 6c7c38ce936c3c0e6f05ef5c5d55b88ff15c8867. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->