### PR TITLE
Add openrouter key

### DIFF
--- a/typescript/fiddle-proxy/server.js
+++ b/typescript/fiddle-proxy/server.js
@@ -38,6 +38,7 @@ const API_KEY_INJECTION_ALLOWED = {
   'https://api.openai.com': { Authorization: `Bearer ${process.env.OPENAI_API_KEY}` },
   'https://api.anthropic.com': { 'x-api-key': process.env.ANTHROPIC_API_KEY },
   'https://generativelanguage.googleapis.com': { 'x-goog-api-key': process.env.GOOGLE_API_KEY },
+  'https://openrouter.ai': { Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}` },
 }
 
 // Consult sam@ before changing this.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for `https://openrouter.ai` API key injection in `server.js`.
> 
>   - **Behavior**:
>     - Add support for `https://openrouter.ai` in `API_KEY_INJECTION_ALLOWED` in `server.js` to inject `OPENROUTER_API_KEY` into requests.
>   - **Misc**:
>     - No other changes or refactoring in the file.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 1410a63d3a7c8966801e2e0d66f67670f6c53010. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->