### PR TITLE
get ring out of the wasm build

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -328,7 +328,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -974,6 +974,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "test-log",
+ "thiserror 2.0.3",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1118,7 +1119,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1322,7 +1323,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1490,7 +1491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
 dependencies = [
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1514,7 +1515,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1525,7 +1526,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1568,7 +1569,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1578,7 +1579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1591,7 +1592,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1603,7 +1604,7 @@ dependencies = [
  "console",
  "shell-words",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.62",
  "zeroize",
 ]
 
@@ -1684,7 +1685,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1704,7 +1705,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1973,7 +1974,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2957,7 +2958,7 @@ checksum = "5968c820e2960565f647819f5928a42d6e874551cab9d88d75e3e0660d7f71e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3087,7 +3088,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3102,7 +3103,7 @@ dependencies = [
  "quote",
  "regex",
  "semver",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3328,7 +3329,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3435,7 +3436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.62",
  "ucd-trie",
 ]
 
@@ -3459,7 +3460,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3490,7 +3491,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3690,7 +3691,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3703,7 +3704,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3805,7 +3806,7 @@ dependencies = [
  "quote",
  "regex",
  "shell-words",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3946,7 +3947,7 @@ dependencies = [
  "nom",
  "pin-project-lite",
  "reqwest",
- "thiserror",
+ "thiserror 1.0.62",
 ]
 
 [[package]]
@@ -3990,7 +3991,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.76",
+ "syn 2.0.87",
  "unicode-ident",
 ]
 
@@ -4289,7 +4290,7 @@ checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4431,7 +4432,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.62",
  "time",
 ]
 
@@ -4539,7 +4540,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4567,9 +4568,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.76"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4658,7 +4659,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4678,7 +4679,16 @@ version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2675633b1499176c2dff06b0856a27976a8f9d436737b4cf4f312d4d91d8bbb"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.62",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -4689,7 +4699,18 @@ checksum = "d20468752b09f49e909e55a5d338caa8bedf615594e9d80bc4c565d30faf798c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4775,7 +4796,7 @@ checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4898,7 +4919,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5216,7 +5237,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -5250,7 +5271,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5283,7 +5304,7 @@ checksum = "b7f89739351a2e03cb94beb799d47fb2cac01759b40ec441f7de39b00cbf7ef0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5596,7 +5617,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.76",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -84,11 +84,11 @@ aws-smithy-runtime = "1.6.0"
 enum_dispatch = "0.3.13"
 ambassador = "0.4.0"
 aws-smithy-json = "0.60.7"
-jsonwebtoken = "9.3.0"
 pretty_assertions = "1.4.0"
 valuable = { version = "0.1.0", features = ["derive"] }
 tracing = { version = "0.1.40", features = ["valuable"] }
 tracing-subscriber = { version = "0.3.18", features = ["json", "env-filter","valuable"] }
+thiserror = "2.0.1"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
@@ -110,14 +110,16 @@ uuid = { version = "1.8.0", features = ["v4", "serde", "js"] }
 wasm-bindgen = "^0.2.74"
 wasm-bindgen-futures = "0.4"
 web-sys = { version = "0.3.69", features = [
+  "Crypto",
+  "CryptoKey",
   "Headers",
   "Request",
   "RequestInit",
   "Response",
   "RequestMode",
+  "SubtleCrypto",
   "Window",
 ] }
