### PR TITLE
[BUGFIX] Fix truthy bug in jinja and improve static analysis

### DIFF
--- a/engine/baml-lib/jinja-runtime/src/baml_value_to_jinja_value.rs
+++ b/engine/baml-lib/jinja-runtime/src/baml_value_to_jinja_value.rs
@@ -1,9 +1,11 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use baml_types::EvaluationContext;
 use indexmap::IndexMap;
 use internal_baml_core::ir::repr::IntermediateRepr;
 use internal_baml_core::ir::IRHelper;
+use minijinja::value::intern;
 
 use crate::{BamlMedia, BamlValue};
 
@@ -194,6 +196,10 @@ impl minijinja::value::StructObject for MinijinjaBamlClass {
 
     fn static_fields(&self) -> Option<&'static [&'static str]> {
         None
+    }
+
+    fn fields(&self) -> Vec<Arc<str>> {
+        self.class.keys().into_iter().map(|k| intern(k)).collect()       
     }
 }
 

--- a/engine/baml-lib/jinja-runtime/src/lib.rs
+++ b/engine/baml-lib/jinja-runtime/src/lib.rs
@@ -1118,7 +1118,6 @@ mod render_tests {
         Ok(())
     }
 
-
     #[test]
     fn render_with_kwargs_default_role() -> anyhow::Result<()> {
         setup_logging();
@@ -2093,4 +2092,119 @@ mod render_tests {
 
     //     Ok(())
     // }
+
+    #[test]
+    fn render_with_truthy_test() {
+        let result = render_minijinja(
+            r#"
+            {% if inp %}
+            {{ inp.name }}
+            {% endif %}
+            "#,
+            &minijinja::Value::from_serialize(HashMap::from([(
+                "inp",
+                HashMap::from([("name", "Greg")]),
+            )])),
+            RenderContext {
+                client: RenderContext_Client {
+                    name: "gpt4".to_string(),
+                    provider: "openai".to_string(),
+                    default_role: "system".to_string(),
+                    allowed_roles: vec!["system".to_string()],
+                },
+                output_format: OutputFormatContent::new_string(),
+                tags: HashMap::from([("ROLE".to_string(), BamlValue::String("system".into()))]),
+            },
+            &[],
+            "user".to_string(),
+            vec!["user".to_string(), "system".to_string()],
+        )
+        .expect("Rendering should succeed");
+        match result {
+            RenderedPrompt::Completion(msg) => assert_eq!(msg, "Greg\n"),
+            _ => panic!("Expected Completion"),
+        }
+    }
+
+    #[test]
+    fn render_prompt_with_truthy_test() {
+        let ir = make_test_ir(
+            r##"
+        class Foo {
+          name string
+        }
+        "##,
+        )
+        .unwrap();
+        let template = r##"
+          {% if inp %}
+          {{ inp.name }}
+          {% endif %}
+        "##;
+        let args = BamlValue::Map(
+            vec![(
+                "inp".to_string(),
+                BamlValue::Class(
+                    "Foo".to_string(),
+                    vec![("name".to_string(), BamlValue::String("Greg".to_string()))]
+                        .into_iter()
+                        .collect(),
+                ),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let ctx = RenderContext {
+            client: RenderContext_Client {
+                name: "gpt4".to_string(),
+                provider: "openai".to_string(),
+                default_role: "system".to_string(),
+                allowed_roles: vec!["system".to_string()],
+            },
+            output_format: OutputFormatContent::new_string(),
+            tags: HashMap::from([("ROLE".to_string(), BamlValue::String("system".into()))]),
+        };
+        let env_vars = HashMap::new();
+        let prompt =
+            render_prompt(template, &args, ctx, &[], &ir, &env_vars).expect("should render");
+        match prompt {
+            RenderedPrompt::Completion(msg) => {
+                assert_eq!(msg, "Greg\n")
+            }
+            _ => panic!("Expected Completion"),
+        }
+    }
+
+    #[test]
+    fn render_with_ne_null() {
+        let result = render_minijinja(
+            r#"
+            {% if inp != Null %}
+            {{ inp.name }}
+            {% endif %}
+            "#,
+            &minijinja::Value::from_serialize(HashMap::from([(
+                "inp",
+                HashMap::from([("name", "Greg")]),
+            )])),
+            RenderContext {
+                client: RenderContext_Client {
+                    name: "gpt4".to_string(),
+                    provider: "openai".to_string(),
+                    default_role: "system".to_string(),
+                    allowed_roles: vec!["system".to_string()],
+                },
+                output_format: OutputFormatContent::new_string(),
+                tags: HashMap::from([("ROLE".to_string(), BamlValue::String("system".into()))]),
+            },
+            &[],
+            "user".to_string(),
+            vec!["user".to_string(), "system".to_string()],
+        )
+        .expect("Rendering should succeed");
+        match result {
+            RenderedPrompt::Completion(msg) => assert_eq!(msg, "Greg\n"),
+            _ => panic!("Expected Completion"),
+        }
+    }
 }

--- a/engine/baml-lib/jinja/src/evaluate_type/stmt.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/stmt.rs
@@ -1,4 +1,4 @@
-use minijinja::machinery::ast::{self, Stmt, UnaryOpKind};
+use minijinja::machinery::ast::{self, Spanned, Stmt, UnaryOpKind, Var};
 
 use crate::evaluate_type::types::Type;
 
@@ -189,21 +189,37 @@ pub fn predicate_implications<'a>(
                 UnaryOpKind::Neg => branch,
             };
             predicate_implications(&unary_op.expr, context, next_branch)
-        },
-        BinOp(binary_op) => {
-            match binary_op.op {
-                ast::BinOpKind::ScAnd => {
-                    let mut left_implications = predicate_implications(&binary_op.left, context, branch);
-                    let right_implications = predicate_implications(&binary_op.right, context, branch);
-                    left_implications.extend(right_implications);
-                    left_implications
-                },
-                _ => vec![]
-                    
-            }
         }
-        _ => vec![]
+        BinOp(binary_op) => match binary_op.op {
+            ast::BinOpKind::ScAnd => {
+                let mut left_implications =
+                    predicate_implications(&binary_op.left, context, branch);
+                let right_implications = predicate_implications(&binary_op.right, context, branch);
+                left_implications.extend(right_implications);
+                left_implications
+            }
+
+            ast::BinOpKind::Ne => {
+                let maybe_non_null_variable = match (&binary_op.left, &binary_op.right) {
+                    (Var { .. }, Var(n)) if fuzzy_null(&n) => Some(&binary_op.left),
+                    (Var(n), Var { .. }) if fuzzy_null(&n) => Some(&binary_op.right),
+                    _ => None,
+                };
+                if let Some(non_null_variable) = maybe_non_null_variable {
+                    predicate_implications(non_null_variable, context, branch)
+                } else {
+                    vec![]
+                }
+            }
+            _ => vec![],
+        },
+        _ => vec![],
     }
+}
+
+/// Whether an identifier is `Null` or `null`.
+fn fuzzy_null(t: &Spanned<Var>) -> bool {
+    t.id.eq_ignore_ascii_case("null")
 }
 
 /// Type-narrowing by truthiness. The truthy version of a value's
