### PR TITLE
one more rerender bug

### DIFF
--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
@@ -19,6 +19,7 @@ import { ParsedResponseRenderer } from './ParsedResponseRender'
 import { TestStatus } from './TestStatus'
 import { ScrollArea } from '~/components/ui/scroll-area'
 import { vscode } from '@/shared/baml-project-panel/vscode'
+import { useMemo } from 'react'
 interface TabularViewProps {
   currentRun: TestHistoryRun
 }
@@ -123,9 +124,11 @@ export const TabularView: React.FC<TabularViewProps> = ({ currentRun }) => {
     }))
   }
 
-  const tc = useAtomValue(
-    testcaseObjectAtom({ functionName: selectedItem?.[0] ?? '', testcaseName: selectedItem?.[1] ?? '' }),
+  const testAtom = useMemo(
+    () => testcaseObjectAtom({ functionName: selectedItem?.[0] ?? '', testcaseName: selectedItem?.[1] ?? '' }),
+    [selectedItem],
   )
+  const tc = useAtomValue(testAtom)
 
   const createSpan = (span: { start: number; end: number; file_path: string; start_line: number }) => ({
     start: span.start,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Optimize `TabularView` re-renders by using `useMemo` for `testAtom`.
> 
>   - **Performance**:
>     - Use `useMemo` for `testAtom` in `TabularView` to optimize re-renders when `selectedItem` changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 4870967cbc3c57ed5947f38a3d0776d348789acc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->