### PR TITLE
remove boundary cloud functions from docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -162,15 +162,15 @@ navigation:
             path: 01-guide/05-baml-advanced/checks-and-asserts.mdx
       - section: Boundary Cloud
         contents:
-          - section: Functions
-            icon: fa-cloud
-            contents:
-              - page: Get Started
-                path: 01-guide/functions/get-started.mdx
-              - page: Using OpenAPI
-                path: 01-guide/functions/using-openapi.mdx
-              - page: Environment Variables
-                path: 01-guide/functions/environment-variables.mdx
+          # - section: Functions
+          #   icon: fa-cloud
+          #   contents:
+          #     - page: Get Started
+          #       path: 01-guide/functions/get-started.mdx
+          #     - page: Using OpenAPI
+          #       path: 01-guide/functions/using-openapi.mdx
+          #     - page: Environment Variables
+          #       path: 01-guide/functions/environment-variables.mdx
           - section: Observability
             icon: fa-chart-simple
             contents:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Comments out 'Functions' section under 'Boundary Cloud' in `docs.yml`, removing related pages from navigation.
> 
>   - **Documentation**:
>     - Comments out the 'Functions' section under 'Boundary Cloud' in `docs.yml`, removing it from the navigation.
>     - Affected pages include 'Get Started', 'Using OpenAPI', and 'Environment Variables'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 216aa010cd8f6e60e1b1d021de45d4c339516856. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->