### PR TITLE
Fix field type parsing

### DIFF
--- a/engine/baml-lib/schema-ast/src/parser/parse_types.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_types.rs
@@ -4,7 +4,7 @@ use super::{helpers::Pair, parse_attribute::parse_attribute, Rule};
 use crate::{
     assert_correct_parser,
     ast::*,
-    parser::{parse_field::parse_field_type_with_attr, parse_identifier::parse_identifier},
+    parser::{helpers::parsing_catch_all, parse_field::parse_field_type_with_attr, parse_identifier::parse_identifier},
     unreachable_rule,
 };
 use baml_types::{LiteralValue, TypeValue};
@@ -33,7 +33,7 @@ pub fn parse_field_type(pair: Pair<'_>, diagnostics: &mut Diagnostics) -> Option
             }
             Rule::optional_token => arity = FieldArity::Optional,
             _ => {
-                unreachable_rule!(current, Rule::field_type)
+                parsing_catch_all(current, "field_type");
             }
         }
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace `unreachable_rule!` with `parsing_catch_all` in `parse_field_type` to improve error handling.
> 
>   - **Error Handling**:
>     - Replace `unreachable_rule!` with `parsing_catch_all` in `parse_field_type` in `parse_types.rs` to handle unexpected cases more gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for fcf3a6e32ae12e14efa99489d13e3528d26ecd52. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->