### PR TITLE
Hide credentials from frontend rendering

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1009,6 +1009,7 @@ dependencies = [
  "ring",
  "rstest",
  "scopeguard",
+ "secrecy",
  "send_wrapper 0.6.0",
  "serde",
  "serde-wasm-bindgen 0.6.5",
@@ -2947,6 +2948,7 @@ dependencies = [
  "env_logger",
  "indexmap 2.2.6",
  "log",
+ "secrecy",
  "serde",
  "serde_json",
  "strum",
@@ -4622,6 +4624,16 @@ checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "secrecy"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
+dependencies = [
+ "serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -89,6 +89,7 @@ reqwest = { version = "0.12.12", features = [
   "stream",
 ] }
 scopeguard = "1.2.0"
+secrecy = { version = "0.10.3", features = ["serde"] }
 serde_json = { version = "1", features = ["float_roundtrip", "preserve_order"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_yaml = "0.9.34"

--- a/engine/baml-lib/llm-client/Cargo.toml
+++ b/engine/baml-lib/llm-client/Cargo.toml
@@ -25,6 +25,7 @@ enum_dispatch = "0.3.13"
 strum.workspace = true
 derive_more.workspace = true
 either.workspace = true
+secrecy.workspace = true
 
 [dev-dependencies]
 env_logger = "0.11.3"

--- a/engine/baml-lib/llm-client/src/clients/anthropic.rs
+++ b/engine/baml-lib/llm-client/src/clients/anthropic.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use crate::{AllowedRoleMetadata, FinishReasonFilter, RolesSelection, SupportedRequestModes, UnresolvedAllowedRoleMetadata, UnresolvedFinishReasonFilter, UnresolvedRolesSelection};
 use anyhow::Result;
+use secrecy::SecretString;
 
 use baml_types::{EvaluationContext, StringOr, UnresolvedValue};
 use indexmap::IndexMap;
@@ -45,7 +46,7 @@ impl<Meta> UnresolvedAnthropic<Meta> {
 
 pub struct ResolvedAnthropic {
     pub base_url: String,
-    pub api_key: String,
+    pub api_key: SecretString,
     role_selection: RolesSelection,
     pub allowed_metadata: AllowedRoleMetadata,
     pub supported_request_modes: SupportedRequestModes,
@@ -124,7 +125,7 @@ impl<Meta: Clone> UnresolvedAnthropic<Meta> {
 
         Ok(ResolvedAnthropic {
             base_url,
-            api_key: self.api_key.resolve(ctx)?,
+            api_key: SecretString::from(self.api_key.resolve(ctx)?),
             role_selection: self.role_selection.resolve(ctx)?,
             allowed_metadata: self.allowed_metadata.resolve(ctx)?,
             supported_request_modes: self.supported_request_modes.clone(),

--- a/engine/baml-lib/llm-client/src/clients/aws_bedrock.rs
+++ b/engine/baml-lib/llm-client/src/clients/aws_bedrock.rs
@@ -5,6 +5,7 @@ use crate::{
     UnresolvedAllowedRoleMetadata, UnresolvedFinishReasonFilter, UnresolvedRolesSelection,
 };
 use anyhow::Result;
+use secrecy::SecretString;
 
 use baml_types::{EvaluationContext, GetEnvVar, StringOr};
 
@@ -67,7 +68,7 @@ pub struct ResolvedAwsBedrock {
     pub model: String,
     pub region: Option<String>,
     pub access_key_id: Option<String>,
-    pub secret_access_key: Option<String>,
+    pub secret_access_key: Option<SecretString>,
     pub session_token: Option<String>,
     pub profile: Option<String>,
     pub inference_config: Option<InferenceConfiguration>,
@@ -186,7 +187,7 @@ impl UnresolvedAwsBedrock {
         };
 
         let secret_access_key = match self.secret_access_key.as_ref() {
-            Some(secret_access_key) => Some(secret_access_key.resolve(ctx)?),
+            Some(secret_access_key) => Some(SecretString::from(secret_access_key.resolve(ctx)?)),
             None => None,
         };
 
@@ -211,7 +212,7 @@ impl UnresolvedAwsBedrock {
                         _ => None,
                     };
                     let secret_access_key = match ctx.get_env_var("AWS_SECRET_ACCESS_KEY") {
-                        Ok(key) if !key.is_empty() => Some(key),
+                        Ok(key) if !key.is_empty() => Some(SecretString::from(key)),
                         _ => None,
                     };
                     let session_token = match ctx.get_env_var("AWS_SESSION_TOKEN") {

--- a/engine/baml-lib/llm-client/src/clients/google_ai.rs
+++ b/engine/baml-lib/llm-client/src/clients/google_ai.rs
@@ -8,6 +8,7 @@ use crate::{
 
 use baml_types::{EvaluationContext, StringOr, UnresolvedValue};
 use indexmap::IndexMap;
+use secrecy::SecretString;
 
 use super::helpers::{Error, PropertyHandler, UnresolvedUrl};
 
@@ -50,7 +51,7 @@ impl<Meta> UnresolvedGoogleAI<Meta> {
 
 pub struct ResolvedGoogleAI {
     role_selection: RolesSelection,
-    pub api_key: String,
+    pub api_key: SecretString,
     pub model: String,
     pub base_url: String,
     pub headers: IndexMap<String, String>,
@@ -121,7 +122,7 @@ impl<Meta: Clone> UnresolvedGoogleAI<Meta> {
 
         Ok(ResolvedGoogleAI {
             role_selection,
-            api_key,
+            api_key: SecretString::from(api_key),
             model,
             base_url,
             headers,

--- a/engine/baml-lib/llm-client/src/clients/openai.rs
+++ b/engine/baml-lib/llm-client/src/clients/openai.rs
@@ -5,6 +5,7 @@ use crate::{
     UnresolvedAllowedRoleMetadata, UnresolvedFinishReasonFilter, UnresolvedRolesSelection,
 };
 use anyhow::Result;
+use secrecy::SecretString;
 
 use baml_types::{GetEnvVar, StringOr, UnresolvedValue};
 use indexmap::IndexMap;
@@ -54,7 +55,7 @@ impl<Meta> UnresolvedOpenAI<Meta> {
 
 pub struct ResolvedOpenAI {
     pub base_url: String,
-    pub api_key: Option<String>,
+    pub api_key: Option<SecretString>,
     role_selection: RolesSelection,
     pub allowed_metadata: AllowedRoleMetadata,
     supported_request_modes: SupportedRequestModes,
@@ -167,7 +168,8 @@ impl<Meta: Clone> UnresolvedOpenAI<Meta> {
             .api_key
             .as_ref()
             .map(|key| key.resolve(ctx))
-            .transpose()?;
+            .transpose()?
+            .map(|key| SecretString::from(key));
 
         let role_selection = self.role_selection.resolve(ctx)?;
 

--- a/engine/baml-lib/llm-client/src/clients/vertex.rs
+++ b/engine/baml-lib/llm-client/src/clients/vertex.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use baml_types::{GetEnvVar, StringOr, UnresolvedValue};
 use either::Either;
 use indexmap::IndexMap;
+use secrecy::SecretString;
 use serde::Deserialize;
 
 use super::helpers::{Error, PropertyHandler, UnresolvedUrl};
@@ -30,7 +31,7 @@ pub struct ServiceAccount {
     pub token_uri: String,
     pub project_id: String,
     pub client_email: String,
-    pub private_key: String,
+    pub private_key: SecretString,
 }
 
 pub enum ResolvedGcpAuthStrategy {

--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -49,6 +49,7 @@ minijinja.workspace = true
 pin-project-lite.workspace = true
 reqwest-eventsource = "0.6.0"
 scopeguard.workspace = true
+secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strsim = "0.11.1"

--- a/engine/baml-runtime/src/internal/llm_client/primitive/request.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/request.rs
@@ -15,6 +15,7 @@ pub trait RequestBuilder {
         prompt: either::Either<&String, &[RenderedChatMessage]>,
         allow_proxy: bool,
         stream: bool,
+        expose_secrets: bool,
     ) -> Result<reqwest::RequestBuilder>;
 
     fn request_options(&self) -> &BamlMap<String, serde_json::Value>;
@@ -39,7 +40,7 @@ pub async fn make_request(
     let (system_now, instant_now) = (web_time::SystemTime::now(), web_time::Instant::now());
 
     let req = match client
-        .build_request(prompt, true, stream)
+        .build_request(prompt, true, stream, true)
         .await
         .context("Failed to build request")
     {

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
@@ -277,6 +277,9 @@ impl RequestBuilder for VertexClient {
         prompt: either::Either<&String, &[RenderedChatMessage]>,
         allow_proxy: bool,
         stream: bool,
+        // There are no leakable secrets in the Vertex request because
+        // VertexAuth can not be built in the WASM environment.
+        _expose_secrets: bool,
     ) -> Result<reqwest::RequestBuilder> {
         let vertex_auth = super::auth::VertexAuth::new(&self.properties.auth_strategy).await?;
 

--- a/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
@@ -283,6 +283,7 @@ where
                 either::Right(&chat_messages),
                 false,
                 render_settings.stream && self.supports_streaming(),
+                render_settings.expose_secrets
             )
             .await?;
         let mut request = request_builder.build()?;
@@ -388,8 +389,9 @@ where
     }
 }
 
-/// We assume b64 with mime-type is the universally accepted format in an API request.
-/// Other formats will be converted into that, depending on what formats are allowed according to supported_media_formats.
+/// We assume b64 with mime-type is the universally accepted format in an API
+/// request. Other formats will be converted into that, depending on what
+/// formats are allowed according to supported_media_formats.
 async fn process_media_urls(
     resolve_media_urls: ResolveMediaUrls,
     resolve_files: bool,
@@ -400,6 +402,7 @@ async fn process_media_urls(
     let render_settings = render_settings.unwrap_or(RenderCurlSettings {
         stream: false,
         as_shell_commands: false,
+        expose_secrets: false,
     });
 
     futures::stream::iter(chat.iter().map(|p| {

--- a/engine/baml-runtime/src/types/mod.rs
+++ b/engine/baml-runtime/src/types/mod.rs
@@ -16,4 +16,5 @@ pub use trace_stats::{InnerTraceStats, TraceStats};
 pub struct RenderCurlSettings {
     pub stream: bool,
     pub as_shell_commands: bool,
+    pub expose_secrets: bool,
 }

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -1603,6 +1603,7 @@ impl WasmFunction {
                 RenderCurlSettings {
                     stream,
                     as_shell_commands: !expand_images,
+                    expose_secrets: false,
                 },
                 wasm_call_context.node_index,
             )

--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,7 @@
               maturin
               nodePackages.pnpm
               nodePackages.nodejs
+              uv
             ]) ++ (if pkgs.stdenv.isDarwin then appleDeps else []);
             nativeBuildInputs = [
               pkgs.openssl
@@ -133,7 +134,7 @@
 
           };
           devShell = pkgs.mkShell rec {
-            buildInputs = [toolchain];
+            buildInputs = with pkgs; [toolchain uv];
             PATH="${clang}/bin:$PATH";
             LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
           };

--- a/integ-tests/python/uv.lock
+++ b/integ-tests/python/uv.lock
@@ -220,6 +220,8 @@ version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz", hash = "sha256:cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5", size = 508502 }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/d4/8095b53c4950f44dc99b8d983b796f405ae1f58d80978fcc0421491b4201/psutil-6.1.1-cp27-none-win32.whl", hash = "sha256:6d4281f5bbca041e2292be3380ec56a9413b790579b8e593b1784499d0005dac", size = 246855 },
+    { url = "https://files.pythonhosted.org/packages/b1/63/0b6425ea4f2375988209a9934c90d6079cc7537847ed58a28fbe30f4277e/psutil-6.1.1-cp27-none-win_amd64.whl", hash = "sha256:c777eb75bb33c47377c9af68f30e9f11bc78e0f07fbf907be4a5d70b2fe5f030", size = 250110 },
     { url = "https://files.pythonhosted.org/packages/61/99/ca79d302be46f7bdd8321089762dd4476ee725fce16fc2b2e1dbba8cac17/psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8", size = 247511 },
     { url = "https://files.pythonhosted.org/packages/0b/6b/73dbde0dd38f3782905d4587049b9be64d76671042fdcaf60e2430c6796d/psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377", size = 248985 },
     { url = "https://files.pythonhosted.org/packages/17/38/c319d31a1d3f88c5b79c68b3116c129e5133f1822157dd6da34043e32ed6/psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003", size = 284488 },
@@ -396,11 +398,6 @@ dependencies = [
     { name = "ruff" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "types-assertpy" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "assertpy" },
@@ -413,9 +410,6 @@ requires-dist = [
     { name = "requests" },
     { name = "ruff" },
 ]
-
-[package.metadata.requires-dev]
-dev = [{ name = "types-assertpy" }]
 
 [[package]]
 name = "requests"
@@ -463,15 +457,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/b9/de2a5c0144d7d75a57ff355c0c24054f965b2dc3036456ae03a51ea6264b/tomli-2.0.2.tar.gz", hash = "sha256:d46d457a85337051c36524bc5349dd91b1877838e2979ac5ced3e710ed8a60ed", size = 16096 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cf/db/ce8eda256fa131af12e0a76d481711abe4681b6923c27efb9a255c9e4594/tomli-2.0.2-py3-none-any.whl", hash = "sha256:2ebe24485c53d303f690b0ec092806a085f07af5a5aa1464f3931eec36caaa38", size = 13237 },
-]
-
-[[package]]
-name = "types-assertpy"
-version = "1.1.0.20240712"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/ff/2080a4537562ee92f4918bf5d6155e076bc5d257ea474dda754d5c75ce3b/types-assertpy-1.1.0.20240712.tar.gz", hash = "sha256:c332d09298b158f09890af12f14d83ebb9f0e5014e91219ae145a6a5af9220f9", size = 5448 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/9e/7bdfdd46ea309e03a678c333a3f45bbbc3fca892ceb4d3898a102c90f463/types_assertpy-1.1.0.20240712-py3-none-any.whl", hash = "sha256:3962d4d863e4c091b9a8d7f02e3ee0d2ac06f25bdca0e6e4f848cf54c7214455", size = 8042 },
 ]
 
 [[package]]

--- a/shell.nix
+++ b/shell.nix
@@ -45,6 +45,7 @@ in pkgs.mkShell {
       lld_19
       turbo # js packaging
       wasm-pack
+      uv
     ] ++ (if pkgs.stdenv.isDarwin then appleDeps else [ ]);
 
   LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";


### PR DESCRIPTION
 - Depend on the `secrecy` crate, which provides the `SecretString`, a wrapper around a `String` with different `Default` and `Display` impls that prevent accidentally printing the contents.
 - Add a parameter `expose_secrets: bool` to `RenderCurlSettings`. This setting determines whether to expose the `SecretString` (which should be done for real web requests), or to replace it by `<SECRET_HIDDEN>` in other contexts (such as rendering a raw cURL request in the playground).

Integ tests:
 - [x] Python
 - [ ]  TypeScript (skipped, no changes expected)
 - [ ] Ruby (skipped, no changes expected)

OpenAI:
<img width="502" alt="Screenshot 2025-02-07 at 12 24 22 PM" src="https://github.com/user-attachments/assets/2b1da8b9-60db-449d-ab26-872b26f07ba1" />

Anthropic:
<img width="506" alt="Screenshot 2025-02-07 at 12 25 13 PM" src="https://github.com/user-attachments/assets/e923118b-d953-452b-9d62-01dc61e9f3c9" />

Bedrock: (no change)
<img width="514" alt="Screenshot 2025-02-07 at 12 25 43 PM" src="https://github.com/user-attachments/assets/81e7bb9b-67eb-46b8-bdb1-d3fbecf3c011" />

Vertex: (Correct?)
<img width="529" alt="Screenshot 2025-02-07 at 12 30 11 PM" src="https://github.com/user-attachments/assets/efb7c745-9b6d-487a-8e5c-19a431696222" />



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Integrate `secrecy` crate to manage sensitive data and add `expose_secrets` parameter to control secret exposure in API requests.
> 
>   - **Security**:
>     - Integrate `secrecy` crate to manage sensitive strings using `SecretString`.
>     - Add `expose_secrets` parameter to `RenderCurlSettings` to control secret exposure.
>   - **Client Updates**:
>     - Update `ResolvedAnthropic`, `ResolvedAwsBedrock`, `ResolvedGoogleAI`, `ResolvedOpenAI`, and `ServiceAccount` to use `SecretString` for API keys and secrets.
>     - Modify request builders in `anthropic_client.rs`, `aws_client.rs`, `googleai_client.rs`, `openai_client.rs`, and `vertex_client.rs` to handle `expose_secrets`.
>   - **Miscellaneous**:
>     - Add `secrecy` crate to `Cargo.toml` and `Cargo.lock`.
>     - Update `flake.nix` and `shell.nix` to include `uv` dependency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c1949b8ccf8384533a4163fca39c74cee2cdf03f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->