@@ -275,15 +291,22 @@ mod tests {
     }
 
     #[test]
+    fn truthy_union_2() {
+        let input = Type::Union(vec![Type::Undefined, Type::ClassRef("Foo".to_string())]);
+        let expected = Type::ClassRef("Foo".to_string());
+        assert_eq!(truthy(&input).unwrap(), expected);
+    }
+
+    #[test]
     fn implication_from_nullable() {
         let mut context = PredefinedTypes::default(JinjaContext::Prompt);
         context.add_variable("a", Type::Union(vec![Type::Int, Type::None]));
-        let expr = Expr::Var(Spanned::new(Var{ id: "a"}, Span::default()));
+        let expr = Expr::Var(Spanned::new(Var { id: "a" }, Span::default()));
         let new_vars = predicate_implications(&expr, &mut context, true);
         match new_vars.as_slice() {
             [(name, Type::Int)] => {
                 assert_eq!(name.as_str(), "a");
-            },
+            }
             _ => panic!("Expected singleton list with Type::Int"),
         }
     }

--- a/engine/baml-lib/jinja/src/lib.rs
+++ b/engine/baml-lib/jinja/src/lib.rs
@@ -71,3 +71,90 @@ pub fn validate_template(
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn mk_params() -> PredefinedTypes {
+        let mut types = PredefinedTypes::default(JinjaContext::Prompt);
+        types.add_class("Foo", HashMap::from([("name".to_string(), Type::String)]));
+        types.add_variable(
+            "foo",
+            Type::Union(vec![Type::None, Type::ClassRef("Foo".to_string())]),
+        );
+        types.add_variable(
+            "foo2",
+            Type::Union(vec![Type::None, Type::ClassRef("Foo".to_string())]),
+        );
+        types
+    }
+
+    #[test]
+    fn test_type_narrowing_not_narrowed() {
+        let mut types = mk_params();
+        let err_unnarrowed = validate_template(
+            "test",
+            r#"
+            {{ foo.name }}
+            "#,
+            &mut types,
+        )
+        .expect_err("Should fail")
+        .errors
+        .into_iter()
+        .next()
+        .unwrap();
+        assert_eq!(
+            err_unnarrowed.message(),
+            "'foo' is a (none | class Foo), expected class"
+        );
+    }
+
+    #[test]
+    fn test_type_narrowing_truthy() {
+        let mut types = mk_params();
+        validate_template(
+            "test",
+            r#"
+            {% if foo %}
+              {{ foo.name }}
+            {% endif %}
+            "#,
+            &mut types,
+        )
+        .expect("Should succeed");
+    }
+
+    #[test]
+    fn test_type_narrowing_truthy_and() {
+        let mut types = mk_params();
+        validate_template(
+            "test",
+            r#"
+            {% if (foo and foo2) %}
+              {{ foo.name }}
+              {{ foo2.name }}
+            {% endif %}
+            "#,
+            &mut types,
+        )
+        .expect("Should succeed");
+    }
+
+    #[test]
+    fn test_type_narrowing_ne_null() {
+        let mut types = mk_params();
+        validate_template(
+            "test",
+            r#"
+            {% if foo!=null %}
+              {{ foo.name }}
+            {% endif %}
+            "#,
+            &mut types,
+        )
+        .expect("Should succeed");
+    }
+}

