### PR TITLE
Fix lang name

### DIFF
--- a/typescript/vscode-ext/packages/syntaxes/baml.tmLanguage.json
+++ b/typescript/vscode-ext/packages/syntaxes/baml.tmLanguage.json
@@ -1,6 +1,6 @@
 {
   "fileTypes": ["baml"],
-  "name": "Baml",
+  "name": "baml",
   "patterns": [{ "include": "#comment" }, { "include": "#schema" }],
   "repository": {
     "schema": {


### PR DESCRIPTION
This will hopefully make our highlights trigger on makrdown when a block is called ``baml in vscode