### PR TITLE
chore: give publish-to-github required permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,8 @@ jobs:
 
   publish-to-github:
     environment: release
+    permissions:
+      contents: write
     needs: [all-builds]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `contents: write` permission to `publish-to-github` job in `release.yml`.
> 
>   - **Permissions**:
>     - Add `contents: write` permission to `publish-to-github` job in `release.yml` to allow modifying repository contents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for b409e07abed9488f6c5bf9fcc4a065b5b4a59c8f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->