### PR TITLE
Update `hoisted_class_prefix` docs with the new `"schema"` change

### DIFF
--- a/fern/03-reference/baml/prompt-syntax/output-format.mdx
+++ b/fern/03-reference/baml/prompt-syntax/output-format.mdx
@@ -127,7 +127,15 @@ You can always set it to ` | ` or something else for a specific model you use.
 Prefix of hoisted classes in the prompt. **Default: `<none>`**
 
 Recursive classes are hoisted in the prompt so that any class field can
-reference them using their name.
+reference them using their name. This parameter controls the prefix used for
+hoisted classes as well as the word used in the render message to refer to the
+output type, which defaults to `"schema"`:
+
+```
+Answer in JSON using this schema:
+```
+
+See examples below.
 
 **Recursive BAML Prompt Example**
 
@@ -176,7 +184,7 @@ interface Node {
   next: Node or null
 }
 
-Answer in JSON using this schema:
+Answer in JSON using this interface:
 {
   head: Node or null,
   len: int

--- a/fern/03-reference/baml/prompt-syntax/output-format.mdx
+++ b/fern/03-reference/baml/prompt-syntax/output-format.mdx
@@ -123,6 +123,67 @@ BAML renders it as `property: string or null` as we have observed some LLMs have
 You can always set it to ` | ` or something else for a specific model you use.
 </ParamField>
 
+<ParamField path="hoisted_class_prefix" type="string"> 
+Prefix of hoisted classes in the prompt. **Default: `<none>`**
+
+Recursive classes are hoisted in the prompt so that any class field can
+reference them using their name.
+
+**Recursive BAML Prompt Example**
+
+```baml
+class Node {
+  data int
+  next Node?
+}
+
+class LinkedList {
+  head Node?
+  len int
+}
+
+function BuildLinkedList(input: int[]) -> LinkedList {
+  prompt #"
+    Build a linked list from the input array of integers.
+
+    INPUT: {{ input }}
+
+    {{ ctx.output_format }}    
+  "#
+}
+```
+
+**Default `hoisted_class_prefix` (none)**
+
+```
+Node {
+  data: int,
+  next: Node or null
+}
+
+Answer in JSON using this schema:
+{
+  head: Node or null,
+  len: int
+}
+```
+
+**Custom Prefix: `hoisted_class_prefix="interface"`**
+
+```
+interface Node {
+  data: int,
+  next: Node or null
+}
+
+Answer in JSON using this schema:
+{
+  head: Node or null,
+  len: int
+}
+```
+</ParamField>
+
 ## Why BAML doesn't use JSON schema format in prompts
 BAML uses "type definitions" or "jsonish" format instead of the long-winded json-schema format.
 The tl;dr is that json schemas are


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `output-format.mdx` to reflect change in default render message word from "schema" to "interface" for hoisted classes.
> 
>   - **Documentation Update**:
>     - In `output-format.mdx`, updated the description of `hoisted_class_prefix` to reflect the change in default render message word from "schema" to "interface".
>     - Updated example in `output-format.mdx` to use "interface" instead of "schema" in the rendered prompt.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0f56dcf0518690b967da079c67a381934de15bca. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->