### PR TITLE
support sigle line quoteless json parsing

### DIFF
--- a/engine/baml-lib/jsonish/src/tests/test_class.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_class.rs
@@ -1348,7 +1348,7 @@ test_deserializer!(
 );
 
 test_deserializer!(
-  test_same_recursive_union_on_multiple_fields,
+  test_recursive_union_on_multiple_fields_single_line,
   r#"class Foo {
       rec_one Foo | int
       rec_two Foo | int
@@ -1357,19 +1357,10 @@ test_deserializer!(
   r#"
     The answer is
     {
-      "rec_one": {
-        "rec_one": 1,
-        "rec_two": 2
-      },
+      "rec_one": { "rec_one": 1, "rec_two": 2 },
       "rec_two": {
-        "rec_one": {
-          "rec_one": 1,
-          "rec_two": 2
-        },
-        "rec_two": {
-          "rec_one": 1,
-          "rec_two": 2
-        }
+        "rec_one": { "rec_one": 1, "rec_two": 2 },
+        "rec_two": { "rec_one": 1, "rec_two": 2 }
       }
     },
 
@@ -1389,6 +1380,111 @@ test_deserializer!(
       "rec_two": {
         "rec_one": 1,
         "rec_two": 2
+      }
+    },
+  }
+);
+
+
+test_deserializer!(
+  test_recursive_union_on_multiple_fields_single_line_without_quotes,
+  r#"class Foo {
+      rec_one Foo | int
+      rec_two Foo | int
+  }
+  "#,
+  r#"
+    The answer is
+    {
+      rec_one: { rec_one: 1, rec_two: 2 },
+      rec_two: {
+        rec_one: { rec_one: 1, rec_two: 2 },
+        rec_two: { rec_one: 1, rec_two: 2 }
+      }
+    },
+
+    Anything else I can help with?
+  "#,
+  FieldType::Class("Foo".to_string()),
+  {
+    "rec_one": {
+      "rec_one": 1,
+      "rec_two": 2
+    },
+    "rec_two": {
+      "rec_one": {
+        "rec_one": 1,
+        "rec_two": 2
+      },
+      "rec_two": {
+        "rec_one": 1,
+        "rec_two": 2
+      }
+    },
+  }
+);
+
+
+test_deserializer!(
+  test_recursive_single_line,
+  r#"class Foo {
+      rec_one Foo | int | bool
+      rec_two Foo | int | bool
+  }
+  "#,
+  r#"
+    The answer is
+    { rec_one: true, rec_two: false },
+
+    Anything else I can help with?
+  "#,
+  FieldType::Class("Foo".to_string()),
+  {
+    "rec_one": true,
+    "rec_two": false
+  }
+);
+
+
+test_deserializer!(
+  test_recursive_union_on_multiple_fields_single_line_without_quotes_complex,
+  r#"class Foo {
+      rec_one Foo | int | bool
+      rec_two Foo | int | bool | null
+  }
+  "#,
+  r#"
+    The answer is
+    {
+      rec_one: { rec_one: { rec_one: true, rec_two: false }, rec_two: null },
+      rec_two: {
+        rec_one: { rec_one: { rec_one: 1, rec_two: 2 }, rec_two: null },
+        rec_two: { rec_one: 1, rec_two: null }
+      }
+    },
+
+    Anything else I can help with?
+  "#,
+  FieldType::Class("Foo".to_string()),
+  {
+    "rec_one": {
+      "rec_one": {
+        "rec_one": true,
+        "rec_two": false
+      },
+      "rec_two": null
+    },
+    "rec_two": {
+      "rec_one": {
+        "rec_one": {
+          "rec_one": 1,
+          "rec_two": 2
+        },
+        "rec_two": null
+      },
+      "rec_two": {
+        "rec_one": 1,
+        "rec_two": null
       }
     },
   }


### PR DESCRIPTION
Prior: minified json didn't parse, now we support minified json for numeric boolean and null values. 

We could improve it further for literals.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for parsing single-line JSON without quotes for numbers, booleans, and null in `JsonParseState`, with new test cases to validate functionality.
> 
>   - **Behavior**:
>     - Support parsing single-line JSON without quotes for numbers, booleans, and null in `JsonParseState`.
>     - Handles cases where values are followed by a comma and space, ensuring correct parsing.
>   - **Tests**:
>     - Add `test_recursive_union_on_multiple_fields_single_line_without_quotes` and `test_recursive_single_line` in `test_class.rs` to validate new parsing behavior.
>     - Add `test_recursive_union_on_multiple_fields_single_line_without_quotes_complex` to test complex nested structures without quotes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 9aa485c6861054e8463758dcaa02e1b8832843a8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->