### PR TITLE
Fix nextjs and TS server hot-reload

### DIFF
--- a/typescript/vscode-ext/packages/language-server/src/bamlConfig.ts
+++ b/typescript/vscode-ext/packages/language-server/src/bamlConfig.ts
@@ -3,7 +3,7 @@ export const bamlConfigSchema = z
   .object({
     cliPath: z.optional(z.string().nullable()).default(null),
     generateCodeOnSave: z.enum(['never', 'always']).default('always'),
-    restartTSServerOnSave: z.boolean().default(true),
+    restartTSServerOnSave: z.boolean().default(false),
     envCommand: z.string().default('env'),
     fileWatcher: z.boolean().default(false),
     trace: z.object({

--- a/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
+++ b/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
@@ -6,7 +6,7 @@ import { TextDocument } from 'vscode-languageserver-textdocument'
 import { CompletionList, CompletionItem } from 'vscode-languageserver'
 import { exec } from 'child_process'
 
-import { existsSync, readFileSync } from 'fs'
+import { existsSync, readFileSync, utimes } from 'fs'
 
 import { URI } from 'vscode-uri'
 import { findTopLevelParent, gatherFiles } from '../file/fileUtils'
@@ -417,6 +417,27 @@ class Project {
             await rename(g.output_dir, backupDir)
           }
           await rename(tmpDir, g.output_dir)
+
+          try {
+            // some filewatchers don't trigger unless the file is touched. Creating the new dir alone doesn't work.
+            // if we remove this, TS will still have the old types, and nextjs will not hot-reload.
+            g.files.map((f) => {
+              const fpath = path.join(g.output_dir, f.path_in_output_dir)
+              const currentTime = new Date()
+              const newTime = new Date(currentTime.getTime() + 100)
+                utimes(fpath, newTime, newTime, (err) => {
+                  if (err) {
+                    console.log(`Error setting file times: ${err.message}`)
+                  }
+                })
+            })
+          } catch (e) {
+            if (e instanceof Error) {
+              console.error(`Error setting file times: ${e.message}`)
+            } else {
+              console.error(`Error setting file times:`)
+            }
+          }
           await rm(backupDir, { recursive: true, force: true })
 
           return g

--- a/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
+++ b/typescript/vscode-ext/packages/language-server/src/lib/baml_project_manager.ts
@@ -425,11 +425,11 @@ class Project {
               const fpath = path.join(g.output_dir, f.path_in_output_dir)
               const currentTime = new Date()
               const newTime = new Date(currentTime.getTime() + 100)
-                utimes(fpath, newTime, newTime, (err) => {
-                  if (err) {
-                    console.log(`Error setting file times: ${err.message}`)
-                  }
-                })
+              utimes(fpath, newTime, newTime, (err) => {
+                if (err) {
+                  console.log(`Error setting file times: ${err.message}`)
+                }
+              })
             })
           } catch (e) {
             if (e instanceof Error) {

--- a/typescript/vscode-ext/packages/package.json
+++ b/typescript/vscode-ext/packages/package.json
@@ -49,8 +49,8 @@
         },
         "baml.restartTSServerOnSave": {
           "type": "boolean",
-          "default": true,
-          "description": "Restart the TypeScript server on save, to have it read the new generated types."
+          "default": false,
+          "description": "Restart the TypeScript server when generating baml_client code, in case it's not reading the new generated types."
         },
         "baml.fileWatcher": {
           "scope": "window",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes Next.js and TypeScript server hot-reload by changing `restartTSServerOnSave` default and modifying file timestamps.
> 
>   - **Behavior**:
>     - Change `restartTSServerOnSave` default to `false` in `bamlConfig.ts` and `package.json`.
>     - Modify file timestamps in `baml_project_manager.ts` to trigger file watchers for hot-reload.
>   - **Imports**:
>     - Add `utimes` import from `fs` in `baml_project_manager.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7c891bcfb66b69845c9e44a355f0f991637357ba. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->