### PR TITLE
Rename Null to None in jinja

### DIFF
--- a/engine/baml-lib/jinja-runtime/src/lib.rs
+++ b/engine/baml-lib/jinja-runtime/src/lib.rs
@@ -2176,10 +2176,10 @@ mod render_tests {
     }
 
     #[test]
-    fn render_with_ne_null() {
+    fn render_with_ne_none() {
         let result = render_minijinja(
             r#"
-            {% if inp != Null %}
+            {% if inp != None %}
             {{ inp.name }}
             {% endif %}
             "#,

--- a/engine/baml-lib/jinja/src/evaluate_type/stmt.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/stmt.rs
@@ -1,4 +1,4 @@
-use minijinja::machinery::ast::{self, Spanned, Stmt, UnaryOpKind, Var};
+use minijinja::machinery::ast::{self, Spanned, Stmt, UnaryOpKind};
 
 use crate::evaluate_type::types::Type;
 
@@ -201,8 +201,8 @@ pub fn predicate_implications<'a>(
 
             ast::BinOpKind::Ne => {
                 let maybe_non_null_variable = match (&binary_op.left, &binary_op.right) {
-                    (Var { .. }, Var(n)) if fuzzy_null(&n) => Some(&binary_op.left),
-                    (Var(n), Var { .. }) if fuzzy_null(&n) => Some(&binary_op.right),
+                    (Var { .. }, Const(n)) if fuzzy_null(&n) => Some(&binary_op.left),
+                    (Const(n), Var { .. }) if fuzzy_null(&n) => Some(&binary_op.right),
                     _ => None,
                 };
                 if let Some(non_null_variable) = maybe_non_null_variable {
@@ -217,9 +217,9 @@ pub fn predicate_implications<'a>(
     }
 }
 
-/// Whether an identifier is `Null` or `null`.
-fn fuzzy_null(t: &Spanned<Var>) -> bool {
-    t.id.eq_ignore_ascii_case("null")
+/// Whether an identifier is `None` or `none`.
+fn fuzzy_null(t: &Spanned<ast::Const>) -> bool {
+    t.value.to_string().as_str().to_lowercase() == "none"
 }
 
 /// Type-narrowing by truthiness. The truthy version of a value's

--- a/engine/baml-lib/jinja/src/lib.rs
+++ b/engine/baml-lib/jinja/src/lib.rs
@@ -144,12 +144,12 @@ mod tests {
     }
 
     #[test]
-    fn test_type_narrowing_ne_null() {
+    fn test_type_narrowing_ne_none() {
         let mut types = mk_params();
         validate_template(
             "test",
             r#"
-            {% if foo!=null %}
+            {% if foo!=none %}
               {{ foo.name }}
             {% endif %}
             "#,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Renames `Null` to `None` in Jinja templates and updates related logic and tests.
> 
>   - **Behavior**:
>     - Renames `Null` to `None` in Jinja templates in `jinja-runtime/src/lib.rs` and `jinja/src/evaluate_type/stmt.rs`.
>     - Updates logic in `predicate_implications()` to handle `None` instead of `Null`.
>   - **Tests**:
>     - Updates test functions `render_with_ne_none` and `test_type_narrowing_ne_none` to reflect the change from `Null` to `None`.
>     - Ensures all relevant test cases check for `None` instead of `Null`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for e007e3cee94d38466f5dabf91180c12ee9dea11e. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->