### PR TITLE
DOCS: deno run instead of dpx

### DIFF
--- a/fern/01-guide/02-languages/typescript.mdx
+++ b/fern/01-guide/02-languages/typescript.mdx
@@ -46,7 +46,7 @@ To set up BAML with Typescript do the following:
         ```
 
         ```bash deno
-        dpx baml-cli init
+        deno run -A npm:@boundaryml/baml/baml-cli init
         ```
     </CodeBlocks>
   
@@ -56,6 +56,9 @@ To set up BAML with Typescript do the following:
 
     ```bash
     npx baml-cli generate
+    ```
+    ```bash deno
+    deno run -A npm:@boundaryml/baml/baml-cli generate
     ```
 
     You can modify your `package.json` so you have a helper prefix in front of your build command.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update TypeScript setup documentation to use `deno run` instead of `dpx` for BAML CLI commands.
> 
>   - **Documentation**:
>     - Replace `dpx baml-cli init` with `deno run -A npm:@boundaryml/baml/baml-cli init` in `typescript.mdx`.
>     - Add `deno run -A npm:@boundaryml/baml/baml-cli generate` as an alternative to `npx baml-cli generate` in `typescript.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c4842a1268103d1aaba387a100af67de9f027c84. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->