### PR TITLE
Report wrong keyword errors in type defs

### DIFF
--- a/engine/baml-lib/baml/tests/validation_files/class/invalid_keyword_in_type_def.baml
+++ b/engine/baml-lib/baml/tests/validation_files/class/invalid_keyword_in_type_def.baml
@@ -1,0 +1,30 @@
+class OkClass {
+  field string
+}
+
+enum OkEnum {
+  A
+  B
+}
+
+classs WrongClass {
+  field string
+}
+
+random_keyword WrongEnum {
+  A
+  B
+}
+
+// error: Error validating: Unexpected keyword 'classs' in type definition. Use 'class' or 'enum'.
+//   -->  class/invalid_keyword_in_type_def.baml:10
+//    | 
+//  9 | 
+// 10 | classs WrongClass {
+//    | 
+// error: Error validating: Unexpected keyword 'random_keyword' in type definition. Use 'class' or 'enum'.
+//   -->  class/invalid_keyword_in_type_def.baml:14
+//    | 
+// 13 | 
+// 14 | random_keyword WrongEnum {
+//    | 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds error reporting for invalid keywords in type definitions, ensuring only 'class' or 'enum' are accepted, with tests for validation.
> 
>   - **Behavior**:
>     - Adds error reporting for unexpected keywords in type definitions in `parse_type_expression_block.rs`. Only 'class' or 'enum' are valid.
>     - Errors for invalid keywords like 'classs' and 'random_keyword' are now reported.
>   - **Tests**:
>     - Adds `invalid_keyword_in_type_def.baml` to test error reporting for invalid keywords in type definitions.
>     - Updates test cases in `parse_type_expression_block.rs` to ensure correct error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ad935721225e98ba8e6a56d791993f94f9677372. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->