### PR TITLE
Fix infinite cycles in client fallbacks

### DIFF
--- a/engine/baml-lib/baml/tests/validation_files/client/infinite_fallback_cycle.baml
+++ b/engine/baml-lib/baml/tests/validation_files/client/infinite_fallback_cycle.baml
@@ -1,0 +1,50 @@
+client<llm> SelfReferentialClient {
+  provider fallback
+  options {
+    strategy [SelfReferentialClient]
+  }
+}
+
+client<llm> ClientA {
+  provider fallback
+  options {
+    strategy [ClientB]
+  }
+}
+
+client<llm> ClientB {
+  provider fallback
+  options {
+    strategy [ClientC]
+  }
+}
+
+client<llm> ClientC {
+  provider fallback
+  options {
+    strategy [ClientA]
+  }
+}
+
+// error: Error validating: These fallback clients form a dependency cycle: SelfReferentialClient
+//   -->  client/infinite_fallback_cycle.baml:1
+//    | 
+//    | 
+//  1 | client<llm> SelfReferentialClient {
+//  2 |   provider fallback
+//  3 |   options {
+//  4 |     strategy [SelfReferentialClient]
+//  5 |   }
+//  6 | }
+//    | 
+// error: Error validating: These fallback clients form a dependency cycle: ClientA -> ClientB -> ClientC
+//   -->  client/infinite_fallback_cycle.baml:8
+//    | 
+//  7 | 
+//  8 | client<llm> ClientA {
+//  9 |   provider fallback
+// 10 |   options {
+// 11 |     strategy [ClientB]
+// 12 |   }
+// 13 | }
+//    | 


### PR DESCRIPTION
Fixes #1347
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds detection and reporting of infinite cycles in client fallback strategies in `cycle.rs`, with tests in `infinite_fallback_cycle.baml`.
> 
>   - **Behavior**:
>     - Adds detection of infinite cycles in client fallback strategies in `cycle.rs`.
>     - Constructs a `client_graph` to map client dependencies and checks for cycles.
>     - Reports cycles with `report_infinite_cycles()`.
>   - **Tests**:
>     - Adds `infinite_fallback_cycle.baml` to test detection of fallback cycles, including self-referential and multi-client cycles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 70078473ecc1e033caeaa6277cc0117583b20106. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->