### PR TITLE
chore: fix elided-named-lifetimes and ban it

### DIFF
--- a/engine/baml-lib/baml-core/Cargo.toml
+++ b/engine/baml-lib/baml-core/Cargo.toml
@@ -8,6 +8,7 @@ license-file.workspace = true
 
 [lints.rust]
 dead_code = "allow"
+elided_named_lifetimes = "deny"
 unused_imports = "allow"
 unused_variables = "allow"
 

--- a/engine/baml-lib/baml-types/Cargo.toml
+++ b/engine/baml-lib/baml-types/Cargo.toml
@@ -8,6 +8,7 @@ license-file.workspace = true
 
 [lints.rust]
 dead_code = "deny"
+elided_named_lifetimes = "deny"
 unused_imports = "deny"
 unused_variables = "deny"
 

--- a/engine/baml-lib/baml/Cargo.toml
+++ b/engine/baml-lib/baml/Cargo.toml
@@ -7,6 +7,12 @@ description.workspace = true
 
 license-file.workspace = true
 
+[lints.rust]
+dead_code = "allow"
+elided_named_lifetimes = "deny"
+unused_imports = "allow"
+unused_variables = "allow"
+
 [dependencies]
 internal-baml-core = { path = "../baml-core" }
 itertools = "0.13.0"

--- a/engine/baml-lib/diagnostics/Cargo.toml
+++ b/engine/baml-lib/diagnostics/Cargo.toml
@@ -4,8 +4,13 @@ name = "internal-baml-diagnostics"
 version.workspace = true
 authors.workspace = true
 description.workspace = true
-
 license-file.workspace = true
+
+[lints.rust]
+dead_code = "deny"
+elided_named_lifetimes = "deny"
+unused_imports = "deny"
+unused_variables = "deny"
 
 [dependencies]
 colored = "2"

--- a/engine/baml-lib/jinja-runtime/Cargo.toml
+++ b/engine/baml-lib/jinja-runtime/Cargo.toml
@@ -8,6 +8,7 @@ license-file.workspace = true
 
 [lints.rust]
 dead_code = "allow"
+elided_named_lifetimes = "deny"
 unused_imports = "deny"
 unused_variables = "deny"
 

--- a/engine/baml-lib/jinja/Cargo.toml
+++ b/engine/baml-lib/jinja/Cargo.toml
@@ -8,6 +8,7 @@ license-file.workspace = true
 
 [lints.rust]
 dead_code = "deny"
+elided_named_lifetimes = "deny"
 unused_imports = "deny"
 unused_variables = "deny"
 

--- a/engine/baml-lib/jsonish/Cargo.toml
+++ b/engine/baml-lib/jsonish/Cargo.toml
@@ -9,6 +9,7 @@ license-file.workspace = true
 
 [lints.rust]
 dead_code = "allow"
+elided_named_lifetimes = "deny"
 unused_imports = "allow"
 unused_variables = "allow"
 

--- a/engine/baml-lib/llm-client/Cargo.toml
+++ b/engine/baml-lib/llm-client/Cargo.toml
@@ -8,6 +8,7 @@ license-file.workspace = true
 
 [lints.rust]
 dead_code = "deny"
+elided_named_lifetimes = "deny"
 unused_imports = "deny"
 unused_variables = "deny"
 

--- a/engine/baml-lib/parser-database/Cargo.toml
+++ b/engine/baml-lib/parser-database/Cargo.toml
@@ -9,6 +9,7 @@ license-file.workspace = true
 
 [lints.rust]
 dead_code = "allow"
+elided_named_lifetimes = "deny"
 unused_imports = "allow"
 unused_variables = "allow"
 

--- a/engine/baml-lib/parser-database/src/coerce_expression.rs
+++ b/engine/baml-lib/parser-database/src/coerce_expression.rs
@@ -60,11 +60,11 @@ pub mod coerce_opt {
         expr.as_raw_string_value()
     }
 
-    pub fn string_with_span<'a>(expr: &'a ast::Expression) -> Option<(&'a str, &ast::Span)> {
+    pub fn string_with_span<'a>(expr: &'a ast::Expression) -> Option<(&'a str, &'a ast::Span)> {
         expr.as_string_value()
     }
 
-    pub fn constant_with_span<'a>(expr: &'a ast::Expression) -> Option<(&'a str, &ast::Span)> {
+    pub fn constant_with_span<'a>(expr: &'a ast::Expression) -> Option<(&'a str, &'a ast::Span)> {
         expr.as_constant_value()
     }
 

