### PR TITLE
Fix default None and Optional Nesting in python partial types

### DIFF
--- a/engine/language_client_codegen/src/python/generate_types.rs
+++ b/engine/language_client_codegen/src/python/generate_types.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use baml_types::LiteralValue;
+use baml_types::{FieldType, LiteralValue, TypeValue};
 use itertools::Itertools;
 use std::borrow::Cow;
 
@@ -8,7 +8,7 @@ use crate::{field_type_attributes, type_check_attributes, TypeCheckAttributes};
 use super::python_language_features::ToPython;
 use internal_baml_core::ir::{
     repr::{Docstring, IntermediateRepr, Walker},
-    ClassWalker, EnumWalker, FieldType, IRHelper,
+    ClassWalker, EnumWalker, IRHelper,
 };
 
 #[derive(askama::Template)]
@@ -74,9 +74,9 @@ impl<'ir> TryFrom<(&'ir IntermediateRepr, &'_ crate::GeneratorArgs)> for PythonT
             classes: ir.walk_classes().map(PythonClass::from).collect::<Vec<_>>(),
             structural_recursive_alias_cycles: {
                 let mut cycles = ir
-                .walk_alias_cycles()
-                .map(PythonTypeAlias::from)
-                .collect::<Vec<_>>();
+                    .walk_alias_cycles()
+                    .map(PythonTypeAlias::from)
+                    .collect::<Vec<_>>();
                 cycles.sort_by_key(|alias| alias.name.clone());
                 cycles
             },
