### PR TITLE
Update gemini 2 flash thinking model name check

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
@@ -468,7 +468,7 @@ impl ToProviderMessage for GoogleAIClient {
 /// For examples of how to introspect the response more safely, see:
 /// https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/getting-started/intro_gemini_2_0_flash_thinking_mode.ipynb
 fn content_part(model_name: &str) -> usize {
-    if model_name == "gemini-2.0-flash-thinking-exp-1219" {
+    if model_name.contains("gemini-2.0-flash-thinking-exp-1219") {
         1
     } else {
         0


### PR DESCRIPTION
a Small change to update the check for gemini 2 flash thinking model to use `contains` instead of `==` to allow specifying a region if needed with OpenAI compatible proxies.

Ex: usage:

```
client<llm> GEMINI_V2_FLASH_THINKING {
  provider "openai-generic"
  retry_policy Exponential
  options {
    model "googlevertexai-us-central1:gemini-2.0-flash-thinking-exp-1219"
    api_key env.MY_TOKEN
    base_url "https://my-proxy.ai/v1"
  }
}
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `content_part()` in `googleai_client.rs` to use `contains` for model name check, allowing region-specific names.
> 
>   - **Behavior**:
>     - Update `content_part()` in `googleai_client.rs` to use `contains` instead of `==` for model name check, allowing region-specific model names.
>   - **Misc**:
>     - No other changes or refactoring in the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 9f19ef8533b76e610b9ac347892196ca9133ee9d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->