--- a/engine/baml-lib/parser-database/src/walkers/mod.rs
+++ b/engine/baml-lib/parser-database/src/walkers/mod.rs
@@ -73,7 +73,7 @@ impl<'db> crate::ParserDatabase {
         })
     }
 
-    fn find_top_by_str(&'db self, name: &str) -> Option<&TopId> {
+    fn find_top_by_str(&'db self, name: &str) -> Option<&'db TopId> {
         self.interner
             .lookup(name)
             .and_then(|name_id| self.names.tops.get(&name_id))

--- a/engine/baml-lib/prompt-parser/Cargo.toml
+++ b/engine/baml-lib/prompt-parser/Cargo.toml
@@ -6,6 +6,12 @@ authors.workspace = true
 description.workspace = true
 license-file.workspace = true
 
+[lints.rust]
+dead_code = "deny"
+elided_named_lifetimes = "deny"
+unused_imports = "deny"
+unused_variables = "deny"
+
 [dependencies]
 internal-baml-diagnostics = { path = "../diagnostics" }
 internal-baml-schema-ast = { path = "../schema-ast" }

--- a/engine/baml-lib/schema-ast/Cargo.toml
+++ b/engine/baml-lib/schema-ast/Cargo.toml
@@ -8,6 +8,7 @@ license-file.workspace = true
 
 [lints.rust]
 dead_code = "deny"
+elided_named_lifetimes = "deny"
 unused_imports = "allow"
 unused_variables = "deny"
 

--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 
 [lints.rust]
 dead_code = "allow"
+elided_named_lifetimes = "deny"
 unused_imports = "allow"
 unused_variables = "allow"
 

--- a/engine/baml-schema-wasm/Cargo.toml
+++ b/engine/baml-schema-wasm/Cargo.toml
@@ -9,6 +9,9 @@ license-file.workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[lints.rust]
+elided_named_lifetimes = "deny"
+
 [dependencies]
 anyhow.workspace = true
 baml-runtime = { path = "../baml-runtime", features = [

--- a/engine/bstd/Cargo.toml
+++ b/engine/bstd/Cargo.toml
@@ -11,6 +11,7 @@ RSTEST_TIMEOUT = "10"
 
 [lints.rust]
 dead_code = "deny"
+elided_named_lifetimes = "deny"
 unused_imports = "deny"
 unused_variables = "deny"
 

--- a/engine/cli/Cargo.toml
+++ b/engine/cli/Cargo.toml
@@ -14,6 +14,7 @@ anyhow.workspace = true
 
 [lints.rust]
 dead_code = "deny"
+elided_named_lifetimes = "deny"
 unused_imports = "deny"
 unused_variables = "deny"
 

--- a/engine/language_client_codegen/Cargo.toml
+++ b/engine/language_client_codegen/Cargo.toml
@@ -8,6 +8,7 @@ license-file.workspace = true
 
 [lints.rust]
 dead_code = "allow"
+elided_named_lifetimes = "deny"
 unused_imports = "allow"
 unused_variables = "allow"
 

--- a/engine/language_client_python/Cargo.toml
+++ b/engine/language_client_python/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 
 [lints.rust]
 dead_code = "deny"
+elided_named_lifetimes = "deny"
 unused_imports = "deny"
 unused_must_use = "deny"
 unused_variables = "deny"

--- a/engine/language_client_typescript/Cargo.toml
+++ b/engine/language_client_typescript/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 
 [lints.rust]
 dead_code = "deny"
+elided_named_lifetimes = "deny"
 unused_imports = "allow"
 unused_variables = "allow"
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `elided_named_lifetimes` lint to `deny` across multiple Cargo.toml files and adjust code for compliance.
> 
>   - **Lints**:
>     - Set `elided_named_lifetimes` to `deny` in `Cargo.toml` for `baml-core`, `baml-types`, `baml`, `diagnostics`, `jinja-runtime`, `jinja`, `jsonish`, `llm-client`, `parser-database`, `prompt-parser`, `schema-ast`, `baml-runtime`, `baml-schema-wasm`, `bstd`, `cli`, `language_client_codegen`, `language_client_python`, and `language_client_typescript`.
>   - **Code Changes**:
>     - Add explicit lifetimes in `string_with_span()` and `constant_with_span()` in `coerce_expression.rs`.
>     - Modify `find_top_by_str()` in `walkers/mod.rs` to include explicit lifetime.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0bce130305dd2424acff89a7d7fb9be78696a055. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->