### PR TITLE
Fix broken link in docs

### DIFF
--- a/fern/01-guide/04-baml-basics/switching-llms.mdx
+++ b/fern/01-guide/04-baml-basics/switching-llms.mdx
@@ -55,7 +55,7 @@ and models, the default options, and setting [retry policies](/ref/llm-client-st
 
 <Tip>
 If you want to specify which client to use at runtime, in your Python/TS/Ruby code,
-you can use the [client registry](/guide/baml-advanced/client-registry) to do so.
+you can use the [client registry](/ref/baml-client/client-registry) to do so.
 
 This can come in handy if you're trying to, say, send 10% of your requests to a
 different model.


### PR DESCRIPTION
Fixes #1429
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken link in `switching-llms.mdx` to correct client registry documentation path.
> 
>   - **Docs**:
>     - Fix broken link in `switching-llms.mdx` from `/guide/baml-advanced/client-registry` to `/ref/baml-client/client-registry`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 65422b14f2b1b8a3e35e6cfb5bfa1ffe68d27e9e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->