### PR TITLE
Fix WASM build

### DIFF
--- a/engine/baml-lib/llm-client/src/clientspec.rs
+++ b/engine/baml-lib/llm-client/src/clientspec.rs
@@ -29,7 +29,7 @@ impl ClientSpec {
 }
 
 /// The provider for the client, e.g. baml-openai-chat
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ClientProvider {
     /// The OpenAI client provider variant
     OpenAI(OpenAIClientProviderVariant),
@@ -46,7 +46,7 @@ pub enum ClientProvider {
 }
 
 /// The OpenAI client provider variant
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum OpenAIClientProviderVariant {
     /// The base OpenAI client provider variant
     Base,
@@ -59,7 +59,7 @@ pub enum OpenAIClientProviderVariant {
 }
 
 /// The strategy client provider variant
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum StrategyClientProvider {
     /// The round-robin strategy client provider variant
     RoundRobin,

--- a/engine/baml-schema-wasm/src/runtime_wasm/runtime_prompt.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/runtime_prompt.rs
@@ -174,37 +174,12 @@ impl WasmScope {
     pub fn get_orchestration_scope_info(&self) -> JsValue {
         self.scope.to_js_value()
     }
-
-    #[wasm_bindgen]
-    pub fn iter_scopes(&self) -> ScopeIterator {
-        ScopeIterator {
-            scopes: self.scope.scope.clone(),
-            index: 0,
-        }
-    }
 }
 
 #[wasm_bindgen]
 pub struct ScopeIterator {
     scopes: Vec<ExecutionScope>,
     index: usize,
-}
-
-#[wasm_bindgen]
-impl ScopeIterator {
-    #[wasm_bindgen]
-    pub fn next(&mut self) -> JsValue {
-        if self.index < self.scopes.len() {
-            let scope = &self.scopes[self.index];
-            self.index += 1;
-            match to_value(scope) {
-                Ok(value) => value,
-                Err(_) => JsValue::NULL,
-            }
-        } else {
-            JsValue::NULL
-        }
-    }
 }
 
 #[wasm_bindgen]


### PR DESCRIPTION
* Adds more unit tests for serialization between of client registry

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix WASM build by adding `PartialEq` and `Eq` to enums and removing unused code in `runtime_prompt.rs`.
> 
>   - **Behavior**:
>     - Add `PartialEq` and `Eq` to `ClientProvider`, `OpenAIClientProviderVariant`, and `StrategyClientProvider` in `clientspec.rs` for equality checks.
>     - Remove `iter_scopes()` and `ScopeIterator` from `runtime_prompt.rs` to fix WASM build by eliminating unused code.
>   - **Tests**:
>     - Add tests in `mod.rs` for deserialization of `ClientProperty` and `ClientRegistry` to ensure correct behavior.
>   - **Misc**:
>     - Minor refactoring in `mod.rs` to improve code clarity and maintainability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for fe3605562dd005a803c6480bfb18c17fe6164bef. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->