### PR TITLE
Fix reqwest caching images on the playground tests

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
@@ -655,8 +655,11 @@ async fn fetch_with_proxy(
     proxy_url: Option<&str>,
 ) -> Result<reqwest::Response, anyhow::Error> {
     let client = reqwest::Client::new();
+
     let request = if let Some(proxy) = proxy_url {
-        client.get(proxy).header("baml-original-url", url)
+        client
+            .get(format!("{}/{}", proxy, url))
+            .header("baml-original-url", url)
     } else {
         client.get(url)
     };

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -228,6 +228,7 @@ impl BamlRuntime {
             let rctx = ctx.create_ctx(None, None)?;
             let (params, constraints) =
                 self.get_test_params_and_constraints(function_name, test_name, &rctx, true)?;
+            log::info!("params: {:#?}", params);
             let rctx_stream = ctx.create_ctx(None, None)?;
             let mut stream = self.inner.stream_function_impl(
                 function_name.into(),
@@ -238,12 +239,14 @@ impl BamlRuntime {
                 self.async_runtime.clone(),
             )?;
             let (response_res, span_uuid) = stream.run(on_event, ctx, None, None).await;
+            log::info!("response_res: {:#?}", response_res);
             let res = response_res?;
             let (_, llm_resp, _, val) = res
                 .event_chain()
                 .iter()
                 .last()
                 .context("Expected non-empty event chain")?;
+            log::info!("llm_resp: {:#?}", llm_resp);
             let complete_resp = match llm_resp {
                 LLMResponse::Success(complete_llm_response) => Ok(complete_llm_response),
                 LLMResponse::InternalFailure(e) => Err(anyhow::anyhow!("{}", e)),

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -60,8 +60,8 @@ pub fn on_wasm_init() {
             const LOG_LEVEL: log::Level = log::Level::Warn;
         }
     };
-    // This line is required if we want to see normal log::info! messages in JS console logs.
-    wasm_logger::init(wasm_logger::Config::new(LOG_LEVEL));
+    // I dont think we need this line anymore -- seems to break logging if you add it.
+    //wasm_logger::init(wasm_logger::Config::new(LOG_LEVEL));
     match console_log::init_with_level(LOG_LEVEL) {
         Ok(_) => web_sys::console::log_1(
             &format!("Initialized BAML runtime logging as log::{}", LOG_LEVEL).into(),
@@ -1660,6 +1660,8 @@ impl WasmFunction {
         let (test_response, span) = rt
             .run_test(&function_name, &test_name, &ctx, Some(cb))
             .await;
+
+        log::info!("test_response: {:#?}", test_response);
 
         Ok(WasmTestResponse {
             test_response,


### PR DESCRIPTION
reqwest caches image requests since the base_url is always empty. Adding the path of the original url into the proxy url fixes it.