### PR TITLE
Resolve all non-google file uris when calling gemini Fixes #1548

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1008,6 +1008,7 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "pretty_assertions",
+ "regex",
  "reqwest",
  "reqwest-eventsource",
  "ring",

--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -67,6 +67,7 @@ web-time.workspace = true
 static_assertions.workspace = true
 mime_guess = "=2.0.5"
 mime = "0.3.17"
+regex.workspace = true
 
 # For tracing
 envy = "0.4.2"

--- a/engine/baml-runtime/src/internal/llm_client/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/mod.rs
@@ -87,10 +87,11 @@ pub enum ResolveMediaUrls {
 
     // aws: supports b64 w mime
     // anthropic: supports b64 w mime
-    // google: supports b64 w mime
+    // google: supports b64 w mime, url if its a google file uri (gs://)
     // openai: supports URLs w/o mime (b64 data URLs also work here)
     // vertex: supports URLs w/ mime, b64 w/ mime
     Always,
+    IfMatchesGoogleFileUri,
     EnsureMime,
     Never,
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
@@ -138,7 +138,7 @@ impl GoogleAIClient {
                 chat: true,
                 completion: false,
                 max_one_system_prompt: true,
-                resolve_media_urls: ResolveMediaUrls::Always,
+                resolve_media_urls: ResolveMediaUrls::IfMatchesGoogleFileUri,
                 allowed_metadata: properties.allowed_metadata.clone(),
             },
             retry_policy: client

--- a/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
@@ -570,6 +570,11 @@ async fn process_media(
                 (ResolveMediaUrls::Always, _) => {}
                 (ResolveMediaUrls::EnsureMime, Some("")) | (ResolveMediaUrls::EnsureMime, None) => {
                 }
+                (ResolveMediaUrls::IfMatchesGoogleFileUri, _) => {
+                    if media_url.url.starts_with("gs://") {
+                        return Ok(part.clone());
+                    }
+                }
                 (ResolveMediaUrls::Never, _) | (ResolveMediaUrls::EnsureMime, _) => {
                     return Ok(part.clone());
                 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `IfMatchesGoogleFileUri` to handle Google file URIs in media URL resolution, updating `GoogleAIClient` and `process_media` logic.
> 
>   - **Behavior**:
>     - Add `IfMatchesGoogleFileUri` variant to `ResolveMediaUrls` enum in `mod.rs` to handle Google file URIs specifically.
>     - Update `process_media` in `traits/mod.rs` to return the original part if the URL starts with `gs://` when `IfMatchesGoogleFileUri` is used.
>     - Change `resolve_media_urls` to `IfMatchesGoogleFileUri` in `GoogleAIClient` in `googleai_client.rs`.
>   - **Dependencies**:
>     - Add `regex` dependency to `Cargo.toml` and `Cargo.lock` for potential pattern matching use.
>   - **Misc**:
>     - Update comments in `mod.rs` and `googleai_client.rs` to reflect new behavior for Google file URIs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 25f577e8818a0524704d66f9272e021fceb65e39. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->