### PR TITLE
fix: make upgrade notifications point to the correct link

### DIFF
--- a/engine/language_client_codegen/src/version_check.rs
+++ b/engine/language_client_codegen/src/version_check.rs
@@ -86,7 +86,7 @@ pub fn check_version(
                     GeneratorType::VSCode => format!("Update the 'version' in your BAML generator config to '{}' to match the VSCode extension version.", runtime_version),
                     GeneratorType::CLI | GeneratorType::VSCodeCLI => format!("Update the 'version' in your BAML generator config to '{}' to match the installed baml package version.", runtime_version),
                 },
-                "https://docs.boundaryml.com/docs/calling-baml/generate-baml-client#troubleshooting-version-conflicts"
+                "https://docs.boundaryml.com/guide/development/upgrade-baml-versions"
             )
         } else if matches!(generator_language, GeneratorOutputType::OpenApi) {
             (
@@ -98,7 +98,7 @@ pub fn check_version(
                         format!("Use BAML v{} to match the version in the BAML generator config, like so: npx @boundaryml/baml@{} generate", gen_version, gen_version)
                     },
                 },
-                "https://docs.boundaryml.com/docs/calling-baml/generate-baml-client#troubleshooting-version-conflicts"
+                "https://docs.boundaryml.com/guide/development/upgrade-baml-versions"
             )
         } else {
             let update_instruction = match generator_language {
@@ -120,7 +120,7 @@ pub fn check_version(
                         format!("Update your installed BAML CLI package to version '{}' to match the version in the BAML generator config: {}", gen_version, update_instruction)
                     },
                 },
-                "https://docs.boundaryml.com/docs/calling-baml/generate-baml-client#troubleshooting-version-conflicts"
+                "https://docs.boundaryml.com/guide/development/upgrade-baml-versions"
             )
         };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update outdated documentation link in `version_check.rs` to the correct BAML upgrade guide.
> 
>   - **Links**:
>     - Update outdated documentation link in `check_version()` in `version_check.rs` to `https://docs.boundaryml.com/guide/development/upgrade-baml-versions`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for fc6431a62e02d4685e5f098464334025307d86e7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->