### PR TITLE
remove win32-arm64 support for now to fix yarn and deno builds

### DIFF
--- a/engine/language_client_typescript/package.json
+++ b/engine/language_client_typescript/package.json
@@ -37,7 +37,6 @@
     "binaryName": "baml",
     "targets": [
       "aarch64-apple-darwin",
-      "aarch64-pc-windows-msvc",
       "aarch64-unknown-linux-gnu",
       "aarch64-unknown-linux-musl",
       "x86_64-apple-darwin",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `aarch64-pc-windows-msvc` target from `package.json` to fix yarn and deno builds.
> 
>   - **Build Configuration**:
>     - Removed `aarch64-pc-windows-msvc` from `targets` in `package.json` to fix yarn and deno builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0f4b1aba39bdf551839e121c5f2d592a94d4c55c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->