### PR TITLE
Add docs for literals and enum keys in map

### DIFF
--- a/fern/03-reference/baml/types.mdx
+++ b/fern/03-reference/baml/types.mdx
@@ -319,11 +319,27 @@ A collection of elements of the same type.
 
 ### Map
 
-A mapping of strings to elements of another type.
+A mapping of strings or enums to elements of another type.
 
 **Syntax**: `map<string, ValueType>`
 
 **Example**: `map<string, string>`
+
+Enums and literal strings can also be used as keys.
+
+```baml
+enum Category {
+  A
+  B
+  C
+}
+
+// Enum key syntax
+map<Category, string>
+
+// Literal strings syntax
+map<"A" | "B" | "C", string>
+```
 
 {/* <Info>
   For TS users: `map<string, ValueType>` will generate a 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add documentation for using enums and literal strings as keys in maps in `types.mdx`.
> 
>   - **Documentation**:
>     - Updated `types.mdx` to include examples of using enums and literal strings as keys in maps.
>     - Added syntax examples for `map<Category, string>` and `map<"A" | "B" | "C", string>` in `types.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7174af0a496ff17de73a943a15119f888a512054. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->