### PR TITLE
fix nextjs readme link that was 404'ing

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 **Try BAML**: [Prompt Fiddle](https://www.promptfiddle.com) • [Examples](https://baml-examples.vercel.app/) • [Example Source Code](https://github.com/BoundaryML/baml-examples)
 
 **5 minute quickstarts**
-[Python](https://docs.boundaryml.com/guide/installation-language/python) • [Typescript](https://docs.boundaryml.com/guide/installation-language/typescript) • [NextJS](https://docs.boundaryml.com/guide/installation-language/next-js) • [Ruby](https://docs.boundaryml.com/guide/installation-language/ruby) • [Others](https://docs.boundaryml.com/guide/installation-language/rest-api-other-languages) (Go, Java, C++, Rust, PHP, etc)
+[Python](https://docs.boundaryml.com/guide/installation-language/python) • [Typescript](https://docs.boundaryml.com/guide/installation-language/typescript) • [NextJS](https://docs.boundaryml.com/guide/framework-integration/react-next-js/quick-start) • [Ruby](https://docs.boundaryml.com/guide/installation-language/ruby) • [Others](https://docs.boundaryml.com/guide/installation-language/rest-api-other-languages) (Go, Java, C++, Rust, PHP, etc)
 
 </div>
 


### PR DESCRIPTION
- Fix broken Next JS Guide Link
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix broken NextJS guide link in `README.md` to prevent 404 errors.
> 
>   - **README.md**:
>     - Fix broken NextJS guide link to point to `https://docs.boundaryml.com/guide/framework-integration/react-next-js/quick-start`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c321015aae691e8e8aa9fc14cda7aaa5a36b93f6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->