### PR TITLE
docs: gemini generationConfig

### DIFF
--- a/fern/03-reference/baml/clients/providers/google-ai.mdx
+++ b/fern/03-reference/baml/clients/providers/google-ai.mdx
@@ -59,6 +59,10 @@ You can use this to modify the `headers` and `base_url` for example.
 See the [Google Model Docs](https://ai.google.dev/gemini-api/docs/models/gemini) for the latest models.
 </ParamField>
 
+<Tip>
+  Some parameters, like temperature, for Gemini Models are specified in the `generationConfig` object. [See Docs](https://ai.google.dev/api/generate-content)
+</Tip>
+
 <ParamField path="headers" type="object">
   Additional headers to send with the request.
 
@@ -70,6 +74,9 @@ client<llm> MyClient {
     model "gemini-1.5-flash"
     headers {
       "X-My-Header" "my-value"
+    }
+    generationConfig {
+      temperature 0.5
     }
   }
 }


### PR DESCRIPTION
Related to discord discussion where confusion arises related to `temperature` field which lies inside generationConfig in gemini
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a tip in `google-ai.mdx` to clarify the location of the `temperature` parameter in the `generationConfig` object for Gemini models.
> 
>   - **Documentation**:
>     - Adds a tip in `google-ai.mdx` to clarify that parameters like `temperature` for Gemini models are specified in the `generationConfig` object.
>     - Provides a link to the relevant [Google API documentation](https://ai.google.dev/api/generate-content).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 747c1b8859f1e8ab11ce4f81aeab187f2b9fc3e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->