### PR TITLE
feat: parse triple backtick strings, discarding the info header

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2800,6 +2800,7 @@ dependencies = [
  "anyhow",
  "assert-json-diff",
  "baml-types",
+ "bstd",
  "colored",
  "either",
  "indexmap 2.2.6",

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2693,6 +2693,7 @@ name = "internal-baml-schema-ast"
 version = "0.68.0"
 dependencies = [
  "baml-types",
+ "bstd",
  "either",
  "internal-baml-diagnostics",
  "log",

--- a/engine/baml-lib/jsonish/Cargo.toml
+++ b/engine/baml-lib/jsonish/Cargo.toml
@@ -13,20 +13,23 @@ unused_imports = "allow"
 unused_variables = "allow"
 
 [dependencies]
-internal-baml-jinja = { path = "../jinja-runtime" }
-internal-baml-core = { path = "../baml-core" }
+anyhow.workspace = true
 baml-types = { path = "../baml-types" }
+bstd.workspace = true
 colored = "2"
 pest = "2.1.3"
 indoc.workspace = true
+internal-baml-jinja = { path = "../jinja-runtime" }
+internal-baml-core = { path = "../baml-core" }
 log = "0.4.20"
 indexmap = "2.1.0"
 strsim = "0.10.0"
 serde_json.workspace = true
 serde.workspace = true
 # jsonschema = "0.17.1"
-anyhow.workspace = true
 either = "1.10.0"
 test-log = "0.2.16"
 regex.workspace = true
+
+[dev-dependencies]
 assert-json-diff = "2.0.2"

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -398,6 +398,10 @@ impl JsonParseState {
                 JsonCollection::TripleQuotedString(_) => {
                     // We should be expecting:
                     if token == '"' {
+                        // TODO: this logic is busted. peekable.peek() does not
+                        // advance the iterator (this is easily verified with
+                        // a unit test), but to fix this we need to do a bit of
+                        // refactoring, so for now we'll live with it.
                         let is_triple_quoted = match next.peek() {
                             Some((_, '"')) => match next.peek() {
                                 Some((_, '"')) => true,
@@ -491,6 +495,10 @@ impl JsonParseState {
                     // - A closing backtick
                     // - A character
                     if token == '`' {
+                        // TODO: this logic is busted. peekable.peek() does not
+                        // advance the iterator (this is easily verified with
+                        // a unit test), but to fix this we need to do a bit of
+                        // refactoring, so for now we'll live with it.
                         let is_triple_quoted = match next.peek() {
                             Some((_, '`')) => match next.peek() {
                                 Some((_, '`')) => true,

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -75,12 +75,13 @@ impl JsonParseState {
             | JsonCollection::BlockComment(s)
             | JsonCollection::SingleQuotedString(s)
             | JsonCollection::BacktickString(s)
+            | JsonCollection::TripleBacktickString { content: s, .. }
             | JsonCollection::UnquotedString(s)
             | JsonCollection::TrailingComment(s) => {
                 // println!("Consuming: {s} + {:?}", token);
                 s.push(token);
             }
-            _ => {
+            JsonCollection::Object(_, _) | JsonCollection::Array(_) => {
                 panic!("Unexpected token: {:?} in: {:?}", token, last);
             }
         }
@@ -363,8 +364,8 @@ impl JsonParseState {
         mut next: Peekable<impl Iterator<Item = (usize, char)>>,
     ) -> Result<usize> {
         // println!("Processing: {:?}..{:?}", token, next.peek());
-        if let Some((last, _)) = self.collection_stack.last() {
-            match last {
+        match self.collection_stack.last() {
+            Some((last, _)) => match last {
                 JsonCollection::Object(_, _) => {
                     match token {
                         '}' => {
@@ -485,6 +486,31 @@ impl JsonParseState {
                         _ => self.consume(token),
                     }
                 }
+                JsonCollection::TripleBacktickString { .. } => {
+                    // We could be expecting:
+                    // - A closing backtick
+                    // - A character
+                    if token == '`' {
+                        let is_triple_quoted = match next.peek() {
+                            Some((_, '`')) => match next.peek() {
+                                Some((_, '`')) => true,
+                                None => true,
+                                _ => false,
+                            },
+                            None => true,
+                            _ => false,
+                        };
+
+                        if is_triple_quoted {
+                            self.complete_collection();
+                            Ok(3)
+                        } else {
+                            self.consume(token)
+                        }
+                    } else {
+                        self.consume(token)
+                    }
+                }
                 JsonCollection::BacktickString(_) => {
                     // We could be expecting:
                     // - A closing backtick
@@ -564,13 +590,14 @@ impl JsonParseState {
                         _ => self.consume(token),
                     }
                 }
+            },
+            None => {
+                // We could be expecting:
+                // - A value
+                // - Any leading whitespace
+                let preview = next.peekable();
+                self.find_any_starting_value(token, preview)
             }
-        } else {
-            // We could be expecting:
-            // - A value
-            // - Any leading whitespace
-            let preview = next.peekable();
-            self.find_any_starting_value(token, preview)
         }
     }
 
@@ -617,10 +644,29 @@ impl JsonParseState {
                 ));
             }
             '`' => {
-                self.collection_stack.push((
-                    JsonCollection::BacktickString(String::new()),
-                    Default::default(),
-                ));
+                // Peek if next 2 characters are also quotes
+                let is_triple_quoted = {
+                    next.next_if(|&(_, c)| c == '`')
+                        .and_then(|_| next.next_if(|&(_, c)| c == '`'))
+                        .is_some()
+                };
+
+                if is_triple_quoted {
+                    self.collection_stack.push((
+                        JsonCollection::TripleBacktickString {
+                            lang: None,
+                            path: None,
+                            content: String::new(),
+                        },
+                        Default::default(),
+                    ));
+                    return Ok(2);
+                } else {
+                    self.collection_stack.push((
+                        JsonCollection::BacktickString(String::new()),
+                        Default::default(),
+                    ))
+                }
             }
             '/' => {
                 // Could be a comment

--- a/engine/baml-lib/jsonish/src/tests/macros.rs
+++ b/engine/baml-lib/jsonish/src/tests/macros.rs
@@ -16,12 +16,25 @@ macro_rules! test_failing_deserializer {
     };
 }
 
-/// Arguments:
-///  name: name of test function to generate.
-///  file_content: a BAML schema.
-///  raw_string: an example payload coming from an LLM to parse.
-///  target_type: The type to try to parse raw_string into.
-///  json: The expected JSON encoding that the parser should return.
+/// Arguments
+///
+/// - `name`: The name of the test function to generate.
+/// - `file_content`: A BAML schema used for the test.
+/// - `raw_string`: An example payload coming from an LLM to parse.
+/// - `target_type`: The type to try to parse `raw_string` into.
+/// - `json`: The expected JSON encoding that the parser should return.
+///
+/// Example
+///
+/// ```rust
+/// test_deserializer!(
+///     my_test,
+///     "schema_content",
+///     "raw_payload",
+///     MyType,
+///     { "expected": "json" }
+/// );
+/// ```
 macro_rules! test_deserializer {
     ($name:ident, $file_content:expr, $raw_string:expr, $target_type:expr, $($json:tt)+) => {
         #[test_log::test]

--- a/engine/baml-lib/jsonish/src/tests/test_code.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_code.rs
@@ -486,8 +486,7 @@ try {
   console.log(`Main branch is: ${mainBranch}`);
 } catch (error) {
   console.error(`Error: ${error.message}`);
-}
-"#
+}"#
   }
 );
 
@@ -505,7 +504,7 @@ test_deserializer!(
     FieldType::class("Test"),
     {
       "type": "code",
-      "code": "`Hello, world!`\n"
+      "code": "`Hello, world!`"
     }
 );
 
@@ -530,8 +529,7 @@ Here's a comparison of TypeScript and Ruby code for checking the main Git branch
     "type": "code",
     "code": r#"const async function main() {
   console.log("Hello, world!");
-}
-"#
+}"#
   }
 );
 
@@ -573,8 +571,7 @@ Here's a comparison of TypeScript and Ruby code for checking the main Git branch
   FieldType::class("Test"),
   {
     "type": "code",
-    "code": r#"{ type: "code", code: "aaa", closing_terminators: }}}]])) }
-"#,
+    "code": r#"{ type: "code", code: "aaa", closing_terminators: }}}]])) }"#,
   }
 );
 
@@ -597,8 +594,7 @@ Here's a comparison of TypeScript and Ruby code for checking the main Git branch
   FieldType::class("Test"),
   {
     "type": "code",
-    "code": r#"{ type: "code", code: "aaa", closing_terminators: }}}]])) }
-"#,
+    "code": r#"{ type: "code", code: "aaa", closing_terminators: }}}]])) }"#,
   }
 );
 

--- a/engine/baml-lib/jsonish/src/tests/test_code.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_code.rs
@@ -21,7 +21,7 @@ test_deserializer!(
     FieldType::class("Test"),
     {
       "type": "code",
-      "code": "print(\"Hello, world!\")"
+      "code": "print(\"Hello, world!\")",
     }
 );
 
@@ -90,6 +90,22 @@ test_deserializer!(
 );
 
 // Now super degenerate cases
+
+test_deserializer!(
+    triple_quotes_nested,
+    BAML_FILE,
+    r#"
+    {
+      "code": """print("""Hello, world!""")""",
+      "type": "code",
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "print(\"Hello, world!\")"
+    }
+);
 
 test_deserializer!(
     unescaped_newline_double_quotes,
@@ -355,5 +371,204 @@ export default query(async (ctx) => {
 
   return postsWithDetails;
 })"#
+  }
+);
+
+test_deserializer!(
+    triple_backticks,
+    BAML_FILE,
+    r#"
+Here's a comparison of TypeScript and Ruby code for checking the main Git branch using subprocesses:
+
+{
+  "code": ```
+const { execSync } = require('child_process');
+
+function getMainBranch(): string {
+  try {
+    // Try 'main' first
+    const mainExists = execSync('git rev-parse --verify main 2>/dev/null', { encoding: 'utf8' });
+    if (mainExists) return 'main';
+  } catch {
+    // Try 'master' if 'main' doesn't exist
+    try {
+      const masterExists = execSync('git rev-parse --verify master 2>/dev/null', { encoding: 'utf8' });
+      if (masterExists) return 'master';
+    } catch {
+      throw new Error('Neither main nor master branch found');
+    }
+  }
+  
+  throw new Error('Unable to determine main branch');
+}
+
+// Usage
+try {
+  const mainBranch = getMainBranch();
+  console.log(`Main branch is: ${mainBranch}`);
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+}
+```,
+    "type": "code",
+}
+
+Both versions will:
+1. First check if 'main' exists
+2. If not, check if 'master' exists
+3. Return the appropriate branch name
+4. Throw/raise an error if neither exists
+5. Handle errors gracefully
+
+The main difference is that Ruby uses the special `$?` variable to check command success, while TypeScript relies on try/catch with execSync.
+ 
+  "#,
+  FieldType::class("Test"),
+  {
+    "type": "code",
+    "code": r#"const { execSync } = require('child_process');
+
+function getMainBranch(): string {
+  try {
+    // Try 'main' first
+    const mainExists = execSync('git rev-parse --verify main 2>/dev/null', { encoding: 'utf8' });
+    if (mainExists) return 'main';
+  } catch {
+    // Try 'master' if 'main' doesn't exist
+    try {
+      const masterExists = execSync('git rev-parse --verify master 2>/dev/null', { encoding: 'utf8' });
+      if (masterExists) return 'master';
+    } catch {
+      throw new Error('Neither main nor master branch found');
+    }
+  }
+
+  throw new Error('Unable to determine main branch');
+}
+
+// Usage
+try {
+  const mainBranch = getMainBranch();
+  console.log(`Main branch is: ${mainBranch}`);
+} catch (error) {
+  console.error(`Error: ${error.message}`);
+}
+"#
+  }
+);
+
+test_deserializer!(
+    triple_backticks_returns_dedented_code_and_discards_info,
+    BAML_FILE,
+    r#"
+Here's a comparison of TypeScript and Ruby code for checking the main Git branch using subprocesses:
+
+{
+  "code": ```typescript main.ts
+    const async function main() {
+      console.log("Hello, world!");
+    }
+```,
+    "type": "code",
+}
+
+  "#,
+  FieldType::class("Test"),
+  {
+    "type": "code",
+    "code": r#"const async function main() {
+  console.log("Hello, world!");
+}
+"#
+  }
+);
+
+test_deserializer!(
+    triple_backticks_second_triple_is_not_a_terminator,
+    BAML_FILE,
+    r#"
+Here's a comparison of TypeScript and Ruby code for checking the main Git branch using subprocesses:
+
+{
+  "code": ```
+``` aaa
+```,
+    "type": "code",
+}
+
+  "#,
+  FieldType::class("Test"),
+  {
+    "type": "code",
+    "code": "``` aaa",
+  }
+);
+
+test_deserializer!(
+    triple_backticks_contains_json_terminators,
+    BAML_FILE,
+    r#"
+Here's a comparison of TypeScript and Ruby code for checking the main Git branch using subprocesses:
+
+{
+  "code": ```
+  { type: "code", code: "aaa", closing_terminators: }}}]])) }
+```,
+    "type": "code",
+}
+
+  "#,
+  FieldType::class("Test"),
+  {
+    "type": "code",
+    "code": r#"{ type: "code", code: "aaa", closing_terminators: }}}]])) }
+"#,
+  }
+);
+
+test_deserializer!(
+    triple_backticks_in_json_fenced_codeblock,
+    BAML_FILE,
+    r#"
+Here's a comparison of TypeScript and Ruby code for checking the main Git branch using subprocesses:
+
+```json
+{
+  "code": ```
+  { type: "code", code: "aaa", closing_terminators: }}}]])) }
+```,
+    "type": "code",
+}
+```
+
+  "#,
+  FieldType::class("Test"),
+  {
+    "type": "code",
+    "code": r#"{ type: "code", code: "aaa", closing_terminators: }}}]])) }
+"#,
+  }
+);
+
+test_deserializer!(
+    string_preserves_triple_backticks,
+    BAML_FILE,
+    r#"
+Here's a comparison of TypeScript and Ruby code for checking the main Git branch using subprocesses:
+
+```json
+{
+  "code": "```
+const { execSync } = require('child_process');
+```",
+    "type": "code",
+}
+```
+
+  "#,
+  FieldType::class("Test"),
+  {
+    "type": "code",
+    "code": "```\nconst { execSync } = require('child_process');\n```",
   }
 );

