### PR TITLE
Add baml-cli to CI

### DIFF
--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -163,57 +163,10 @@ jobs:
         with:
           workspaces: engine
       - name: Build CLI
-        run: cargo build --release --bin baml-cli
+        run: cargo build --release --bin baml-cli --target ${{ matrix.target }}
         working-directory: engine
       - name: Upload CLI artifact
         uses: actions/upload-artifact@v4
         with:
           name: baml-cli-${{ matrix.target }}
           path: engine/target/release/baml-cli*
-  build-vscode:
-    needs: build-cli
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: engine
-      - uses: jetli/wasm-bindgen-action@v0.2.0
-        with:
-          version: '0.2.100'
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9.12.0
-      - name: Download all CLI artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: baml-cli-*
-          path: cli-artifacts
-      - name: Copy binaries to language server
-        run: |
-          mkdir -p typescript/vscode-ext/packages/vscode/language-server/server
-          cp cli-artifacts/baml-cli-x86_64-unknown-linux-gnu/baml-cli typescript/vscode-ext/packages/vscode/language-server/server/baml-cli
-          cp cli-artifacts/baml-cli-x86_64-apple-darwin/baml-cli typescript/vscode-ext/packages/vscode/language-server/server/baml-cli
-          cp cli-artifacts/baml-cli-x86_64-pc-windows-msvc/baml-cli.exe typescript/vscode-ext/packages/vscode/language-server/server/baml-cli.exe
-          chmod +x typescript/vscode-ext/packages/vscode/language-server/server/baml-cli*
-      - name: Install dependencies
-        run: pnpm install && pnpm build
-        working-directory: typescript
-      - name: Build VSCode extension
-        run: pnpm build
-        working-directory: typescript/vscode-ext/packages/vscode
-      - name: Package VSIX
-        run: npm upgrade && pnpm vscode:prepublish && npx @vscode/vsce package
-        working-directory: typescript/vscode-ext/packages/vscode
-      # - name: Upload VSIX artifact
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: baml-vscode-extension
-      #     path: typescript/vscode-ext/packages/vscode/*.vsix

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -182,6 +182,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: engine
+      - uses: jetli/wasm-bindgen-action@v0.2.0
+        with:
+          version: '0.2.100'
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -194,8 +194,8 @@ jobs:
           cp cli-artifacts/baml-cli-x86_64-pc-windows-msvc/baml-cli.exe typescript/vscode-ext/packages/vscode/language-server/server/baml-cli.exe
           chmod +x typescript/vscode-ext/packages/vscode/language-server/server/baml-cli*
       - name: Install dependencies
-        run: pnpm install
-        working-directory: typescript/vscode-ext
+        run: pnpm install && pnpm build
+        working-directory: typescript
       - name: Build VSCode extension
         run: pnpm build
         working-directory: typescript/vscode-ext/packages/vscode

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -175,6 +175,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -207,4 +214,3 @@ jobs:
       #   with:
       #     name: baml-vscode-extension
       #     path: typescript/vscode-ext/packages/vscode/*.vsix
-

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -141,3 +141,32 @@ jobs:
         run: |
           cd integ-tests/python
           ./run_tests.sh
+  build-cli:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest 
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine
+      - name: Build CLI
+        run: cargo build --release --bin baml-cli
+        working-directory: engine
+      - name: Upload CLI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: baml-cli-${{ matrix.target }}
+          path: engine/target/release/baml-cli*

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -170,3 +170,41 @@ jobs:
         with:
           name: baml-cli-${{ matrix.target }}
           path: engine/target/release/baml-cli*
+  build-vscode:
+    needs: build-cli
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9.12.0
+      - name: Download all CLI artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: baml-cli-*
+          path: cli-artifacts
+      - name: Copy binaries to language server
+        run: |
+          mkdir -p typescript/vscode-ext/packages/vscode/language-server/server
+          cp cli-artifacts/baml-cli-x86_64-unknown-linux-gnu/baml-cli typescript/vscode-ext/packages/vscode/language-server/server/baml-cli
+          cp cli-artifacts/baml-cli-x86_64-apple-darwin/baml-cli typescript/vscode-ext/packages/vscode/language-server/server/baml-cli
+          cp cli-artifacts/baml-cli-x86_64-pc-windows-msvc/baml-cli.exe typescript/vscode-ext/packages/vscode/language-server/server/baml-cli.exe
+          chmod +x typescript/vscode-ext/packages/vscode/language-server/server/baml-cli*
+      - name: Install dependencies
+        run: pnpm install
+        working-directory: typescript/vscode-ext
+      - name: Build VSCode extension
+        run: pnpm build
+        working-directory: typescript/vscode-ext/packages/vscode
+      - name: Package VSIX
+        run: pnpm vscode:prepublish && npx @vscode/vsce package
+        working-directory: typescript/vscode-ext/packages/vscode
+      # - name: Upload VSIX artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: baml-vscode-extension
+      #     path: typescript/vscode-ext/packages/vscode/*.vsix
+

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -210,7 +210,7 @@ jobs:
         run: pnpm build
         working-directory: typescript/vscode-ext/packages/vscode
       - name: Package VSIX
-        run: pnpm vscode:prepublish && npx @vscode/vsce package
+        run: npm upgrade && pnpm vscode:prepublish && npx @vscode/vsce package
         working-directory: typescript/vscode-ext/packages/vscode
       # - name: Upload VSIX artifact
       #   uses: actions/upload-artifact@v4

--- a/typescript/vscode-ext/packages/vscode/package.json
+++ b/typescript/vscode-ext/packages/vscode/package.json
@@ -29,7 +29,7 @@
     "clean": "rimraf out"
   },
   "dependencies": {
-    "@baml/common": "workspace:*",
+    "@baml/common": "*",
     "@types/semver": "^7.5.6",
     "axios": "^1.6.8",
     "cors": "^2.8.5",

--- a/typescript/vscode-ext/packages/vscode/package.json
+++ b/typescript/vscode-ext/packages/vscode/package.json
@@ -19,6 +19,7 @@
   ],
   "main": "./out/extension.js",
   "scripts": {
+    "server:build": "mkdir -p server && cd ../../../../engine && cargo build --bin baml-cli --release && cp target/release/baml-cli ../typescript/vscode-ext/packages/vscode/server/",
     "vscode:prepublish": "pnpm run esbuild-base --minify",
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/extension.js --external:vscode --format=cjs --platform=node ",
     "esbuild-build": "pnpm run esbuild-base --sourcemap",
@@ -29,7 +30,7 @@
     "clean": "rimraf out"
   },
   "dependencies": {
-    "@baml/common": "*",
+    "@baml/common": "workspace:*",
     "@types/semver": "^7.5.6",
     "axios": "^1.6.8",
     "cors": "^2.8.5",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add CI job to build and upload `baml-cli` for multiple OS targets and update `package.json` with a build script.
> 
>   - **CI/CD**:
>     - Adds `build-cli` job to `.github/workflows/primary.yml` for building `baml-cli` on `ubuntu-latest`, `macos-latest`, and `windows-latest`.
>     - Uses `cargo build` to compile `baml-cli` for `x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, and `x86_64-pc-windows-msvc` targets.
>     - Uploads built CLI as artifacts named `baml-cli-${{ matrix.target }}`.
>   - **Scripts**:
>     - Adds `server:build` script in `package.json` to build `baml-cli` and copy it to `typescript/vscode-ext/packages/vscode/server/`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 5c8605f7ed0ded90e5702d850f4ece2808aca076. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->