### PR TITLE
Implement jump to definition for type aliases

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     ir::{
         repr::{IntermediateRepr, Walker},
         Class, Client, Enum, EnumValue, Field, FunctionNode, RetryPolicy, TemplateString, TestCase,
+        TypeAlias,
     },
 };
 use anyhow::Result;
@@ -25,6 +26,7 @@ pub type FunctionWalker<'a> = Walker<'a, &'a FunctionNode>;
 pub type EnumWalker<'a> = Walker<'a, &'a Enum>;
 pub type EnumValueWalker<'a> = Walker<'a, &'a EnumValue>;
 pub type ClassWalker<'a> = Walker<'a, &'a Class>;
+pub type TypeAliasWalker<'a> = Walker<'a, &'a TypeAlias>;
 pub type TemplateStringWalker<'a> = Walker<'a, &'a TemplateString>;
 pub type ClientWalker<'a> = Walker<'a, &'a Client>;
 pub type RetryPolicyWalker<'a> = Walker<'a, &'a RetryPolicy>;
@@ -34,6 +36,7 @@ pub type ClassFieldWalker<'a> = Walker<'a, &'a Field>;
 pub trait IRHelper {
     fn find_enum<'a>(&'a self, enum_name: &str) -> Result<EnumWalker<'a>>;
     fn find_class<'a>(&'a self, class_name: &str) -> Result<ClassWalker<'a>>;
+    fn find_type_alias<'a>(&'a self, alias_name: &str) -> Result<TypeAliasWalker<'a>>;
     fn find_function<'a>(&'a self, function_name: &str) -> Result<FunctionWalker<'a>>;
     fn find_client<'a>(&'a self, client_name: &str) -> Result<ClientWalker<'a>>;
     fn find_retry_policy<'a>(&'a self, retry_policy_name: &str) -> Result<RetryPolicyWalker<'a>>;
@@ -103,6 +106,20 @@ impl IRHelper for IntermediateRepr {
                 // Get best match.
                 let classes = self.walk_classes().map(|e| e.name()).collect::<Vec<_>>();
                 error_not_found!("class", class_name, &classes)
+            }
+        }
+    }
+
+    fn find_type_alias<'a>(&'a self, alias_name: &str) -> Result<TypeAliasWalker<'a>> {
+        match self.walk_type_aliases().find(|e| e.name() == alias_name) {
+            Some(e) => Ok(e),
+            None => {
+                // Get best match.
+                let aliases = self
+                    .walk_type_aliases()
+                    .map(|e| e.name())
+                    .collect::<Vec<_>>();
+                error_not_found!("type alias", alias_name, &aliases)
             }
         }
     }

--- a/engine/baml-lib/baml-core/src/ir/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/mod.rs
@@ -15,6 +15,7 @@ pub(super) use repr::IntermediateRepr;
 pub type Enum = repr::Node<repr::Enum>;
 pub type EnumValue = repr::Node<repr::EnumValue>;
 pub type Class = repr::Node<repr::Class>;
+pub type TypeAlias = repr::Node<repr::TypeAlias>;
 pub type Field = repr::Node<repr::Field>;
 pub type FieldType = baml_types::FieldType;
 pub type TypeValue = baml_types::TypeValue;

--- a/engine/baml-lib/baml-core/src/ir/walker.rs
+++ b/engine/baml-lib/baml-core/src/ir/walker.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 use super::{
     repr::{self, FunctionConfig, WithRepr},
     Class, Client, Enum, EnumValue, Field, FunctionNode, IRHelper, Impl, RetryPolicy,
-    TemplateString, TestCase, Walker,
+    TemplateString, TestCase, TypeAlias, Walker,
 };
 use crate::ir::jinja_helpers::render_expression;
 
@@ -300,6 +300,20 @@ impl<'a> Walker<'a, &'a Class> {
 
     pub fn inputs(&self) -> &'a Vec<(String, baml_types::FieldType)> {
         self.elem().inputs()
+    }
+}
+
+impl<'a> Walker<'a, &'a TypeAlias> {
+    pub fn elem(&self) -> &'a repr::TypeAlias {
+        &self.item.elem
+    }
+
+    pub fn name(&self) -> &'a str {
+        &self.elem().name
+    }
+
+    pub fn span(&self) -> Option<&crate::Span> {
+        self.item.attributes.span.as_ref()
     }
 }
 

--- a/engine/baml-lib/parser-database/src/walkers/alias.rs
+++ b/engine/baml-lib/parser-database/src/walkers/alias.rs
@@ -1,14 +1,21 @@
 use std::collections::HashSet;
 
 use super::TypeWalker;
-use internal_baml_schema_ast::ast::{self, FieldType, Identifier, WithName};
+use internal_baml_diagnostics::Span;
+use internal_baml_schema_ast::ast::{self, FieldType, Identifier, WithName, WithSpan};
 
+/// Type alias walker
 pub type TypeAliasWalker<'db> = super::Walker<'db, ast::TypeAliasId>;
 
 impl<'db> TypeAliasWalker<'db> {
     /// Name of the type alias.
     pub fn name(&self) -> &str {
         &self.db.ast[self.id].identifier.name()
+    }
+
+    /// Identifier span.
+    pub fn span(&self) -> &Span {
+        self.db.ast[self.id].identifier.span()
     }
 
     /// Returns the field type that the alias points to.

--- a/engine/baml-lib/parser-database/src/walkers/mod.rs
+++ b/engine/baml-lib/parser-database/src/walkers/mod.rs
@@ -15,7 +15,7 @@ mod field;
 mod function;
 mod template_string;
 
-use alias::TypeAliasWalker;
+pub use alias::TypeAliasWalker;
 use baml_types::TypeValue;
 pub use client::*;
 pub use configuration::*;

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -1213,6 +1213,19 @@ impl WasmRuntime {
                 end_character: e_character,
             });
         }
+        if let Ok(walker) = runtime.find_type_alias(symbol) {
+            let elem = walker.span().unwrap();
+
+            let _uri_str = elem.file.path().to_string(); // Store the String in a variable
+            let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
+            return Some(SymbolLocation {
+                uri: elem.file.path().to_string(), // Use the variable here
+                start_line: s_line,
+                start_character: s_character,
+                end_line: e_line,
+                end_character: e_character,
+            });
+        }
 
         if let Ok(walker) = runtime.find_function(symbol) {
             let elem = walker.span().unwrap();


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Implement jump to definition for type aliases by adding support in runtime, IR, and walkers.
> 
>   - **Behavior**:
>     - Implement jump to definition for type aliases in `runtime_wasm/mod.rs` by adding support in `search_for_symbol()`.
>     - Add `find_type_alias()` to `IRHelper` trait in `ir_helpers/mod.rs`.
>   - **Models**:
>     - Add `TypeAlias` struct to `repr.rs`.
>     - Add `TypeAliasWalker` to `walkers/mod.rs` and `alias.rs`.
>   - **Misc**:
>     - Add `walk_type_aliases()` to `IntermediateRepr` in `repr.rs`.
>     - Add `TypeAlias` to `ir/mod.rs` type aliases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7200129983425f1fc2d27ec035033dd01024798d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->