### PR TITLE
Revert integ-tests script for typescript

### DIFF
--- a/integ-tests/typescript/package.json
+++ b/integ-tests/typescript/package.json
@@ -8,7 +8,7 @@
     "build:debug": "cd ../../engine/language_client_typescript && pnpm run build:debug && cd - && pnpm i",
     "build": "cd ../../engine/language_client_typescript && npm run build && cd - && pnpm i",
     "integ-tests:ci": "infisical run --env=test -- pnpm test -- --ci --silent false --testTimeout 30000 --verbose=false --reporters=jest-junit",
-    "integ-tests": "infisical run --env=test -- pnpm test -- --silent false --testTimeout 30000 --bail --reporters=default --reporters=jest-html-reporter --reporters=jest-summary-reporter",
+    "integ-tests": "infisical run --env=test -- pnpm test -- --silent false --testTimeout 30000",
     "integ-tests:dotenv": "dotenv -e ../.env -- pnpm test -- --silent false --testTimeout 30000",
     "generate": "baml-cli generate --from ../baml_src"
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Revert `integ-tests` script in `package.json` to remove additional test reporters and options.
> 
>   - **Scripts**:
>     - Revert `integ-tests` script in `package.json` to remove `--bail`, `--reporters=default`, `--reporters=jest-html-reporter`, and `--reporters=jest-summary-reporter` options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for d6f581c6070e347fb78b159ef2fdcf106235b7a0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->