### PR TITLE
Update Vertex docs for different publishers

### DIFF
--- a/fern/03-reference/baml/clients/providers/vertex.mdx
+++ b/fern/03-reference/baml/clients/providers/vertex.mdx
@@ -273,8 +273,19 @@ client<llm> MyClient {
 
 For all other options, see the [official Vertex AI documentation](https://cloud.google.com/vertex-ai/generative-ai/docs/start/quickstarts/quickstart-multimodal).
 
+## Publishers Other Than Google
 
+If you are using models from publishers other than Google, such as Llama from
+Meta, use your project endpoint as the `base_url` in BAML:
 
-
-
+```baml
+client<llm> VertexLlama {
+  provider vertex-ai
+  options {  
+    base_url "https://${LOCATION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${LOCATION}/endpoints/"
+    project_id my-project-id
+    location us-central1
+  }
+}
+```
 


### PR DESCRIPTION
Add [instructions for publishers such as Meta](https://discord.com/channels/1119368998161752075/1293965556994801767/1294021207225532529)

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for using non-Google publishers with Vertex AI, including an example for Meta's Llama model.
> 
>   - **Documentation**:
>     - Adds section for using non-Google publishers in `vertex.mdx`.
>     - Provides example for configuring `base_url` for Meta's Llama model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f15a8a6aea3aaf8c8441ca099fa5a0b4ce4a85e0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->