### PR TITLE
Rename enums & type aliases

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
@@ -57,6 +57,8 @@ pub trait IRHelper {
     ) -> Result<TestCaseWalker<'a>>;
 
     fn find_class_locations(&self, type_name: &str) -> Vec<Span>;
+    fn find_enum_locations(&self, type_name: &str) -> Vec<Span>;
+    fn find_type_alias_locations(&self, type_name: &str) -> Vec<Span>;
 
     fn check_function_params<'a>(
         &'a self,
@@ -297,6 +299,139 @@ impl IRHelper for IntermediateRepr {
                 .iter()
                 .for_each(|(name, spans)| {
                     if name == class_name {
+                        locations.extend(spans.iter().cloned());
+                    }
+                });
+        }
+
+        locations
+    }
+
+    fn find_enum_locations(&self, enum_name: &str) -> Vec<Span> {
+        let mut locations = vec![];
+
+        // First look for the definition of the enum.
+        for enm in self.walk_enums() {
+            if enm.name() == enum_name {
+                locations.push(
+                    enm.item
+                        .attributes
+                        .identifier_span
+                        .as_ref()
+                        .unwrap()
+                        .to_owned(),
+                );
+            }
+        }
+
+        // Then find all the references to this enum in the fields of other
+        // classes.
+        for cls in self.walk_classes() {
+            for field in cls.walk_fields() {
+                field
+                    .elem()
+                    .r#type
+                    .attributes
+                    .symbol_spans
+                    .iter()
+                    .for_each(|(name, spans)| {
+                        if name == enum_name {
+                            locations.extend(spans.iter().cloned());
+                        }
+                    });
+            }
+        }
+
+        // Now do the same for type aliases.
+        for alias in self.walk_type_aliases() {
+            alias
+                .elem()
+                .r#type
+                .attributes
+                .symbol_spans
+                .iter()
+                .for_each(|(name, spans)| {
+                    if name == enum_name {
+                        locations.extend(spans.iter().cloned());
+                    }
+                });
+        }
+
+        // Then find function inputs and outputs pointing to this enum.
+        for func in self.walk_functions() {
+            func.item
+                .attributes
+                .symbol_spans
+                .iter()
+                .for_each(|(name, spans)| {
+                    if name == enum_name {
+                        locations.extend(spans.iter().cloned());
+                    }
+                });
+        }
+
+        locations
+    }
+
+    fn find_type_alias_locations(&self, type_alias_name: &str) -> Vec<Span> {
+        let mut locations = vec![];
+
+        // First look for the definition of the type alias.
+        for alias in self.walk_type_aliases() {
+            if alias.name() == type_alias_name {
+                locations.push(
+                    alias
+                        .item
+                        .attributes
+                        .identifier_span
+                        .as_ref()
+                        .unwrap()
+                        .to_owned(),
+                );
+            }
+        }
+
+        // Then find all the references to this type alias in the fields of other
+        // classes.
+        for cls in self.walk_classes() {
+            for field in cls.walk_fields() {
+                field
+                    .elem()
+                    .r#type
+                    .attributes
+                    .symbol_spans
+                    .iter()
+                    .for_each(|(name, spans)| {
+                        if name == type_alias_name {
+                            locations.extend(spans.iter().cloned());
+                        }
+                    });
+            }
+        }
+
+        // Now do the same for type aliases.
+        for alias in self.walk_type_aliases() {
+            alias
+                .elem()
+                .r#type
+                .attributes
+                .symbol_spans
+                .iter()
+                .for_each(|(name, spans)| {
+                    if name == type_alias_name {
+                        locations.extend(spans.iter().cloned());
+                    }
+                });
+        }
+
+        // Then find function inputs and outputs pointing to this type alias.
+        for func in self.walk_functions() {
+            func.item
+                .attributes
+                .symbol_spans
+                .iter()
+                .for_each(|(name, spans)| {
+                    if name == type_alias_name {
                         locations.extend(spans.iter().cloned());
                     }
                 });

--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -1012,6 +1012,7 @@ impl WithRepr<TypeAlias> for TypeAliasWalker<'_> {
     fn attributes(&self, _: &ParserDatabase) -> NodeAttributes {
         NodeAttributes {
             span: Some(self.span().clone()),
+            identifier_span: Some(self.identifier().span().clone()),
             ..Default::default() // TODO: Rest of attributes.
         }
     }

--- a/engine/baml-lib/parser-database/src/walkers/alias.rs
+++ b/engine/baml-lib/parser-database/src/walkers/alias.rs
@@ -18,6 +18,11 @@ impl<'db> TypeAliasWalker<'db> {
         self.db.ast[self.id].identifier.span()
     }
 
+    /// Identifier of the type alias.
+    pub fn identifier(&self) -> &Identifier {
+        &self.db.ast[self.id].identifier
+    }
+
     /// Returns the field type that the alias points to.
     pub fn target(&self) -> &'db FieldType {
         &self.db.ast[self.id].value

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -1252,6 +1252,11 @@ impl WasmRuntime {
     }
 
     #[wasm_bindgen]
+    pub fn is_valid_type_alias(&self, symbol: &str) -> bool {
+        self.runtime.internal().ir().find_type_alias(symbol).is_ok()
+    }
+
+    #[wasm_bindgen]
     pub fn is_valid_function(&self, symbol: &str) -> bool {
         self.runtime.internal().ir().find_function(symbol).is_ok()
     }
@@ -1262,6 +1267,48 @@ impl WasmRuntime {
             .internal()
             .ir()
             .find_class_locations(symbol)
+            .into_iter()
+            .map(|span| {
+                let ((start_line, start_character), (end_line, end_character)) =
+                    span.line_and_column();
+                SymbolLocation {
+                    uri: span.file.path().to_string(),
+                    start_line,
+                    start_character,
+                    end_line,
+                    end_character,
+                }
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen]
+    pub fn search_for_enum_locations(&self, symbol: &str) -> Vec<SymbolLocation> {
+        self.runtime
+            .internal()
+            .ir()
+            .find_enum_locations(symbol)
+            .into_iter()
+            .map(|span| {
+                let ((start_line, start_character), (end_line, end_character)) =
+                    span.line_and_column();
+                SymbolLocation {
+                    uri: span.file.path().to_string(),
+                    start_line,
+                    start_character,
+                    end_line,
+                    end_character,
+                }
+            })
+            .collect()
+    }
+
+    #[wasm_bindgen]
+    pub fn search_for_type_alias_locations(&self, symbol: &str) -> Vec<SymbolLocation> {
+        self.runtime
+            .internal()
+            .ir()
+            .find_type_alias_locations(symbol)
             .into_iter()
             .map(|span| {
                 let ((start_line, start_character), (end_line, end_character)) =

--- a/typescript/vscode-ext/packages/language-server/src/server.ts
+++ b/typescript/vscode-ext/packages/language-server/src/server.ts
@@ -46,6 +46,7 @@ import { getWordAtPosition } from './lib/ast'
 import BamlProjectManager, { GeneratorDisabledReason, GeneratorStatus, GeneratorType } from './lib/baml_project_manager'
 import type { LSOptions, LSSettings } from './lib/types'
 import { BamlWasm } from './lib/wasm'
+import { SymbolLocation } from '@gloo-ai/baml-schema-wasm-node'
 
 try {
   // only required on vscode versions 1.89 and below.
@@ -761,20 +762,33 @@ export function startServer(options?: LSOptions): void {
 
     const symbol = getWordAtPosition(doc, params.position)
 
-    // TODO: Enums, type aliases, etc.
-    if (project.runtime().is_valid_enum(symbol)) {
-      throw new ResponseError(ErrorCodes.InvalidRequest, `Enum renaming is not yet supported: '${symbol}'`)
-    }
+    // TODO: type alias renaming, class field renaming, etc.
     if (project.runtime().is_valid_function(symbol)) {
       throw new ResponseError(ErrorCodes.InvalidRequest, `Function renaming is not yet supported: '${symbol}'`)
     }
-    if (!project.runtime().is_valid_class(symbol)) {
+
+    const is_valid_class = project.runtime().is_valid_class(symbol)
+    const is_valid_enum = project.runtime().is_valid_enum(symbol)
+    const is_valid_type_alias = project.runtime().is_valid_type_alias(symbol)
+
+    // Only classes and enums can be renamed for now.
+    if (!is_valid_class && !is_valid_enum && !is_valid_type_alias) {
       throw new ResponseError(ErrorCodes.InvalidRequest, `Cannot rename symbol '${symbol}'`)
     }
 
     const changes: { [uri: string]: TextEdit[] } = {}
 
-    for (const location of project.runtime().search_for_class_locations(symbol)) {
+    let locations: SymbolLocation[] = []
+
+    if (is_valid_class) {
+      locations = project.runtime().search_for_class_locations(symbol)
+    } else if (is_valid_enum) {
+      locations = project.runtime().search_for_enum_locations(symbol)
+    } else if (is_valid_type_alias) {
+      locations = project.runtime().search_for_type_alias_locations(symbol)
+    }
+
+    for (const location of locations) {
       if (!changes[location.uri]) {
         changes[location.uri] = []
       }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add support for renaming enums and type aliases in BAML language server, updating references across the codebase.
> 
>   - **Behavior**:
>     - Add `find_enum_locations()` and `find_type_alias_locations()` to `IRHelper` in `mod.rs` to locate enum and type alias references.
>     - Update `rename` functionality in `server.ts` to support enums and type aliases, using `search_for_enum_locations()` and `search_for_type_alias_locations()`.
>   - **Functions**:
>     - Implement `find_enum_locations()` and `find_type_alias_locations()` in `IntermediateRepr` in `repr.rs` to gather all references.
>     - Add `is_valid_type_alias()` and `search_for_type_alias_locations()` to `WasmRuntime` in `mod.rs` to validate and locate type aliases.
>   - **Misc**:
>     - Add `identifier()` method to `TypeAliasWalker` in `alias.rs` for retrieving identifier information.
>     - Update `search_for_symbol()` in `mod.rs` to include type alias search.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 8729af3adebf2a8b19303d602bf3c36aff4bf4f9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->