### PR TITLE
Drop unnecessary jsonwebtoken dep in wasm build

### DIFF
--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -97,7 +97,6 @@ tracing-subscriber = { version = "0.3.18", features = [
 ] }
 thiserror = "2.0.1"
 log-once = "0.4.1"
-jsonwebtoken = "9.3.0"
 
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/wasm_auth.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/wasm_auth.rs
@@ -41,12 +41,6 @@ impl VertexAuth {
     pub async fn token(&self, scopes: &[&str]) -> Result<Arc<Token>> {
         let claims = Claims::from_service_account(&self.0);
 
-        let jwt = jsonwebtoken::encode(
-            &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
-            &claims,
-            &jsonwebtoken::EncodingKey::from_rsa_pem(self.0.private_key.as_bytes())?,
-        )?;
-
         let jwt = encode_jwt(&serde_json::to_value(claims)?, &self.0.private_key)
             .await
             .map_err(|e| anyhow::anyhow!(format!("{e:?}")))?;
@@ -118,12 +112,6 @@ pub struct ServiceAccount {
 async fn get_access_token(service_account: &ServiceAccount) -> Result<String> {
     // Create the JWT
     let claims = Claims::from_service_account(service_account);
-
-    let jwt = jsonwebtoken::encode(
-        &jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256),
-        &claims,
-        &jsonwebtoken::EncodingKey::from_rsa_pem(service_account.private_key.as_bytes())?,
-    )?;
 
     let jwt = encode_jwt(&serde_json::to_value(claims)?, &service_account.private_key)
         .await


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `jsonwebtoken` dependency from WASM build by using `encode_jwt` in `wasm_auth.rs`.
> 
>   - **Dependencies**:
>     - Remove `jsonwebtoken` from `Cargo.toml`.
>   - **Code Changes**:
>     - Replace `jsonwebtoken::encode` with `encode_jwt` in `wasm_auth.rs` in `token()` and `get_access_token()` functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 08445f3862b7426f01007a4d819b8ea531e6c819. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->