### PR TITLE
Add basic grammar for `a` vs `an` articles

### DIFF
--- a/fern/03-reference/baml/prompt-syntax/output-format.mdx
+++ b/fern/03-reference/baml/prompt-syntax/output-format.mdx
@@ -71,7 +71,8 @@ BAML's default prefix varies based on the function's return type.
 | Fuction return type | Default Prefix |
 | --- | --- |
 | Primitive (String) |  |
-| Primitive (Other) | `Answer as a: ` |
+| Primitive (Int) | `Answer as an ` |
+| Primitive (Other) | `Answer as a ` |
 | Enum | `Answer with any of the categories:\n` |
 | Class | `Answer in JSON using this schema:\n` |
 | List | `Answer with a JSON Array using this schema:\n` |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add function to determine 'a' or 'an' for indefinite articles and integrate it into output format rendering logic.
> 
>   - **Behavior**:
>     - Add `indefinite_article_a_or_an()` function in `types.rs` to determine 'a' or 'an' based on the first letter of a word.
>     - Update `OutputFormatContent::prefix()` to use `indefinite_article_a_or_an()` for primitive types.
>   - **Documentation**:
>     - Update `output-format.mdx` to reflect changes in default prefixes for primitive types.
>   - **Tests**:
>     - Add tests `render_int()` and `render_float()` in `types.rs` to verify correct article usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7c264361d2e7564f1bde87a4ffe4146fe8951695. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->