### PR TITLE
bug: dedent strings parsed within triple quote blocks

### DIFF
--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_collection.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_collection.rs
@@ -80,7 +80,7 @@ impl From<JsonCollection> for Option<Value> {
             }
             JsonCollection::Array(values, completion_state) => Value::Array(values, completion_state),
             JsonCollection::QuotedString(s, completion_state) => Value::String(s, completion_state),
-            JsonCollection::TripleQuotedString(s, completion_state) => Value::String(s, completion_state),
+            JsonCollection::TripleQuotedString(s, completion_state) => Value::String(dedent(s.as_str()).content, completion_state),
             JsonCollection::SingleQuotedString(s, completion_state) => Value::String(s, completion_state),
             JsonCollection::TripleBacktickString { content, .. } => {
                 let Some((fenced_codeblock_info, codeblock_contents)) = content.0.split_once("\n")

--- a/engine/baml-lib/jsonish/src/tests/test_code.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_code.rs
@@ -121,9 +121,30 @@ test_deserializer!(
     FieldType::class("Test"),
     {
       "type": "code",
-      "code": "\n\"Hello, world!\"\n"
+      "code": "\"Hello, world!\""
     }
 );
+
+
+test_deserializer!(
+  triple_quotes_contains_only_quoted_string_dedent,
+  BAML_FILE,
+  r#"
+  {
+    "code": """
+        def main():
+          print("Hello, world!")
+    """,
+    "type": "code",
+  }
+  "#,
+  FieldType::class("Test"),
+  {
+    "type": "code",
+    "code": "def main():\n  print(\"Hello, world!\")"
+  }
+);
+
 
 // test_deserializer!(
 //     triple_quotes_nested,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Dedent strings parsed within triple-quoted blocks in `JsonCollection` before conversion to `Value::String`.
> 
>   - **Behavior**:
>     - Dedent strings parsed within `TripleQuotedString` in `JsonCollection` before converting to `Value::String` in `json_collection.rs`.
>   - **Tests**:
>     - Add test `triple_quotes_contains_only_quoted_string_dedent` in `test_code.rs` to verify dedentation of triple-quoted strings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 1b2addef096094211843153f7d38503a8a6a7b92. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->