### PR TITLE
remove log stateemetns i added in

### DIFF
--- a/engine/baml-lib/llm-client/src/clientspec.rs
+++ b/engine/baml-lib/llm-client/src/clientspec.rs
@@ -248,14 +248,6 @@ impl UnresolvedFinishReasonFilter {
 
 impl FinishReasonFilter {
     pub fn is_allowed(&self, reason: Option<impl AsRef<str>>) -> bool {
-        log::warn!(
-            "debug is_allowed: {:?} {}",
-            self,
-            reason
-                .as_ref()
-                .map(|r| r.as_ref().to_string())
-                .unwrap_or("<none>".into())
-        );
         match self {
             Self::AllowList(allow) => {
                 let Some(reason) = reason.map(|r| r.as_ref().to_string()) else {

--- a/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
@@ -150,7 +150,6 @@ where
 {
     #[allow(async_fn_in_trait)]
     async fn single_call(&self, ctx: &RuntimeContext, prompt: &RenderedPrompt) -> LLMResponse {
-        log::warn!("debug single_call start: {:?}", prompt);
         if let RenderedPrompt::Chat(chat) = &prompt {
             match process_media_urls(
                 self.model_features().resolve_media_urls,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove debug log statements from `is_allowed()` in `clientspec.rs` and `single_call()` in `mod.rs`.
> 
>   - **Logging**:
>     - Remove debug log statement from `is_allowed()` in `clientspec.rs`.
>     - Remove debug log statement from `single_call()` in `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 00f413aaa452bba7db79123d5ba5a1ecaa9480df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->