--- a/engine/baml-runtime/src/internal/llm_client/orchestrator/call.rs
+++ b/engine/baml-runtime/src/internal/llm_client/orchestrator/call.rs
@@ -7,7 +7,9 @@ use web_time::Duration;
 use crate::{
     internal::{
         llm_client::{
-            parsed_value_to_response, traits::{WithClientProperties, WithPrompt, WithSingleCallable}, LLMErrorResponse, LLMResponse
+            parsed_value_to_response,
+            traits::{WithClientProperties, WithPrompt, WithSingleCallable},
+            LLMErrorResponse, LLMResponse,
         },
         prompt_renderer::PromptRenderer,
     },
@@ -53,38 +55,41 @@ pub async fn orchestrate(
                     .finish_reason_filter()
                     .is_allowed(s.metadata.finish_reason.as_ref())
                 {
-                    Some(Err(anyhow::anyhow!(crate::errors::ExposedError::FinishReasonError {
-                        prompt: prompt.to_string(),
-                        raw_output: s.content.clone(),
-                        message: "Finish reason not allowed".to_string(),
-                        finish_reason: s.metadata.finish_reason.clone(),
-                    })))
+                    Some(Err(anyhow::anyhow!(
+                        crate::errors::ExposedError::FinishReasonError {
+                            prompt: prompt.to_string(),
+                            raw_output: s.content.clone(),
+                            message: "Finish reason not allowed".to_string(),
+                            finish_reason: s.metadata.finish_reason.clone(),
+                        }
+                    )))
                 } else {
                     Some(parse_fn(&s.content))
                 }
-            },
-            LLMResponse::LLMFailure(LLMErrorResponse { code, client, message, .. }) => {
+            }
+            LLMResponse::LLMFailure(LLMErrorResponse {
+                code,
+                client,
+                message,
+                ..
+            }) => {
                 match code {
                     // This is some internal BAML error, so handle it like any other error
                     crate::internal::llm_client::ErrorCode::Other(2) => None,
-                    _ => {
-                        Some(Err(anyhow::anyhow!(crate::errors::ExposedError::ClientHttpError {
+                    _ => Some(Err(anyhow::anyhow!(
+                        crate::errors::ExposedError::ClientHttpError {
                             client_name: client.clone(),
                             message: message.clone(),
                             status_code: code.clone(),
-                        })))
-                    }
+                        }
+                    ))),
                 }
             }
             _ => None,
         };
 
         let sleep_duration = node.error_sleep_duration().cloned();
