### PR TITLE
fix: bad link in docs

### DIFF
--- a/fern/01-guide/03-development/upgrade-baml-versions.mdx
+++ b/fern/01-guide/03-development/upgrade-baml-versions.mdx
@@ -40,4 +40,4 @@ You only need to do this for minor version upgrades (e.g., 0.54.0 -> 0.62.0), no
 
 ## Troubleshooting
 
-See the [VSCode BAML Extension reference](/guide/reference/vscode-ext/clipath) for more information on how to prevent version mismatches.
+See the [VSCode BAML Extension reference](/ref/editor-extension-settings/baml-cli-path) for more information on how to prevent version mismatches.


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix broken link in `upgrade-baml-versions.mdx` documentation file.
> 
>   - **Docs**:
>     - Fix broken link in `upgrade-baml-versions.mdx` from `/guide/reference/vscode-ext/clipath` to `/ref/editor-extension-settings/baml-cli-path`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 54e62d173c43893d00e7895d289da917bc874ae4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->