-ring = { version = "0.17.4", features = ["std", "wasm32_unknown_unknown_js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 aws-config = "1.5.3"
@@ -125,7 +127,9 @@ aws-sdk-bedrockruntime = "1.37.0"
 axum = "0.7.5"
 axum-extra = { version = "0.9.3", features = ["erased-json", "typed-header"] }
 hostname = "0.3.1"
+jsonwebtoken = { version="9.3.0"}
 notify-debouncer-full = "0.3.1"
+ring = { version = "0.17.4", features = ["std"] }
 tokio = { version = "1", features = ["full"] }
 reqwest.workspace = true
 walkdir = "2.5.0"
@@ -138,7 +142,6 @@ which = "6.0.3"
 defaults = []
 internal = []
 skip-integ-tests = []
-
 
 
 [dev-dependencies]

--- a/engine/baml-runtime/src/internal/mod.rs
+++ b/engine/baml-runtime/src/internal/mod.rs
@@ -1,3 +1,6 @@
 pub mod ir_features;
 pub mod llm_client;
 pub mod prompt_renderer;
+
+#[cfg(target_arch = "wasm32")]
+pub mod wasm_jwt;

--- a/engine/baml-runtime/src/internal/wasm_jwt.rs
+++ b/engine/baml-runtime/src/internal/wasm_jwt.rs
@@ -1,0 +1,112 @@
+/// Use the browser's Subtle.Crypto API to sign JWT's.
+/// This module is meant to be imported conditionally during wasm builds, to
+/// replace our JWT creation code for native targets.
+///
+/// The main motivation is to use browser APIs via web-sys, and to avoid
+/// compiling the native-targeting crypto library `ring`, which can be
+/// problematic for some toolchains to cross-compile to WASM.
+///
+/// At the time of writing, the Vertex provider is the only code in the
+/// runtime that produces JWT's.
+use aws_smithy_types::event_stream::Header;
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+    Engine,
+};
+use js_sys::{Array, Object, Uint8Array};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{window, CryptoKey, SubtleCrypto};
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum JwtError {
+    #[error("JavaScript error: {0:?}")]
+    JsError(JsValue),
+    #[error("Base64 decode error: {0}")]
+    Base64Error(#[from] base64::DecodeError),
+    #[error("JSON error: {0}")]
+    JsonError(#[from] serde_json::Error),
+    #[error("Missing window object")]
+    NoWindow,
+    #[error("Missing crypto API")]
+    NoCrypto,
+}
+
+impl From<JsValue> for JwtError {
+    fn from(err: JsValue) -> Self {
+        JwtError::JsError(err)
+    }
+}
+
+pub async fn encode_jwt(
+    claims: &serde_json::Value,
+    private_key_pem: &str,
+) -> Result<String, JwtError> {
+    // Extract the crypto.subtle API
+    let window = window().ok_or(JwtError::NoWindow)?;
+    let crypto = window.crypto()?;
+    let subtle = crypto.subtle();
+
+    // Create the JWT header and claims segments
+    let header_json = json!({
+        "alg": "RS256",
+        "typ": "JWT"
+    });
+    let header_segment = URL_SAFE_NO_PAD.encode(header_json.to_string());
+    let claims_segment = URL_SAFE_NO_PAD.encode(serde_json::to_string(claims)?);
+
+    // Combine header and claims
+    let signing_input = format!("{}.{}", header_segment, claims_segment);
+
+    // Convert PEM to importable key format
+    let pem = private_key_pem
+        .trim()
+        .replace("-----BEGIN PRIVATE KEY-----", "")
+        .replace("-----END PRIVATE KEY-----", "")
+        .replace('\n', "");
+    let key_data = STANDARD.decode(pem)?;
+
+    // Import the key
+    let import_params = Object::new();
+    js_sys::Reflect::set(&import_params, &"name".into(), &"RSASSA-PKCS1-v1_5".into())?;
+    js_sys::Reflect::set(&import_params, &"hash".into(), &"SHA-256".into())?;
+
+    let key_usage = Array::new();
+    key_usage.push(&"sign".into());
+
+    let key: CryptoKey = JsFuture::from(subtle.import_key_with_object(
+        "pkcs8",
+        &Uint8Array::from(&key_data[..]),
+        &import_params,
+        false,
+        &key_usage,
+    )?)
+    .await?
+    .into();
+
+    // Sign the input
+    let sign_params = Object::new();
+    js_sys::Reflect::set(&sign_params, &"name".into(), &"RSASSA-PKCS1-v1_5".into())?;
+
+    let signature = JsFuture::from(subtle.sign_with_object_and_u8_array(
+        &sign_params,
+        &key,
+        signing_input.as_bytes(),
+    )?)
+    .await?;
+
+    let signature_array = Uint8Array::new(&signature);
+    let mut signature_vec = vec![0; signature_array.length() as usize];
+    signature_array.copy_to(&mut signature_vec);
+
+    // Create final JWT
+    let signature_segment = URL_SAFE_NO_PAD.encode(&signature_vec);
+    Ok(format!(
+        "{}.{}.{}",
+        header_segment, claims_segment, signature_segment
+    ))
+}

--- a/shell.nix
+++ b/shell.nix
@@ -16,6 +16,8 @@ let
     dependencies = [ ];
   };
 
+  clang = pkgs.llvmPackages_19.clang;
+
   appleDeps = with pkgs.darwin.apple_sdk.frameworks; [
     CoreServices
     SystemConfiguration
@@ -40,18 +42,19 @@ in pkgs.mkShell {
       ruby
       nixfmt-classic
       swc
-      lld_18
+      lld_19
+      turbo # js packaging
       wasm-pack
     ] ++ (if pkgs.stdenv.isDarwin then appleDeps else [ ]);
 
   LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
   BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin then
-    "-I${pkgs.llvmPackages_18.libclang.lib}/lib/clang/18/headers "
+    "-I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/headers "
   else
-    "-isystem ${pkgs.llvmPackages_18.libclang.lib}/lib/clang/18/include -isystem ${pkgs.glibc.dev}/include";
+    "-isystem ${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include -isystem ${pkgs.glibc.dev}/include";
 
   shellHook = ''
     export PROJECT_ROOT=/$(pwd)
-    export PATH=/$PROJECT_ROOT/tools:$PROJECT_ROOT/integ-tests/typescript/node_modules/.bin:$PATH
+    export PATH=${clang}/bin:/$PROJECT_ROOT/tools:$PROJECT_ROOT/integ-tests/typescript/node_modules/.bin:$PATH
   '';
 }


### PR DESCRIPTION
Testing done:
 - python integ tests confirmed vertex is still working on native targets
 - manual testing showed vertex works in the playground

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `ring` from WASM build by using `wasm_jwt` for JWT signing, updating dependencies and build configurations.
> 
>   - **Behavior**:
>     - Replace `ring` with `wasm_jwt` for JWT signing in WASM builds using `encode_jwt()` in `wasm_jwt.rs`.
>     - Update `get_access_token()` in `vertex_client.rs` to use `encode_jwt()` for WASM.
>   - **Dependencies**:
>     - Add `thiserror 2.0.3` and update `syn` to `2.0.87` in `Cargo.lock`.
>     - Add `thiserror = "2.0.1"` in `baml-runtime/Cargo.toml`.
>   - **Misc**:
>     - Add `wasm_jwt.rs` module for WASM-specific JWT handling.
>     - Update `shell.nix` to use `llvmPackages_19` and `lld_19`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 15a01f3c045399cc5ca947b84ebfd08472fc68c9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->