### PR TITLE
bump 0.76.1

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "baml-cli"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -897,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "baml-lib"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "base64 0.13.1",
  "dissimilar",
@@ -941,7 +941,7 @@ dependencies = [
 
 [[package]]
 name = "baml-runtime"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "ambassador",
  "anyhow",
@@ -1041,7 +1041,7 @@ dependencies = [
 
 [[package]]
 name = "baml-schema-build"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "baml-runtime",
@@ -1079,7 +1079,7 @@ dependencies = [
 
 [[package]]
 name = "baml-types"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "bstd"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "btrace"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "baml-types",
@@ -2765,7 +2765,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-codegen"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "askama",
@@ -2790,7 +2790,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-core"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "baml-types",
@@ -2827,7 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-diagnostics"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "colored",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-jinja"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "askama",
@@ -2861,7 +2861,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-jinja-types"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "askama",
@@ -2880,7 +2880,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-parser-database"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "baml-types",
@@ -2905,7 +2905,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-prompt-parser"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "internal-baml-diagnostics",
  "internal-baml-schema-ast",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "internal-baml-schema-ast"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "baml-types",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "internal-llm-client"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "aws-config",
@@ -3049,7 +3049,7 @@ checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "jsonish"
-version = "0.76.0"
+version = "0.76.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -106,7 +106,7 @@ web-time = "1.1.0"
 
 
 [workspace.package]
-version = "0.76.0"
+version = "0.76.1"
 authors = ["Boundary <contact@boundaryml.com>"]
 
 description = "BAML Toolchain"

--- a/engine/language_client_typescript/package.json
+++ b/engine/language_client_typescript/package.json
@@ -46,8 +46,7 @@
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-linux-gnu",
       "x86_64-unknown-linux-musl"
-    ],
-    "npmClient": "pnpm"
+    ]
   },
   "engines": {
     "node": ">= 10"

--- a/tools/versions/engine.cfg
+++ b/tools/versions/engine.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.76.0
+current_version = 0.76.1
 commit = False
 tag = False
 parse = ^(?P<major>\d+)\.(?P<minor>\d+).(?P<patch>\d+)$


### PR DESCRIPTION
- **dont set pnpm as package manager**
- **bump version 0.76.1**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Bump version to 0.76.1 and remove `pnpm` as package manager in `language_client_typescript/package.json`.
> 
>   - **Version Bump**:
>     - Update version from `0.76.0` to `0.76.1` in `Cargo.lock`, `Cargo.toml`, and `engine.cfg`.
>   - **Configuration**:
>     - Remove `pnpm` as the package manager in `language_client_typescript/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 05b4171ee23a34b3bd94c53702b9b029875eabac. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->