### PR TITLE
chore: allow forcing the pypi release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,17 @@
 name: BAML Release
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      publish-to-pypi:
+        description: "Publish to PyPI"
+        required: false
+      publish-to-npm:
+        description: "Publish to NPM"
+        required: false
+      publish-to-rubygems:
+        description: "Publish to RubyGems"
+        required: false
   # need to run this periodically on the default branch to populate the build cache
   schedule:
     # daily at 2am PST
@@ -112,7 +122,7 @@ jobs:
 
   publish-to-pypi:
     environment: release
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' || github.event.inputs.publish-to-pypi == 'true'
     needs: [assert-all-builds-passed]
     runs-on: ubuntu-latest
     steps:
@@ -133,7 +143,7 @@ jobs:
 
   publish-to-npm:
     environment: release
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' || github.event.inputs.publish-to-npm == 'true'
     needs: [assert-all-builds-passed]
     runs-on: ubuntu-latest
     env:
@@ -184,7 +194,7 @@ jobs:
 
   publish-to-rubygems:
     environment: release
-    if: github.ref_type == 'tag'
+    if: github.ref_type == 'tag' || github.event.inputs.publish-to-rubygems == 'true'
     needs: [assert-all-builds-passed]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allows manual triggering of PyPI, NPM, and RubyGems releases via workflow inputs in `release.yml`.
> 
>   - **Workflow Dispatch**:
>     - Adds `publish-to-pypi`, `publish-to-npm`, and `publish-to-rubygems` as optional inputs in `release.yml`.
>   - **Conditional Execution**:
>     - Updates `if` conditions in `publish-to-pypi`, `publish-to-npm`, and `publish-to-rubygems` jobs to allow execution if corresponding input is `true`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for aaa6614049951f394473561ce0ace9e14df816e8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->