### PR TITLE
fix: CreateDeployment returns deployment_tag, not deployment_id

### DIFF
--- a/engine/cli/src/api_client.rs
+++ b/engine/cli/src/api_client.rs
@@ -113,7 +113,7 @@ pub struct CreateDeploymentRequest {
 #[derive(Debug, Deserialize)]
 pub struct CreateDeploymentResponse {
     #[allow(dead_code)]
-    deployment_id: String,
+    deployment_tag: String,
 }
 
 impl ApiClient {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `deployment_id` to `deployment_tag` in `CreateDeploymentResponse` to match API response in `api_client.rs`.
> 
>   - **Behavior**:
>     - Rename `deployment_id` to `deployment_tag` in `CreateDeploymentResponse` in `api_client.rs` to match API response.
>   - **Functions**:
>     - `create_deployment` in `ApiClient` now correctly handles `deployment_tag` instead of `deployment_id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 05fd646d881019a013b72b030c622fd4be2cc772. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->