### PR TITLE
chat bubble opacity lowered

### DIFF
--- a/typescript/vscode-ext/packages/web-panel/src/App.css
+++ b/typescript/vscode-ext/packages/web-panel/src/App.css
@@ -331,7 +331,7 @@
 }
 
 button.woot-widget-bubble:nth-child(1) {
-  @apply scale-50 origin-bottom-left left-1 bottom-1;
+  @apply scale-50 origin-bottom-left left-1 bottom-1 opacity-30;
 }
 
 button.woot-elements--right:nth-child(2) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Lowered opacity of `button.woot-widget-bubble:nth-child(1)` to 30% in `App.css`.
> 
>   - **CSS Changes**:
>     - Lowered opacity to 30% for `button.woot-widget-bubble:nth-child(1)` in `App.css` to adjust chat bubble appearance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for dd5c25bff6aac3c703a1ae34232c7ff7c57de113. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->