### PR TITLE
chore: never trigger merge conflicts in baml_client

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -14,3 +14,5 @@ else
     
     export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 fi
+
+git config --local include.path ../.gitconfig

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 **/baml_client/inlinedbaml.py binary
 **/baml_client/inlinedbaml.ts binary
 **/baml_client/inlined.rb binary
+**/baml_client/** merge=baml_client

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,3 @@
+[merge "baml_client"]
+        driver = true
+


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Configure Git to prevent merge conflicts in `baml_client` by using a custom merge driver.
> 
>   - **Git Configuration**:
>     - Add `.gitconfig` with a custom merge driver `baml_client`.
>     - Update `.gitattributes` to use `merge=baml_client` for all files in `baml_client` directory.
>   - **Environment Configuration**:
>     - Update `.envrc` to include local `.gitconfig` configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for dc02b071056bf907e127c1dc40fe958704a2e9ac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->