### PR TITLE
Fix panic when using type alias that points to enum

### DIFF
--- a/engine/baml-lib/baml/tests/validation_files/class/type_aliases.baml
+++ b/engine/baml-lib/baml/tests/validation_files/class/type_aliases.baml
@@ -13,6 +13,18 @@ type Amount = Currency @assert({{ this > 0 }})
 // Should be allowed.
 type MultipleAttrs = int @assert({{ this > 0 }}) @check(gt_ten, {{ this > 10 }})
 
+enum SomeEnum {
+    A
+    B
+    C
+}
+
+type EnumAlias = SomeEnum
+
+class TypeAliasPointsToEnum {
+    enm EnumAlias
+}
+
 class MergeAttrs {
     amount Amount @description("In USD")
 }

--- a/engine/baml-lib/parser-database/src/lib.rs
+++ b/engine/baml-lib/parser-database/src/lib.rs
@@ -172,15 +172,14 @@ impl ParserDatabase {
                             |ident| {
                                 match self.find_type_by_str(ident.name()) {
                                     Some(TypeWalker::Class(cls)) => Some(cls.id),
-                                    Some(TypeWalker::Enum(_)) => {
-                                        panic!("Enums are not allowed in type aliases")
-                                    }
-                                    Some(TypeWalker::TypeAlias(alias)) => {
-                                        // Skip this one, recursive type aliases
-                                        // are not part of the finite class cycle.
-                                        // They are handled separately.
-                                        None
-                                    }
+                                    // Enums are not part of the dependency
+                                    // graph because they can't depend on other
+                                    // enums.
+                                    Some(TypeWalker::Enum(_)) => None,
+                                    // Skip this one, recursive type aliases are
+                                    // not part of the finite class cycle. They
+                                    // are handled separately.
+                                    Some(TypeWalker::TypeAlias(alias)) => None,
                                     None => panic!("Unknown class `{dep}`"),
                                 }
                             },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes panic in `ParserDatabase` when using type alias pointing to enum by modifying `TypeWalker::Enum` handling and adds a test case.
> 
>   - **Behavior**:
>     - Fixes panic in `ParserDatabase` when using type alias pointing to enum by changing `TypeWalker::Enum` handling to return `None` instead of panicking.
>   - **Tests**:
>     - Adds `TypeAliasPointsToEnum` class in `type_aliases.baml` to test type alias pointing to enum.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for d71512d538202045be2e38bc60f3dee7331a9889. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->