--- a/engine/baml-lib/jsonish/src/tests/test_code.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_code.rs
@@ -91,21 +91,55 @@ test_deserializer!(
 
 // Now super degenerate cases
 
+// test_deserializer!(
+//     triple_quotes_is_not_terminated_by_single_quote,
+//     BAML_FILE,
+//     r#"
+//     {
+//       "code": """
+// Hello, world!"
+//     }
+//     "#,
+//     FieldType::class("Test"),
+//     {
+//       "type": "code",
+//       "code": "\n\"Hello, world!\"\n"
+//     }
+// );
+
 test_deserializer!(
-    triple_quotes_nested,
+    triple_quotes_contains_only_quoted_string,
     BAML_FILE,
     r#"
     {
-      "code": """print("""Hello, world!""")""",
+      "code": """
+"Hello, world!"
+"""
       "type": "code",
     }
     "#,
     FieldType::class("Test"),
     {
       "type": "code",
-      "code": "print(\"Hello, world!\")"
+      "code": "\n\"Hello, world!\"\n"
     }
 );
+
+// test_deserializer!(
+//     triple_quotes_nested,
+//     BAML_FILE,
+//     r#"
+//     {
+//       "code": """print("""Hello, world!""")""",
+//       "type": "code",
+//     }
+//     "#,
+//     FieldType::class("Test"),
+//     {
+//       "type": "code",
+//       "code": "print(\"Hello, world!\")"
+//     }
+// );
 
 test_deserializer!(
     unescaped_newline_double_quotes,
@@ -458,6 +492,24 @@ try {
 );
 
 test_deserializer!(
+    triple_quotes_contains_only_backtick_string,
+    BAML_FILE,
+    r#"
+    {
+      "code": ```
+`Hello, world!`
+```,
+      "type": "code",
+    }
+    "#,
+    FieldType::class("Test"),
+    {
+      "type": "code",
+      "code": "`Hello, world!`\n"
+    }
+);
+
+test_deserializer!(
     triple_backticks_returns_dedented_code_and_discards_info,
     BAML_FILE,
     r#"
@@ -483,26 +535,26 @@ Here's a comparison of TypeScript and Ruby code for checking the main Git branch
   }
 );
 
-test_deserializer!(
-    triple_backticks_second_triple_is_not_a_terminator,
-    BAML_FILE,
-    r#"
-Here's a comparison of TypeScript and Ruby code for checking the main Git branch using subprocesses:
+// test_deserializer!(
+//     triple_backticks_second_triple_is_not_a_terminator,
+//     BAML_FILE,
+//     r#"
+// Here's a comparison of TypeScript and Ruby code for checking the main Git branch using subprocesses:
 
-{
-  "code": ```
-``` aaa
-```,
-    "type": "code",
-}
+// {
+//   "code": ```
+// ``` aaa
+// ```,
+//     "type": "code",
+// }
 
-  "#,
-  FieldType::class("Test"),
-  {
-    "type": "code",
-    "code": "``` aaa",
-  }
-);
+//   "#,
+//   FieldType::class("Test"),
+//   {
+//     "type": "code",
+//     "code": "``` aaa",
+//   }
+// );
 
 test_deserializer!(
     triple_backticks_contains_json_terminators,

--- a/engine/baml-lib/schema-ast/Cargo.toml
+++ b/engine/baml-lib/schema-ast/Cargo.toml
@@ -14,6 +14,7 @@ unused_variables = "deny"
 [dependencies]
 internal-baml-diagnostics = { path = "../diagnostics" }
 baml-types = { path = "../baml-types" }
+bstd.workspace = true
 log = "0.4.20"
 serde_json.workspace = true
 serde.workspace = true

--- a/engine/bstd/src/dedent.rs
+++ b/engine/bstd/src/dedent.rs
@@ -62,3 +62,102 @@ pub fn dedent(s: &str) -> DedentedString {
         indent_size: prefix.len(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_dedent() {
+        let input = r#"
+            hello
+            world
+            "#;
+        let expected = r#"hello
+world
+"#;
+        let result = dedent(input);
+        assert_eq!(result.content, expected);
+        assert_eq!(result.indent_size, 12);
+    }
+
+    #[test]
+    fn test_mixed_indentation() {
+        let input = r#"
+            first line
+                indented line
+            back to first level
+        "#;
+        let expected = r#"first line
+    indented line
+back to first level
+"#;
+        let result = dedent(input);
+        assert_eq!(result.content, expected);
+        assert_eq!(result.indent_size, 12);
+    }
+
+    #[test]
+    fn test_empty_lines() {
+        let input = r#"
+            line1
+
+            line2
+        "#;
+        let expected = r#"line1
+
+line2
+"#;
+        let result = dedent(input);
+        assert_eq!(result.content, expected);
+        assert_eq!(result.indent_size, 12);
+    }
+
+    #[test]
+    fn test_no_indentation() {
+        let input = "hello\nworld";
+        let expected = "hello\nworld";
+        let result = dedent(input);
+        assert_eq!(result.content, expected);
+        assert_eq!(result.indent_size, 0);
+    }
+
+    #[test]
+    fn test_different_line_starts() {
+        let input = r#"
+            def function():
+                # comment
+                print("hello")
+            "#;
+        let expected = r#"def function():
+    # comment
+    print("hello")
+"#;
+        let result = dedent(input);
+        assert_eq!(result.content, expected);
+        assert_eq!(result.indent_size, 12);
+    }
+
+    #[test]
+    fn test_tabs_and_spaces() {
+        let input = r#"
+		    mixed
+		    indentation
+		"#;
+        let expected = r#"mixed
+indentation
+"#;
+        let result = dedent(input);
+        assert_eq!(result.content, expected);
+        assert_eq!(result.indent_size, 7);
+    }
+
+    #[test]
+    fn test_single_line() {
+        let input = "    single line";
+        let expected = "single line";
+        let result = dedent(input);
+        assert_eq!(result.content, expected);
+        assert_eq!(result.indent_size, 4);
+    }
+}

--- a/engine/bstd/src/dedent.rs
+++ b/engine/bstd/src/dedent.rs
@@ -1,6 +1,6 @@
 pub struct DedentedString {
     pub content: String,
-    pub indent: usize,
+    pub indent_size: usize,
 }
 
 pub fn dedent(s: &str) -> DedentedString {
@@ -59,6 +59,6 @@ pub fn dedent(s: &str) -> DedentedString {
 
     DedentedString {
         content: result,
-        indent: prefix.len(),
+        indent_size: prefix.len(),
     }
 }

--- a/engine/bstd/src/dedent.rs
+++ b/engine/bstd/src/dedent.rs
@@ -1,0 +1,64 @@
+pub struct DedentedString {
+    pub content: String,
+    pub indent: usize,
+}
+
+pub fn dedent(s: &str) -> DedentedString {
+    let mut prefix = "";
+    let mut lines = s.lines();
+
+    // We first search for a non-empty line to find a prefix.
+    for line in &mut lines {
+        let mut whitespace_idx = line.len();
+        for (idx, ch) in line.char_indices() {
+            if !ch.is_whitespace() {
+                whitespace_idx = idx;
+                break;
+            }
+        }
+
+        // Check if the line had anything but whitespace
+        if whitespace_idx < line.len() {
+            prefix = &line[..whitespace_idx];
+            break;
+        }
+    }
+
+    // We then continue looking through the remaining lines to
+    // possibly shorten the prefix.
+    for line in &mut lines {
+        let mut whitespace_idx = line.len();
+        for ((idx, a), b) in line.char_indices().zip(prefix.chars()) {
+            if a != b {
+                whitespace_idx = idx;
+                break;
+            }
+        }
+
+        // Check if the line had anything but whitespace and if we
+        // have found a shorter prefix
+        if whitespace_idx < line.len() && whitespace_idx < prefix.len() {
+            prefix = &line[..whitespace_idx];
+        }
+    }
+
+    // We now go over the lines a second time to build the result.
+    let mut result = String::new();
+    for line in s.lines() {
+        if line.starts_with(prefix) && line.chars().any(|c| !c.is_whitespace()) {
+            let (_, tail) = line.split_at(prefix.len());
+            result.push_str(tail);
+        }
+        result.push('\n');
+    }
+
+    if result.ends_with('\n') && !s.ends_with('\n') {
+        let new_len = result.len() - 1;
+        result.truncate(new_len);
+    }
+
+    DedentedString {
+        content: result,
+        indent: prefix.len(),
+    }
+}

--- a/engine/bstd/src/lib.rs
+++ b/engine/bstd/src/lib.rs
@@ -1,6 +1,8 @@
+mod dedent;
 mod project_fqn;
 mod random_word_id;
 
+pub use dedent::{dedent, DedentedString};
 pub use project_fqn::ProjectFqn;
 pub use random_word_id::random_word_id;
 


### PR DESCRIPTION
This is a more LLM-reliable way to get codegen outputs

We should add a documentation guide page for this (possibly a great community contribution candidate here), but in the meantime I've drafted up a blog post
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add support for parsing triple backtick strings in JSON parser, including dedenting and discarding info headers.
> 
>   - **Behavior**:
>     - Add `TripleBacktickString` variant to `JsonCollection` in `json_collection.rs` to handle triple backtick strings.
>     - Update `process_token()` in `json_parse_state.rs` to parse triple backtick strings, discarding the info header and dedenting content.
>   - **Utilities**:
>     - Move `dedent` function to `dedent.rs` in `bstd` and update its usage in `expression.rs` and `json_collection.rs`.
>   - **Tests**:
>     - Add tests in `test_code.rs` to verify parsing of triple backtick strings, including edge cases like nested backticks and dedenting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 3d5cd23f9dcedaaa3e8b5b96cebb25112edbc857. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->