### PR TITLE
Fix VSCode link

### DIFF
--- a/typescript/fiddle-frontend/app/[project_id]/_components/ProjectView.tsx
+++ b/typescript/fiddle-frontend/app/[project_id]/_components/ProjectView.tsx
@@ -202,7 +202,7 @@ const ProjectViewImpl = ({ project }: { project: BAMLProject }) => {
                 </div>
                 <div className='flex h-full'>
                   <Link
-                    href='https://docs.boundaryml.com/v3/home/installation'
+                    href='https://docs.boundaryml.com/guide/installation-editors/vs-code-extension'
                     className='h-full pt-0 w-fit text-zinc-300 hover:text-zinc-50'
                   >
                     <div className='flex flex-row items-center text-xs 2xl:text-sm gap-x-4 grayscale hover:grayscale-0'>


### PR DESCRIPTION
Previous link (https://docs.boundaryml.com/v3/home/installation) is a 404.
The new link (https://docs.boundaryml.com/guide/installation-editors/vs-code-extension) points to the current VSCode installation instructions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken VSCode installation link in `ProjectView.tsx`.
> 
>   - **Link Update**:
>     - In `ProjectView.tsx`, updated VSCode installation link from `https://docs.boundaryml.com/v3/home/installation` to `https://docs.boundaryml.com/guide/installation-editors/vs-code-extension` to fix 404 error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7a80dd9ba2a2481cb667cf0edbeca59a7d628d1c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->