### PR TITLE
Use env var when hiding secrets

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1088,6 +1088,7 @@ dependencies = [
  "log",
  "minijinja",
  "once_cell",
+ "secrecy",
  "serde",
  "serde_json",
  "strum",

--- a/engine/baml-lib/baml-types/Cargo.toml
+++ b/engine/baml-lib/baml-types/Cargo.toml
@@ -21,6 +21,7 @@ derive_builder.workspace = true
 log.workspace = true
 minijinja.workspace = true
 once_cell.workspace = true
+secrecy.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true

--- a/engine/baml-lib/baml-types/src/lib.rs
+++ b/engine/baml-lib/baml-types/src/lib.rs
@@ -18,5 +18,6 @@ pub use map::Map as BamlMap;
 pub use media::{BamlMedia, BamlMediaContent, BamlMediaType, MediaBase64, MediaUrl};
 pub use minijinja::JinjaExpression;
 pub use value_expr::{
-    EvaluationContext, GetEnvVar, Resolvable, ResolvedValue, StringOr, UnresolvedValue,
+    ApiKeyWithProvenance, EvaluationContext, GetEnvVar, Resolvable, ResolvedValue, StringOr,
+    UnresolvedValue,
 };

--- a/engine/baml-lib/llm-client/src/clients/anthropic.rs
+++ b/engine/baml-lib/llm-client/src/clients/anthropic.rs
@@ -2,9 +2,8 @@ use std::collections::HashSet;
 
 use crate::{AllowedRoleMetadata, FinishReasonFilter, RolesSelection, SupportedRequestModes, UnresolvedAllowedRoleMetadata, UnresolvedFinishReasonFilter, UnresolvedRolesSelection};
 use anyhow::Result;
-use secrecy::SecretString;
 
-use baml_types::{EvaluationContext, StringOr, UnresolvedValue};
+use baml_types::{ApiKeyWithProvenance, EvaluationContext, StringOr, UnresolvedValue};
 use indexmap::IndexMap;
 
 use super::helpers::{Error, PropertyHandler, UnresolvedUrl};
@@ -46,7 +45,7 @@ impl<Meta> UnresolvedAnthropic<Meta> {
 
 pub struct ResolvedAnthropic {
     pub base_url: String,
-    pub api_key: SecretString,
+    pub api_key: ApiKeyWithProvenance,
     role_selection: RolesSelection,
     pub allowed_metadata: AllowedRoleMetadata,
     pub supported_request_modes: SupportedRequestModes,
@@ -125,7 +124,7 @@ impl<Meta: Clone> UnresolvedAnthropic<Meta> {
 
         Ok(ResolvedAnthropic {
             base_url,
-            api_key: SecretString::from(self.api_key.resolve(ctx)?),
+            api_key: self.api_key.resolve_api_key(ctx)?,
             role_selection: self.role_selection.resolve(ctx)?,
             allowed_metadata: self.allowed_metadata.resolve(ctx)?,
             supported_request_modes: self.supported_request_modes.clone(),

--- a/engine/baml-lib/llm-client/src/clients/aws_bedrock.rs
+++ b/engine/baml-lib/llm-client/src/clients/aws_bedrock.rs
@@ -7,7 +7,7 @@ use crate::{
 use anyhow::Result;
 use secrecy::SecretString;
 
-use baml_types::{EvaluationContext, GetEnvVar, StringOr};
+use baml_types::{ApiKeyWithProvenance, EvaluationContext, GetEnvVar, StringOr};
 
 use super::helpers::{Error, PropertyHandler};
 
@@ -68,7 +68,7 @@ pub struct ResolvedAwsBedrock {
     pub model: String,
     pub region: Option<String>,
     pub access_key_id: Option<String>,
-    pub secret_access_key: Option<SecretString>,
+    pub secret_access_key: Option<ApiKeyWithProvenance>,
     pub session_token: Option<String>,
     pub profile: Option<String>,
     pub inference_config: Option<InferenceConfiguration>,
@@ -186,10 +186,11 @@ impl UnresolvedAwsBedrock {
             None => None,
         };
 
-        let secret_access_key = match self.secret_access_key.as_ref() {
-            Some(secret_access_key) => Some(SecretString::from(secret_access_key.resolve(ctx)?)),
-            None => None,
-        };
+        let secret_access_key = self
+            .secret_access_key
+            .as_ref()
+            .map(|key| key.resolve_api_key(ctx))
+            .transpose()?;
 
         let session_token = match self.session_token.as_ref() {
             Some(session_token) => {
@@ -212,7 +213,10 @@ impl UnresolvedAwsBedrock {
                         _ => None,
                     };
                     let secret_access_key = match ctx.get_env_var("AWS_SECRET_ACCESS_KEY") {
-                        Ok(key) if !key.is_empty() => Some(SecretString::from(key)),
+                        Ok(key) if !key.is_empty() => Some(ApiKeyWithProvenance {
+                            api_key: SecretString::from(key),
+                            provenance: Some("AWS_SECRET_ACCESS_KEY".to_string()),
+                        }),
                         _ => None,
                     };
                     let session_token = match ctx.get_env_var("AWS_SESSION_TOKEN") {

--- a/engine/baml-lib/llm-client/src/clients/google_ai.rs
+++ b/engine/baml-lib/llm-client/src/clients/google_ai.rs
@@ -6,9 +6,8 @@ use crate::{
     FinishReasonFilter, RolesSelection, UnresolvedFinishReasonFilter, UnresolvedRolesSelection
 };
 
-use baml_types::{EvaluationContext, StringOr, UnresolvedValue};
+use baml_types::{ApiKeyWithProvenance, EvaluationContext, StringOr, UnresolvedValue};
 use indexmap::IndexMap;
-use secrecy::SecretString;
 
 use super::helpers::{Error, PropertyHandler, UnresolvedUrl};
 
@@ -51,7 +50,7 @@ impl<Meta> UnresolvedGoogleAI<Meta> {
 
 pub struct ResolvedGoogleAI {
     role_selection: RolesSelection,
-    pub api_key: SecretString,
+    pub api_key: ApiKeyWithProvenance,
     pub model: String,
     pub base_url: String,
     pub headers: IndexMap<String, String>,
@@ -102,7 +101,7 @@ impl<Meta: Clone> UnresolvedGoogleAI<Meta> {
     }
 
     pub fn resolve(&self, ctx: &EvaluationContext<'_>) -> Result<ResolvedGoogleAI> {
-        let api_key = self.api_key.resolve(ctx)?;
+        let api_key = self.api_key.resolve_api_key(ctx)?;
         let role_selection = self.role_selection.resolve(ctx)?;
 
         let model = self
@@ -122,7 +121,7 @@ impl<Meta: Clone> UnresolvedGoogleAI<Meta> {
 
         Ok(ResolvedGoogleAI {
             role_selection,
-            api_key: SecretString::from(api_key),
+            api_key,
             model,
             base_url,
             headers,

--- a/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/anthropic_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/anthropic_client.rs
@@ -343,11 +343,7 @@ impl RequestBuilder for AnthropicClient {
         for (key, value) in &self.properties.headers {
             req = req.header(key, value);
         }
-        let api_key = if expose_secrets {
-            self.properties.api_key.expose_secret()
-        } else {
-            "<SECRET_HIDDEN>"
-        };
+        let api_key = self.properties.api_key.render(expose_secrets);
         req = req.header("x-api-key", api_key);
 
         if allow_proxy {

--- a/engine/baml-runtime/src/internal/llm_client/primitive/aws/aws_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/aws/aws_client.rs
@@ -176,10 +176,10 @@ impl AwsClient {
                     // Exposing the secret key here is relatively safe. First, we expose it only
                     // to check if it starts with $. If so, the remainer should be an env
                     // var name, which is also safe to expose.
-                    if aws_secret_access_key.expose_secret().starts_with("$") {
+                    if aws_secret_access_key.api_key.expose_secret().starts_with("$") {
                         return Err(anyhow::anyhow!(
                             "AWS secret access key expected, please set: env.{}",
-                            &aws_secret_access_key.expose_secret()[1..]
+                            &aws_secret_access_key.api_key.expose_secret()[1..]
                         ));
                     }
                 }
@@ -196,7 +196,7 @@ impl AwsClient {
                     self.properties
                         .secret_access_key
                         .as_ref()
-                        .map_or("", |key| key.expose_secret())
+                        .map_or("", |key| key.api_key.expose_secret())
                         .to_string(),
                     self.properties.session_token.clone(),
                     None,

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
@@ -295,11 +295,10 @@ impl RequestBuilder for GoogleAIClient {
             req = req.header(key, value);
         }
 
-        if expose_secrets {
-            req = req.header("x-goog-api-key", self.properties.api_key.expose_secret());
-        } else {
-            req = req.header("x-goog-api-key", "<SECRET_HIDDEN>");
-        }
+        req = req.header(
+            "x-goog-api-key",
+            self.properties.api_key.render(expose_secrets),
+        );
 
         let mut body = json!(self.properties.properties);
         let body_obj = body.as_object_mut().unwrap();

--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/openai_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/openai_client.rs
@@ -254,11 +254,7 @@ impl RequestBuilder for OpenAIClient {
             req = req.header(key, value);
         }
         if let Some(key) = &self.properties.api_key {
-            if expose_secrets {
-                req = req.bearer_auth(key.expose_secret());
-            } else {
-                req = req.bearer_auth("<SECRET_HIDDEN>");
-            }
+            req = req.bearer_auth(key.render(expose_secrets));
         }
 
         // Don't attach BAML creds to localhost requests, i.e. ollama


### PR DESCRIPTION
When hiding secrets in the raw cURL view of the UI, it would be nice if we use `$THE_ENV_VAR_NAME` instead of `<SECRET_HIDDEN>`, so that users can copy-paste the raw cURL command into a terminal and expect it to work (as long as their shell has the needed environment variables).

This PR caries env var provenance from api keys through to http request rendering, so we can do this substitution.

When an API key was specified as a plain string (rather than an env var), we fall back to `<SECRET_HIDDEN>`.

Fiddle example: using default env var:

<img width="1225" alt="Screenshot 2025-02-10 at 2 13 12 PM" src="https://github.com/user-attachments/assets/3c0e98e6-3783-455d-98c0-da0d5bf450a7" />

Fiddle example: using custom env var:
<img width="1374" alt="Screenshot 2025-02-10 at 2 16 02 PM" src="https://github.com/user-attachments/assets/285c5ca1-c0dc-46af-b6ef-35ec084e891f" />

Fiddle example: using a bare string as a secret:
<img width="1467" alt="Screenshot 2025-02-10 at 2 16 52 PM" src="https://github.com/user-attachments/assets/3596a085-14db-4d16-942d-47c7c4236fd6" />

These changes do not impact actual calls to the LLM providers - real LLM calls receive the API key directly.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance cURL command usability by replacing `<SECRET_HIDDEN>` with environment variable names when available, across multiple client implementations.
> 
>   - **Behavior**:
>     - Replace `<SECRET_HIDDEN>` with `$THE_ENV_VAR_NAME` in cURL commands if API key is from an env var.
>     - Fallback to `<SECRET_HIDDEN>` if API key is a plain string.
>   - **Implementation**:
>     - Introduce `ApiKeyWithProvenance` in `value_expr.rs` to store API key and its env var provenance.
>     - Update `resolve_api_key()` in `StringOr` to return `ApiKeyWithProvenance`.
>     - Modify `render()` in `ApiKeyWithProvenance` to output env var name or `<SECRET_HIDDEN>`.
>   - **Client Updates**:
>     - Update `anthropic_client.rs`, `aws_client.rs`, `googleai_client.rs`, and `openai_client.rs` to use `ApiKeyWithProvenance` for API key handling.
>     - Adjust request building to use `render()` for API keys in headers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 85a5215817c1240559e02c1e42faf25e3d48a161. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->