### PR TITLE
Show last computed prompt when runtime is loading, and be more resilient to exception from rust

### DIFF
--- a/typescript/playground-common/src/shared/baml-project-panel/atoms.ts
+++ b/typescript/playground-common/src/shared/baml-project-panel/atoms.ts
@@ -78,13 +78,13 @@ export const ctxAtom = atom((get) => {
 })
 
 export const runtimeAtom = atom((get) => {
-  const wasm = get(wasmAtom)
-  const project = get(projectAtom)
-  const envVars = get(envVarsAtom)
-  if (wasm === undefined || project === undefined) {
-    return { rt: undefined, diags: undefined }
-  }
   try {
+    const wasm = get(wasmAtom)
+    const project = get(projectAtom)
+    const envVars = get(envVarsAtom)
+    if (wasm === undefined || project === undefined) {
+      return { rt: undefined, diags: undefined }
+    }
     const selectedEnvVars = Object.fromEntries(Object.entries(envVars).filter(([key, value]) => value !== undefined))
     const rt = project.runtime(selectedEnvVars)
     const diags = project.diagnostics(rt)

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/prompt-preview-content.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/prompt-preview-content.tsx
@@ -20,8 +20,12 @@ export const PromptPreviewContent = () => {
     if (rt === undefined || ctx === undefined || selectedFn === undefined || selectedTc === undefined) {
       return
     }
-    return selectedFn.render_prompt_for_test(rt, selectedTc.name, ctx, findMediaFile)
+    const newPreview = await selectedFn.render_prompt_for_test(rt, selectedTc.name, ctx, findMediaFile)
+    setLastKnownPreview(newPreview)
+    return newPreview
   }
+
+  const [lastKnownPreview, setLastKnownPreview] = useState<WasmPrompt | undefined>()
 
   const {
     data: preview,
@@ -33,8 +37,11 @@ export const PromptPreviewContent = () => {
     generatePreview,
   )
 
-  if (isLoading) {
-    return <Loader message='Refreshing...' />
+  if (isLoading && !preview) {
+    if (lastKnownPreview) {
+      return <RenderPrompt prompt={lastKnownPreview} testCase={selectedTc} />
+    }
+    return <Loader message='Loading...' />
   }
 
   if (error) {

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ClientGraphView.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/ClientGraphView.tsx
@@ -121,7 +121,7 @@ export const ClientGraphView: React.FC = () => {
   return (
     <div className='w-full h-full'>
       <ClientHeader />
-      <div className='h-[400px] border-b-red-500 border-b-24 border'>
+      <div className='h-[350px] '>
         <ReactFlow
           style={styles}
           nodes={flowNodes}

--- a/typescript/playground-common/src/utils/ErrorFallback.tsx
+++ b/typescript/playground-common/src/utils/ErrorFallback.tsx
@@ -8,10 +8,10 @@ const ErrorFallback: (message?: string) => React.FC<FallbackProps> = (message) =
     return (
       <div
         role='alert'
-        className='p-4 bg-vscode-notifications-background border border-vscode-notifications-border rounded'
+        className='p-4 rounded border bg-vscode-notifications-background border-vscode-notifications-border'
       >
-        <div className='flex items-center justify-between mb-4'>
-          <p className='text-vscode-foreground font-medium'>{message ?? 'Something went wrong'}</p>
+        <div className='flex justify-between items-center mb-4'>
+          <p className='font-medium text-vscode-foreground'>{message ?? 'Something went wrong'}</p>
           <Button onClick={resetErrorBoundary} variant='outline' className='hover:bg-vscode-button-hoverBackground'>
             <RefreshCcw className='w-4 h-4' />
             Reload
@@ -21,24 +21,24 @@ const ErrorFallback: (message?: string) => React.FC<FallbackProps> = (message) =
         {error instanceof Error && (
           <div className='space-y-2'>
             {error.message && (
-              <pre className='p-3 bg-vscode-editor-background border border-vscode-panel-border rounded text-sm whitespace-pre-wrap'>
+              <pre className='p-3 text-sm whitespace-pre-wrap rounded border bg-vscode-editor-background border-vscode-panel-border'>
                 {error.message}
               </pre>
             )}
             {error.stack && (
-              <pre className='p-3 bg-vscode-editor-background border border-vscode-panel-border rounded text-sm whitespace-pre-wrap'>
+              <pre className='p-3 text-sm whitespace-pre-wrap rounded border bg-vscode-editor-background border-vscode-panel-border'>
                 {error.stack}
               </pre>
             )}
             {error && Object.keys(error).length > 0 && (
-              <pre className='p-3 bg-vscode-editor-background border border-vscode-panel-border rounded text-sm whitespace-pre-wrap'>
+              <pre className='p-3 text-sm whitespace-pre-wrap rounded border bg-vscode-editor-background border-vscode-panel-border'>
                 {JSON.stringify(error, null, 2)}
               </pre>
             )}
           </div>
         )}
         {error && typeof error === 'string' && (
-          <pre className='p-3 bg-vscode-editor-background border border-vscode-panel-border rounded text-sm whitespace-pre-wrap'>
+          <pre className='p-3 text-sm whitespace-pre-wrap rounded border bg-vscode-editor-background border-vscode-panel-border'>
             {error}
           </pre>
         )}
@@ -59,6 +59,7 @@ const CustomErrorBoundary: React.FC<MyErrorBoundaryProps> = ({ children, message
       FallbackComponent={ErrorFallback(message)}
       onReset={() => {
         // Reset the state of your app so the error doesn't happen again
+        window.location.reload()
       }}
     >
       {children}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance prompt preview loading and error handling in the playground panel, with UI adjustments in `ClientGraphView.tsx` and `ErrorFallback.tsx`.
> 
>   - **Behavior**:
>     - In `prompt-preview-content.tsx`, show last known prompt if runtime is loading and no new preview is available.
>     - In `atoms.ts`, wrap runtime computation in a `try-catch` to handle exceptions from Rust gracefully.
>   - **UI Changes**:
>     - Adjust `ClientGraphView.tsx` height from 400px to 350px.
>     - Update `ErrorFallback.tsx` to reload the page on error reset.
>   - **Misc**:
>     - Minor CSS class reordering in `ErrorFallback.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 63e376df0d14041d01ba61fa069a5a418d6fd4e2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->