### PR TITLE
updated documentation for TypeBuilder python client

### DIFF
--- a/fern/03-reference/baml_client/typebuilder.mdx
+++ b/fern/03-reference/baml_client/typebuilder.mdx
@@ -29,18 +29,27 @@ function Categorize(text: string) -> Category {
 <CodeBlocks>
 ```python Python
 from baml_client.type_builder import TypeBuilder
-from baml_client import b
+from baml_client.async_client import b
+import asyncio
 
 # Create a TypeBuilder instance
 tb = TypeBuilder()
 
 # Add new values to the Category enum
-tb.Category.add_value('GREEN') 
+tb.Category.add_value('GREEN')
 tb.Category.add_value('YELLOW')
 
-# Pass the typebuilder when calling the function
-result = await b.Categorize("The sun is bright", {"tb": tb})
-# result can now be RED, BLUE, GREEN, or YELLOW
+async def categorize_text():
+    # Pass the typebuilder when calling the function
+    result = await b.Categorize("The sun is bright", {"tb": tb})
+    # result can now be RED, BLUE, GREEN, or YELLOW
+    print(result)
+
+async def main():
+    await categorize_text()
+
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 ```typescript TypeScript
 import { TypeBuilder } from '../baml_client/type_builder'


### PR DESCRIPTION
Current example fails as the await statement is not wrapped inside an async function
We get below error.

`"await" allowed only within async function
`
updated the python example so that it works with existing BAML example.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated Python example in `typebuilder.mdx` to correctly use async/await syntax.
> 
>   - **Documentation Update**:
>     - In `typebuilder.mdx`, updated Python example to wrap `await` in an `async` function `categorize_text()`.
>     - Added `asyncio.run(main())` to execute the async function.
>     - Ensures example runs without syntax errors related to `await` usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ef9068f88c499580fe2360279081a4ba52b10765. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->