### PR TITLE
fixup streaming docs

### DIFF
--- a/fern/01-guide/04-baml-basics/streaming.mdx
+++ b/fern/01-guide/04-baml-basics/streaming.mdx
@@ -51,7 +51,7 @@ function ExtractReceiptInfo(email: string) -> ReceiptInfo {
 </Accordion>
 
 The BAML code generator creates a set of types in the `baml_client` library
-in a module called `partial` in `baml_client`. These types are modified
+in a module called `partial_types` in `baml_client`. These types are modified
 from your original types to support streaming.
 
 By default, BAML will convert all Class fields into nullable fields, and
@@ -269,21 +269,36 @@ numbers like 1, 12, 129.9, etc.
 
 ## Semantic Streaming
 
-The BAML language provides several attributes that can be attached to types
+Sometimes you will want streaming to behave differently from the behavior
+described above for `Partial` types.
+
+BAML provides several attributes that can be attached to types
 to control streaming behavior, ensuring that the partial values streamed to you
 are always valid within your own semantics.
 
   - `@stream.done`: Marks a type that should only be streamed when it is
     done being read from the LLM response.
-  - `@stream.not_null`: Marks a field to indicate that the class containing
-     that field should only be streamed if that field is present (the field needed
-     not be completed)
-  - `@stream.with_state`: Adds metadata to a type indicating whether types appearing
+  - `@stream.not_null`: Indicates that the class containing
+     that field should only be streamed if that field is present.
+  - `@stream.with_state`: Adds metadata to a type indicating whether is has
+    finished streaming or not.
+
+This table summarizes how the attributes impact types your will consume from
+streaming clients:
+
+| BAML type                         | Generated type             |
+| --------------------------------- | -------------------------- |
+| `T`                               | `Partial[T]?`              |
+| `T @stream.done`                  | `T?`                       |
+| `T @stream.not_null`              | `Partial[T]`               |
+| `T @stream.done @stream.not_null` | `T`                        |
+| `T @stream.with_state`            | `StreamState[Partial[T]?]` |
+
     
 ### `@stream.done`
 
 To demonstrate the use of `@stream.done`, imagine that a `ReceiptItem`
-must only be consider valid and can only reach the client when its `name`,
+must only be considered valid and can only reach the client when its `name`,
 `description`, `quantity` and `price` fields are completely streamed in.
 To achieve this we can annotate the `ReceiptItem` class with the
 `@stream.done` attribute:
@@ -294,37 +309,51 @@ class ReceiptItem {
   description string?
   quantity int
   price float
-  @@stream.done
+  @@stream.done // <-- This annotation make ReceiptItem non-streaming.
 }
 ```
 
 When generating the client code for `ReceiptType` none of the fields of
-`ReceiptItem` will be converted to optional. And when parsing an LLM response,
-no `ReceiptItem` will be streamed out until all of its fields are done being
+`ReceiptItem` will be Optional or Partial. And when parsing an LLM response,
+no `ReceiptItem` will be streamed ot you until all of its fields are done being
 streamed in.
+
+```rust
+class Person {
+  name string @stream.done
+  phone_number string @stream.done
+  description string
+}
+```
+
+When using `@stream.done` on fields, the fields will never be partially filled,
+although they may be `null`. This `Person` will be streamed to your client one
+piece at a time, and the `description` will be streamed one token at a time.
+However, you will never see a partial `name` or a partial `phone_number` - these
+values will be delivered atomically.
 
 ### `@stream.not_null`
 
 Sometimes the presence of a value is important to the correct interpretation
 of a containing value. This commonly occurs with tags used to determine which
-part of a union is being used.
+variant of a union is being used.
 
-For example, in this code block, `@stream.not_null` on each of the
+For example, in this code, `@stream.not_null` on each of the
 `message_type` fields will ensure that an `Event` is never streamed until
-enough tokens have been received to precisely know what the message type is,
+enough tokens have been received to know precisely what the message type is,
 allowing you to build UI appropriate to the message type before the other
 fields have been completed.
 
 ```rust
 class Message {
   message_type "greeting" | "within-convo" | "farewell" @stream.not_null
-  gesture ("gesticulate" | "wave" | "shake-hands" | "hug")?
+  gesture ("gesticulate" | "wave" | "shake-hands" | "hug")
   message string
 }
 
 class Event {
+  speaker string @stream.done
   event_message: Message
-  speaker string
 }
 
 function Chat(history: Event[]) -> Event { ... }
@@ -335,10 +364,13 @@ You might wonder if it's sufficient to use `@stream.done` on the
 `message_type` field. `@stream.done` applies to types, preventing them
 from streaming out until they are completed. On the other hand,
 `@stream.not_null` applies to fields and prevents a containing object
-from streaming out until that field is present.
+from streaming out until that field is present. `@stream.not_null` is more
+appropriate here so that your client will never see a `Message` until
+there is enough information (the `message_type` field) to begin to render
+it.
 
-A type with `@stream.done` on it will still be converted to a
-nullable field in the generated partial types, so this change would not
+A type with `@stream.done` will still be converted to a
+nullable field in the generated partial types, and would not
 produce the desired result of witholding a `Message` until its type is
 known. Messages would be streamed with `message_type: null`.
 
@@ -350,8 +382,10 @@ containing context.
 
 ### `@stream.with_state`
 
-It is often useful to know in client code whether a value is finished, or
-could be updated in future messages. The `@stream.with_state` attribute lets
+It is often useful to know whether a value is finished, or
+could be updated in future messages. For example, in a frontend,
+you could use this information to render a spinner on data that are
+still streaming. The `@stream.with_state` attribute lets
 you attach metadata to types to indicate this state in client code.
 
 <Tabs>
@@ -417,24 +451,33 @@ class Recommendation {
   @@stream.done
 }
 
-class Message {
+class AssistantMessage {
   message_type "greeting" | "conversation" | "farewell" @stream.not_null
   message string @stream.with_state @stream.not_null
 }
 
 function Respond(
-  history: (Message | Recommendation | UserMessage)[]
-) -> Message | Recommendation { ... }
+  history: (UserMessage | AssistantMessage | Recommendation)[]
+) -> Message | Recommendation { 
+  client DeepseekR1
+  prompt #"
+    Make the message in the conversation, using a conversational
+    message or a stock recommendation, based on this conversation history:
+    {{ history }}.
+
+    {{ ctx.output_format }}
+  "#
+}
 ```
 
 <Tabs>
 
 <Tab title="Python">
 The above BAML code will generate the following Python definitions in the
-`partial` module. The use of streaming attributes has several effects on
+`partial_types` module. The use of streaming attributes has several effects on
 the generated code:
 
- - `Recommendation` does not have any partial field because it was marked
+ - `Recommendation` does not have any partial fields because it was marked
    `@stream.done`.
  - The `Message.message` `string` is wrapped in `StreamState`, allowing
    runtime checking of its completion status. This status could be used
@@ -445,7 +488,7 @@ the generated code:
 ```python
 class StreamState(BaseModel, Generic[T]):
   value: T,
-  state: Union[Literal["incomplete"] | Literal[]]
+  state: Literal["Incomplete", "Complete"]
 
 class Stock(str, Enum):
     APPL = "APPL"
@@ -456,20 +499,20 @@ class Stock(str, Enum):
 class Recommendation(BaseClass):
     stock: Stock
     amount: float
-    action: Union[Literal["buy"], Literal["sell"]]
+    action: Literal["buy", "sell"]
 
 class Message(BaseClass):
-  message_type: Union[Literal["gretting"], Literal["conversation"], Literal["farewell"]]
+  message_type: Literal["gretting","conversation","farewell"]
   message: StreamState[string]
 ```
 </Tab>
 
 <Tab title="Typescript">
-The above BAML code will generate the following Typescript definitions in the
-`partial` module. The use of streaming attributes has several effects on
+This BAML code will generate the following Typescript definitions in the
+`partial_types` module. The use of streaming attributes has several effects on
 the generated code:
 
- - `Recommendation` does not have any partial field because it was marked
+ - `Recommendation` does not have any partial fields because it was marked
    `@stream.done`.
  - The `Message.message` `string` is wrapped in `StreamState`, allowing
    runtime checking of its completion status. This status could be used
@@ -480,7 +523,7 @@ the generated code:
 ```typescript
 export interface StreamState<T> {
   value: T,
-  state: "incomplete" | "complete"
+  state: "Incomplete" | "Complete"
 }
 
 export enum Category {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve BAML streaming documentation by renaming a module, clarifying streaming attributes, and adding examples in multiple languages.
> 
>   - **Documentation**:
>     - Rename module `partial` to `partial_types` in `streaming.mdx`.
>     - Clarify the use of `@stream.done`, `@stream.not_null`, and `@stream.with_state` attributes.
>     - Add a table summarizing the impact of streaming attributes on generated types.
>     - Provide examples in Python, TypeScript, and Ruby for using `b.stream.ExtractReceiptInfo()`.
>     - Explain the distinction between `@stream.done` and `@stream.not_null` attributes.
>     - Update examples to reflect changes in streaming behavior and attributes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 5c499c940c6917ade085511322812401225b0a8b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->