### PR TITLE
Fix proxy not returning errors if an image couldnt be fetched

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ on:
     tags:
       - "test-release/*.*"
       - "*.*"
-    branches: []
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -49,7 +48,7 @@ jobs:
       - build-vscode-release
     steps:
       - run: echo "::do-nothing::" >/dev/null
-  
+
   publish-to-pypi:
     environment: release
     needs: [all-builds]
@@ -221,4 +220,4 @@ jobs:
           cd typescript/vscode-ext/packages
           pnpm vsce publish --packagePath ./out/*.vsix
         env:
-          VSCE_PAT: ${{ secrets.VSCODE_PAT }} 
+          VSCE_PAT: ${{ secrets.VSCODE_PAT }}

--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -63,7 +63,7 @@ tokio-stream = "0.1.15"
 uuid = { version = "1.8.0", features = ["v4", "serde"] }
 web-time.workspace = true
 static_assertions.workspace = true
-mime_guess = "2.0.4"
+mime_guess = "=2.0.5"
 mime = "0.3.17"
 
 # For tracing

--- a/typescript/vscode-ext/packages/vscode/src/extension.ts
+++ b/typescript/vscode-ext/packages/vscode/src/extension.ts
@@ -197,6 +197,7 @@ export function activate(context: vscode.ExtensionContext) {
         if (path.endsWith('/')) {
           return path.slice(0, -1)
         }
+        console.log('pathRewrite', path, req)
         return path
       },
       router: (req) => {
@@ -211,15 +212,44 @@ export function activate(context: vscode.ExtensionContext) {
           if (originalUrl.endsWith('/')) {
             originalUrl = originalUrl.slice(0, -1)
           }
-          return originalUrl
+          console.log('returning original url', originalUrl)
+          return new URL(originalUrl).origin
         } else {
+          console.log('baml-original-url header is missing or invalid')
           throw new Error('baml-original-url header is missing or invalid')
         }
       },
       logger: console,
       on: {
         proxyReq: (proxyReq, req, res) => {
-          console.debug('Proxying an LLM request (to bypass CORS)', { proxyReq, req, res })
+          console.log('proxying request')
+          
+          try {
+            const bamlOriginalUrl = req.headers['baml-original-url']
+            if (bamlOriginalUrl === undefined) {
+              return
+            }
+            const targetUrl = new URL(bamlOriginalUrl)
+            // proxyReq.path = targetUrl.pathname
+            // proxyReq.p
+            // It is very important that we ONLY resolve against API_KEY_INJECTION_ALLOWED
+            // by using the URL origin! (i.e. NOT using str.startsWith - the latter can still
+            // leak API keys to malicious subdomains e.g. https://api.openai.com.evil.com)
+            // const headers = API_KEY_INJECTION_ALLOWED[proxyOrigin]
+            // if (headers === undefined) {
+            //   return
+            // }
+            // for (const [header, value] of Object.entries(headers)) {
+            //   proxyReq.setHeader(header, value)
+            // }
+            // proxyReq.removeHeader('origin')
+            // proxyReq.setHeader('Origin', targetUrl.origin)
+            console.info('Proxying an LLM request (to bypass CORS)', { proxyReq, req, res })
+
+          } catch (err) {
+            // This is not console.warn because it's not important
+            console.log('baml-original-url is not parsable', err)
+          }
         },
         proxyRes: (proxyRes, req, res) => {
           proxyRes.headers['Access-Control-Allow-Origin'] = '*'

--- a/typescript/vscode-ext/packages/vscode/src/extension.ts
+++ b/typescript/vscode-ext/packages/vscode/src/extension.ts
@@ -223,7 +223,7 @@ export function activate(context: vscode.ExtensionContext) {
       on: {
         proxyReq: (proxyReq, req, res) => {
           console.log('proxying request')
-          
+
           try {
             const bamlOriginalUrl = req.headers['baml-original-url']
             if (bamlOriginalUrl === undefined) {
@@ -245,7 +245,6 @@ export function activate(context: vscode.ExtensionContext) {
             // proxyReq.removeHeader('origin')
             // proxyReq.setHeader('Origin', targetUrl.origin)
             console.info('Proxying an LLM request (to bypass CORS)', { proxyReq, req, res })
-
           } catch (err) {
             // This is not console.warn because it's not important
             console.log('baml-original-url is not parsable', err)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix proxy error handling for image fetching failures and improve logging in Rust and TypeScript code.
> 
>   - **Behavior**:
>     - `to_base64_with_inferred_mime_type()` in `mod.rs` now returns an error if the response status is not successful, including status and response text.
>     - `fetch_with_proxy()` in `mod.rs` ensures URL parsing and path extraction are handled correctly.
>   - **Dependencies**:
>     - Update `mime_guess` version in `Cargo.toml` to `2.0.5`.
>   - **Logging**:
>     - Add logging in `extension.ts` to track proxy request handling and error scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 5afd5df3cda238773f40d683e34a70098cf54ca7. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->