### PR TITLE
Add docs for recursive type aliases

### DIFF
--- a/fern/03-reference/baml/types.mdx
+++ b/fern/03-reference/baml/types.mdx
@@ -358,6 +358,10 @@ map<"A" | "B" | "C", string>
 
 ## Type Aliases
 
+<Info>
+  This feature was added in: v0.71.0.
+</Info>
+
 A _type alias_ is an alternative name for an existing type. It can be used to
 simplify complex types or to give a more descriptive name to a type. Type
 aliases are defined using the `type` keyword:
@@ -370,6 +374,28 @@ Type aliases can point to other aliases:
 
 ```baml
 type DataStructure = string[] | Graph
+```
+
+Recursive type aliases are supported only through map or list containers, just
+like in TypeScript:
+
+```baml
+type JsonValue = int | string | bool | float | JsonObject | JsonArray
+type JsonObject = map<string, JsonValue>
+type JsonArray = JsonValue[]
+```
+
+Aliases can also refer to themselves:
+
+```baml
+type JsonValue = int | float | bool | string | null | JsonValue[] | map<string, JsonValue> 
+```
+
+However, this is invalid since no value can satisfy this type:
+
+```baml
+type A = B
+type B = A
 ```
 
 ## Examples and Equivalents


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for recursive type aliases in BAML, including examples and limitations.
> 
>   - **Documentation**:
>     - Adds section on recursive type aliases in `types.mdx`.
>     - Explains support for recursive type aliases through map or list containers.
>     - Provides examples of valid recursive type aliases and invalid self-referential aliases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 49000232b3f03780c1c56be1ba92fa4d0e43fd14. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->