### PR TITLE
add baml-cli fmt docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -318,6 +318,8 @@ navigation:
             path: 03-reference/baml-cli/serve.mdx
           - page: dev
             path: 03-reference/baml-cli/dev.mdx
+          - page: fmt
+            path: 03-reference/baml-cli/fmt.mdx
       - section: Language Reference
         slug: baml
         contents:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `fmt` page to `baml-cli` section in `docs.yml`.
> 
>   - **Documentation**:
>     - Add `fmt` page to `baml-cli` section in `docs.yml`, located at `03-reference/baml-cli/fmt.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 3afefd33a89a85663039ac859caee302348f9a12. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->