### PR TITLE
[BUGFIX] Track Pending fields in Semantic Streaming

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/ir_ref/coerce_class.rs
@@ -196,7 +196,6 @@ impl TypeCoercer for Class {
                             None => Some(BamlValueWithFlags::Null(
                                 DeserializerConditions::new()
                                     .with_flag(Flag::OptionalDefaultFromNoValue)
-                                    .with_flag(Flag::Incomplete),
                             )),
                         };
 
@@ -213,7 +212,7 @@ impl TypeCoercer for Class {
                                 Some(BamlValueWithFlags::Null(
                                     DeserializerConditions::new()
                                         .with_flag(Flag::OptionalDefaultFromNoValue)
-                                        .with_flag(Flag::Incomplete),
+                                        .with_flag(Flag::Pending),
                                 ))
                             } else {
                                 None
@@ -224,7 +223,7 @@ impl TypeCoercer for Class {
                                 Some(BamlValueWithFlags::Null(
                                     DeserializerConditions::new()
                                         .with_flag(Flag::OptionalDefaultFromNoValue)
-                                        .with_flag(Flag::Incomplete),
+                                        .with_flag(Flag::Pending),
                                 ))
                             } else {
                                 None

--- a/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
@@ -134,7 +134,7 @@ fn process_node(
                         .expect("This field is guaranteed to be in the field set");
                     let use_state = type_streaming_behavior(ir, field.meta().1).state;
                     let field_stream_state = Completion {
-                        state: CompletionState::Incomplete,
+                        state: CompletionState::Pending,
                         display: use_state,
                         required_done: false,
                     };
@@ -340,13 +340,17 @@ fn required_done(ir: &IntermediateRepr, field_type: &FieldType) -> bool {
 }
 
 fn completion_state(flags: &Vec<Flag>) -> CompletionState {
-    if flags
-        .iter()
-        .any(|f| matches!(f, Flag::Incomplete) || matches!(f, Flag::Pending))
-    {
-        CompletionState::Incomplete
+    if flags.iter().any(|f| matches!(f, Flag::Pending)) {
+        CompletionState::Pending
     } else {
-        CompletionState::Complete
+        if flags
+            .iter()
+            .any(|f| matches!(f, Flag::Incomplete))
+        {
+            CompletionState::Incomplete
+        } else {
+            CompletionState::Complete
+        }
     }
 }
 

--- a/engine/baml-lib/jsonish/src/tests/test_streaming.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_streaming.rs
@@ -19,6 +19,7 @@ test_partial_deserializer_streaming!(
 const NUMBERS_STATE: &str = r#"
 class Foo {
   nums int[] @stream.with_state
+  bar int @stream.with_state
 }
 "#;
 
@@ -27,7 +28,7 @@ test_partial_deserializer_streaming!(
     NUMBERS_STATE,
     "{'nums': [1,2",
     FieldType::class("Foo"),
-    {"nums": {"value": [1], "state": "Incomplete"}}
+    {"nums": {"value": [1], "state": "Incomplete"}, "bar": {"value": null, "state": "Pending"}}
 );
 
 const TOPLEVEL_DONE: &str = r#"

--- a/fern/01-guide/04-baml-basics/streaming.mdx
+++ b/fern/01-guide/04-baml-basics/streaming.mdx
@@ -435,7 +435,7 @@ the generated code:
 ```python
 class StreamState(BaseModel, Generic[T]):
   value: T,
-  state: Literal["Incomplete", "Complete"]
+  state: Literal["Pending", "Incomplete", "Complete"]
 
 class Stock(str, Enum):
     APPL = "APPL"
@@ -470,7 +470,7 @@ the generated code:
 ```typescript
 export interface StreamState<T> {
   value: T,
-  state: "Incomplete" | "Complete"
+  state: "Pending" | "Incomplete" | "Complete"
 }
 
 export enum Category {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Introduce `Pending` state in semantic streaming to better track incomplete fields, updating deserialization logic, tests, and documentation.
> 
>   - **Behavior**:
>     - Replace `Flag::Incomplete` with `Flag::Pending` in `coerce_class.rs` and `semantic_streaming.rs` to track fields not yet complete.
>     - Update `completion_state()` in `semantic_streaming.rs` to prioritize `Pending` over `Incomplete`.
>   - **Tests**:
>     - Update `test_streaming.rs` to reflect new `Pending` state in test cases like `test_number_list_state_incomplete`.
>   - **Documentation**:
>     - Update `streaming.mdx` to include `Pending` state in `StreamState` examples for Python and TypeScript.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for dafb0268a65d31ed288facc5eef31a5d993cad29. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->