### PR TITLE
expand prompt parts by default to prevent weird scrolling behavior

### DIFF
--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-part.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-part.tsx
@@ -1,5 +1,5 @@
 import type { WasmChatMessagePart, WasmParam, WasmTestCase } from '@gloo-ai/baml-schema-wasm-web'
-import { RenderText } from './render-text'
+import { RenderPromptPart } from './render-text'
 import { WebviewMedia } from './webview-media'
 
 export const RenderPart: React.FC<{
@@ -48,7 +48,7 @@ export const RenderPart: React.FC<{
       }
     })
 
-    return text ? <RenderText text={text} highlightChunks={highlightChunks} /> : null
+    return text ? <RenderPromptPart text={text} highlightChunks={highlightChunks} /> : null
   }
 
   const media = part.as_media()
@@ -57,11 +57,11 @@ export const RenderPart: React.FC<{
   }
 
   if (part.is_image()) {
-    return <WebviewMedia bamlMediaType='image' media={media} />
+    return <WebviewMedia bamlMediaType="image" media={media} />
   }
 
   if (part.is_audio()) {
-    return <WebviewMedia bamlMediaType='audio' media={media} />
+    return <WebviewMedia bamlMediaType="audio" media={media} />
   }
 
   return null

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-part.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-part.tsx
@@ -57,11 +57,11 @@ export const RenderPart: React.FC<{
   }
 
   if (part.is_image()) {
-    return <WebviewMedia bamlMediaType="image" media={media} />
+    return <WebviewMedia bamlMediaType='image' media={media} />
   }
 
   if (part.is_audio()) {
-    return <WebviewMedia bamlMediaType="audio" media={media} />
+    return <WebviewMedia bamlMediaType='audio' media={media} />
   }
 
   return null

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-text.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-text.tsx
@@ -60,28 +60,28 @@ export const RenderPromptPart: React.FC<{
   }, [text, highlightChunks, tokenizer])
 
   return (
-    <div className="flex flex-col">
+    <div className='flex flex-col'>
       {isDebugMode && (
-        <div className="flex flex-row gap-4 justify-start items-center px-3 py-2 text-xs border-b border-border bg-muted text-muted-foreground">
-          <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground/60">Characters:</span>
-            <span className="font-medium">{text.length}</span>
+        <div className='flex flex-row gap-4 justify-start items-center px-3 py-2 text-xs border-b border-border bg-muted text-muted-foreground'>
+          <div className='flex items-center gap-1.5'>
+            <span className='text-muted-foreground/60'>Characters:</span>
+            <span className='font-medium'>{text.length}</span>
           </div>
-          <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground/60">Words:</span>
-            <span className="font-medium">{text.split(/\s+/).filter(Boolean).length}</span>
+          <div className='flex items-center gap-1.5'>
+            <span className='text-muted-foreground/60'>Words:</span>
+            <span className='font-medium'>{text.split(/\s+/).filter(Boolean).length}</span>
           </div>
-          <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground/60">Lines:</span>
-            <span className="font-medium">{text.split('\n').length}</span>
+          <div className='flex items-center gap-1.5'>
+            <span className='text-muted-foreground/60'>Lines:</span>
+            <span className='font-medium'>{text.split('\n').length}</span>
           </div>
-          <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground/60">Tokens (est.):</span>
-            <span className="font-medium">{Math.ceil(text.length / 4)}</span>
+          <div className='flex items-center gap-1.5'>
+            <span className='text-muted-foreground/60'>Tokens (est.):</span>
+            <span className='font-medium'>{Math.ceil(text.length / 4)}</span>
           </div>
         </div>
       )}
-      <ScrollArea className="relative flex-1 p-2 pb-6 bg-muted/50 dark:bg-slate-900" type="always">
+      <ScrollArea className='relative flex-1 p-2 pb-6 bg-muted/50 dark:bg-slate-900' type='always'>
         <pre
           className={`whitespace-pre-wrap text-xs  ${isFullTextVisible ? 'max-h-fit' : 'max-h-64'}`}
           dangerouslySetInnerHTML={{ __html: renderContent }}
@@ -90,17 +90,17 @@ export const RenderPromptPart: React.FC<{
         {isLongText && (
           <button
             onClick={() => setIsFullTextVisible(!isFullTextVisible)}
-            className="flex absolute right-0 bottom-0 gap-1 items-center p-2 text-xs rounded-tr-md rounded-bl-md transition-colors bg-muted/50 text-muted-foreground hover:text-foreground"
+            className='flex absolute right-0 bottom-0 gap-1 items-center p-2 text-xs rounded-tr-md rounded-bl-md transition-colors bg-muted/50 text-muted-foreground hover:text-foreground'
           >
             {isFullTextVisible ? (
               <>
                 Show less
-                <ChevronUp className="w-3 h-3" />
+                <ChevronUp className='w-3 h-3' />
               </>
             ) : (
               <>
                 Show more
-                <ChevronDown className="w-3 h-3" />
+                <ChevronDown className='w-3 h-3' />
               </>
             )}
           </button>

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-text.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-text.tsx
@@ -4,10 +4,9 @@ import { useMemo, useState } from 'react'
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { TokenEncoderCache } from './render-tokens'
-import { currentClientsAtom } from '../atoms-orch-graph'
 export const isDebugModeAtom = atom((get) => get(renderModeAtom) === 'tokens')
 
-export const RenderText: React.FC<{
+export const RenderPromptPart: React.FC<{
   text: string
   highlightChunks?: string[]
   model?: string
@@ -16,7 +15,8 @@ export const RenderText: React.FC<{
   const isDebugMode = useAtomValue(isDebugModeAtom)
   const isLongText = useMemo(() => text.split('\n').length > 18, [text])
   // const currentClient = useAtomValue(currentClientsAtom)
-  const [isFullTextVisible, setIsFullTextVisible] = useState(false)
+  // this causes weird scroll issues
+  const [isFullTextVisible, setIsFullTextVisible] = useState(true)
 
   const tokenizer = useMemo(() => {
     if (!isDebugMode) return undefined
@@ -60,47 +60,47 @@ export const RenderText: React.FC<{
   }, [text, highlightChunks, tokenizer])
 
   return (
-    <div className='flex flex-col'>
+    <div className="flex flex-col">
       {isDebugMode && (
-        <div className='flex flex-row gap-4 justify-start items-center px-3 py-2 text-xs border-b border-border bg-muted text-muted-foreground'>
-          <div className='flex items-center gap-1.5'>
-            <span className='text-muted-foreground/60'>Characters:</span>
-            <span className='font-medium'>{text.length}</span>
+        <div className="flex flex-row gap-4 justify-start items-center px-3 py-2 text-xs border-b border-border bg-muted text-muted-foreground">
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground/60">Characters:</span>
+            <span className="font-medium">{text.length}</span>
           </div>
-          <div className='flex items-center gap-1.5'>
-            <span className='text-muted-foreground/60'>Words:</span>
-            <span className='font-medium'>{text.split(/\s+/).filter(Boolean).length}</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground/60">Words:</span>
+            <span className="font-medium">{text.split(/\s+/).filter(Boolean).length}</span>
           </div>
-          <div className='flex items-center gap-1.5'>
-            <span className='text-muted-foreground/60'>Lines:</span>
-            <span className='font-medium'>{text.split('\n').length}</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground/60">Lines:</span>
+            <span className="font-medium">{text.split('\n').length}</span>
           </div>
-          <div className='flex items-center gap-1.5'>
-            <span className='text-muted-foreground/60'>Tokens (est.):</span>
-            <span className='font-medium'>{Math.ceil(text.length / 4)}</span>
+          <div className="flex items-center gap-1.5">
+            <span className="text-muted-foreground/60">Tokens (est.):</span>
+            <span className="font-medium">{Math.ceil(text.length / 4)}</span>
           </div>
         </div>
       )}
-      <ScrollArea className='relative flex-1 p-2 pb-6 bg-muted/50 dark:bg-slate-900' type='always'>
+      <ScrollArea className="relative flex-1 p-2 pb-6 bg-muted/50 dark:bg-slate-900" type="always">
         <pre
-          className={`whitespace-pre-wrap text-xs  ${isFullTextVisible ? 'max-h-96' : 'max-h-64'}`}
+          className={`whitespace-pre-wrap text-xs  ${isFullTextVisible ? 'max-h-fit' : 'max-h-64'}`}
           dangerouslySetInnerHTML={{ __html: renderContent }}
         />
 
         {isLongText && (
           <button
             onClick={() => setIsFullTextVisible(!isFullTextVisible)}
-            className='flex absolute right-0 bottom-0 gap-1 items-center p-2 text-xs rounded-tr-md rounded-bl-md transition-colors bg-muted/50 text-muted-foreground hover:text-foreground'
+            className="flex absolute right-0 bottom-0 gap-1 items-center p-2 text-xs rounded-tr-md rounded-bl-md transition-colors bg-muted/50 text-muted-foreground hover:text-foreground"
           >
             {isFullTextVisible ? (
               <>
                 Show less
-                <ChevronUp className='w-3 h-3' />
+                <ChevronUp className="w-3 h-3" />
               </>
             ) : (
               <>
                 Show more
-                <ChevronDown className='w-3 h-3' />
+                <ChevronDown className="w-3 h-3" />
               </>
             )}
           </button>

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ParsedResponseRender.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ParsedResponseRender.tsx
@@ -3,7 +3,7 @@ import { githubLightTheme as lightTheme } from '@uiw/react-json-view/githubLight
 import { vscodeTheme as darkTheme } from '@uiw/react-json-view/vscode'
 import { type WasmFunctionResponse, type WasmTestResponse } from '@gloo-ai/baml-schema-wasm-web'
 import { useTheme } from 'next-themes'
-import { RenderText } from '../../render-text'
+import { RenderPromptPart } from '../../render-text'
 import { ScrollArea } from '@/components/ui/scroll-area'
 
 // Renders the parsed response only
@@ -11,7 +11,7 @@ export const ParsedResponseRenderer: React.FC<{
   response?: WasmFunctionResponse | WasmTestResponse
 }> = ({ response }) => {
   if (!response || !response.parsed_response()) {
-    return <div className='text-xs text-muted-foreground'>Waiting for response...</div>
+    return <div className="text-xs text-muted-foreground">Waiting for response...</div>
   }
 
   const parsedResponse = response.parsed_response()
@@ -36,14 +36,14 @@ const ParsedResponseRender = ({ response }: { response: string }) => {
   }
 
   if (typeof parsedResponseObj === 'string') {
-    return <RenderText text={parsedResponseObj} />
+    return <RenderPromptPart text={parsedResponseObj} />
   }
 
   return (
-    <div className='flex max-h-[500px]  text-xs'>
-      <ScrollArea className='pr-2 w-full text-xs' type='always'>
+    <div className="flex max-h-[500px]  text-xs">
+      <ScrollArea className="pr-2 w-full text-xs" type="always">
         <JsonView
-          className='p-1 w-full rounded-md'
+          className="p-1 w-full rounded-md"
           value={parsedResponseObj}
           collapsed={false}
           enableClipboard={true}
@@ -60,8 +60,8 @@ const ParsedResponseRender = ({ response }: { response: string }) => {
               }
               if (type === 'value') {
                 return (
-                  <span {...reset} className='whitespace-pre-wrap break-all'>
-                    &quot;{children}&quot;<span className='text-muted-foreground'>, </span>
+                  <span {...reset} className="whitespace-pre-wrap break-all">
+                    &quot;{children}&quot;<span className="text-muted-foreground">, </span>
                   </span>
                 )
               }
@@ -78,14 +78,14 @@ const ParsedResponseRender = ({ response }: { response: string }) => {
 
           <JsonView.Null
             render={({ children, ...reset }) => (
-              <span {...reset} className='whitespace-pre-wrap break-words'>
+              <span {...reset} className="whitespace-pre-wrap break-words">
                 null
               </span>
             )}
           />
           <JsonView.Undefined
             render={({ children, ...reset }) => (
-              <span {...reset} className='whitespace-pre-wrap break-words'>
+              <span {...reset} className="whitespace-pre-wrap break-words">
                 undefined
               </span>
             )}
@@ -93,9 +93,9 @@ const ParsedResponseRender = ({ response }: { response: string }) => {
           <JsonView.KeyName
             render={({ ...props }, { parentValue, value, keyName }) => {
               if (Array.isArray(parentValue) && Number.isFinite(props.children)) {
-                return <span className='' />
+                return <span className="" />
               }
-              return <span className='' {...props} />
+              return <span className="" {...props} />
             }}
           />
         </JsonView>

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ParsedResponseRender.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ParsedResponseRender.tsx
@@ -11,7 +11,7 @@ export const ParsedResponseRenderer: React.FC<{
   response?: WasmFunctionResponse | WasmTestResponse
 }> = ({ response }) => {
   if (!response || !response.parsed_response()) {
-    return <div className="text-xs text-muted-foreground">Waiting for response...</div>
+    return <div className='text-xs text-muted-foreground'>Waiting for response...</div>
   }
 
   const parsedResponse = response.parsed_response()
@@ -40,10 +40,10 @@ const ParsedResponseRender = ({ response }: { response: string }) => {
   }
 
   return (
-    <div className="flex max-h-[500px]  text-xs">
-      <ScrollArea className="pr-2 w-full text-xs" type="always">
+    <div className='flex max-h-[500px]  text-xs'>
+      <ScrollArea className='pr-2 w-full text-xs' type='always'>
         <JsonView
-          className="p-1 w-full rounded-md"
+          className='p-1 w-full rounded-md'
           value={parsedResponseObj}
           collapsed={false}
           enableClipboard={true}
@@ -60,8 +60,8 @@ const ParsedResponseRender = ({ response }: { response: string }) => {
               }
               if (type === 'value') {
                 return (
-                  <span {...reset} className="whitespace-pre-wrap break-all">
-                    &quot;{children}&quot;<span className="text-muted-foreground">, </span>
+                  <span {...reset} className='whitespace-pre-wrap break-all'>
+                    &quot;{children}&quot;<span className='text-muted-foreground'>, </span>
                   </span>
                 )
               }
@@ -78,14 +78,14 @@ const ParsedResponseRender = ({ response }: { response: string }) => {
 
           <JsonView.Null
             render={({ children, ...reset }) => (
-              <span {...reset} className="whitespace-pre-wrap break-words">
+              <span {...reset} className='whitespace-pre-wrap break-words'>
                 null
               </span>
             )}
           />
           <JsonView.Undefined
             render={({ children, ...reset }) => (
-              <span {...reset} className="whitespace-pre-wrap break-words">
+              <span {...reset} className='whitespace-pre-wrap break-words'>
                 undefined
               </span>
             )}
@@ -93,9 +93,9 @@ const ParsedResponseRender = ({ response }: { response: string }) => {
           <JsonView.KeyName
             render={({ ...props }, { parentValue, value, keyName }) => {
               if (Array.isArray(parentValue) && Number.isFinite(props.children)) {
-                return <span className="" />
+                return <span className='' />
               }
-              return <span className="" {...props} />
+              return <span className='' {...props} />
             }}
           />
         </JsonView>

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ResponseRenderer.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ResponseRenderer.tsx
@@ -7,7 +7,7 @@ import { Button } from '~/components/ui/button'
 import { Badge } from '~/components/ui/badge'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '~/components/ui/tooltip'
 import { ParsedResponseRenderer } from './ParsedResponseRender'
-import { RenderText } from '../../render-text'
+import { RenderPromptPart } from '../../render-text'
 
 interface ResponseRendererProps {
   response?: WasmFunctionResponse | WasmTestResponse
@@ -20,7 +20,7 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
   const [llmCopied, setLlmCopied] = useState(false)
 
   if (!response) {
-    return <div className='text-xs text-muted-foreground'>Waiting for response...</div>
+    return <div className="text-xs text-muted-foreground">Waiting for response...</div>
   }
 
   const llmFailure = response.llm_failure()
@@ -54,10 +54,10 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
   }
 
   return (
-    <div className='space-y-4'>
+    <div className="space-y-4">
       {/* Metadata Section */}
       {llmResponse && (
-        <div className='flex flex-wrap gap-2'>
+        <div className="flex flex-wrap gap-2">
           <MetadataBadges llmResponse={llmResponse} />
         </div>
       )}
@@ -66,10 +66,10 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
       <div className={`grid ${shouldShowParsedSeparately() ? 'grid-cols-2' : 'grid-cols-1'} gap-4`}>
         {/* LLM Response */}
         {llmResponse && (
-          <div className='relative group'>
-            <div className='space-y-2'>
-              <span className='text-xs text-muted-foreground'>Raw LLM Response</span>
-              <RenderText text={llmResponse.content} />
+          <div className="relative group">
+            <div className="space-y-2">
+              <span className="text-xs text-muted-foreground">Raw LLM Response</span>
+              <RenderPromptPart text={llmResponse.content} />
             </div>
             <CopyButton copied={llmCopied} onCopy={handleLlmCopy} />
           </div>
@@ -77,12 +77,12 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
 
         {/* Parsed Response */}
         {shouldShowParsedSeparately() && (
-          <div className='relative group'>
-            <div className='space-y-2'>
-              <span className='flex flex-row gap-x-1 text-xs text-muted-foreground'>
+          <div className="relative group">
+            <div className="space-y-2">
+              <span className="flex flex-row gap-x-1 text-xs text-muted-foreground">
                 <div>Parsed Response</div>
                 {parsedResponse && typeof parsedResponse !== 'string' && parsedResponse.check_count > 0 ? (
-                  <div className='flex items-center space-x-1'>
+                  <div className="flex items-center space-x-1">
                     {/* <CheckCircle className="w-3 h-3" /> */}
                     <span>({parsedResponse.check_count} checks ran)</span>
                   </div>
@@ -96,7 +96,7 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
       </div>
 
       {/* Error Messages */}
-      {failureMessage && <div className='text-xs text-red-500'>Error: {failureMessage}</div>}
+      {failureMessage && <div className="text-xs text-red-500">Error: {failureMessage}</div>}
     </div>
   )
 }
@@ -106,17 +106,17 @@ export const RawResponseRenderer: React.FC<{
   response?: WasmFunctionResponse | WasmTestResponse
 }> = ({ response }) => {
   if (!response) {
-    return <div className='text-xs text-muted-foreground'>Waiting for response...</div>
+    return <div className="text-xs text-muted-foreground">Waiting for response...</div>
   }
-  return <RenderText text={response.llm_response()?.content ?? ''} />
+  return <RenderPromptPart text={response.llm_response()?.content ?? ''} />
 }
 
 const MetadataBadges: React.FC<{ llmResponse: WasmLLMResponse }> = ({ llmResponse }) => (
   <TooltipProvider>
     <Tooltip>
       <TooltipTrigger asChild>
-        <Badge variant='outline' className='flex items-center space-x-1 font-light text-muted-foreground'>
-          <Brain className='w-3 h-3' />
+        <Badge variant="outline" className="flex items-center space-x-1 font-light text-muted-foreground">
+          <Brain className="w-3 h-3" />
           <span>{llmResponse.model}</span>
         </Badge>
       </TooltipTrigger>
@@ -125,8 +125,8 @@ const MetadataBadges: React.FC<{ llmResponse: WasmLLMResponse }> = ({ llmRespons
 
     <Tooltip>
       <TooltipTrigger asChild>
-        <Badge variant='outline' className='flex items-center space-x-1 font-light text-muted-foreground'>
-          <Clock className='w-3 h-3' />
+        <Badge variant="outline" className="flex items-center space-x-1 font-light text-muted-foreground">
+          <Clock className="w-3 h-3" />
           <span>{(Number(llmResponse.latency_ms) / 1000).toFixed(2)}s</span>
         </Badge>
       </TooltipTrigger>
@@ -137,12 +137,12 @@ const MetadataBadges: React.FC<{ llmResponse: WasmLLMResponse }> = ({ llmRespons
 
 const CopyButton: React.FC<{ copied: boolean; onCopy: () => void }> = ({ copied, onCopy }) => (
   <Button
-    variant='ghost'
-    size='icon'
-    className='absolute top-0 right-0 w-4 h-4 opacity-0 transition-opacity bg-muted group-hover:opacity-100'
+    variant="ghost"
+    size="icon"
+    className="absolute top-0 right-0 w-4 h-4 opacity-0 transition-opacity bg-muted group-hover:opacity-100"
     onClick={onCopy}
   >
-    {copied ? <Check className='w-4 h-4' /> : <Copy className='w-4 h-4' />}
+    {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
   </Button>
 )
 
@@ -150,28 +150,28 @@ const LLMFailureView: React.FC<{ failure: WasmLLMFailure }> = ({ failure }) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (
-    <div className='space-y-3 text-xs'>
-      <div className='flex items-center space-x-2 text-destructive'>
-        <AlertCircle className='w-4 h-4' />
-        <span className='font-semibold'>{failure.code}</span>
+    <div className="space-y-3 text-xs">
+      <div className="flex items-center space-x-2 text-destructive">
+        <AlertCircle className="w-4 h-4" />
+        <span className="font-semibold">{failure.code}</span>
       </div>
 
-      <Button variant='ghost' size='sm' onClick={() => setIsExpanded(!isExpanded)} className='p-0 h-auto font-normal'>
+      <Button variant="ghost" size="sm" onClick={() => setIsExpanded(!isExpanded)} className="p-0 h-auto font-normal">
         {isExpanded ? (
           <>
-            <ChevronUp className='mr-1 w-4 h-4' />
+            <ChevronUp className="mr-1 w-4 h-4" />
             Hide full message
           </>
         ) : (
           <>
-            <ChevronDown className='mr-1 w-4 h-4' />
+            <ChevronDown className="mr-1 w-4 h-4" />
             Show full message
           </>
         )}
       </Button>
 
       {isExpanded && (
-        <div className='p-3 mt-2 font-mono text-xs whitespace-pre-wrap rounded-md bg-muted'>{failure.message}</div>
+        <div className="p-3 mt-2 font-mono text-xs whitespace-pre-wrap rounded-md bg-muted">{failure.message}</div>
       )}
 
       {/* <MetadataBadges llmResponse={failure.} /> */}

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ResponseRenderer.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ResponseRenderer.tsx
@@ -20,7 +20,7 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
   const [llmCopied, setLlmCopied] = useState(false)
 
   if (!response) {
-    return <div className="text-xs text-muted-foreground">Waiting for response...</div>
+    return <div className='text-xs text-muted-foreground'>Waiting for response...</div>
   }
 
   const llmFailure = response.llm_failure()
@@ -54,10 +54,10 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
   }
 
   return (
-    <div className="space-y-4">
+    <div className='space-y-4'>
       {/* Metadata Section */}
       {llmResponse && (
-        <div className="flex flex-wrap gap-2">
+        <div className='flex flex-wrap gap-2'>
           <MetadataBadges llmResponse={llmResponse} />
         </div>
       )}
@@ -66,9 +66,9 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
       <div className={`grid ${shouldShowParsedSeparately() ? 'grid-cols-2' : 'grid-cols-1'} gap-4`}>
         {/* LLM Response */}
         {llmResponse && (
-          <div className="relative group">
-            <div className="space-y-2">
-              <span className="text-xs text-muted-foreground">Raw LLM Response</span>
+          <div className='relative group'>
+            <div className='space-y-2'>
+              <span className='text-xs text-muted-foreground'>Raw LLM Response</span>
               <RenderPromptPart text={llmResponse.content} />
             </div>
             <CopyButton copied={llmCopied} onCopy={handleLlmCopy} />
@@ -77,12 +77,12 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
 
         {/* Parsed Response */}
         {shouldShowParsedSeparately() && (
-          <div className="relative group">
-            <div className="space-y-2">
-              <span className="flex flex-row gap-x-1 text-xs text-muted-foreground">
+          <div className='relative group'>
+            <div className='space-y-2'>
+              <span className='flex flex-row gap-x-1 text-xs text-muted-foreground'>
                 <div>Parsed Response</div>
                 {parsedResponse && typeof parsedResponse !== 'string' && parsedResponse.check_count > 0 ? (
-                  <div className="flex items-center space-x-1">
+                  <div className='flex items-center space-x-1'>
                     {/* <CheckCircle className="w-3 h-3" /> */}
                     <span>({parsedResponse.check_count} checks ran)</span>
                   </div>
@@ -96,7 +96,7 @@ export const ResponseRenderer: React.FC<ResponseRendererProps> = ({ response, st
       </div>
 
       {/* Error Messages */}
-      {failureMessage && <div className="text-xs text-red-500">Error: {failureMessage}</div>}
+      {failureMessage && <div className='text-xs text-red-500'>Error: {failureMessage}</div>}
     </div>
   )
 }
@@ -106,7 +106,7 @@ export const RawResponseRenderer: React.FC<{
   response?: WasmFunctionResponse | WasmTestResponse
 }> = ({ response }) => {
   if (!response) {
-    return <div className="text-xs text-muted-foreground">Waiting for response...</div>
+    return <div className='text-xs text-muted-foreground'>Waiting for response...</div>
   }
   return <RenderPromptPart text={response.llm_response()?.content ?? ''} />
 }
@@ -115,8 +115,8 @@ const MetadataBadges: React.FC<{ llmResponse: WasmLLMResponse }> = ({ llmRespons
   <TooltipProvider>
     <Tooltip>
       <TooltipTrigger asChild>
-        <Badge variant="outline" className="flex items-center space-x-1 font-light text-muted-foreground">
-          <Brain className="w-3 h-3" />
+        <Badge variant='outline' className='flex items-center space-x-1 font-light text-muted-foreground'>
+          <Brain className='w-3 h-3' />
           <span>{llmResponse.model}</span>
         </Badge>
       </TooltipTrigger>
@@ -125,8 +125,8 @@ const MetadataBadges: React.FC<{ llmResponse: WasmLLMResponse }> = ({ llmRespons
 
     <Tooltip>
       <TooltipTrigger asChild>
-        <Badge variant="outline" className="flex items-center space-x-1 font-light text-muted-foreground">
-          <Clock className="w-3 h-3" />
+        <Badge variant='outline' className='flex items-center space-x-1 font-light text-muted-foreground'>
+          <Clock className='w-3 h-3' />
           <span>{(Number(llmResponse.latency_ms) / 1000).toFixed(2)}s</span>
         </Badge>
       </TooltipTrigger>
@@ -137,12 +137,12 @@ const MetadataBadges: React.FC<{ llmResponse: WasmLLMResponse }> = ({ llmRespons
 
 const CopyButton: React.FC<{ copied: boolean; onCopy: () => void }> = ({ copied, onCopy }) => (
   <Button
-    variant="ghost"
-    size="icon"
-    className="absolute top-0 right-0 w-4 h-4 opacity-0 transition-opacity bg-muted group-hover:opacity-100"
+    variant='ghost'
+    size='icon'
+    className='absolute top-0 right-0 w-4 h-4 opacity-0 transition-opacity bg-muted group-hover:opacity-100'
     onClick={onCopy}
   >
-    {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+    {copied ? <Check className='w-4 h-4' /> : <Copy className='w-4 h-4' />}
   </Button>
 )
 
@@ -150,28 +150,28 @@ const LLMFailureView: React.FC<{ failure: WasmLLMFailure }> = ({ failure }) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
   return (
-    <div className="space-y-3 text-xs">
-      <div className="flex items-center space-x-2 text-destructive">
-        <AlertCircle className="w-4 h-4" />
-        <span className="font-semibold">{failure.code}</span>
+    <div className='space-y-3 text-xs'>
+      <div className='flex items-center space-x-2 text-destructive'>
+        <AlertCircle className='w-4 h-4' />
+        <span className='font-semibold'>{failure.code}</span>
       </div>
 
-      <Button variant="ghost" size="sm" onClick={() => setIsExpanded(!isExpanded)} className="p-0 h-auto font-normal">
+      <Button variant='ghost' size='sm' onClick={() => setIsExpanded(!isExpanded)} className='p-0 h-auto font-normal'>
         {isExpanded ? (
           <>
-            <ChevronUp className="mr-1 w-4 h-4" />
+            <ChevronUp className='mr-1 w-4 h-4' />
             Hide full message
           </>
         ) : (
           <>
-            <ChevronDown className="mr-1 w-4 h-4" />
+            <ChevronDown className='mr-1 w-4 h-4' />
             Show full message
           </>
         )}
       </Button>
 
       {isExpanded && (
-        <div className="p-3 mt-2 font-mono text-xs whitespace-pre-wrap rounded-md bg-muted">{failure.message}</div>
+        <div className='p-3 mt-2 font-mono text-xs whitespace-pre-wrap rounded-md bg-muted'>{failure.message}</div>
       )}
 
       {/* <MetadataBadges llmResponse={failure.} /> */}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Expands prompt parts by default to prevent scrolling issues and renames `RenderText` to `RenderPromptPart`.
> 
>   - **Behavior**:
>     - Expands prompt parts by default in `RenderPromptPart` to prevent scrolling issues.
>     - Changes `max-h-96` to `max-h-fit` in `render-text.tsx` to accommodate full text visibility.
>   - **Renames**:
>     - Renames `RenderText` to `RenderPromptPart` in `render-text.tsx` and updates references in `render-part.tsx`, `ParsedResponseRender.tsx`, and `ResponseRenderer.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for d823056abb4eb44324d518178dcf111697289c6b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->