### PR TITLE
[BUGFIX] fix field ordering

### DIFF
--- a/engine/baml-lib/baml-types/src/baml_value.rs
+++ b/engine/baml-lib/baml-types/src/baml_value.rs
@@ -4,7 +4,6 @@ use std::{
 };
 
 use anyhow::{Context,Result};
-use std::collections::HashMap;
 use indexmap::IndexMap;
 use serde::{de::Visitor, ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 
@@ -741,7 +740,7 @@ fn add_checks<'a, S: SerializeMap>(
 ) -> Result<(), S::Error>
 {
     if !checks.is_empty() {
-        let checks_map: HashMap<_,_> = checks.iter().map(|check| (check.name.clone(), check)).collect();
+        let checks_map: BamlMap<_,_> = checks.iter().map(|check| (check.name.clone(), check)).collect();
         map.serialize_entry("checks", &checks_map)?;
     }
     Ok(())


### PR DESCRIPTION
The semantic streaming algorithm works by deleting some fields and replacing them by nulls, when processing a class instance. This manipulation was shuffling field orders.

This PR aligns the fields of response values according the order they are defined in the original class definition.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes field ordering in semantic streaming by sorting fields according to class definition using `IndexSet` and `IndexMap`.
> 
>   - **Behavior**:
>     - Fixes field ordering in `process_node()` in `semantic_streaming.rs` by sorting fields according to their original class definition.
>     - Uses `IndexSet` and `IndexMap` to maintain field order.
>   - **Data Structures**:
>     - Replaces `HashMap` with `BamlMap` in `baml_value.rs` and `semantic_streaming.rs` for ordered map behavior.
>     - Introduces `type_field_names()` in `semantic_streaming.rs` to extract and order field names from class definitions.
>   - **Misc**:
>     - Removes unused `HashMap` import in `baml_value.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 2033f3f7599843dd34d0307663f2d956b9faf9fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->