### PR TITLE
feat: add fern darkmode

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -9,11 +9,16 @@
 
 .fern-prose code {
   background-color: #f8f8f8;
-  /* font-weight: 600; */
+}
+.dark .fern-prose code {
+  background-color: #1e293b;
 }
 
 .prose code {
   background-color: #f8f8f8;
+}
+.dark .prose code {
+  background-color: #1e293b;
 }
 
 .fern-sidebar-link-container[data-state="active"] .fern-sidebar-link {
@@ -33,13 +38,11 @@
 
 .fern-header-tab-button > * {
   font-size: 12px;
-  /* color */
   color: #333333;
 }
-
-/* .fern-sidebar-container {
-  color: #000000;
-} */
+.dark .fern-header-tab-button > * {
+  color: #e2e8f0;
+}
 
 body .p {
   font-size: 1rem !important;
@@ -48,34 +51,47 @@ body .p {
 p {
   color: #333333;
 }
+.dark p {
+  color: #e2e8f0;
+}
 
 fern-docs {
   color: #333333;
 }
+.dark fern-docs {
+  color: #e2e8f0;
+}
 
 ul {
   color: #333333;
+}
+.dark ul {
+  color: #e2e8f0;
 }
 
 fern-button-text {
   color: #ffffff;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1, h2, h3, h4, h5, h6 {
   color: #333333;
+}
+.dark h1, .dark h2, .dark h3, .dark h4, .dark h5, .dark h6 {
+  color: #e2e8f0;
 }
 
 .fern-sidebar-link-container:not([data-state="active"]) .fern-sidebar-link {
   color: #333333;
 }
+.dark .fern-sidebar-link-container:not([data-state="active"]) .fern-sidebar-link {
+  color: #e2e8f0;
+}
 
 span:not(a span) {
   color: #333333;
+}
+.dark span:not(a span) {
+  color: #e2e8f0;
 }
 
 :root {
@@ -84,6 +100,9 @@ span:not(a span) {
 
 .fern-mdx-link {
   text-decoration-color: rgba(167, 139, 250, 1);
+}
+.dark .fern-mdx-link {
+  text-decoration-color: rgba(173, 255, 140, 1);
 }
 
 /* .fern-sidebar-group li {

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -544,12 +544,16 @@ navbar-links:
 colors:
   accentPrimary:
     light: "#a78bfa"
+    dark: "#a78bfa"
   background:
     light: "#ffffff"
+    dark: "#1e293b"
   sidebar-background:
     light: "#fefefe"
+    dark: "#1e293b"
 logo:
   light: assets/favicon.ico
+  dark: assets/favicon.ico
   height: 40
 favicon: assets/favicon.ico
 css: assets/styles.css


### PR DESCRIPTION
Closes https://github.com/BoundaryML/baml/issues/1049 https://github.com/BoundaryML/baml/issues/1378 

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add dark mode support to Fern documentation by updating CSS styles and configuration in `docs.yml`.
> 
>   - **Dark Mode Support**:
>     - Added dark mode styles in `styles.css` for elements like `.fern-prose code`, `.fern-header-tab-button`, `p`, `fern-docs`, `ul`, `h1` to `h6`, `.fern-sidebar-link-container`, `span`, and `.fern-mdx-link`.
>     - Updated `docs.yml` to include dark mode color settings for `accentPrimary`, `background`, `sidebar-background`, and `logo`.
>   - **Misc**:
>     - Removed commented-out CSS code in `styles.css`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for de8b26d94650793d276f3cba4162229a72aba13a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->