-        results.push((
-            node.scope,
-            response,
-            parsed_response,
-        ));
+        results.push((node.scope, response, parsed_response));
 
         // Currently, we break out of the loop if an LLM responded, even if we couldn't parse the result.
         if results

--- a/engine/baml-runtime/src/internal/prompt_renderer/mod.rs
+++ b/engine/baml-runtime/src/internal/prompt_renderer/mod.rs
@@ -18,6 +18,7 @@ use crate::RuntimeContext;
 
 use super::llm_client::parsed_value_to_response;
 
+#[derive(Debug)]
 pub struct PromptRenderer {
     function_name: String,
     client_spec: ClientSpec,
@@ -55,7 +56,7 @@ impl PromptRenderer {
         &self,
         ir: &IntermediateRepr,
         raw_string: &str,
-        allow_partials: bool
+        allow_partials: bool,
     ) -> Result<ResponseBamlValue> {
         let parsed = jsonish::from_str(
             &self.output_defs,

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,8 @@
         toolchain = with fenix.packages.${system}; combine [
           minimal.cargo
           minimal.rustc
-          latest.rust-std
+          minimal.rust-std
+          targets.wasm32-unknown-unknown.latest.rust-std
         ];
 
         version = (builtins.fromTOML (builtins.readFile ./engine/Cargo.toml)).workspace.package.version;
@@ -88,6 +89,7 @@
           nodePackages.nodejs
           toolchain
           uv
+          wasm-pack
         ]) ++ (if pkgs.stdenv.isDarwin then appleDeps else []);
         nativeBuildInputs = [
           pkgs.openssl


### PR DESCRIPTION
This prompt fails to render correctly when `foo` is an optional BAML `Class`.

```
{% if foo %}
{{ foo.some_field }}
{% endif %}
```

This PR fixes truthyness handling for classes in jinja statements.

---

It also improves static analysis for explicit null checks. The following prompt exhibits correct type narrowing for the value `foo` with type `Foo?`:

```
{% if foo != null %}
{{ foo.some_field }}
{% endif %}
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes truthy handling for optional BAML classes in Jinja and improves static analysis for null checks.
> 
>   - **Behavior**:
>     - Fixes truthy handling for optional BAML `Class` in Jinja templates in `baml_value_to_jinja_value.rs`.
>     - Improves static analysis for explicit null checks in `stmt.rs`.
>   - **Tests**:
>     - Adds tests for truthy handling and null checks in `lib.rs` and `stmt.rs`.
>   - **Misc**:
>     - Updates `flake.nix` to include `wasm-pack` in the build inputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 277567b3b5ba10d8b7545ec52b6d55f1c60af4ae. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->