### PR TITLE
fix: fix baml options client provider deserialization

### DIFF
--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -420,9 +420,9 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
         if let Some(options_value) = b_args.get("__baml_options__") {
             match serde_json::from_value::<BamlOptions>(options_value.clone()) {
                 Ok(opts) => b_options = Some(opts),
-                Err(_) => {
+                Err(e) => {
                     return BamlError::InvalidArgument {
-                        message: "Failed to parse __baml_options__".to_string(),
+                        message: format!("Failed to parse __baml_options__: {}", e),
                     }
                     .into_response()
                 }
@@ -555,9 +555,9 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
         if let Some(options_value) = body.get("__baml_options__") {
             match serde_json::from_value::<BamlOptions>(options_value.clone()) {
                 Ok(opts) => b_options = Some(opts),
-                Err(_) => {
+                Err(e) => {
                     return BamlError::InvalidArgument {
-                        message: "Failed to parse __baml_options__".to_string(),
+                        message: format!("Failed to parse __baml_options__: {}", e),
                     }
                     .into_response()
                 }

--- a/engine/baml-runtime/src/client_registry/mod.rs
+++ b/engine/baml-runtime/src/client_registry/mod.rs
@@ -132,8 +132,8 @@ fn deserialize_client_provider<'de, D>(deserializer: D) -> Result<ClientProvider
 where
     D: Deserializer<'de>,
 {
-    let s: &str = Deserialize::deserialize(deserializer)?;
-    ClientProvider::from_str(s).map_err(|e| serde::de::Error::custom(e.to_string()))
+    let s: String = Deserialize::deserialize(deserializer)?;
+    ClientProvider::from_str(&s).map_err(|e| serde::de::Error::custom(e.to_string()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix deserialization of `ClientProvider` and improve error messages for BAML options in `serve/mod.rs`.
> 
>   - **Deserialization Fix**:
>     - Fix `deserialize_client_provider` in `client_registry/mod.rs` to correctly deserialize `ClientProvider` as `String` instead of `&str`.
>   - **Error Handling**:
>     - Improve error messages in `serve/mod.rs` for `__baml_options__` deserialization failures by including the error details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for dead0d5ff2927a5f8ca7110ba1dd725765fe1208. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->