### PR TITLE
feat: Add duration display option to test panel tabular view

### DIFF
--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
@@ -329,9 +329,7 @@ export const TabularView: React.FC<TabularViewProps> = ({ currentRun }) => {
                 {config.showDuration && (
                   <TableCell className='px-1 py-1 whitespace-normal'>
                     {test.response.status === 'done' && (
-                      <span className='text-xs text-muted-foreground'>
-                        {(test.response.latency_ms).toFixed(0)} ms
-                      </span>
+                      <span className='text-xs text-muted-foreground'>{test.response.latency_ms.toFixed(0)} ms</span>
                     )}
                   </TableCell>
                 )}

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
@@ -88,7 +88,8 @@ const ResponseContent = ({
         <>
           <ParsedResponseRenderer response={getTestStateResponse(state)} />
 
-          {getExplanation(state) && (
+          {/* Don't show the explanation for now. */}
+          {false && getExplanation(state) && (
             <div className='flex flex-col gap-2 mt-2 text-xs text-muted-foreground/80'>
               <div>BAML parser fixed the following issues:</div>
               <pre>{getExplanation(state)}</pre>
@@ -178,6 +179,18 @@ export const TabularView: React.FC<TabularViewProps> = ({ currentRun }) => {
             Model
           </Label>
         </div>
+        <div className='flex items-center space-x-2'>
+          <input
+            type='checkbox'
+            id='showDuration'
+            checked={config.showDuration}
+            onChange={() => toggleConfig('showDuration')}
+            className='w-4 h-4 rounded opacity-80 text-primary focus:ring-primary'
+          />
+          <Label htmlFor='showDuration' className='text-muted-foreground/80'>
+            Duration
+          </Label>
+        </div>
       </div>
 
       <Table className='w-full table-fixed'>
@@ -199,6 +212,7 @@ export const TabularView: React.FC<TabularViewProps> = ({ currentRun }) => {
             </TableHead>
             <TableHead className='w-[10%] px-1 py-1'>Status</TableHead>
             {config.showModel && <TableHead className='w-[10%] py-1'>Model</TableHead>}
+            {config.showDuration && <TableHead className='w-[10%] py-1'>Duration</TableHead>}
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -308,6 +322,15 @@ export const TabularView: React.FC<TabularViewProps> = ({ currentRun }) => {
                     {test.response.status === 'done' && test.response.response && (
                       <span className='text-xs text-muted-foreground'>
                         {test.response.response.llm_response()?.model}
+                      </span>
+                    )}
+                  </TableCell>
+                )}
+                {config.showDuration && (
+                  <TableCell className='px-1 py-1 whitespace-normal'>
+                    {test.response.status === 'done' && (
+                      <span className='text-xs text-muted-foreground'>
+                        {(test.response.latency_ms).toFixed(0)} ms
                       </span>
                     )}
                   </TableCell>

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/atoms.ts
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/atoms.ts
@@ -14,6 +14,7 @@ export interface TabularViewConfig {
   showInputs: boolean
   showModel: boolean
   responseViewType: ResponseViewType
+  showDuration: boolean
 }
 
 export const testPanelViewTypeAtom = atomWithStorage<TestPanelViewType>('testPanelViewType', TestPanelViewType.TABULAR)
@@ -21,4 +22,5 @@ export const tabularViewConfigAtom = atomWithStorage<TabularViewConfig>('tabular
   showInputs: true,
   showModel: false,
   responseViewType: 'parsed',
+  showDuration: false,
 })


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add duration display option to test panel's tabular view with a toggle in `TabularView.tsx`.
> 
>   - **Feature**:
>     - Add `showDuration` checkbox to `TabularView.tsx` to toggle duration display in test panel.
>     - Display duration in milliseconds if `showDuration` is enabled and test status is 'done'.
>   - **Configuration**:
>     - Add `showDuration` to `TabularViewConfig` in `atoms.ts`.
>     - Default `showDuration` to `false` in `tabularViewConfigAtom`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 114831f60ea3883e232fc2767aeb3532188dca8d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->