### PR TITLE
bug fix: Fix the way we parse providers for during reading client-registry

### DIFF
--- a/engine/baml-lib/llm-client/src/clientspec.rs
+++ b/engine/baml-lib/llm-client/src/clientspec.rs
@@ -2,9 +2,8 @@ use anyhow::Result;
 use std::collections::HashSet;
 
 use baml_types::{GetEnvVar, StringOr};
-use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 pub enum ClientSpec {
     Named(String),
     /// Shorthand for "<provider>/<model>"
@@ -30,7 +29,7 @@ impl ClientSpec {
 }
 
 /// The provider for the client, e.g. baml-openai-chat
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub enum ClientProvider {
     /// The OpenAI client provider variant
     OpenAI(OpenAIClientProviderVariant),
@@ -47,7 +46,7 @@ pub enum ClientProvider {
 }
 
 /// The OpenAI client provider variant
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub enum OpenAIClientProviderVariant {
     /// The base OpenAI client provider variant
     Base,
@@ -60,7 +59,7 @@ pub enum OpenAIClientProviderVariant {
 }
 
 /// The strategy client provider variant
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug)]
 pub enum StrategyClientProvider {
     /// The round-robin strategy client provider variant
     RoundRobin,

--- a/engine/baml-runtime/src/internal/llm_client/orchestrator/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/orchestrator/mod.rs
@@ -136,7 +136,7 @@ impl OrchestrationScope {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug)]
 pub enum ExecutionScope {
     Direct(String),
     // PolicyName, RetryCount, RetryDelayMs

--- a/engine/baml-runtime/src/internal/llm_client/strategy/roundrobin.rs
+++ b/engine/baml-runtime/src/internal/llm_client/strategy/roundrobin.rs
@@ -24,7 +24,7 @@ use crate::{
 use serde::Serialize;
 use serde::Serializer;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug)]
 pub struct RoundRobinStrategy {
     pub name: String,
     pub(super) retry_policy: Option<String>,


### PR DESCRIPTION
Prior: We used deserialize on an descriminated union
Now: We use the FromStr capability so a user can use the strings we document

Address bug first spotted in: #892 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch from `Deserialize` to `FromStr` for parsing `ClientProvider`, adding custom deserialization in `client_registry/mod.rs`.
> 
>   - **Behavior**:
>     - Switch from `Deserialize` to `FromStr` for parsing `ClientProvider` in `client_registry/mod.rs`.
>     - Add `deserialize_client_provider` function in `client_registry/mod.rs` to handle custom deserialization.
>   - **Enums**:
>     - Remove `Deserialize` and `Serialize` from `ClientProvider`, `OpenAIClientProviderVariant`, and `StrategyClientProvider` in `clientspec.rs`.
>     - Remove `Serialize` from `ExecutionScope` in `orchestrator/mod.rs` and `RoundRobinStrategy` in `roundrobin.rs`.
>   - **Misc**:
>     - Add `FromStr` implementation for `ClientProvider`, `OpenAIClientProviderVariant`, and `StrategyClientProvider` in `clientspec.rs`.
>     - Minor code cleanup in `orchestrator/mod.rs` and `roundrobin.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0aa1115d34835aba210c91ebd4eb5523c8492fe1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->