@@ -128,6 +128,8 @@ impl<'ir> From<ClassWalker<'ir>> for PythonClass<'ir> {
                     (
                         Cow::Borrowed(f.elem.name.as_str()),
                         add_default_value(
+                            c.db,
+                            &f.elem.r#type.elem,
                             &f.elem.r#type.elem.to_type_ref(c.db, false),
                         ),
                         f.elem.docstring.as_ref().map(render_docstring),
@@ -185,14 +187,26 @@ impl<'ir> From<ClassWalker<'ir>> for PartialPythonClass<'ir> {
                     let field = match (done, needed) {
                         // A normal partial field.
                         (false, false) => add_default_value(
-                            &f.elem.r#type.elem.to_partial_type_ref(c.db, false, false)),
+                            c.db,
+                            &f.elem.r#type.elem,
+                            &f.elem.r#type.elem.to_partial_type_ref(c.db, false, false),
+                        ),
                         // A field with @stream.done and no @stream.not_null
                         (true, false) => add_default_value(
-                            &optional(&f.elem.r#type.elem.to_type_ref(c.db, true))
+                            c.db,
+                            &f.elem.r#type.elem,
+                            &optional(&f.elem.r#type.elem.to_type_ref(c.db, true)),
                         ),
                         (false, true) => add_default_value(
-                            &f.elem.r#type.elem.to_partial_type_ref(c.db, false, true)),
-                        (true, true) => f.elem.r#type.elem.to_type_ref(c.db, true), // TODO: Fix.
+                            c.db,
+                            &f.elem.r#type.elem,
+                            &f.elem.r#type.elem.to_partial_type_ref(c.db, false, true),
+                        ),
+                        (true, true) => add_default_value(
+                            c.db,
+                            &f.elem.r#type.elem,
+                            &f.elem.r#type.elem.to_type_ref(c.db, true), // TODO: Fix.
+                        ),
                     };
                     (
                         f.elem.name.as_str(),
@@ -206,12 +220,48 @@ impl<'ir> From<ClassWalker<'ir>> for PartialPythonClass<'ir> {
     }
 }
 
-/// For a field whose type
-pub fn add_default_value(type_str: &String) -> String {
+/// Add a default None value to class fields that support defaulting, i.e.
+/// `Optional[T]` fields and fields with a type that is unioned with `None`.
+pub fn add_default_value(
+    ir: &IntermediateRepr,
+    field_type: &FieldType,
+    type_str: &String,
+) -> String {
+    // Short-circuite with a None default value if the type starts with
+    // `Optional` because this case always unambiguously requires None.
     if type_str.starts_with("Optional[") {
+        return format!("{} = None", type_str);
+    }
+    if has_none_default(ir, field_type) {
         format!("{} = None", type_str)
     } else {
         type_str.clone()
+    }
+}
+
+/// Helper function for determining whether a field type should
+/// be given a default None value when generating a python class
+/// with that field.
+fn has_none_default(ir: &IntermediateRepr, field_type: &FieldType) -> bool {
+    let base_type = ir.distribute_metadata(field_type).0;
+    match base_type {
+        FieldType::Primitive(TypeValue::Null) => true,
+        FieldType::Primitive(_) => false,
+        FieldType::Optional(_) => true,
+        FieldType::Class(_) => false,
+        FieldType::Enum(_) => false,
+        FieldType::List(_) => false,
+        FieldType::Literal(_) => false,
+        FieldType::Map(_, _) => false,
+        FieldType::RecursiveTypeAlias(_) => false,
+        FieldType::Tuple(_) => false,
+        FieldType::Union(variants) => variants
+            .iter()
+            .map(|variant| has_none_default(ir, variant))
+            .any(|b| b),
+        FieldType::WithMetadata { .. } => {
+            unreachable!("FieldType::WithMetadata is always consumed by distribute_metadata")
+        }
     }
 }
 
@@ -250,7 +300,7 @@ trait ToTypeReferenceInTypeDefinition {
 impl ToTypeReferenceInTypeDefinition for FieldType {
     // TODO: use_module_prefix boolean blindness. Replace with str?
     fn to_type_ref(&self, ir: &IntermediateRepr, use_module_prefix: bool) -> String {
-        let module_prefix = if use_module_prefix { "types." } else {""};
+        let module_prefix = if use_module_prefix { "types." } else { "" };
         match self {
             FieldType::Enum(name) => {
                 if ir
@@ -268,7 +318,11 @@ impl ToTypeReferenceInTypeDefinition for FieldType {
             FieldType::Class(name) => format!("\"{module_prefix}{name}\""),
             FieldType::List(inner) => format!("List[{}]", inner.to_type_ref(ir, use_module_prefix)),
             FieldType::Map(key, value) => {
-                format!("Dict[{}, {}]", key.to_type_ref(ir, use_module_prefix), value.to_type_ref(ir, use_module_prefix))
+                format!(
+                    "Dict[{}, {}]",
+                    key.to_type_ref(ir, use_module_prefix),
+                    value.to_type_ref(ir, use_module_prefix)
+                )
             }
             FieldType::Primitive(r#type) => r#type.to_python(),
             FieldType::Union(inner) => format!(
@@ -287,7 +341,9 @@ impl ToTypeReferenceInTypeDefinition for FieldType {
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-            FieldType::Optional(inner) => format!("Optional[{}]", inner.to_type_ref(ir, use_module_prefix)),
+            FieldType::Optional(inner) => {
+                format!("Optional[{}]", inner.to_type_ref(ir, use_module_prefix))
+            }
             FieldType::WithMetadata { base, .. } => match field_type_attributes(self) {
                 Some(checks) => {
                     let base_type_ref = base.to_type_ref(ir, use_module_prefix);
@@ -298,7 +354,6 @@ impl ToTypeReferenceInTypeDefinition for FieldType {
             },
         }
     }
-
 
     fn to_partial_type_ref(&self, ir: &IntermediateRepr, wrapped: bool, needed: bool) -> String {
         let (base_type, metadata) = ir.distribute_metadata(self);
@@ -321,12 +376,16 @@ impl ToTypeReferenceInTypeDefinition for FieldType {
                     .map(|e| e.item.attributes.get("dynamic_type").is_some())
                     .unwrap_or(false)
                 {
-                    format!("Optional[Union[types.{name}, str]]")
+                    if needed || wrapped {
+                        format!("Union[types.{name}, str]")
+                    } else {
+                        format!("Optional[Union[types.{name}, str]]")
+                    }
                 } else {
-                    if needed {
+                    if needed || wrapped {
                         format!("types.{name}")
                     } else {
-                      format!("Optional[types.{name}]")
+                        format!("Optional[types.{name}]")
                     }
                 }
             }
@@ -337,47 +396,57 @@ impl ToTypeReferenceInTypeDefinition for FieldType {
                     format!("Optional[\"{name}\"]")
                 }
             }
-            FieldType::Literal(value) => format!("Optional[{}]", to_python_literal(value)), // TODO: Handle `needed` here.
-            FieldType::List(inner) => format!("List[{}]", inner.to_partial_type_ref(ir, true, false)),
-            FieldType::Map(key, value) => {
-                format!(
-                    "Dict[{}, {}]",
-                    key.to_type_ref(ir, use_module_prefix),
-                    value.to_partial_type_ref(ir, false, false)
-                )
+            FieldType::Literal(value) => if needed || wrapped {
+                to_python_literal(value)
+            } else {
+                format!("Optional[{}]", to_python_literal(value))
+            }, // TODO: Handle `needed` here.
+
+            FieldType::List(inner) => {
+                format!("List[{}]", inner.to_partial_type_ref(ir, true, false))
             }
+            FieldType::Map(key, value) => format!(
+                "Dict[{}, {}]",
+                key.to_type_ref(ir, use_module_prefix),
+                value.to_partial_type_ref(ir, false, false)
+            ),
             FieldType::Primitive(r#type) => {
-                if needed {
+                if needed || wrapped {
                     r#type.to_python()
                 } else {
-                format!("Optional[{}]", r#type.to_python())
+                    format!("Optional[{}]", r#type.to_python())
                 }
-            },
+            }
             FieldType::Union(inner) => {
-                let union_contents =
-                inner
+                let union_contents = inner
                     .iter()
                     .map(|t| t.to_partial_type_ref(ir, true, false))
                     .collect::<Vec<_>>()
                     .join(", ");
-                if needed {
+                if needed || wrapped {
                     format!("Union[{union_contents}]")
                 } else {
                     format!("Optional[Union[{union_contents}]]")
                 }
-            },
+            }
             FieldType::Tuple(inner) => {
-                let tuple_contents =
-                inner
+                let tuple_contents = inner
                     .iter()
                     .map(|t| t.to_partial_type_ref(ir, false, false))
                     .collect::<Vec<_>>()
                     .join(", ");
-                if needed { format!("Tuple[{tuple_contents}]") } else { format!("Optional[Tuple[{tuple_contents}]]")
+                if needed || wrapped {
+                    format!("Tuple[{tuple_contents}]")
+                } else {
+                    format!("Optional[Tuple[{tuple_contents}]]")
                 }
-            },
-            FieldType::Optional(inner) => inner.to_partial_type_ref(ir, false, false),
-            FieldType::WithMetadata{..} => unreachable!("distribute_metadata makes this branch unreachable."),
+            }
+            FieldType::Optional(inner) => {
+                format!("Optional[{}]", inner.to_partial_type_ref(ir, true, false))
+            }
+            FieldType::WithMetadata { .. } => {
+                unreachable!("distribute_metadata makes this branch unreachable.")
+            }
         };
         let base_type_ref = if is_partial_type {
             base_rep
@@ -389,16 +458,16 @@ impl ToTypeReferenceInTypeDefinition for FieldType {
             }
         };
         let rep_with_checks = match field_type_attributes(self) {
-          Some(checks) => {
-            let checks_type_ref = type_name_for_checks(&checks);
-            format!("Checked[{base_type_ref},{checks_type_ref}]")
-          },
-          None => base_type_ref
+            Some(checks) => {
+                let checks_type_ref = type_name_for_checks(&checks);
+                format!("Checked[{base_type_ref},{checks_type_ref}]")
+            }
+            None => base_type_ref,
         };
         let rep_with_stream_state = if with_state {
-          stream_state(&rep_with_checks)
+            stream_state(&rep_with_checks)
         } else {
-          rep_with_checks
+            rep_with_checks
         };
         rep_with_stream_state
     }
@@ -419,3 +488,32 @@ fn stream_state(base: &str) -> String {
     format!("StreamState[{base}]")
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use internal_baml_core::ir::repr::{make_test_ir, IntermediateRepr};
+
+    #[test]
+    fn test_optional_list() {
+        let ir = make_test_ir("").unwrap();
+        let optional_list = FieldType::Optional(Box::new(FieldType::List(Box::new(
+            FieldType::Primitive(TypeValue::String),
+        ))));
+        let full = optional_list.to_type_ref(&ir, false);
+        let partial = optional_list.to_partial_type_ref(&ir, false, false);
+        assert_eq!(full, "Optional[List[str]]");
+        assert_eq!(partial, "Optional[List[str]]");
+    }
+
+    #[test]
+    fn test_union() {
+        let ir = make_test_ir("").unwrap();
+        let optional_list = FieldType::Optional(Box::new(FieldType::List(Box::new(
+            FieldType::Primitive(TypeValue::String),
+        ))));
+        let full = optional_list.to_type_ref(&ir, false);
+        let partial = optional_list.to_partial_type_ref(&ir, false, false);
+        assert_eq!(full, "Optional[List[str]]");
+        assert_eq!(partial, "Optional[List[str]]");
+    }
+}

--- a/integ-tests/python/baml_client/partial_types.py
+++ b/integ-tests/python/baml_client/partial_types.py
@@ -97,7 +97,7 @@ class ComplexMemoryObject(BaseModel):
     id: Optional[str] = None
     name: Optional[str] = None
     description: Optional[str] = None
-    metadata: List[Optional[Union[Optional[str], Optional[int], Optional[float]]]]
+    metadata: List[Union[str, int, float]]
 
 class CompoundBigNumbers(BaseModel):
     big: Optional["BigNumbers"] = None
@@ -106,7 +106,7 @@ class CompoundBigNumbers(BaseModel):
 
 class ContactInfo(BaseModel):
     primary: Optional[Union["PhoneNumber", "EmailAddress"]] = None
-    secondary: Optional[Union["PhoneNumber", "EmailAddress", Optional[None]]] = None
+    secondary: Optional[Union["PhoneNumber", "EmailAddress", None]] = None
 
 class CustomTaskResult(BaseModel):
     bookOrder: Optional[Union["BookOrder", Optional[None]]] = None
@@ -141,7 +141,7 @@ class Education(BaseModel):
     institution: Optional[str] = None
     location: Optional[str] = None
     degree: Optional[str] = None
-    major: List[Optional[str]]
+    major: List[str]
     graduation_date: Optional[str] = None
 
 class Email(BaseModel):
@@ -195,7 +195,7 @@ class FormatterTest3(BaseModel):
 class GroceryReceipt(BaseModel):
     receiptId: Optional[str] = None
     storeName: Optional[str] = None
-    items: List[Optional[Union[Optional[str], Optional[int], Optional[float]]]]
+    items: List[Union[str, int, float]]
     totalAmount: Optional[float] = None
 
 class InnerClass(BaseModel):
@@ -259,13 +259,13 @@ class NamedArgsSingleClass(BaseModel):
     key_three: Optional[int] = None
 
 class Nested(BaseModel):
-    prop3: Optional[Union[Optional[str], Optional[None]]] = None
-    prop4: Optional[Union[Optional[str], Optional[None]]] = None
+    prop3: Optional[Union[str, Optional[None]]] = None
+    prop4: Optional[Union[str, Optional[None]]] = None
     prop20: Optional["Nested2"] = None
 
 class Nested2(BaseModel):
-    prop11: Optional[Union[Optional[str], Optional[None]]] = None
-    prop12: Optional[Union[Optional[str], Optional[None]]] = None
+    prop11: Optional[Union[str, Optional[None]]] = None
+    prop12: Optional[Union[str, Optional[None]]] = None
 
 class NestedBlockConstraint(BaseModel):
     nbc: Checked[Optional["BlockConstraint"],Literal["cross_field"]]
@@ -282,8 +282,8 @@ class NodeWithAliasIndirection(BaseModel):
     next: Optional["NodeWithAliasIndirection"] = None
 
 class OptionalListAndMap(BaseModel):
-    p: List[Optional[str]]
-    q: Dict[str, Optional[str]]
+    p: Optional[List[str]] = None
+    q: Optional[Dict[str, Optional[str]]] = None
 
 class OptionalTest_Prop1(BaseModel):
     omega_a: Optional[str] = None
@@ -315,7 +315,7 @@ class PhoneNumber(BaseModel):
     value: Optional[str] = None
 
 class Quantity(BaseModel):
-    amount: Optional[Union[Optional[int], Optional[float]]] = None
+    amount: Optional[Union[int, float]] = None
     unit: Optional[str] = None
 
 class RaysData(BaseModel):
@@ -325,7 +325,7 @@ class RaysData(BaseModel):
 class ReceiptInfo(BaseModel):
     items: List["ReceiptItem"]
     total_cost: Optional[float] = None
-    venue: Optional[Union[Optional[Literal["barisa"]], Optional[Literal["ox_burger"]]]] = None
+    venue: Optional[Union[Literal["barisa"], Literal["ox_burger"]]] = None
 
 class ReceiptItem(BaseModel):
     name: Optional[str] = None
@@ -335,7 +335,7 @@ class ReceiptItem(BaseModel):
 
 class Recipe(BaseModel):
     ingredients: Dict[str, Optional["Quantity"]]
-    recipe_type: Optional[Union[Optional[Literal["breakfast"]], Optional[Literal["dinner"]]]] = None
+    recipe_type: Optional[Union[Literal["breakfast"], Literal["dinner"]]] = None
 
 class RecursiveAliasDependency(BaseModel):
     value: Optional["JsonValue"] = None
@@ -345,25 +345,25 @@ class Resume(BaseModel):
     email: Optional[str] = None
     phone: Optional[str] = None
     experience: List["Education"]
-    education: List[Optional[str]]
-    skills: List[Optional[str]]
+    education: List[str]
+    skills: List[str]
 
 class Schema(BaseModel):
-    prop1: Optional[Union[Optional[str], Optional[None]]] = None
-    prop2: Optional[Union["Nested", Optional[str]]] = None
-    prop5: List[Optional[Union[Optional[str], Optional[None]]]]
-    prop6: Optional[Union[Optional[str], List["Nested"]]] = None
-    nested_attrs: List[Optional[Union[Optional[str], Optional[None], "Nested"]]]
-    parens: Optional[Union[Optional[str], Optional[None]]] = None
-    other_group: Optional[Union[Optional[str], Optional[Union[Optional[int], Optional[str]]]]] = None
+    prop1: Optional[Union[str, Optional[None]]] = None
+    prop2: Optional[Union["Nested", str]] = None
+    prop5: List[Union[str, Optional[None]]]
+    prop6: Optional[Union[str, List["Nested"]]] = None
+    nested_attrs: List[Union[str, Optional[None], "Nested"]]
+    parens: Optional[Union[str, Optional[None]]] = None
+    other_group: Optional[Union[str, Union[int, str]]] = None
 
 class SearchParams(BaseModel):
     dateRange: Optional[int] = None
-    location: List[Optional[str]]
+    location: List[str]
     jobTitle: Optional["WithReasoning"] = None
     company: Optional["WithReasoning"] = None
     description: List["WithReasoning"]
-    tags: List[Optional[Union[Optional[types.Tag], Optional[str]]]]
+    tags: List[Union[types.Tag, str]]
 
 class SemanticContainer(BaseModel):
     sixteen_digit_number: Optional[int] = None
@@ -405,8 +405,8 @@ class TestClassWithEnum(BaseModel):
     prop2: Optional[types.EnumInClass] = None
 
 class TestMemoryOutput(BaseModel):
-    items: List[Optional[Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]]
-    more_items: List[Optional[Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]]
+    items: List[Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
+    more_items: List[Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
 
 class TestOutputClass(BaseModel):
     prop1: Optional[str] = None
@@ -422,9 +422,9 @@ class TwoStoriesOneTitle(BaseModel):
     story_b: Optional[str] = None
 
 class UnionTest_ReturnType(BaseModel):
-    prop1: Optional[Union[Optional[str], Optional[bool]]] = None
-    prop2: List[Optional[Union[Optional[float], Optional[bool]]]]
-    prop3: Optional[Union[List[Optional[bool]], List[Optional[int]]]] = None
+    prop1: Optional[Union[str, bool]] = None
+    prop2: List[Union[float, bool]]
+    prop3: Optional[Union[List[bool], List[int]]] = None
 
 class WithReasoning(BaseModel):
     value: Optional[str] = None

--- a/integ-tests/python/baml_client/types.py
+++ b/integ-tests/python/baml_client/types.py
@@ -227,12 +227,12 @@ class CompoundBigNumbers(BaseModel):
 
 class ContactInfo(BaseModel):
     primary: Union["PhoneNumber", "EmailAddress"]
-    secondary: Union["PhoneNumber", "EmailAddress", None]
+    secondary: Union["PhoneNumber", "EmailAddress", None] = None
 
 class CustomTaskResult(BaseModel):
-    bookOrder: Union["BookOrder", Optional[None]]
-    flightConfirmation: Union["FlightConfirmation", Optional[None]]
-    groceryReceipt: Union["GroceryReceipt", Optional[None]]
+    bookOrder: Union["BookOrder", Optional[None]] = None
+    flightConfirmation: Union["FlightConfirmation", Optional[None]] = None
+    groceryReceipt: Union["GroceryReceipt", Optional[None]] = None
 
 class DummyOutput(BaseModel):
     model_config = ConfigDict(extra='allow')
@@ -380,13 +380,13 @@ class NamedArgsSingleClass(BaseModel):
     key_three: int
 
 class Nested(BaseModel):
-    prop3: Union[str, Optional[None]]
-    prop4: Union[str, Optional[None]]
+    prop3: Union[str, Optional[None]] = None
+    prop4: Union[str, Optional[None]] = None
     prop20: "Nested2"
 
 class Nested2(BaseModel):
-    prop11: Union[str, Optional[None]]
-    prop12: Union[str, Optional[None]]
+    prop11: Union[str, Optional[None]] = None
+    prop12: Union[str, Optional[None]] = None
 
 class NestedBlockConstraint(BaseModel):
     nbc: Checked["BlockConstraint",Literal["cross_field"]]
@@ -470,12 +470,12 @@ class Resume(BaseModel):
     skills: List[str]
 
 class Schema(BaseModel):
-    prop1: Union[str, Optional[None]]
+    prop1: Union[str, Optional[None]] = None
     prop2: Union["Nested", str]
     prop5: List[Union[str, Optional[None]]]
     prop6: Union[str, List["Nested"]]
     nested_attrs: List[Union[str, Optional[None], "Nested"]]
-    parens: Union[str, Optional[None]]
+    parens: Union[str, Optional[None]] = None
     other_group: Union[str, Union[int, str]]
 
 class SearchParams(BaseModel):


### PR DESCRIPTION
 - Closes #1419 by fixing the way Optional values and lists interact in the generation of partial Python types.
 - Adds `field = Null` default values to fields of pydantic classes in more cases (i.e. fields with `Union[.., None]` or `Union[.., Optional[..]]`

Tested with python integ-tests.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes handling of `Optional` and `Union` types in Python partial types generation, ensuring correct defaulting to `None`.
> 
>   - **Behavior**:
>     - Fixes interaction of `Optional` and `Union` types in partial Python types generation in `generate_types.rs`.
>     - Adds `field = None` default for fields with `Union[.., None]` or `Optional` types.
>   - **Functions**:
>     - Modifies `add_default_value()` to handle `Optional` and `Union` types correctly.
>     - Adds `has_none_default()` to determine if a field should default to `None`.
>   - **Tests**:
>     - Updates `partial_types.py` and `types.py` to reflect changes in default values.
>     - Adds test cases in `generate_types.rs` to verify `Optional` and `Union` handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c120579fd444ded8653ddfe10260a5ee0b92f309. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->