### PR TITLE
bug: finish_reason_allow_list and finish_reason_deny_list should be case insensitive

### DIFF
--- a/engine/baml-lib/llm-client/src/clientspec.rs
+++ b/engine/baml-lib/llm-client/src/clientspec.rs
@@ -251,16 +251,18 @@ impl FinishReasonFilter {
         match self {
             Self::AllowList(allow) => {
                 let Some(reason) = reason.map(|r| r.as_ref().to_string()) else {
-                    return false;
+                    // if no reason is provided, allow all
+                    return true;
                 };
                 // check case insensitive
-                allow.iter().any(|r| r.to_lowercase() == reason.to_lowercase())
+                allow.iter().any(|r| r.eq_ignore_ascii_case(&reason))
             }
             Self::DenyList(deny) => {
                 let Some(reason) = reason.map(|r| r.as_ref().to_string()) else {
+                    // if no reason is provided, allow all
                     return true;
                 };
-                !deny.iter().any(|r| r.to_lowercase() == reason.to_lowercase())
+                !deny.iter().any(|r| r.eq_ignore_ascii_case(&reason))
             }
             Self::All => true,
         }

--- a/engine/baml-lib/llm-client/src/clientspec.rs
+++ b/engine/baml-lib/llm-client/src/clientspec.rs
@@ -253,13 +253,14 @@ impl FinishReasonFilter {
                 let Some(reason) = reason.map(|r| r.as_ref().to_string()) else {
                     return false;
                 };
-                allow.contains(&reason)
+                // check case insensitive
+                allow.iter().any(|r| r.to_lowercase() == reason.to_lowercase())
             }
             Self::DenyList(deny) => {
                 let Some(reason) = reason.map(|r| r.as_ref().to_string()) else {
                     return true;
                 };
-                !deny.contains(&reason)
+                !deny.iter().any(|r| r.to_lowercase() == reason.to_lowercase())
             }
             Self::All => true,
         }

--- a/fern/snippets/finish-reason.mdx
+++ b/fern/snippets/finish-reason.mdx
@@ -4,6 +4,8 @@
 >
   Which finish reasons are allowed? **Default: `null`**
 
+  <Warning>version 0.73.0 onwards: This is case insensitive.</Warning>
+
   Will raise a `BamlClientFinishReasonError` if the finish reason is not in the allow list. See [Exceptions](/guide/baml-basics/error-handling#bamlclientfinishreasonerror) for more details.
 
   Note, only one of `finish_reason_allow_list` or `finish_reason_deny_list` can be set.
@@ -29,6 +31,8 @@
   type="string[]"
 >
   Which finish reasons are denied? **Default: `null`**
+
+  <Warning>version 0.73.0 onwards: This is case insensitive.</Warning>
 
   Will raise a `BamlClientFinishReasonError` if the finish reason is in the deny list. See [Exceptions](/guide/baml-basics/error-handling#bamlclientfinishreasonerror) for more details.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make `finish_reason_allow_list` and `finish_reason_deny_list` case insensitive in `clientspec.rs` and update documentation in `finish-reason.mdx`.
> 
>   - **Behavior**:
>     - `FinishReasonFilter::is_allowed()` in `clientspec.rs` now checks `finish_reason_allow_list` and `finish_reason_deny_list` case insensitively.
>     - If no reason is provided, both lists allow all by default.
>   - **Documentation**:
>     - Updated `finish-reason.mdx` to indicate that `finish_reason_allow_list` and `finish_reason_deny_list` are case insensitive from version 0.73.0 onwards.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 08ecc0c8e295f2009090267dae2c459badde93b2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->