### PR TITLE
fix(vscode): allow json files in baml_src

### DIFF
--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -583,7 +583,7 @@ impl ExperimentalTracingInterface for BamlRuntime {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn baml_src_files(dir: &std::path::PathBuf) -> Result<Vec<PathBuf>> {
-    static VALID_EXTENSIONS: [&str; 2] = ["baml"];
+    static VALID_EXTENSIONS: [&str; 1] = ["baml"];
 
     log::trace!("Reading files from {:#}", dir.to_string_lossy());
 

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -583,7 +583,7 @@ impl ExperimentalTracingInterface for BamlRuntime {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn baml_src_files(dir: &std::path::PathBuf) -> Result<Vec<PathBuf>> {
-    static VALID_EXTENSIONS: [&str; 2] = ["baml", "json"];
+    static VALID_EXTENSIONS: [&str; 2] = ["baml"];
 
     log::trace!("Reading files from {:#}", dir.to_string_lossy());
 

--- a/typescript/vscode-ext/packages/language-server/src/file/fileUtils.ts
+++ b/typescript/vscode-ext/packages/language-server/src/file/fileUtils.ts
@@ -22,7 +22,7 @@ export function findTopLevelParent(filePath: string) {
 }
 
 /**
- * Non-recursively gathers files with .baml or .json extensions from a given directory,
+ * Non-recursively gathers files with .baml extensions from a given directory,
  * avoiding processing the same directory more than once.
  *
  * @param {vscode.Uri} uri - The URI of the directory to search.
@@ -66,7 +66,7 @@ export function gatherFiles(rootPath: string, debug = false): URI[] {
 
         if (fileStat.isDirectory()) {
           addDir(fileUri)
-        } else if (filePath.endsWith('.baml') || filePath.endsWith('.json')) {
+        } else if (filePath.endsWith('.baml')) {
           fileList.push(fileUri)
         }
       })
@@ -82,5 +82,5 @@ export function gatherFiles(rootPath: string, debug = false): URI[] {
 export function convertToTextDocument(filePath: URI): TextDocument {
   const fileContent = fs.readFileSync(filePath.fsPath, 'utf-8')
   const fileExtension = path.extname(filePath.fsPath)
-  return TextDocument.create(filePath.toString(), fileExtension === '.baml' ? 'baml' : 'json', 1, fileContent)
+  return TextDocument.create(filePath.toString(), fileExtension.replace('.', ''), 1, fileContent)
 }

--- a/typescript/vscode-ext/packages/language-server/src/server.ts
+++ b/typescript/vscode-ext/packages/language-server/src/server.ts
@@ -158,7 +158,7 @@ export function startServer(options?: LSOptions): void {
                 {
                   scheme: 'file',
                   pattern: {
-                    glob: '**/*.{baml, json}',
+                    glob: '**/*.baml',
                   },
                 },
               ],
@@ -168,7 +168,7 @@ export function startServer(options?: LSOptions): void {
                 {
                   scheme: 'file',
                   pattern: {
-                    glob: '**/*.{baml, json}',
+                    glob: '**/*.baml',
                   },
                 },
               ],
@@ -178,7 +178,7 @@ export function startServer(options?: LSOptions): void {
                 {
                   scheme: 'file',
                   pattern: {
-                    glob: '**/*.{baml, json}',
+                    glob: '**/*.baml',
                   },
                 },
               ],

--- a/typescript/vscode-ext/packages/package.json
+++ b/typescript/vscode-ext/packages/package.json
@@ -16,14 +16,12 @@
   ],
   "activationEvents": [
     "onLanguage:baml",
-    "onLanguage:python",
-    "onLanguage:json"
+    "onLanguage:python"
   ],
   "main": "./vscode/out/extension.js",
   "contributes": {
     "activationEvents": [
       "onLanguage:baml",
-      "onLanguage:json",
       "onLanguage:python"
     ],
     "configuration": {
@@ -193,3 +191,4 @@
   },
   "preview": false
 }
+


### PR DESCRIPTION
BAML, a long time ago, used to allow defining tests in JSON files, so we included them in baml_src.

Now that tests are defined exclusively in baml files, the extension implodes if there are .json files in baml_src.

This is in direct conflict with the new playground proxy setting toggle, which creates and updates `.vscode/settings.json` in baml_src if you have that folder open.