### PR TITLE
clean up log statements

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/response_handler.rs
@@ -47,8 +47,6 @@ pub fn parse_anthropic_response<C: WithClient + RequestBuilder>(
         Err(e) => return LLMResponse::LLMFailure(e),
     };
 
-    println!("response: {:?}", response.content);
-
     let content = response
         .content
         .iter()
@@ -146,14 +144,12 @@ pub fn scan_anthropic_response_stream(
             inner.output_tokens = Some(body.usage.output_tokens);
             inner.total_tokens = Some(body.usage.input_tokens + body.usage.output_tokens);
         }
-        MessageChunk::ContentBlockDelta(event) => {
-            match event.delta {
-                super::types::ContentBlockDelta::TextDelta { text } => {
-                    inner.content += &text;
-                }
-                _ => (),
+        MessageChunk::ContentBlockDelta(event) => match event.delta {
+            super::types::ContentBlockDelta::TextDelta { text } => {
+                inner.content += &text;
             }
-        }
+            _ => (),
+        },
         MessageChunk::ContentBlockStart(_) => (),
         MessageChunk::ContentBlockStop(_) => (),
         MessageChunk::Ping => (),

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -258,14 +258,12 @@ impl BamlRuntime {
                 vec![],
             )?;
             let (response_res, span_uuid) = stream.run(on_event, ctx, None, None).await;
-            log::info!("response_res: {:#?}", response_res);
             let res = response_res?;
             let (_, llm_resp, val) = res
                 .event_chain()
                 .iter()
                 .last()
                 .context("Expected non-empty event chain")?;
-            log::info!("llm_resp: {:#?}", llm_resp);
             let complete_resp = match llm_resp {
                 LLMResponse::Success(complete_llm_response) => Ok(complete_llm_response),
                 LLMResponse::InternalFailure(e) => Err(anyhow::anyhow!("{}", e)),

--- a/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
@@ -65,7 +65,7 @@ impl TracePublisher {
                             }
                         },
                         PublisherMessage::Flush(flush_ack) => {
-                            log::info!("Got a flush event");
+                            // log::info!("Got a flush event");
                             // Flush the current buffer if it has any pending events.
                             if !buffer.is_empty() {
                                 self.process_batch(std::mem::take(&mut buffer)).await;
@@ -150,7 +150,7 @@ impl TracePublisher {
 // but that's ok since noone uses our wasm build in node for logging.
 // https://github.com/whizsid/wasmtimer-rs/issues/26
 pub async fn flush() {
-    log::info!("flushing");
+    // log::info!("flushing");
     let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
     if let Err(e) = PUBLISHING_CHANNEL.send(PublisherMessage::Flush(ack_tx)) {
         log::error!("Failed to send flush request: {:?}", e);

--- a/engine/baml-runtime/src/types/stream.rs
+++ b/engine/baml-runtime/src/types/stream.rs
@@ -87,7 +87,6 @@ impl FunctionResultStream {
     where
         F: Fn(FunctionResult),
     {
-        log::info!("### FunctionResultStream::run");
         let mut local_orchestrator = Vec::new();
         std::mem::swap(&mut local_orchestrator, &mut self.orchestrator);
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Clean up log statements by removing or commenting out unnecessary logs in several files.
> 
>   - **Log Cleanup**:
>     - Remove `println!` statement in `parse_anthropic_response()` in `response_handler.rs`.
>     - Comment out `log::info!` statements in `run()` in `lib.rs` and `flush()` in `publisher.rs`.
>     - Comment out `log::info!` in `run()` in `publisher.rs` and `run()` in `stream.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for e6a90ed113747f96e8538893756f2cc2dd664d04. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->