### PR TITLE
remove await in python snippet in typebuilder.mdx

### DIFF
--- a/fern/03-reference/baml_client/typebuilder.mdx
+++ b/fern/03-reference/baml_client/typebuilder.mdx
@@ -39,7 +39,7 @@ tb.Category.add_value('GREEN')
 tb.Category.add_value('YELLOW')
 
 # Pass the typebuilder when calling the function
-result = await b.Categorize("The sun is bright", {"tb": tb})
+result = b.Categorize("The sun is bright", {"tb": tb})
 # result can now be RED, BLUE, GREEN, or YELLOW
 ```
 ```typescript TypeScript


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `await` from Python code snippet for `b.Categorize` in `typebuilder.mdx`.
> 
>   - **Code Change**:
>     - Removed `await` from the Python code snippet in `typebuilder.mdx` for `b.Categorize` function call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for bec1300d56b17b191e4a859817a97560451755d5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->