### PR TITLE
Correctly compute required_env_vars even for shorthand clients.

### DIFF
--- a/engine/baml-lib/parser-database/src/walkers/function.rs
+++ b/engine/baml-lib/parser-database/src/walkers/function.rs
@@ -126,7 +126,7 @@ pub enum ClientSpec {
     Named(String),
 
     /// Defined inline using shorthand "<provider>/<model>" syntax
-    Shorthand(String),
+    Shorthand(String, String),
 }
 
 impl<'db> FunctionWalker<'db> {
@@ -143,7 +143,7 @@ impl<'db> FunctionWalker<'db> {
         match client.0.split_once("/") {
             // TODO: do this in a more robust way
             // actually validate which clients are and aren't allowed
-            Some((provider, model)) => Ok(ClientSpec::Shorthand(format!("{}/{}", provider, model))),
+            Some((provider, model)) => Ok(ClientSpec::Shorthand(provider.to_string(), model.to_string())),
             None => match self.db.find_client(client.0.as_str()) {
                 Some(client) => Ok(ClientSpec::Named(client.name().to_string())),
                 None => {

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
@@ -568,7 +568,6 @@ impl WithChat for VertexClient {
                 .properties
                 .get("model")
                 .and_then(|v| v.as_str().map(|s| s.to_string()))
-                .or_else(|| _ctx.env.get("default model").map(|s| s.to_string()))
                 .unwrap_or_else(|| "".to_string()),
             metadata: LLMCompleteResponseMetadata {
                 baml_is_complete: match response.candidates[0].finish_reason {

--- a/engine/baml-runtime/src/runtime/runtime_interface.rs
+++ b/engine/baml-runtime/src/runtime/runtime_interface.rs
@@ -43,14 +43,9 @@ impl<'a> InternalClientLookup<'a> for InternalBamlRuntime {
         ctx: &RuntimeContext,
     ) -> Result<Arc<LLMProvider>> {
         match client_spec {
-            ClientSpec::Shorthand(shorthand) => {
-                let (provider, model) = shorthand.split_once("/").context(format!(
-                    "Invalid client shorthand: {} (expected format: provider/model)",
-                    shorthand
-                ))?;
-
+            ClientSpec::Shorthand(provider, model) => {
                 let client_property = ClientProperty {
-                    name: shorthand.clone(),
+                    name: format!("{}/{}", provider, model),
                     provider: provider.into(),
                     retry_policy: None,
                     options: vec![("model".to_string(), BamlValue::String(model.to_string()))]
@@ -60,7 +55,7 @@ impl<'a> InternalClientLookup<'a> for InternalBamlRuntime {
                 // TODO: allow other providers
                 let llm_primitive_provider =
                     LLMPrimitiveProvider::try_from((&client_property, ctx))
-                        .context(format!("Failed to parse client: {}", shorthand))?;
+                        .context(format!("Failed to parse client: {}/{}", provider, model))?;
 
                 Ok(Arc::new(LLMProvider::Primitive(Arc::new(
                     llm_primitive_provider,

--- a/root-wasm32.code-workspace
+++ b/root-wasm32.code-workspace
@@ -4,7 +4,7 @@
       "path": ".github"
     },
     {
-      "path": "docs"
+      "path": "fern"
     },
     {
       "path": "engine"


### PR DESCRIPTION
* This makes the playground experience much nicer

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve environment variable computation for shorthand clients in BAML engine, with refactoring and minor formatting changes.
> 
>   - **Behavior**:
>     - Correctly compute `required_env_vars` for shorthand clients in `repr.rs` and `walker.rs`.
>     - Update `required_env_vars()` in `IntermediateRepr` to handle shorthand clients.
>   - **Refactoring**:
>     - Refactor `ClientSpec` to handle provider/model as separate fields in `repr.rs`.
>     - Update `provider_to_env_vars()` to include more providers in `walker.rs`.
>   - **Misc**:
>     - Minor formatting changes in `ir_helpers/mod.rs` and `runtime_interface.rs`.
>     - Update `root-wasm32.code-workspace` to change path from `docs` to `fern`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c421a466d30cad9cc6a6da2d7d32904b585aa207. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->