### PR TITLE
fix: get python release working again

### DIFF
--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -65,6 +65,13 @@ jobs:
         env: ${{ matrix._.env || fromJSON('{}') }}
         with:
           target: ${{ matrix._.target }}
+          # TODO: unpin the maturin version
+          # 1.7.7+ builds wheels that gh-action-pypi-publish can't upload
+          # see:
+          #   - release failure: https://github.com/BoundaryML/baml/actions/runs/12154379580/job/33894619438
+          #   - maturin changelog: https://github.com/PyO3/maturin/blob/ba4d482809a73669242bd7fe7dd5f9106f42702f/Changelog.md?plain=1#L13
+          #   - gh-action-pypi-publish issue: https://github.com/pypa/gh-action-pypi-publish/issues/310
+          maturin-version: "1.7.6"
           command: build
           # building in engine/ ensures that we pick up .cargo/config.toml
           working-directory: engine


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pin `maturin` version to `1.7.6` in GitHub Actions to fix Python release issues.
> 
>   - **GitHub Actions Workflow**:
>     - Pin `maturin` version to `1.7.6` in `.github/workflows/build-python-release.reusable.yaml` to fix release issues with `gh-action-pypi-publish`.
>     - Added comments explaining the issue with `maturin` versions `1.7.7+` and links to related issues and changelogs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 11050069254ab4ca51bcad5c68617a2d87a06b66. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->