### PR TITLE
Enhance error handling and validation for duplicate definitions

### DIFF
--- a/engine/baml-lib/baml-core/src/lib.rs
+++ b/engine/baml-lib/baml-core/src/lib.rs
@@ -152,10 +152,9 @@ fn validate_type_builder_blocks(
         for type_def in &type_builder.entries {
             local_ast.tops.push(match type_def {
                 ast::TypeBuilderEntry::Class(c) => {
-                    if c.attributes.iter().any(|attr| attr.name.name() == "dynamic") {
-                        diagnostics.push_error(DatamodelError::new_validation_error(
-                            "The `@@dynamic` attribute is not allowed in type_builder blocks",
-                            c.span.to_owned(),
+                    if let Some(attr) = c.attributes.iter().find(|attr| attr.name.name() == "dynamic") {
+                        diagnostics.push_error(DatamodelError::disallow_dynamic_type_definitions(
+                            attr.span.to_owned(),
                         ));
                         continue;
                     }
@@ -163,10 +162,9 @@ fn validate_type_builder_blocks(
                     ast::Top::Class(c.to_owned())
                 },
                 ast::TypeBuilderEntry::Enum(e) => {
-                    if e.attributes.iter().any(|attr| attr.name.name() == "dynamic") {
-                        diagnostics.push_error(DatamodelError::new_validation_error(
-                            "The `@@dynamic` attribute is not allowed in type_builder blocks",
-                            e.span.to_owned(),
+                    if let Some(attr) = e.attributes.iter().find(|attr| attr.name.name() == "dynamic") {
+                        diagnostics.push_error(DatamodelError::disallow_dynamic_type_definitions(
+                            attr.span.to_owned(),
                         ));
                         continue;
                     }
@@ -174,10 +172,9 @@ fn validate_type_builder_blocks(
                     ast::Top::Enum(e.to_owned())
                 },
                 ast::TypeBuilderEntry::Dynamic(d) => {
-                    if d.attributes.iter().any(|attr| attr.name.name() == "dynamic") {
-                        diagnostics.push_error(DatamodelError::new_validation_error(
-                            "Dynamic type definitions cannot contain the `@@dynamic` attribute",
-                            d.span.to_owned(),
+                    if let Some(attr) = d.attributes.iter().find(|attr| attr.name.name() == "dynamic") {
+                        diagnostics.push_error(DatamodelError::disallow_dynamic_type_definitions(
+                            attr.span.to_owned(),
                         ));
                         continue;
                     }
@@ -229,7 +226,7 @@ fn validate_type_builder_blocks(
                             TypeWalker::TypeAlias(_) => {
                                 diagnostics.push_error(DatamodelError::new_validation_error(
                                     &format!("The `dynamic` keyword only works on classes and enums, but type '{}' is a type alias", d.name()),
-                                    d.span.to_owned(),
+                                    d.type_span.to_owned(),
                                 ));
                                 continue;
                             },

--- a/engine/baml-lib/baml/tests/validation_files/class/duplicate_definitions.baml
+++ b/engine/baml-lib/baml/tests/validation_files/class/duplicate_definitions.baml
@@ -1,0 +1,58 @@
+class A {
+  field string
+}
+
+class A {
+  field string
+}
+
+type A = int
+
+// error: The class "A" cannot be re-defined because it is already defined as one of these: "class", "type_alias".
+//   -->  class/duplicate_definitions.baml:1
+//    | 
+//    | 
+//  1 | class A {
+//    | 
+//   -->  class/duplicate_definitions.baml:5
+//    | 
+//  4 | 
+//  5 | class A {
+//    | 
+//   -->  class/duplicate_definitions.baml:9
+//    | 
+//  8 | 
+//  9 | type A = int
+//    | 
+// error: The class "A" cannot be re-defined because it is already defined as one of these: "class", "type_alias".
+//   -->  class/duplicate_definitions.baml:5
+//    | 
+//  4 | 
+//  5 | class A {
+//    | 
+//   -->  class/duplicate_definitions.baml:1
+//    | 
+//    | 
+//  1 | class A {
+//    | 
+//   -->  class/duplicate_definitions.baml:9
+//    | 
+//  8 | 
+//  9 | type A = int
+//    | 
+// error: The type_alias "A" cannot be re-defined because it is already defined as a class.
+//   -->  class/duplicate_definitions.baml:9
+//    | 
+//  8 | 
+//  9 | type A = int
+//    | 
+//   -->  class/duplicate_definitions.baml:1
+//    | 
+//    | 
+//  1 | class A {
+//    | 
+//   -->  class/duplicate_definitions.baml:5
+//    | 
+//  4 | 
+//  5 | class A {
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/class/invalid_type_aliases.baml
+++ b/engine/baml-lib/baml/tests/validation_files/class/invalid_type_aliases.baml
@@ -20,11 +20,27 @@ type Four = int | string | b
 //  8 | // Unexpected keyword.
 //  9 | typpe Two = float
 //    | 
-// error: The type_alias "One" cannot be defined because a class with that name already exists.
+// error: The class "One" cannot be re-defined because a type_alias with that name already exists.
+//   -->  class/invalid_type_aliases.baml:1
+//    | 
+//    | 
+//  1 | class One {
+//    | 
 //   -->  class/invalid_type_aliases.baml:6
 //    | 
 //  5 | // Already existing name.
 //  6 | type One = int
+//    | 
+// error: The type_alias "One" cannot be re-defined because a class with that name already exists.
+//   -->  class/invalid_type_aliases.baml:6
+//    | 
+//  5 | // Already existing name.
+//  6 | type One = int
+//    | 
+//   -->  class/invalid_type_aliases.baml:1
+//    | 
+//    | 
+//  1 | class One {
 //    | 
 // error: Error validating: Type alias points to unknown identifier `i`
 //   -->  class/invalid_type_aliases.baml:12

--- a/engine/baml-lib/baml/tests/validation_files/functions_v2/duplicate_names.baml
+++ b/engine/baml-lib/baml/tests/validation_files/functions_v2/duplicate_names.baml
@@ -8,11 +8,27 @@ function Bar(a: string, b: int | bool) -> int {
   prompt #"fa"#
 }
 
-// error: The function "Bar" cannot be defined because a function with that name already exists.
+// error: The function "Bar" cannot be re-defined because a function with that name already exists.
+//   -->  functions_v2/duplicate_names.baml:1
+//    | 
+//    | 
+//  1 | function Bar {
+//    | 
 //   -->  functions_v2/duplicate_names.baml:6
 //    | 
 //  5 | 
 //  6 | function Bar(a: string, b: int | bool) -> int {
+//    | 
+// error: The function "Bar" cannot be re-defined because a function with that name already exists.
+//   -->  functions_v2/duplicate_names.baml:6
+//    | 
+//  5 | 
+//  6 | function Bar(a: string, b: int | bool) -> int {
+//    | 
+//   -->  functions_v2/duplicate_names.baml:1
+//    | 
+//    | 
+//  1 | function Bar {
 //    | 
 // error: Invalid syntax for function "Bar". Use:
 // function Bar(params...) -> ReturnType { ... }

--- a/engine/baml-lib/baml/tests/validation_files/functions_v2/tests/failing_tests.baml
+++ b/engine/baml-lib/baml/tests/validation_files/functions_v2/tests/failing_tests.baml
@@ -80,15 +80,47 @@ test Bar {
   }
 }
 
-// error: Test "Foo" is already defined for function "InputImage".
-//   -->  functions_v2/tests/failing_tests.baml:71
+// error: Test "Foo" is already defined for function "InputImage"
+//   -->  functions_v2/tests/failing_tests.baml:72
 //    | 
-// 70 | 
 // 71 | test Foo {
+// 72 |   functions [InputImage]
 //    | 
-// error: Test "Bar" is already defined for function "InputEnum".
-//   -->  functions_v2/tests/failing_tests.baml:77
+//   -->  functions_v2/tests/failing_tests.baml:72
 //    | 
-// 76 | 
+// 71 | test Foo {
+// 72 |   functions [InputImage]
+//    | 
+// error: Test "Foo" is already defined for function "InputImage"
+//   -->  functions_v2/tests/failing_tests.baml:72
+//    | 
+// 71 | test Foo {
+// 72 |   functions [InputImage]
+//    | 
+//   -->  functions_v2/tests/failing_tests.baml:72
+//    | 
+// 71 | test Foo {
+// 72 |   functions [InputImage]
+//    | 
+// error: Test "Bar" is already defined for function "InputEnum"
+//   -->  functions_v2/tests/failing_tests.baml:78
+//    | 
 // 77 | test Bar {
+// 78 |   functions [InputEnum, InputEnum]
+//    | 
+//   -->  functions_v2/tests/failing_tests.baml:78
+//    | 
+// 77 | test Bar {
+// 78 |   functions [InputEnum, InputEnum]
+//    | 
+// error: Test "Bar" is already defined for function "InputEnum"
+//   -->  functions_v2/tests/failing_tests.baml:78
+//    | 
+// 77 | test Bar {
+// 78 |   functions [InputEnum, InputEnum]
+//    | 
+//   -->  functions_v2/tests/failing_tests.baml:78
+//    | 
+// 77 | test Bar {
+// 78 |   functions [InputEnum, InputEnum]
 //    | 

--- a/engine/baml-lib/baml/tests/validation_files/functions_v2/tests/failing_tests.baml
+++ b/engine/baml-lib/baml/tests/validation_files/functions_v2/tests/failing_tests.baml
@@ -86,16 +86,16 @@ test Bar {
 // 71 | test Foo {
 // 72 |   functions [InputImage]
 //    | 
-//   -->  functions_v2/tests/failing_tests.baml:72
+//   -->  functions_v2/tests/failing_tests.baml:66
 //    | 
-// 71 | test Foo {
-// 72 |   functions [InputImage]
+// 65 | test Foo {
+// 66 |   functions [InputImage]
 //    | 
 // error: Test "Foo" is already defined for function "InputImage"
-//   -->  functions_v2/tests/failing_tests.baml:72
+//   -->  functions_v2/tests/failing_tests.baml:66
 //    | 
-// 71 | test Foo {
-// 72 |   functions [InputImage]
+// 65 | test Foo {
+// 66 |   functions [InputImage]
 //    | 
 //   -->  functions_v2/tests/failing_tests.baml:72
 //    | 

--- a/engine/baml-lib/baml/tests/validation_files/tests/dynamic_types_validation_errors.baml
+++ b/engine/baml-lib/baml/tests/validation_files/tests/dynamic_types_validation_errors.baml
@@ -8,18 +8,6 @@ class NonDynamic {
   b string
 }
 
-test AttemptToModifyNonDynamicClass {
-  functions [TypeBuilderFn]
-  type_builder {
-    dynamic NonDynamic {
-      c string
-    }
-  }
-  args {
-    from_text "Test"
-  }
-}
-
 type SomeAlias = NonDynamic
 
 test AttemptToModifyTypeAlias {
@@ -92,60 +80,79 @@ test NameAlreadyExists {
   }
 }
 
-// error: Error validating: Type 'NonDynamic' does not contain the `@@dynamic` attribute so it cannot be modified in a type builder block
-//   -->  tests/dynamic_types_validation_errors.baml:14
-//    | 
-// 13 |   type_builder {
-// 14 |     dynamic NonDynamic {
-// 15 |       c string
-// 16 |     }
-//    | 
 // error: Error validating: The `dynamic` keyword only works on classes and enums, but type 'SomeAlias' is a type alias
-//   -->  tests/dynamic_types_validation_errors.baml:28
+//   -->  tests/dynamic_types_validation_errors.baml:16
 //    | 
-// 27 |   type_builder {
-// 28 |     dynamic SomeAlias {
-// 29 |       c string
-// 30 |     }
+// 15 |   type_builder {
+// 16 |     dynamic SomeAlias {
 //    | 
-// error: Error validating: The `@@dynamic` attribute is not allowed in type_builder blocks
-//   -->  tests/dynamic_types_validation_errors.baml:46
+// error: The `@@dynamic` attribute is not allowed in type_builder blocks.
+//   -->  tests/dynamic_types_validation_errors.baml:36
 //    | 
-// 45 |   type_builder {
-// 46 |     class NotAllowedHere {
-// 47 |       a string
-// 48 |       @@dynamic
-// 49 |     }
+// 35 |       a string
+// 36 |       @@dynamic
 //    | 
-// error: Error validating: The `@@dynamic` attribute is not allowed in type_builder blocks
-//   -->  tests/dynamic_types_validation_errors.baml:50
+// error: The `@@dynamic` attribute is not allowed in type_builder blocks.
+//   -->  tests/dynamic_types_validation_errors.baml:40
 //    | 
-// 49 |     }
-// 50 |     enum StillNotAllowed {
-// 51 |       A
-// 52 |       @@dynamic
-// 53 |     }
+// 39 |       A
+// 40 |       @@dynamic
 //    | 
-// error: Error validating: Dynamic type definitions cannot contain the `@@dynamic` attribute
-//   -->  tests/dynamic_types_validation_errors.baml:54
+// error: The `@@dynamic` attribute is not allowed in type_builder blocks.
+//   -->  tests/dynamic_types_validation_errors.baml:44
 //    | 
-// 53 |     }
-// 54 |     dynamic DynamicClass {
-// 55 |       c string
-// 56 |       @@dynamic
+// 43 |       c string
+// 44 |       @@dynamic
+//    | 
+// error: The class "DynamicClass" cannot be re-defined because a class with that name already exists.
+//   -->  tests/dynamic_types_validation_errors.baml:55
+//    | 
+// 54 |   type_builder {
+// 55 |     dynamic DynamicClass {
+// 56 |       c string
 // 57 |     }
 //    | 
-// error: Error validating: Multiple dynamic definitions for type `DynamicClass`
+//   -->  tests/dynamic_types_validation_errors.baml:58
+//    | 
+// 57 |     }
+// 58 |     dynamic DynamicClass {
+// 59 |       d string
+// 60 |     }
+//    | 
+// error: The class "DynamicClass" cannot be re-defined because a class with that name already exists.
+//   -->  tests/dynamic_types_validation_errors.baml:58
+//    | 
+// 57 |     }
+// 58 |     dynamic DynamicClass {
+// 59 |       d string
+// 60 |     }
+//    | 
+//   -->  tests/dynamic_types_validation_errors.baml:55
+//    | 
+// 54 |   type_builder {
+// 55 |     dynamic DynamicClass {
+// 56 |       c string
+// 57 |     }
+//    | 
+// error: The class "NonDynamic" cannot be re-defined because a class with that name already exists.
+//   -->  tests/dynamic_types_validation_errors.baml:6
+//    | 
+//  5 | 
+//  6 | class NonDynamic {
+//    | 
 //   -->  tests/dynamic_types_validation_errors.baml:70
 //    | 
-// 69 |     }
-// 70 |     dynamic DynamicClass {
-// 71 |       d string
-// 72 |     }
+// 69 |   type_builder {
+// 70 |     class NonDynamic {
 //    | 
-// error: The class "NonDynamic" cannot be defined because a class with that name already exists.
-//   -->  tests/dynamic_types_validation_errors.baml:82
+// error: The class "NonDynamic" cannot be re-defined because a class with that name already exists.
+//   -->  tests/dynamic_types_validation_errors.baml:70
 //    | 
-// 81 |   type_builder {
-// 82 |     class NonDynamic {
+// 69 |   type_builder {
+// 70 |     class NonDynamic {
+//    | 
+//   -->  tests/dynamic_types_validation_errors.baml:6
+//    | 
+//  5 | 
+//  6 | class NonDynamic {
 //    | 

--- a/engine/baml-lib/diagnostics/src/error.rs
+++ b/engine/baml-lib/diagnostics/src/error.rs
@@ -10,6 +10,7 @@ use std::{borrow::Cow, ops::Index};
 #[derive(Debug, Clone)]
 pub struct DatamodelError {
     span: Span,
+    multi_span: Option<Vec<Span>>,
     message: Cow<'static, str>,
 }
 
@@ -66,7 +67,12 @@ where
 impl DatamodelError {
     pub(crate) fn new(message: impl Into<Cow<'static, str>>, span: Span) -> Self {
         let message = message.into();
-        DatamodelError { message, span }
+        DatamodelError { message, span, multi_span: None }
+    }
+
+    pub(crate) fn new_with_span(message: impl Into<Cow<'static, str>>, span: Span, other_spans: Vec<Span>) -> Self {
+        let message = message.into();
+        DatamodelError { message, span, multi_span: Some(other_spans) }
     }
 
     pub fn new_anyhow_error(error: anyhow::Error, span: Span) -> Self {
@@ -213,25 +219,56 @@ impl DatamodelError {
     }
 
     pub fn new_duplicate_test_error(
-        test_name: &str,
         function_name: &str,
-        span: Span,
+        test_name: &str,
+        function_name_span: Span,
+        other_function_spans: Vec<Span>,
     ) -> DatamodelError {
-        let msg =
-            format!("Test \"{test_name}\" is already defined for function \"{function_name}\".");
-        Self::new(msg, span)
+        match other_function_spans.len() {
+            0 => {
+                unreachable!("Duplicate test error should only be called with a list of other tests");
+            }
+            _ => {
+                let msg = format!("Test \"{test_name}\" is already defined for function \"{function_name}\"");
+                Self::new_with_span(msg, function_name_span, other_function_spans)
+            }
+        }
     }
 
     pub fn new_duplicate_top_error(
         name: &str,
         top_type: &str,
-        existing_top_type: &str,
-        span: Span,
+        top_span: Span,
+        mut others: Vec<(&str, Span)>,
     ) -> DatamodelError {
-        let msg = format!(
-            "The {top_type} \"{name}\" cannot be defined because a {existing_top_type} with that name already exists.",
-        );
-        Self::new(msg, span)
+        match others.len() {
+            0 => {
+                unreachable!("Duplicate top error should only be called with a list of other tops");
+            }
+            1 => {
+                let (existing_top_type, existing_span) = others.remove(0);
+                let msg = format!(
+                    "The {top_type} \"{name}\" cannot be re-defined because a {existing_top_type} with that name already exists.",
+                );
+                Self::new_with_span(msg, top_span, vec![existing_span])
+            }
+            _ => {
+                let mut existing_top_types = others.iter().map(|(top_type, _)| top_type).collect::<Vec<_>>();
+                existing_top_types.sort();
+                // Remove duplicates
+                existing_top_types.dedup();
+                let existing_top_types = match existing_top_types.len() {
+                    0 => "".to_string(),
+                    1 => format!("a {}", existing_top_types[0]),
+                    _ => format!("one of these: {}", existing_top_types.iter().map(|top_type| format!("\"{}\"", top_type)).collect::<Vec<_>>().join(", "))
+                };
+
+                let msg = format!(
+                    "The {top_type} \"{name}\" cannot be re-defined because it is already defined as {existing_top_types}.",
+                );
+                Self::new_with_span(msg, top_span, others.into_iter().map(|(_, span)| span).collect())
+            }
+        }
     }
 
     pub fn new_duplicate_config_key_error(
@@ -367,6 +404,10 @@ impl DatamodelError {
             format!("Error validating datasource `{source}`: {message}"),
             span,
         )
+    }
+
+    pub fn disallow_dynamic_type_definitions(span: Span) -> DatamodelError {
+        Self::new("The `@@dynamic` attribute is not allowed in type_builder blocks.", span)
     }
 
     pub fn new_validation_error(message: &str, span: Span) -> DatamodelError {
@@ -647,7 +688,7 @@ impl DatamodelError {
     pub fn pretty_print(&self, f: &mut dyn std::io::Write) -> std::io::Result<()> {
         pretty_print(
             f,
-            self.span(),
+            &std::iter::once(self.span()).chain(self.multi_span.iter().flatten()).collect::<Vec<_>>(),
             self.message.as_ref(),
             &DatamodelErrorColorer {},
         )

--- a/engine/baml-lib/diagnostics/src/pretty_print.rs
+++ b/engine/baml-lib/diagnostics/src/pretty_print.rs
@@ -11,37 +11,13 @@ pub trait DiagnosticColorer {
 /// the offending portion of the source code, for human-friendly reading.
 pub(crate) fn pretty_print(
     f: &mut dyn std::io::Write,
-    span: &Span,
+    spans: &[&Span],
     description: &str,
     colorer: &'static dyn DiagnosticColorer,
 ) -> std::io::Result<()> {
-    let file_name = span.file.path();
-    let text = span.file.as_str();
-
-    let start_line_number = text[..span.start].matches('\n').count();
-    let end_line_number = text[..span.end].matches('\n').count();
-    let file_lines = text.split('\n').collect::<Vec<&str>>();
-
-    let chars_in_line_before: usize = file_lines[..start_line_number]
-        .iter()
-        .map(|l| l.len())
-        .sum();
-    // Don't forget to count the all the line breaks.
-    let chars_in_line_before = chars_in_line_before + start_line_number;
-
-    let line = &file_lines[start_line_number];
-
-    let start_in_line = span.start - chars_in_line_before;
-    let end_in_line = std::cmp::min(start_in_line + (span.end - span.start), line.len());
-
-    let prefix = &line[..start_in_line];
-    let offending = colorer
-        .primary_color(&line[start_in_line..end_in_line])
-        .bold();
-    let suffix = &line[end_in_line..];
-
-    let arrow = "-->".bright_blue().bold();
-    let file_path = format!("{}:{}", file_name, start_line_number + 1).underline();
+    if spans.is_empty() {
+        return Ok(());
+    }
 
     writeln!(
         f,
@@ -49,42 +25,60 @@ pub(crate) fn pretty_print(
         colorer.primary_color(colorer.title()).bold(),
         description.bold()
     )?;
-    writeln!(f, "  {arrow}  {file_path}")?;
-    writeln!(f, "{}", format_line_number(0))?;
 
-    writeln!(
-        f,
-        "{}",
-        format_line_number_with_line(start_line_number, &file_lines)
-    )?;
-    writeln!(
-        f,
-        "{}{}{}{}",
-        format_line_number(start_line_number + 1),
-        prefix,
-        offending,
-        suffix
-    )?;
-    if offending.len() == 0 {
-        let spacing = " ".repeat(start_in_line);
-        writeln!(
-            f,
-            "{}{}{}",
-            format_line_number(0),
-            spacing,
-            colorer.primary_color("^ Unexpected token.").bold()
+    for span in spans {
+        let file_name = span.file.path();
+        let text = span.file.as_str();
+        let file_lines = text.split('\n').collect::<Vec<&str>>();
+
+        let start_line_number = text[..span.start].matches('\n').count();
+        let end_line_number = text[..span.end].matches('\n').count();
+
+        let chars_in_line_before: usize = file_lines[..start_line_number]
+            .iter()
+            .map(|l| l.len())
+            .sum::<usize>()
+            + start_line_number;
+
+        let line = &file_lines[start_line_number];
+
+        let start_in_line = span.start - chars_in_line_before;
+        let end_in_line = std::cmp::min(start_in_line + (span.end - span.start), line.len());
+
+        let prefix = &line[..start_in_line];
+        let offending = colorer.primary_color(&line[start_in_line..end_in_line]).bold();
+        let suffix = &line[end_in_line..];
+
+        let arrow = "-->".bright_blue().bold();
+        let file_path = format!("{}:{}", file_name, start_line_number + 1).underline();
+
+        writeln!(f, "  {arrow}  {file_path}")?;
+        writeln!(f, "{}", format_line_number(0))?;
+
+        writeln!(f, "{}", format_line_number_with_line(start_line_number, &file_lines))?;
+        writeln!(f, "{}{}{}{}",
+                 format_line_number(start_line_number + 1),
+                 prefix,
+                 offending,
+                 suffix
         )?;
+        if offending.len() == 0 {
+            let spacing = " ".repeat(start_in_line);
+            writeln!(f, "{}{}{}",
+                     format_line_number(0),
+                     spacing,
+                     colorer.primary_color("^ Unexpected token.").bold()
+            )?;
+        }
+
+        for line_number in start_line_number + 2..end_line_number + 2 {
+            writeln!(f, "{}", format_line_number_with_line(line_number, &file_lines))?;
+        }
+
+        writeln!(f, "{}", format_line_number(0))?;
     }
 
-    for line_number in start_line_number + 2..end_line_number + 2 {
-        writeln!(
-            f,
-            "{}",
-            format_line_number_with_line(line_number, &file_lines)
-        )?;
-    }
-
-    writeln!(f, "{}", format_line_number(0))
+    Ok(())
 }
 
 fn format_line_number_with_line(line_number: usize, lines: &[&str]) -> colored::ColoredString {

--- a/engine/baml-lib/diagnostics/src/warning.rs
+++ b/engine/baml-lib/diagnostics/src/warning.rs
@@ -160,7 +160,7 @@ impl DatamodelWarning {
     pub fn pretty_print(&self, f: &mut dyn std::io::Write) -> std::io::Result<()> {
         pretty_print(
             f,
-            self.span(),
+            &[self.span()],
             self.message.as_ref(),
             &DatamodelWarningColorer {},
         )

--- a/engine/baml-lib/parser-database/src/names/mod.rs
+++ b/engine/baml-lib/parser-database/src/names/mod.rs
@@ -22,8 +22,8 @@ pub(super) struct Names {
     pub(super) tops: HashMap<StringId, TopId>,
     /// Generators have their own namespace.
     pub(super) generators: HashMap<StringId, TopId>,
-    /// Tests have their own namespace.
-    pub(super) tests: HashMap<StringId, HashMap<StringId, TopId>>,
+    /// Tests have their own namespace. <function_name, <test_name, test_id>>
+    pub(super) tests: HashMap<StringId, HashMap<StringId, Span>>,
     pub(super) model_fields: HashMap<(ast::TypeExpId, StringId), ast::FieldId>,
 }
 
@@ -73,7 +73,10 @@ impl DuplicateNames {
                     .filter_map(|(i, data)| if i != idx { Some(data.clone()) } else { None })
                     .collect::<Vec<_>>();
                 ctx.push_error(DatamodelError::new_duplicate_top_error(
-                    ast_top.name().strip_prefix(ast::DYNAMIC_TYPE_NAME_PREFIX).unwrap(),
+                    ast_top
+                        .name()
+                        .strip_prefix(ast::DYNAMIC_TYPE_NAME_PREFIX)
+                        .unwrap(),
                     ast_top.get_type(),
                     ast_top.identifier().span().clone(),
                     others,
@@ -83,7 +86,11 @@ impl DuplicateNames {
 
         for (test_name, tests) in self.tests {
             for (idx, (function_name, function_name_span)) in tests.iter().enumerate() {
-                let others = tests.iter().enumerate().filter_map(|(i, data)| if i != idx { Some(data.clone()) } else { None }).collect::<Vec<_>>();
+                let others = tests
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, data)| if i != idx { Some(data.clone()) } else { None })
+                    .collect::<Vec<_>>();
                 let test_name = ctx.interner.get(test_name).unwrap();
                 ctx.push_error(DatamodelError::new_duplicate_test_error(
                     function_name,
@@ -262,7 +269,7 @@ pub(super) fn resolve_names(ctx: &mut Context<'_>) {
                     let func_id = ctx.interner.intern(func_name);
                     let namespace = names.tests.entry(func_id).or_insert_with(HashMap::default);
                     let test_name = ctx.interner.intern(top.name());
-                    if let Some(existing) = namespace.insert(test_name, top_id) {
+                    if let Some(existing) = namespace.insert(test_name, func_name_span.clone()) {
                         duplicate_names
                             .tests
                             .entry(test_name)
@@ -272,7 +279,7 @@ pub(super) fn resolve_names(ctx: &mut Context<'_>) {
                             .tests
                             .entry(test_name)
                             .or_insert_with(Vec::default)
-                            .push((func_name.to_string(), func_name_span.clone()));
+                            .push((func_name.to_string(), existing));
                     }
                 }
             }

--- a/engine/baml-lib/parser-database/src/names/mod.rs
+++ b/engine/baml-lib/parser-database/src/names/mod.rs
@@ -5,7 +5,9 @@ use crate::{
     coerce, coerce_array, Context, DatamodelError, StaticType, StringId,
 };
 
-use baml_types::FieldType;
+use baml_types::{BamlMap, FieldType};
+use indexmap::map::IndexedEntry;
+use internal_baml_diagnostics::Span;
 use internal_baml_schema_ast::ast::{ConfigBlockProperty, Expression, Field, WithIdentifier};
 
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -23,7 +25,75 @@ pub(super) struct Names {
     /// Tests have their own namespace.
     pub(super) tests: HashMap<StringId, HashMap<StringId, TopId>>,
     pub(super) model_fields: HashMap<(ast::TypeExpId, StringId), ast::FieldId>,
-    // pub(super) composite_type_fields: HashMap<(ast::CompositeTypeId, StringId), ast::FieldId>,
+}
+
+#[derive(Default)]
+struct DuplicateNames {
+    tops: BamlMap<StringId, indexmap::IndexSet<TopId>>,
+    generators: BamlMap<StringId, indexmap::IndexSet<TopId>>,
+    // test_name: vec<(function_name, function_name_span)>
+    tests: BamlMap<StringId, Vec<(String, Span)>>,
+    dynamic_types: BamlMap<StringId, indexmap::IndexSet<TopId>>,
+}
+
+impl DuplicateNames {
+    fn to_errors(self, ctx: &mut Context<'_>) {
+        for category in [self.tops, self.generators] {
+            for (name, ids) in category {
+                let ast_tops = ids.iter().map(|id| &ctx.ast[*id]).collect::<Vec<_>>();
+                let others = ast_tops
+                    .iter()
+                    .map(|ast_top| (ast_top.get_type(), ast_top.identifier().span().clone()))
+                    .collect::<Vec<_>>();
+                for (idx, ast_top) in ast_tops.iter().enumerate() {
+                    let others = others
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(i, data)| if i != idx { Some(data.clone()) } else { None })
+                        .collect::<Vec<_>>();
+                    ctx.push_error(DatamodelError::new_duplicate_top_error(
+                        ast_top.name(),
+                        ast_top.get_type(),
+                        ast_top.identifier().span().clone(),
+                        others,
+                    ));
+                }
+            }
+        }
+        for (name, ids) in self.dynamic_types {
+            let ast_tops = ids.iter().map(|id| &ctx.ast[*id]).collect::<Vec<_>>();
+            let others = ast_tops
+                .iter()
+                .map(|ast_top| (ast_top.get_type(), ast_top.identifier().span().clone()))
+                .collect::<Vec<_>>();
+            for (idx, ast_top) in ast_tops.iter().enumerate() {
+                let others = others
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, data)| if i != idx { Some(data.clone()) } else { None })
+                    .collect::<Vec<_>>();
+                ctx.push_error(DatamodelError::new_duplicate_top_error(
+                    ast_top.name().strip_prefix(ast::DYNAMIC_TYPE_NAME_PREFIX).unwrap(),
+                    ast_top.get_type(),
+                    ast_top.identifier().span().clone(),
+                    others,
+                ));
+            }
+        }
+
+        for (test_name, tests) in self.tests {
+            for (idx, (function_name, function_name_span)) in tests.iter().enumerate() {
+                let others = tests.iter().enumerate().filter_map(|(i, data)| if i != idx { Some(data.clone()) } else { None }).collect::<Vec<_>>();
+                let test_name = ctx.interner.get(test_name).unwrap();
+                ctx.push_error(DatamodelError::new_duplicate_test_error(
+                    function_name,
+                    test_name,
+                    function_name_span.clone(),
+                    others.iter().map(|(_, span)| span.clone()).collect(),
+                ));
+            }
+        }
+    }
 }
 
 /// `resolve_names()` is responsible for populating `ParserDatabase.names` and
@@ -35,6 +105,8 @@ pub(super) struct Names {
 pub(super) fn resolve_names(ctx: &mut Context<'_>) {
     let mut tmp_names: HashSet<&str> = HashSet::default(); // throwaway container for duplicate checking
     let mut names = Names::default();
+
+    let mut duplicate_names = DuplicateNames::default();
 
     for (top_id, top) in ctx.ast.iter_tops() {
         assert_is_not_a_reserved_scalar_type(top.identifier(), ctx);
@@ -163,7 +235,7 @@ pub(super) fn resolve_names(ctx: &mut Context<'_>) {
                     .iter_fields()
                     .find(|f| f.1.name() == "functions")
                     .and_then(|f| match f.1.expr {
-                        Some(ref v) => coerce_array(v, &coerce::string, ctx.diagnostics),
+                        Some(ref v) => coerce_array(v, &coerce::string_with_span, ctx.diagnostics),
                         None => None,
                     });
 
@@ -183,19 +255,24 @@ pub(super) fn resolve_names(ctx: &mut Context<'_>) {
 
         match namespace {
             Some(either::Left(namespace)) => {
-                insert_name(top_id, top, namespace, ctx);
+                insert_name(top_id, top, &mut duplicate_names, namespace, ctx);
             }
             Some(either::Right(test_functions)) => {
-                for func_name in test_functions {
+                for (func_name, func_name_span) in test_functions {
                     let func_id = ctx.interner.intern(func_name);
                     let namespace = names.tests.entry(func_id).or_insert_with(HashMap::default);
-                    let name = ctx.interner.intern(top.name());
-                    if namespace.insert(name, top_id).is_some() {
-                        ctx.push_error(DatamodelError::new_duplicate_test_error(
-                            top.name(),
-                            func_name,
-                            top.identifier().span().clone(),
-                        ));
+                    let test_name = ctx.interner.intern(top.name());
+                    if let Some(existing) = namespace.insert(test_name, top_id) {
+                        duplicate_names
+                            .tests
+                            .entry(test_name)
+                            .or_insert_with(Vec::default)
+                            .push((func_name.to_string(), func_name_span.clone()));
+                        duplicate_names
+                            .tests
+                            .entry(test_name)
+                            .or_insert_with(Vec::default)
+                            .push((func_name.to_string(), func_name_span.clone()));
                     }
                 }
             }
@@ -203,50 +280,48 @@ pub(super) fn resolve_names(ctx: &mut Context<'_>) {
         }
     }
 
+    duplicate_names.to_errors(ctx);
     let _ = std::mem::replace(ctx.names, names);
 }
 
 fn insert_name(
     top_id: TopId,
     top: &ast::Top,
+    duplicate_names: &mut DuplicateNames,
     namespace: &mut HashMap<StringId, TopId>,
     ctx: &mut Context<'_>,
 ) {
     let name = ctx.interner.intern(top.name());
 
     if let Some(existing) = namespace.insert(name, top_id) {
-        let current_type = top.get_type();
-
         // TODO: #1343 Temporary solution until we implement scoping in the AST.
         if ctx.ast[existing]
             .name()
             .starts_with(ast::DYNAMIC_TYPE_NAME_PREFIX)
         {
-            return ctx.push_error(DatamodelError::new_validation_error(
-                &format!(
-                    "Multiple dynamic definitions for type `{}`",
-                    ctx.ast[existing]
-                        .name()
-                        .strip_prefix(ast::DYNAMIC_TYPE_NAME_PREFIX)
-                        .unwrap()
-                ),
-                top.span().to_owned(),
-            ));
-        }
-
-        if current_type != "impl<llm>" && current_type != "impl<?>" {
-            ctx.push_error(duplicate_top_error(&ctx.ast[existing], top));
+            duplicate_names
+                .dynamic_types
+                .entry(name)
+                .or_insert_with(indexmap::IndexSet::default)
+                .insert(existing);
+            duplicate_names
+                .dynamic_types
+                .entry(name)
+                .or_insert_with(indexmap::IndexSet::default)
+                .insert(top_id);
+        } else {
+            duplicate_names
+                .tops
+                .entry(name)
+                .or_insert_with(indexmap::IndexSet::default)
+                .insert(existing);
+            duplicate_names
+                .tops
+                .entry(name)
+                .or_insert_with(indexmap::IndexSet::default)
+                .insert(top_id);
         }
     }
-}
-
-fn duplicate_top_error(existing: &ast::Top, duplicate: &ast::Top) -> DatamodelError {
-    DatamodelError::new_duplicate_top_error(
-        duplicate.name(),
-        duplicate.get_type(),
-        existing.get_type(),
-        duplicate.identifier().span().clone(),
-    )
 }
 
 fn assert_is_not_a_reserved_scalar_type(ident: &ast::Identifier, ctx: &mut Context<'_>) {

--- a/engine/baml-lib/schema-ast/src/ast/top.rs
+++ b/engine/baml-lib/schema-ast/src/ast/top.rs
@@ -32,7 +32,6 @@ impl Top {
     /// A string saying what kind of item this is.
     pub fn get_type(&self) -> &str {
         match self {
-            // Top::CompositeType(_) => "composite type",
             Top::Enum(_) => "enum",
             Top::Class(_) => "class",
             Top::Function(_) => "function",

--- a/engine/baml-lib/schema-ast/src/ast/type_expression_block.rs
+++ b/engine/baml-lib/schema-ast/src/ast/type_expression_block.rs
@@ -86,6 +86,7 @@ pub struct TypeExpressionBlock {
 
     /// This is used to distinguish between enums and classes.
     pub sub_type: SubType,
+    pub type_span: Span,
     /// TODO: #1343 Temporary solution until we implement scoping in the AST.
     pub is_dynamic_type_def: bool,
 }

--- a/engine/baml-lib/schema-ast/src/parser/parse_type_expression_block.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_type_expression_block.rs
@@ -23,7 +23,7 @@ pub(crate) fn parse_type_expression_block(
     let mut name: Option<Identifier> = None;
     let mut attributes: Vec<Attribute> = Vec::new();
     let mut fields: Vec<Field<FieldType>> = Vec::new();
-    let mut sub_type: Option<SubType> = None;
+    let mut sub_type: Option<_> = None;
     let mut input = None;
 
     for current in pair.into_inner() {
@@ -36,9 +36,9 @@ pub(crate) fn parse_type_expression_block(
                 if sub_type.is_none() {
                     // First identifier is the type of block (e.g. class, enum).
                     match current.as_str() {
-                        "class" => sub_type = Some(SubType::Class),
-                        "enum" => sub_type = Some(SubType::Enum),
-                        "dynamic" => sub_type = Some(SubType::Dynamic),
+                        "class" => sub_type = Some((SubType::Class, current.as_span())),
+                        "enum" => sub_type = Some((SubType::Enum, current.as_span())),
+                        "dynamic" => sub_type = Some((SubType::Dynamic, current.as_span())),
 
                         // Report this as an error, otherwise the syntax will be
                         // correct but the type will not be registered and the
@@ -51,7 +51,7 @@ pub(crate) fn parse_type_expression_block(
                                 diagnostics.span(current.as_span()),
                             ));
 
-                            sub_type = Some(SubType::Other(other.to_string()))
+                            sub_type = Some((SubType::Other(other.to_string()), current.as_span()));
                         }
                     }
                 } else {
@@ -74,14 +74,14 @@ pub(crate) fn parse_type_expression_block(
                             attributes.push(parse_attribute(item, false, diagnostics));
                         }
                         Rule::type_expression =>{
-                            let sub_type_is_enum = matches!(sub_type, Some(SubType::Enum));
+                            let sub_type_is_enum = matches!(sub_type, Some((SubType::Enum, _)));
                             let sub_type_expression = parse_type_expr(
                                 &name,
                                 sub_type.clone().map(|st| match st {
-                                    SubType::Enum => "Enum",
-                                    SubType::Class => "Class",
-                                    SubType::Dynamic => "Dynamic",
-                                    SubType::Other(_) => "Other",
+                                    (SubType::Enum, _) => "Enum",
+                                    (SubType::Class, _) => "Class",
+                                    (SubType::Dynamic, _) => "Dynamic",
+                                    (SubType::Other(_), _) => "Other",
                                 }).unwrap_or(""),
                                 item,
                                 pending_field_comment.take(),
@@ -97,7 +97,7 @@ pub(crate) fn parse_type_expression_block(
                         Rule::BLOCK_LEVEL_CATCH_ALL => {
                             diagnostics.push_error(DatamodelError::new_validation_error(
                                 match sub_type {
-                                    Some(SubType::Enum) => "This line is not an enum value definition. BAML enums don't have commas, and all values must be all caps.",
+                                    Some((SubType::Enum, _)) => "This line is not an enum value definition. BAML enums don't have commas, and all values must be all caps.",
                                     _ => "This line is not a valid field or attribute definition. A valid class property looks like: 'myProperty string[] @description(\"This is a description\")'",
                                 },
                                 diagnostics.span(item.as_span()),
@@ -112,6 +112,9 @@ pub(crate) fn parse_type_expression_block(
         }
     }
 
+    let sub_type = sub_type.unwrap_or((SubType::Other("Subtype not found".to_string()), pair_span));
+    let is_dynamic_type_def = matches!(sub_type.0, SubType::Dynamic);
+
     match name {
         Some(name) => TypeExpressionBlock {
             name,
@@ -120,10 +123,9 @@ pub(crate) fn parse_type_expression_block(
             attributes,
             documentation: doc_comment.and_then(parse_comment_block),
             span: diagnostics.span(pair_span),
-            sub_type: sub_type
-                .clone()
-                .unwrap_or(SubType::Other("Subtype not found".to_string())),
-            is_dynamic_type_def: matches!(sub_type, Some(SubType::Dynamic)),
+            sub_type: sub_type.0,
+            type_span: diagnostics.span(sub_type.1),
+            is_dynamic_type_def,
         },
         _ => panic!("Encountered impossible type_expression declaration during parsing",),
     }


### PR DESCRIPTION
- Improve error messages for duplicate class, type alias, function, and test definitions
- Update error reporting to show multiple spans for duplicate definitions
- Add support for showing multiple conflicting definition types in error messages

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance error handling for duplicate definitions by improving error messages and supporting multiple spans and conflicting types.
> 
>   - **Error Handling**:
>     - Improved error messages for duplicate class, type alias, function, and test definitions in `lib.rs` and `error.rs`.
>     - Updated error reporting to show multiple spans for duplicate definitions in `pretty_print.rs`.
>     - Added support for showing multiple conflicting definition types in error messages in `error.rs`.
>   - **Validation**:
>     - Enhanced validation logic in `names/mod.rs` to handle duplicate names and dynamic types.
>     - Added new test cases for duplicate definitions in `duplicate_definitions.baml` and `invalid_type_aliases.baml`.
>   - **Miscellaneous**:
>     - Refactored `parse_type_expression_block.rs` to handle new error types.
>     - Updated `TypeExpressionBlock` in `type_expression_block.rs` to include `type_span` and `is_dynamic_type_def`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 215d746e6d24747d6c08aca24cd22c061d41f512. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->