### PR TITLE
Fix type alias highlighting in promptfiddle

### DIFF
--- a/typescript/codemirror-lang-baml/src/index.ts
+++ b/typescript/codemirror-lang-baml/src/index.ts
@@ -51,6 +51,9 @@ export const BAMLLanguage = LRLanguage.define({
         ClassDecl: t.keyword,
         'ClassDecl/IdentifierDecl': t.typeName,
 
+        TypeAliasDecl: t.keyword,
+        'TypeAliasDecl/IdentifierDecl': t.typeName,
+
         ClientDecl: t.keyword,
         'ClientDecl/IdentifierDecl': t.typeName,
 
@@ -122,6 +125,7 @@ const exampleCompletion = BAMLLanguage.data.of({
     snippetCompletion('template_string MyString(${arg1}: string) #"\n  A jinja string\n"#', {
       label: 'template_string',
     }),
+    snippetCompletion('type ${AliasName} = ${TypeExpr};', { label: 'type alias' }),
   ],
 })
 

--- a/typescript/codemirror-lang-baml/src/syntax.grammar
+++ b/typescript/codemirror-lang-baml/src/syntax.grammar
@@ -1,12 +1,17 @@
 @top Baml { Decl* }
 
-Decl { ClassDecl | EnumDecl | FunctionDecl | ClientDecl | TemplateStringDecl | TestDecl }
+Decl { ClassDecl | EnumDecl | FunctionDecl | ClientDecl | TemplateStringDecl | TestDecl | TypeAliasDecl }
 
 ClassDecl { "class" IdentifierDecl "{" (BlockAttribute | ClassField)* "}" }
 
 ClassField {
   IdentifierDecl TypeExpr FieldAttribute*
 }
+
+TypeAliasDecl {
+  "type" IdentifierDecl "=" TypeExpr
+}
+
 TypeExpr { ComplexTypeExpr | UnionTypeExpr }
 ComplexTypeExpr {
   "(" UnionTypeExpr ")" |
@@ -51,7 +56,7 @@ ClientDecl {
 }
 
 TestDecl {
-  "test" IdentifierDecl "{" (BlockAttribute | TupleValue)* "}" 
+  "test" IdentifierDecl "{" (BlockAttribute | TupleValue)* "}"
 }
 
 LiteralDecl { NumericLiteral | QuotedString | UnquotedString }
@@ -87,7 +92,7 @@ TemplateStringDecl {
   whitespace { $[ \n\r\t] }
 
   UnquotedStringChar { ![#@{}()[\]<>,'\n\r\t/ ]}
-  
+
   TrailingComment { "//" ![\n]* }
   MultilineComment { "{//"![]*"//}" }
 
@@ -95,7 +100,7 @@ TemplateStringDecl {
 }
 
 @skip {
-  whitespace | MultilineComment | TrailingComment 
+  whitespace | MultilineComment | TrailingComment
 }
 
 @skip {} {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for type alias declarations in BAML language syntax and highlighting.
> 
>   - **Syntax and Grammar**:
>     - Add `TypeAliasDecl` to `Decl` in `syntax.grammar`.
>     - Define `TypeAliasDecl` structure in `syntax.grammar`.
>   - **Highlighting**:
>     - Add `TypeAliasDecl` and `TypeAliasDecl/IdentifierDecl` to `styleTags` in `index.ts` for keyword and type name highlighting.
>   - **Autocomplete**:
>     - Add snippet completion for type alias in `exampleCompletion` in `index.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 23e10154b5d75c27b4106422e6631306c308cdd3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->