### PR TITLE
fix openapi parser for baml_options

### DIFF
--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -771,12 +771,12 @@ mod tests {
         let client_property =
             ClientProperty::new("testing".into(), provider, retry_policy, options);
 
-        let client_registry = {
+        let expected_client_registry = {
             let mut client_registry = ClientRegistry::new();
             client_registry.add_client(client_property);
             client_registry.set_primary("testing".to_string());
             client_registry
         };
-        assert_eq!(client_registry, client_registry);
+        assert_eq!(client_registry, expected_client_registry);
     }
 }

--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -26,17 +26,15 @@ use axum_extra::{
 use baml_types::{BamlValue, GeneratorDefaultClientMode, GeneratorOutputType};
 use core::pin::Pin;
 use futures::Stream;
+use jsonish::ResponseBamlValue;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{path::PathBuf, sync::Arc, task::Poll};
 use tokio::{net::TcpListener, sync::RwLock};
 use tokio_stream::StreamExt;
-use jsonish::ResponseBamlValue;
 
 use crate::{
-    client_registry::ClientRegistry,
-    errors::ExposedError,
-    internal::llm_client::LLMResponse,
+    client_registry::ClientRegistry, errors::ExposedError, internal::llm_client::LLMResponse,
     BamlRuntime, FunctionResult, RuntimeContextManager,
 };
 use internal_baml_codegen::openapi::OpenApiSchema;
@@ -370,8 +368,9 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
                 LLMResponse::Success(_) => {
                     match function_result.result_with_constraints_content() {
                         // Just because the LLM returned 2xx doesn't mean that it returned parse-able content!
-                        Ok(parsed) => (StatusCode::OK, Json(parsed.serialize_final()))
-                            .into_response(),
+                        Ok(parsed) => {
+                            (StatusCode::OK, Json(parsed.serialize_final())).into_response()
+                        }
                         Err(e) => {
                             if let Some(ExposedError::ValidationError {
                                 prompt,
@@ -717,4 +716,67 @@ fn parse_args(
     }
 
     Ok(args)
+}
+
+#[cfg(test)]
+mod tests {
+    use baml_types::BamlMap;
+    use internal_llm_client::{ClientProvider, OpenAIClientProviderVariant};
+
+    use crate::client_registry::ClientProperty;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_baml_options() {
+        let baml_options: BamlOptions = serde_json::from_str(
+            r#"
+        {
+            "client_registry": {
+                "clients": [
+                    {
+                        "name": "testing",
+                        "provider": "openai",
+                        "options": {
+                            "model": "gpt-4o",
+                            "api_key": "[redacted]",
+                            "base_url": "[redacted]"
+                        }
+                    }
+                ],
+                "primary": "testing"
+            }
+        }"#,
+        )
+        .unwrap();
+        assert!(
+            baml_options.client_registry.is_some(),
+            "client_registry should be Some"
+        );
+        let client_registry = baml_options.client_registry.unwrap();
+        
+        
+        let provider = ClientProvider::OpenAI(OpenAIClientProviderVariant::Base);
+        let retry_policy = None;
+        let options = BamlMap::from_iter(vec![(
+            "model".to_string(),
+            BamlValue::String("gpt-4o".to_string()),
+        ), (
+            "api_key".to_string(),
+            BamlValue::String("[redacted]".to_string()),
+        ), (
+            "base_url".to_string(),
+            BamlValue::String("[redacted]".to_string()),
+        ),]);
+        let client_property =
+            ClientProperty::new("testing".into(), provider, retry_policy, options);
+
+        let client_registry = {
+            let mut client_registry = ClientRegistry::new();
+            client_registry.add_client(client_property);
+            client_registry.set_primary("testing".to_string());
+            client_registry
+        };
+        assert_eq!(client_registry, client_registry);
+    }
 }

--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -417,11 +417,11 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
     ) -> Response {
         let mut b_options = None;
         if let Some(options_value) = b_args.get("__baml_options__") {
-            match serde_json::from_value::<BamlOptions>(options_value.clone()) {
+            match BamlOptions::deserialize(options_value) {
                 Ok(opts) => b_options = Some(opts),
-                Err(_) => {
+                Err(e) => {
                     return BamlError::InvalidArgument {
-                        message: "Failed to parse __baml_options__".to_string(),
+                        message: format!("Failed to parse __baml_options__: {}", e),
                     }
                     .into_response()
                 }
@@ -552,11 +552,11 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
     ) -> Response {
         let mut b_options = None;
         if let Some(options_value) = body.get("__baml_options__") {
-            match serde_json::from_value::<BamlOptions>(options_value.clone()) {
+            match BamlOptions::deserialize(options_value) {
                 Ok(opts) => b_options = Some(opts),
-                Err(_) => {
+                Err(e) => {
                     return BamlError::InvalidArgument {
-                        message: "Failed to parse __baml_options__".to_string(),
+                        message: format!("Failed to parse __baml_options__: {}", e),
                     }
                     .into_response()
                 }

--- a/engine/baml-runtime/src/client_registry/mod.rs
+++ b/engine/baml-runtime/src/client_registry/mod.rs
@@ -18,7 +18,7 @@ pub enum PrimitiveClient {
     Vertex,
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, PartialEq)]
 pub struct ClientProperty {
     pub name: String,
     #[serde(deserialize_with = "deserialize_client_provider")]
@@ -74,7 +74,7 @@ impl ClientProperty {
     }
 }
 
-#[derive(Clone, Deserialize, Debug)]
+#[derive(Clone, Deserialize, Debug, PartialEq)]
 pub struct ClientRegistry {
     #[serde(deserialize_with = "deserialize_clients")]
     clients: HashMap<String, ClientProperty>,

--- a/engine/baml-runtime/tests/harness.rs
+++ b/engine/baml-runtime/tests/harness.rs
@@ -40,7 +40,7 @@ impl Harness {
     pub fn run_cli<S: AsRef<str>>(&self, args: S) -> Result<Command> {
         let args = args.as_ref();
 
-        let mut cmd = Command::cargo_bin(env!("CARGO_PKG_NAME"))?;
+        let mut cmd = Command::cargo_bin("baml-cli")?;
 
         cmd.args(args.split_ascii_whitespace());
         cmd.current_dir(&self.test_dir);

--- a/engine/baml-runtime/tests/test_cli.rs
+++ b/engine/baml-runtime/tests/test_cli.rs
@@ -308,6 +308,98 @@ mod test_cli {
         Ok(())
     }
 
+
+    #[rstest]
+    #[tokio::test]
+    async fn call_function_with_baml_options() -> Result<()> {
+        let h = Harness::new(format!("baml_options_test"))?;
+
+        const PORT: &str = "2035";
+
+        let run = h.run_cli("init")?.output()?;
+        assert_eq!(run.status.code(), Some(0));
+
+        let mut child = h
+            .run_cli(format!("serve --preview --port {PORT}"))?
+            .spawn()?;
+        defer! { let _ = child.kill(); }
+
+        assert!(
+            reqwest::get(&format!("http://localhost:{PORT}/_debug/ping"))
+                .await?
+                .status()
+                .is_success()
+        );
+
+        let resume = indoc! {"
+      Vaibhav Gupta
+      vbv@boundaryml.com
+
+      Experience:
+      - Founder at BoundaryML
+      - CV Engineer at Google
+      - CV Engineer at Microsoft
+
+      Skills:
+      - Rust
+      - C++
+    "};
+        let resp = reqwest::Client::new()
+            .post(&format!("http://localhost:{PORT}/call/ExtractResume"))
+            .json(&json!({ 
+                "resume": resume, 
+                "__baml_options__": {
+                    "client_registry": {
+                        "clients": [
+                            {
+                                "name": "testing",
+                                "provider": "openai",
+                                "options": {
+                                    "model": "gpt-4o-mini",
+                                    "api_key": "my-super-secret-password"
+                                }
+                            }
+                        ],
+                        "primary": "testing"
+                    }
+                }
+            }))
+            .send()
+            .await?;
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let resp_json = resp.json::<serde_json::Value>().await?;
+        println!("baml options error expected: {:?}", resp_json);
+        assert!(resp_json.get("error").is_some(), "error field not found in error object of response");
+        assert!(resp_json.get("message").is_some(), "message field not found in error object of response");
+        assert!(resp_json.get("message").unwrap().as_str().unwrap().contains("Incorrect API key provided: my-super"), "message does not contain expected content");
+
+        let resp = reqwest::Client::new()
+            .post(&format!("http://localhost:{PORT}/call/ExtractResume"))
+            .json(&json!({ 
+                "resume": resume, 
+                "__baml_options__": {
+                    "client_registry": {
+                        "clients": [
+                            {
+                                "name": "testing",
+                                "provider": "openai",
+                                "options": {
+                                    "model": "gpt-4o-mini",
+                                    "api_key": std::env::var("OPENAI_API_KEY").unwrap()
+                                }
+                            }
+                        ],
+                        "primary": "testing"
+                    }
+                }
+            }))
+            .send()
+            .await?;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        Ok(())
+    }
+
     #[rstest]
     #[tokio::test]
     async fn call_function_validation_error() -> Result<()> {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add tests for BAML runtime CLI, improve error handling, and enhance code readability.
> 
>   - **Tests**:
>     - Add `test_parse_baml_options` in `mod.rs` to verify BAML options parsing.
>     - Add `call_function_with_baml_options` in `test_cli.rs` to test BAML options in API calls.
>     - Add `serve_respects_baml_password` in `test_cli.rs` to test password protection.
>     - Add `call_function_error_codes` in `test_cli.rs` to verify error handling.
>   - **Code Improvements**:
>     - Add `PartialEq` to `ClientProperty` and `ClientRegistry` structs in `mod.rs`.
>     - Improve error messages in `mod.rs` for BAML options parsing failures.
>   - **Misc**:
>     - Change CLI command in `harness.rs` to use `baml-cli` instead of package name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 5d7a0fa4348ba70858c92e0d94b3ed3bfd91eef0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->


Co-authored-by: Tsvetomir Bonev <me@invak.id>