### PR TITLE
fix: propagate finish reason correctly, add tests to ensure correct deserialization

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/mod.rs
@@ -112,7 +112,7 @@ pub struct RetryLLMResponse {
     pub failed: Vec<LLMResponse>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum LLMResponse {
     /// BAML was able to successfully make the HTTP request and got a 2xx
     /// response from the model provider
@@ -176,7 +176,7 @@ impl LLMResponse {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct LLMErrorResponse {
     pub client: String,
     pub model: Option<String>,
@@ -191,7 +191,7 @@ pub struct LLMErrorResponse {
     pub code: ErrorCode,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
 pub enum ErrorCode {
     InvalidAuthentication, // 401
     NotSupported,          // 403
@@ -256,7 +256,7 @@ impl ErrorCode {
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 pub struct LLMCompleteResponse {
     pub client: String,
     pub model: String,
@@ -269,7 +269,7 @@ pub struct LLMCompleteResponse {
     pub metadata: LLMCompleteResponseMetadata,
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
 pub struct LLMCompleteResponseMetadata {
     pub baml_is_complete: bool,
     pub finish_reason: Option<String>,

--- a/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/anthropic_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/anthropic_client.rs
@@ -23,7 +23,7 @@ use crate::{
     client_registry::ClientProperty,
     internal::llm_client::{
         primitive::{
-            anthropic::types::{AnthropicMessageResponse, StopReason},
+            anthropic::types::AnthropicMessageResponse,
             request::{make_parsed_request, make_request, RequestBuilder},
         },
         traits::{

--- a/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/response_handler.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use baml_types::BamlMap;
 
-use super::types::{AnthropicMessageContent, AnthropicMessageResponse, MessageChunk, StopReason};
+use super::types::{AnthropicMessageContent, AnthropicMessageResponse, MessageChunk};
 use crate::internal::llm_client::{
     primitive::request::RequestBuilder, traits::WithClient, ErrorCode, LLMCompleteResponse,
     LLMCompleteResponseMetadata, LLMErrorResponse, LLMResponse,
@@ -17,6 +17,10 @@ fn to_prompt(
         either::Left(prompt) => internal_baml_jinja::RenderedPrompt::Completion(prompt.clone()),
         either::Right(prompt) => internal_baml_jinja::RenderedPrompt::Chat(prompt.to_vec()),
     }
+}
+
+fn is_done(stop_reason: &Option<String>) -> bool {
+    stop_reason.as_ref().map_or(false, |r| r.eq_ignore_ascii_case("end_turn") || r.eq_ignore_ascii_case("stop_sequence"))
 }
 
 pub fn parse_anthropic_response<C: WithClient + RequestBuilder>(
@@ -80,14 +84,8 @@ pub fn parse_anthropic_response<C: WithClient + RequestBuilder>(
         request_options: client.request_options().clone(),
         model: response.model,
         metadata: LLMCompleteResponseMetadata {
-            baml_is_complete: matches!(
-                response.stop_reason,
-                Some(StopReason::StopSequence) | Some(StopReason::EndTurn)
-            ),
-            finish_reason: response
-                .stop_reason
-                .as_ref()
-                .map(|r| serde_json::to_string(r).unwrap_or("".into())),
+            baml_is_complete: is_done(&response.stop_reason),
+            finish_reason: response.stop_reason.clone(),
             prompt_tokens: Some(response.usage.input_tokens),
             output_tokens: Some(response.usage.output_tokens),
             total_tokens: Some(response.usage.input_tokens + response.usage.output_tokens),
@@ -135,11 +133,8 @@ pub fn scan_anthropic_response_stream(
             let body = chunk.message;
             inner.model = body.model;
             let inner = &mut inner.metadata;
-            inner.baml_is_complete = matches!(
-                body.stop_reason,
-                Some(StopReason::StopSequence) | Some(StopReason::EndTurn)
-            );
-            inner.finish_reason = body.stop_reason.as_ref().map(ToString::to_string);
+            inner.baml_is_complete = is_done(&body.stop_reason);
+            inner.finish_reason = body.stop_reason.clone();
             inner.prompt_tokens = Some(body.usage.input_tokens);
             inner.output_tokens = Some(body.usage.output_tokens);
             inner.total_tokens = Some(body.usage.input_tokens + body.usage.output_tokens);
@@ -156,15 +151,8 @@ pub fn scan_anthropic_response_stream(
         MessageChunk::MessageDelta(body) => {
             let inner = &mut inner.metadata;
 
-            inner.baml_is_complete = matches!(
-                body.delta.stop_reason,
-                Some(StopReason::StopSequence) | Some(StopReason::EndTurn)
-            );
-            inner.finish_reason = body
-                .delta
-                .stop_reason
-                .as_ref()
-                .map(|r| serde_json::to_string(r).unwrap_or("".into()));
+            inner.baml_is_complete = is_done(&body.delta.stop_reason);
+            inner.finish_reason = body.delta.stop_reason.clone();
             inner.output_tokens = Some(body.usage.output_tokens);
             inner.total_tokens = Some(inner.prompt_tokens.unwrap_or(0) + body.usage.output_tokens);
         }
@@ -186,4 +174,53 @@ pub fn scan_anthropic_response_stream(
 
     inner.latency = instant_now.elapsed();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::internal::llm_client::primitive::tests::MockClient;
+
+    use super::*;
+
+    const RESPONSE: &str = r#"
+{"id":"msg_01TmchHftFKihgeV7Zy9vCvZ","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"{\n  \"isCompanyPost\": false,\n  \"companyName\": null,\n  \"stage\": null,\n  \"engineeringAssessment\": \"UNKNOWN\",\n  \"teamMembers\": [],\n  \"technicalHighlights\": []\n}\n\nNotes:\n- This is a general discussion post asking for programming book recommendations\n- Not a company/startup related post\n- No technical signals or team information can be extracted\n- Cannot make engineering assessment as this is just a question\n\nThis appears to be a learning/discussion oriented post rather than a startup/company related post, so most of the structured fields are null or empty. The post doesn't contain any analyzable technical due diligence information."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":321,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":158}}
+    "#;
+
+    #[test]
+    fn test_parse_anthropic_response() {
+        let client = MockClient::new();
+        let prompt = vec![];
+        let response_body = serde_json::from_str(RESPONSE.trim()).unwrap();
+        let system_now = web_time::SystemTime::now();
+        let instant_now = web_time::Instant::now();
+        let model_name = "claude-3-5-sonnet-20240620".to_string();
+
+        let result = parse_anthropic_response(
+            &client,
+            either::Right(prompt.as_slice()),
+            response_body,
+            system_now,
+            instant_now,
+            Some(model_name.clone()),
+        );
+
+        let expected = LLMCompleteResponse {
+        client: "mock".to_string(),
+        prompt: internal_baml_jinja::RenderedPrompt::Chat(vec![]),
+        content: "{\n  \"isCompanyPost\": false,\n  \"companyName\": null,\n  \"stage\": null,\n  \"engineeringAssessment\": \"UNKNOWN\",\n  \"teamMembers\": [],\n  \"technicalHighlights\": []\n}\n\nNotes:\n- This is a general discussion post asking for programming book recommendations\n- Not a company/startup related post\n- No technical signals or team information can be extracted\n- Cannot make engineering assessment as this is just a question\n\nThis appears to be a learning/discussion oriented post rather than a startup/company related post, so most of the structured fields are null or empty. The post doesn't contain any analyzable technical due diligence information.".to_string(),
+        start_time: system_now,
+        latency: instant_now.elapsed(),
+        model: model_name,
+        request_options: client.request_options().clone(),
+        metadata: LLMCompleteResponseMetadata {
+            baml_is_complete: true,
+            finish_reason: Some("end_turn".to_string()),
+            prompt_tokens: Some(321),
+            output_tokens: Some(158),
+            total_tokens: Some(479),
+        },
+    };
+
+        assert!(matches!(result, LLMResponse::Success(response)));
+    }
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/response_handler.rs
@@ -20,7 +20,9 @@ fn to_prompt(
 }
 
 fn is_done(stop_reason: &Option<String>) -> bool {
-    stop_reason.as_ref().map_or(false, |r| r.eq_ignore_ascii_case("end_turn") || r.eq_ignore_ascii_case("stop_sequence"))
+    stop_reason.as_ref().map_or(false, |r| {
+        r.eq_ignore_ascii_case("end_turn") || r.eq_ignore_ascii_case("stop_sequence")
+    })
 }
 
 pub fn parse_anthropic_response<C: WithClient + RequestBuilder>(
@@ -181,6 +183,8 @@ mod tests {
     use crate::internal::llm_client::primitive::tests::MockClient;
 
     use super::*;
+    use pretty_assertions::assert_eq;
+    use web_time::Duration;
 
     const RESPONSE: &str = r#"
 {"id":"msg_01TmchHftFKihgeV7Zy9vCvZ","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"{\n  \"isCompanyPost\": false,\n  \"companyName\": null,\n  \"stage\": null,\n  \"engineeringAssessment\": \"UNKNOWN\",\n  \"teamMembers\": [],\n  \"technicalHighlights\": []\n}\n\nNotes:\n- This is a general discussion post asking for programming book recommendations\n- Not a company/startup related post\n- No technical signals or team information can be extracted\n- Cannot make engineering assessment as this is just a question\n\nThis appears to be a learning/discussion oriented post rather than a startup/company related post, so most of the structured fields are null or empty. The post doesn't contain any analyzable technical due diligence information."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":321,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":158}}
@@ -193,7 +197,7 @@ mod tests {
         let response_body = serde_json::from_str(RESPONSE.trim()).unwrap();
         let system_now = web_time::SystemTime::now();
         let instant_now = web_time::Instant::now();
-        let model_name = "claude-3-5-sonnet-20240620".to_string();
+        let model_name = "claude-3-5-sonnet-20241022".to_string();
 
         let result = parse_anthropic_response(
             &client,
@@ -205,22 +209,27 @@ mod tests {
         );
 
         let expected = LLMCompleteResponse {
-        client: "mock".to_string(),
-        prompt: internal_baml_jinja::RenderedPrompt::Chat(vec![]),
-        content: "{\n  \"isCompanyPost\": false,\n  \"companyName\": null,\n  \"stage\": null,\n  \"engineeringAssessment\": \"UNKNOWN\",\n  \"teamMembers\": [],\n  \"technicalHighlights\": []\n}\n\nNotes:\n- This is a general discussion post asking for programming book recommendations\n- Not a company/startup related post\n- No technical signals or team information can be extracted\n- Cannot make engineering assessment as this is just a question\n\nThis appears to be a learning/discussion oriented post rather than a startup/company related post, so most of the structured fields are null or empty. The post doesn't contain any analyzable technical due diligence information.".to_string(),
-        start_time: system_now,
-        latency: instant_now.elapsed(),
-        model: model_name,
-        request_options: client.request_options().clone(),
-        metadata: LLMCompleteResponseMetadata {
-            baml_is_complete: true,
-            finish_reason: Some("end_turn".to_string()),
-            prompt_tokens: Some(321),
-            output_tokens: Some(158),
-            total_tokens: Some(479),
-        },
-    };
+            client: "mock".to_string(),
+            prompt: internal_baml_jinja::RenderedPrompt::Chat(vec![]),
+            content: "{\n  \"isCompanyPost\": false,\n  \"companyName\": null,\n  \"stage\": null,\n  \"engineeringAssessment\": \"UNKNOWN\",\n  \"teamMembers\": [],\n  \"technicalHighlights\": []\n}\n\nNotes:\n- This is a general discussion post asking for programming book recommendations\n- Not a company/startup related post\n- No technical signals or team information can be extracted\n- Cannot make engineering assessment as this is just a question\n\nThis appears to be a learning/discussion oriented post rather than a startup/company related post, so most of the structured fields are null or empty. The post doesn't contain any analyzable technical due diligence information.".to_string(),
+            start_time: system_now,
+            latency: Duration::ZERO,
+            model: model_name,
+            request_options: client.request_options().clone(),
+            metadata: LLMCompleteResponseMetadata {
+                baml_is_complete: true,
+                finish_reason: Some("end_turn".to_string()),
+                prompt_tokens: Some(321),
+                output_tokens: Some(158),
+                total_tokens: Some(479),
+            },
+        };
 
-        assert!(matches!(result, LLMResponse::Success(response)));
+        if let LLMResponse::Success(mut actual_result) = result {
+            actual_result.latency = Duration::ZERO;
+            assert_eq!(actual_result, expected);
+        } else {
+            panic!("Expected LLMResponse::Success, got {:?}", result);
+        }
     }
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/anthropic/types.rs
@@ -41,20 +41,9 @@ pub struct AnthropicMessageResponse {
     pub r#type: String,
     pub content: Vec<AnthropicMessageContent>,
     pub model: String,
-    pub stop_reason: Option<StopReason>, // can be null when streaming
+    pub stop_reason: Option<String>, // can be null when streaming
     pub stop_sequence: Option<StopSequence>,
     pub usage: AnthropicUsage,
-}
-
-#[derive(Clone, Debug, Deserialize, strum_macros::Display, PartialEq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[strum(serialize_all = "snake_case")]
-pub enum StopReason {
-    MaxTokens,
-    StopSequence,
-    EndTurn,
-    #[serde(other)]
-    Unknown,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -188,7 +177,7 @@ pub struct TextDeltaContentBlock {
 #[derive(Debug, Deserialize, Clone, PartialEq, Serialize)]
 pub struct StreamStop {
     /// The stop reason of this stream.
-    pub stop_reason: Option<StopReason>,
+    pub stop_reason: Option<String>,
     /// The stop sequence of this stream.
     pub stop_sequence: Option<StopSequence>,
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
@@ -8,7 +8,7 @@ use crate::RuntimeContext;
 use crate::{
     internal::llm_client::{
         primitive::{
-            google::types::{FinishReason, GoogleResponse},
+            google::types::GoogleResponse,
             request::{make_parsed_request, make_request, RequestBuilder},
         },
         traits::{

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 
-use super::types::{FinishReason, GoogleResponse};
-use crate::internal::llm_client::{primitive::request::RequestBuilder, traits::WithClient, ErrorCode, LLMCompleteResponse, LLMCompleteResponseMetadata, LLMErrorResponse, LLMResponse};
+use super::types::GoogleResponse;
+use crate::internal::llm_client::{
+    primitive::request::RequestBuilder, traits::WithClient, ErrorCode, LLMCompleteResponse,
+    LLMCompleteResponseMetadata, LLMErrorResponse, LLMResponse,
+};
 use anyhow::Context;
 use serde::Deserialize;
 use serde_json::Value;
@@ -23,11 +26,13 @@ pub fn parse_google_response<C: WithClient + RequestBuilder>(
     instant_now: web_time::Instant,
     model_name: Option<String>,
 ) -> LLMResponse {
-    let response = match GoogleResponse::deserialize(&response_body).context(format!(
-        "Failed to parse into a response accepted by {}: {}",
-        std::any::type_name::<GoogleResponse>(),
-        response_body
-    )).map_err(|e| LLMErrorResponse {
+    let response = match GoogleResponse::deserialize(&response_body)
+        .context(format!(
+            "Failed to parse into a response accepted by {}: {}",
+            std::any::type_name::<GoogleResponse>(),
+            response_body
+        ))
+        .map_err(|e| LLMErrorResponse {
             client: client.context().name.to_string(),
             model: model_name.clone(),
             prompt: to_prompt(prompt),
@@ -36,12 +41,10 @@ pub fn parse_google_response<C: WithClient + RequestBuilder>(
             latency: instant_now.elapsed(),
             message: format!("{:?}", e),
             code: ErrorCode::Other(2),
-        })
-    {
+        }) {
         Ok(response) => response,
         Err(e) => return LLMResponse::LLMFailure(e),
     };
-
 
     if response.candidates.len() != 1 {
         return LLMResponse::LLMFailure(LLMErrorResponse {
@@ -59,7 +62,9 @@ pub fn parse_google_response<C: WithClient + RequestBuilder>(
         });
     }
 
-    let Some(content) = response.candidates[0].content.as_ref() else {
+    let candidate = &response.candidates[0];
+
+    let Some(content) = candidate.content.as_ref() else {
         return LLMResponse::LLMFailure(LLMErrorResponse {
             client: client.context().name.to_string(),
             model: None,
@@ -83,14 +88,12 @@ pub fn parse_google_response<C: WithClient + RequestBuilder>(
         request_options: client.request_options().clone(),
         model: model_name,
         metadata: LLMCompleteResponseMetadata {
-            baml_is_complete: matches!(
-                response.candidates[0].finish_reason,
-                Some(FinishReason::Stop)
-            ),
-            finish_reason: response.candidates[0]
+            baml_is_complete: candidate
                 .finish_reason
                 .as_ref()
-                .map(|r| serde_json::to_string(r).unwrap_or("".into())),
+                .map(|r| r == "STOP")
+                .unwrap_or(false),
+            finish_reason: candidate.finish_reason.clone(),
             prompt_tokens: response.usage_metadata.prompt_token_count,
             output_tokens: response.usage_metadata.candidates_token_count,
             total_tokens: response.usage_metadata.total_token_count,
@@ -119,14 +122,16 @@ pub fn scan_google_response_stream(
     let inner = match accumulated {
         Ok(accumulated) => accumulated,
         // We'll just keep the first error and return it
-        Err(e) => return Ok(())
+        Err(e) => return Ok(()),
     };
 
-    let event = match GoogleResponse::deserialize(&event_body).context(format!(
-        "Failed to parse into a response accepted by {}: {}",
-        std::any::type_name::<GoogleResponse>(),
-        event_body
-    )).map_err(|e| LLMErrorResponse {
+    let event = match GoogleResponse::deserialize(&event_body)
+        .context(format!(
+            "Failed to parse into a response accepted by {}: {}",
+            std::any::type_name::<GoogleResponse>(),
+            event_body
+        ))
+        .map_err(|e| LLMErrorResponse {
             client: client_name.to_string(),
             model: model_name.clone(),
             prompt: prompt.clone(),
@@ -135,13 +140,17 @@ pub fn scan_google_response_stream(
             latency: instant_now.elapsed(),
             message: format!("{:?}", e),
             code: ErrorCode::Other(2),
-        })
-    {
+        }) {
         Ok(response) => response,
         Err(e) => return Err(e),
     };
     if let Some(choice) = event.candidates.get(0) {
-        let part_index = content_part(model_name.as_ref().map(|s| s.as_str()).unwrap_or("<unknown>"));
+        let part_index = content_part(
+            model_name
+                .as_ref()
+                .map(|s| s.as_str())
+                .unwrap_or("<unknown>"),
+        );
         if let Some(content) = choice
             .content
             .as_ref()
@@ -150,11 +159,135 @@ pub fn scan_google_response_stream(
             inner.content += &content.text;
         }
         inner.metadata.finish_reason = choice.finish_reason.as_ref().map(|r| r.to_string());
-        if let Some(FinishReason::Stop) = choice.finish_reason.as_ref() {
+        if choice
+            .finish_reason
+            .as_ref()
+            .map(|r| r == "STOP")
+            .unwrap_or(false)
+        {
             inner.metadata.baml_is_complete = true;
         }
     }
 
     inner.latency = instant_now.elapsed();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::internal::llm_client::primitive::{google::types::{
+        Candidate, Content, Part, UsageMetaData,
+    }, tests::MockClient};
+
+    use super::*;
+
+    const RESPONSE: &str = r#"
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "```json\n{\n  name: {\n    first: null,\n    last: null\n  },\n  email: null,\n  experience: []\n}\n```\n"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "avgLogprobs": -0.0090854397186866179
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 166,
+    "candidatesTokenCount": 39,
+    "totalTokenCount": 205,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 166
+      }
+    ],
+    "candidatesTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 39
+      }
+    ]
+  },
+  "modelVersion": "gemini-1.5-flash"
+}
+        "#;
+
+    #[test]
+    fn test_parsing_google_response() {
+        let response: GoogleResponse = serde_json::from_str(RESPONSE).unwrap();
+        let expected = GoogleResponse {
+            candidates: vec![Candidate {
+                index: None,
+                content: Some(Content {
+                    parts: vec![Part {
+                        text: "```json\n{\n  name: {\n    first: null,\n    last: null\n  },\n  email: null,\n  experience: []\n}\n```\n".to_string(),
+                        inline_data: None,
+                        file_data: None,
+                        function_call: None,
+                        function_response: None,
+                        video_metadata: None,
+                    }],
+                    role: Some("model".to_string()),
+                }),
+                finish_reason: Some("STOP".to_string()),
+                safety_ratings: None,
+                grounding_metadata: None,
+                finish_message: None,
+            }],
+            prompt_feedback: None,
+            usage_metadata: UsageMetaData {
+                prompt_token_count: Some(166),
+                candidates_token_count: Some(39),
+                total_token_count: Some(205),
+            },
+        };
+
+        let response_json = serde_json::to_string(&response).unwrap();
+        let expected_json = serde_json::to_string(&expected).unwrap();
+        assert_eq!(response_json, expected_json);
+    }
+
+    #[test]
+    fn test_parse_google_response() {
+        let client = MockClient::new();
+        let prompt = vec![];
+        let response_body = serde_json::from_str(RESPONSE.trim()).unwrap();
+        let system_now = web_time::SystemTime::now();
+        let instant_now = web_time::Instant::now();
+        let model_name = Some("gemini-1.5-flash".to_string());
+
+        let result = parse_google_response(
+            &client,
+            either::Right(prompt.as_slice()),
+            response_body,
+            system_now,
+            instant_now,
+            model_name,
+        );
+
+        let expected = LLMCompleteResponse {
+            client: "mock".to_string(),
+            prompt: internal_baml_jinja::RenderedPrompt::Chat(vec![]),
+            content: "```json\n{\n  name: {\n    first: null,\n    last: null\n  },\n  email: null,\n  experience: []\n}\n```\n".to_string(),
+            start_time: system_now,
+            latency: instant_now.elapsed(),
+            model: "gemini-1.5-flash".to_string(),
+            request_options: client.request_options().clone(),
+            metadata: LLMCompleteResponseMetadata {
+                baml_is_complete: true,
+                finish_reason: Some("STOP".to_string()),
+                prompt_tokens: Some(166),
+                output_tokens: Some(39),
+                total_tokens: Some(205),
+            },
+        };
+
+        assert!(matches!(result, LLMResponse::Success(response)));
+    }
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs
@@ -175,11 +175,14 @@ pub fn scan_google_response_stream(
 
 #[cfg(test)]
 mod tests {
-    use crate::internal::llm_client::primitive::{google::types::{
-        Candidate, Content, Part, UsageMetaData,
-    }, tests::MockClient};
+    use crate::internal::llm_client::primitive::{
+        google::types::{Candidate, Content, Part, UsageMetaData},
+        tests::MockClient,
+    };
 
     use super::*;
+    use pretty_assertions::assert_eq;
+    use web_time::Duration;
 
     const RESPONSE: &str = r#"
 {
@@ -219,7 +222,7 @@ mod tests {
         "#;
 
     #[test]
-    fn test_parsing_google_response() {
+    fn test_json_deserialization() {
         let response: GoogleResponse = serde_json::from_str(RESPONSE).unwrap();
         let expected = GoogleResponse {
             candidates: vec![Candidate {
@@ -276,7 +279,7 @@ mod tests {
             prompt: internal_baml_jinja::RenderedPrompt::Chat(vec![]),
             content: "```json\n{\n  name: {\n    first: null,\n    last: null\n  },\n  email: null,\n  experience: []\n}\n```\n".to_string(),
             start_time: system_now,
-            latency: instant_now.elapsed(),
+            latency: Duration::ZERO,
             model: "gemini-1.5-flash".to_string(),
             request_options: client.request_options().clone(),
             metadata: LLMCompleteResponseMetadata {
@@ -288,6 +291,11 @@ mod tests {
             },
         };
 
-        assert!(matches!(result, LLMResponse::Success(response)));
+        if let LLMResponse::Success(mut actual_result) = result {
+            actual_result.latency = Duration::ZERO;
+            assert_eq!(actual_result, expected);
+        } else {
+            panic!("Expected LLMResponse::Success, got {:?}", result);
+        }
     }
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
@@ -222,7 +222,7 @@ pub enum HarmSeverity {
 pub struct Candidate {
     pub index: Option<i32>,
     pub content: Option<Content>,
-    pub finish_reason: Option<FinishReason>,
+    pub finish_reason: Option<String>,
     pub safety_ratings: Option<Vec<SafetyRating>>,
     // pub citation_metadata: Option<CitationMetadata>,
     pub grounding_metadata: Option<GroundingMetadata>,
@@ -289,28 +289,6 @@ pub struct VideoMetadata {
 pub struct Duration {
     pub seconds: i64,
     pub nanos: i32,
-}
-
-#[derive(Serialize, Deserialize, Debug, strum_macros::Display)]
-pub enum FinishReason {
-    #[serde(rename = "FINISH_REASON_UNSPECIFIED")]
-    Unspecified,
-    #[serde(rename = "STOP")]
-    Stop,
-    #[serde(rename = "MAX_TOKENS")]
-    MaxTokens,
-    #[serde(rename = "SAFETY")]
-    Safety,
-    #[serde(rename = "RECITATION")]
-    Recitation,
-    #[serde(rename = "OTHER")]
-    Other,
-    #[serde(rename = "BLOCKLIST")]
-    Blocklist,
-    #[serde(rename = "PROHIBITED_CONTENT")]
-    ProhibitedContent,
-    #[serde(rename = "SPII")]
-    Spii,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/engine/baml-runtime/src/internal/llm_client/primitive/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/mod.rs
@@ -283,3 +283,68 @@ impl LLMPrimitiveProvider {
         match_llm_provider!(self, request_options)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::internal::llm_client::traits::WithClient;
+
+    use super::request::RequestBuilder;
+    use anyhow::Result;
+
+    pub struct MockClient {
+        model_features: crate::internal::llm_client::ModelFeatures,
+        context: internal_baml_jinja::RenderContext_Client,
+        request_options: baml_types::BamlMap<String, serde_json::Value>,
+    }
+
+    impl MockClient {
+        pub fn new() -> Self {
+            Self {
+                model_features: crate::internal::llm_client::ModelFeatures {
+                    completion: false,
+                    chat: false,
+                    max_one_system_prompt: false,
+                    resolve_media_urls: crate::internal::llm_client::ResolveMediaUrls::Always,
+                    allowed_metadata: crate::internal::llm_client::AllowedRoleMetadata::All,
+                },
+                context: internal_baml_jinja::RenderContext_Client {
+                    name: "mock".to_string(),
+                    provider: "mock".to_string(),
+                    default_role: "user".to_string(),
+                    allowed_roles: vec![],
+                },
+                request_options: baml_types::BamlMap::new(),
+            }
+        }
+    }
+
+    impl WithClient for MockClient {
+        fn model_features(&self) -> &crate::internal::llm_client::ModelFeatures {
+            &self.model_features
+        }
+
+        fn context(&self) -> &internal_baml_jinja::RenderContext_Client {
+            &self.context
+        }
+    }
+
+    impl RequestBuilder for MockClient {
+        async fn build_request(
+            &self,
+            prompt: either::Either<&String, &[internal_baml_jinja::RenderedChatMessage]>,
+            allow_proxy: bool,
+            stream: bool,
+            expose_secrets: bool,
+        ) -> Result<reqwest::RequestBuilder> {
+            unimplemented!("Not used in tests")
+        }
+    
+        fn request_options(&self) -> &baml_types::BamlMap<String, serde_json::Value> {
+            &self.request_options
+        }
+    
+        fn http_client(&self) -> &reqwest::Client {
+            unimplemented!("Not used in tests")
+        }
+    }
+}

--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/response_handler.rs
@@ -2,7 +2,10 @@ use anyhow::Result;
 use baml_types::BamlMap;
 
 use super::types::{ChatCompletionResponse, ChatCompletionResponseDelta};
-use crate::internal::llm_client::{primitive::request::RequestBuilder, traits::WithClient, ErrorCode, LLMCompleteResponse, LLMCompleteResponseMetadata, LLMErrorResponse, LLMResponse};
+use crate::internal::llm_client::{
+    primitive::request::RequestBuilder, traits::WithClient, ErrorCode, LLMCompleteResponse,
+    LLMCompleteResponseMetadata, LLMErrorResponse, LLMResponse,
+};
 use anyhow::Context;
 use serde::Deserialize;
 use serde_json::Value;
@@ -24,11 +27,13 @@ pub fn parse_openai_response<C: WithClient + RequestBuilder>(
     instant_now: web_time::Instant,
     model_name: Option<String>,
 ) -> LLMResponse {
-    let response = match ChatCompletionResponse::deserialize(&response_body).context(format!(
-        "Failed to parse into a response accepted by {}: {}",
-        std::any::type_name::<ChatCompletionResponse>(),
-        response_body
-    )).map_err(|e| LLMErrorResponse {
+    let response = match ChatCompletionResponse::deserialize(&response_body)
+        .context(format!(
+            "Failed to parse into a response accepted by {}: {}",
+            std::any::type_name::<ChatCompletionResponse>(),
+            response_body
+        ))
+        .map_err(|e| LLMErrorResponse {
             client: client.context().name.to_string(),
             model: model_name.clone(),
             prompt: to_prompt(prompt),
@@ -37,8 +42,7 @@ pub fn parse_openai_response<C: WithClient + RequestBuilder>(
             latency: instant_now.elapsed(),
             message: format!("{:?}", e),
             code: ErrorCode::Other(2),
-        })
-    {
+        }) {
         Ok(response) => response,
         Err(e) => return LLMResponse::LLMFailure(e),
     };
@@ -90,7 +94,6 @@ pub fn parse_openai_response<C: WithClient + RequestBuilder>(
     })
 }
 
-
 pub fn scan_openai_response_stream(
     client_name: &str,
     request_options: &BamlMap<String, serde_json::Value>,
@@ -104,14 +107,16 @@ pub fn scan_openai_response_stream(
     let inner = match accumulated {
         Ok(accumulated) => accumulated,
         // We'll just keep the first error and return it
-        Err(e) => return Ok(())
+        Err(e) => return Ok(()),
     };
 
-    let event = match ChatCompletionResponseDelta::deserialize(&event_body).context(format!(
-        "Failed to parse into a response accepted by {}: {}",
-        std::any::type_name::<ChatCompletionResponseDelta>(),
-        event_body
-    )).map_err(|e| LLMErrorResponse {
+    let event = match ChatCompletionResponseDelta::deserialize(&event_body)
+        .context(format!(
+            "Failed to parse into a response accepted by {}: {}",
+            std::any::type_name::<ChatCompletionResponseDelta>(),
+            event_body
+        ))
+        .map_err(|e| LLMErrorResponse {
             client: client_name.to_string(),
             model: model_name.clone(),
             prompt: prompt.clone(),
@@ -120,8 +125,7 @@ pub fn scan_openai_response_stream(
             latency: instant_now.elapsed(),
             message: format!("{:?}", e),
             code: ErrorCode::Other(2),
-        })
-    {
+        }) {
         Ok(response) => response,
         Err(e) => return Err(e),
     };
@@ -144,15 +148,50 @@ pub fn scan_openai_response_stream(
     Ok(())
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::internal::llm_client::primitive::tests::MockClient;
 
     use super::*;
-
+    use pretty_assertions::assert_eq;
+    use web_time::Duration;
     const RESPONSE: &str = r#"
-{"id":"msg_01TmchHftFKihgeV7Zy9vCvZ","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"{\n  \"isCompanyPost\": false,\n  \"companyName\": null,\n  \"stage\": null,\n  \"engineeringAssessment\": \"UNKNOWN\",\n  \"teamMembers\": [],\n  \"technicalHighlights\": []\n}\n\nNotes:\n- This is a general discussion post asking for programming book recommendations\n- Not a company/startup related post\n- No technical signals or team information can be extracted\n- Cannot make engineering assessment as this is just a question\n\nThis appears to be a learning/discussion oriented post rather than a startup/company related post, so most of the structured fields are null or empty. The post doesn't contain any analyzable technical due diligence information."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":321,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":158}}
+{
+  "id": "chatcmpl-B7rcnRIX2lh1okEeeIrCtzLppkaSw",
+  "object": "chat.completion",
+  "created": 1741214129,
+  "model": "gpt-4o-2024-08-06",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "```json\n{\n  \"name\": \"John Doe\",\n  \"education\": [\n    {\n      \"school\": \"University of California, Berkeley\",\n      \"degree\": \"B.S. in Computer Science\",\n      \"year\": 2020\n    }\n  ],\n  \"skills\": [\"Python\", \"Java\", \"C++\"]\n}\n```",
+        "refusal": null
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 128,
+    "completion_tokens": 71,
+    "total_tokens": 199,
+    "prompt_tokens_details": {
+      "cached_tokens": 0,
+      "audio_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "audio_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
+  },
+  "service_tier": "default",
+  "system_fingerprint": "fp_eb9dce56a8"
+}
+
     "#;
 
     #[test]
@@ -174,22 +213,27 @@ mod tests {
         );
 
         let expected = LLMCompleteResponse {
-        client: "mock".to_string(),
-        prompt: internal_baml_jinja::RenderedPrompt::Chat(vec![]),
-        content: "{\n  \"isCompanyPost\": false,\n  \"companyName\": null,\n  \"stage\": null,\n  \"engineeringAssessment\": \"UNKNOWN\",\n  \"teamMembers\": [],\n  \"technicalHighlights\": []\n}\n\nNotes:\n- This is a general discussion post asking for programming book recommendations\n- Not a company/startup related post\n- No technical signals or team information can be extracted\n- Cannot make engineering assessment as this is just a question\n\nThis appears to be a learning/discussion oriented post rather than a startup/company related post, so most of the structured fields are null or empty. The post doesn't contain any analyzable technical due diligence information.".to_string(),
-        start_time: system_now,
-        latency: instant_now.elapsed(),
-        model: model_name,
-        request_options: client.request_options().clone(),
-        metadata: LLMCompleteResponseMetadata {
-            baml_is_complete: true,
-            finish_reason: Some("end_turn".to_string()),
-            prompt_tokens: Some(321),
-            output_tokens: Some(158),
-            total_tokens: Some(479),
-        },
-    };
+            client: "mock".to_string(),
+            prompt: internal_baml_jinja::RenderedPrompt::Chat(vec![]),
+            content: "```json\n{\n  \"name\": \"John Doe\",\n  \"education\": [\n    {\n      \"school\": \"University of California, Berkeley\",\n      \"degree\": \"B.S. in Computer Science\",\n      \"year\": 2020\n    }\n  ],\n  \"skills\": [\"Python\", \"Java\", \"C++\"]\n}\n```".to_string(),
+            start_time: system_now,
+            latency: Duration::ZERO,
+            model: "gpt-4o-2024-08-06".to_string(),
+            request_options: client.request_options().clone(),
+            metadata: LLMCompleteResponseMetadata {
+                baml_is_complete: true,
+                finish_reason: Some("stop".to_string()),
+                prompt_tokens: Some(128),
+                output_tokens: Some(71),
+                total_tokens: Some(199),
+            },
+        };
 
-        assert!(matches!(result, LLMResponse::Success(response)));
+        if let LLMResponse::Success(mut actual_result) = result {
+            actual_result.latency = Duration::ZERO;
+            assert_eq!(actual_result, expected);
+        } else {
+            panic!("Expected LLMResponse::Success, got {:?}", result);
+        }
     }
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/response_handler.rs
@@ -143,3 +143,53 @@ pub fn scan_openai_response_stream(
 
     Ok(())
 }
+
+
+#[cfg(test)]
+mod tests {
+    use crate::internal::llm_client::primitive::tests::MockClient;
+
+    use super::*;
+
+    const RESPONSE: &str = r#"
+{"id":"msg_01TmchHftFKihgeV7Zy9vCvZ","type":"message","role":"assistant","model":"claude-3-5-sonnet-20241022","content":[{"type":"text","text":"{\n  \"isCompanyPost\": false,\n  \"companyName\": null,\n  \"stage\": null,\n  \"engineeringAssessment\": \"UNKNOWN\",\n  \"teamMembers\": [],\n  \"technicalHighlights\": []\n}\n\nNotes:\n- This is a general discussion post asking for programming book recommendations\n- Not a company/startup related post\n- No technical signals or team information can be extracted\n- Cannot make engineering assessment as this is just a question\n\nThis appears to be a learning/discussion oriented post rather than a startup/company related post, so most of the structured fields are null or empty. The post doesn't contain any analyzable technical due diligence information."}],"stop_reason":"end_turn","stop_sequence":null,"usage":{"input_tokens":321,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":158}}
+    "#;
+
+    #[test]
+    fn test_parse_openai_response() {
+        let client = MockClient::new();
+        let prompt = vec![];
+        let response_body = serde_json::from_str(RESPONSE.trim()).unwrap();
+        let system_now = web_time::SystemTime::now();
+        let instant_now = web_time::Instant::now();
+        let model_name = "gpt-4o-mini".to_string();
+
+        let result = parse_openai_response(
+            &client,
+            either::Right(prompt.as_slice()),
+            response_body,
+            system_now,
+            instant_now,
+            Some(model_name.clone()),
+        );
+
+        let expected = LLMCompleteResponse {
+        client: "mock".to_string(),
+        prompt: internal_baml_jinja::RenderedPrompt::Chat(vec![]),
+        content: "{\n  \"isCompanyPost\": false,\n  \"companyName\": null,\n  \"stage\": null,\n  \"engineeringAssessment\": \"UNKNOWN\",\n  \"teamMembers\": [],\n  \"technicalHighlights\": []\n}\n\nNotes:\n- This is a general discussion post asking for programming book recommendations\n- Not a company/startup related post\n- No technical signals or team information can be extracted\n- Cannot make engineering assessment as this is just a question\n\nThis appears to be a learning/discussion oriented post rather than a startup/company related post, so most of the structured fields are null or empty. The post doesn't contain any analyzable technical due diligence information.".to_string(),
+        start_time: system_now,
+        latency: instant_now.elapsed(),
+        model: model_name,
+        request_options: client.request_options().clone(),
+        metadata: LLMCompleteResponseMetadata {
+            baml_is_complete: true,
+            finish_reason: Some("end_turn".to_string()),
+            prompt_tokens: Some(321),
+            output_tokens: Some(158),
+            total_tokens: Some(479),
+        },
+    };
+
+        assert!(matches!(result, LLMResponse::Success(response)));
+    }
+}

--- a/engine/baml-runtime/src/internal/llm_client/primitive/request.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/request.rs
@@ -31,7 +31,7 @@ pub struct LoggedHttpResponse {
 }
 
 impl LoggedHttpResponse {
-    pub async fn new_from_reqwest(mut resp: reqwest::Response) -> Result<Self, reqwest::Error> {
+    pub async fn new_from_reqwest(resp: reqwest::Response) -> Result<Self, reqwest::Error> {
         let status = resp.status();
         let url = resp.url().to_string();
         let headers = resp.headers().clone();

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/response_handler.rs
@@ -1,7 +1,10 @@
 use anyhow::Result;
 
-use super::types::{FinishReason, VertexResponse};
-use crate::internal::llm_client::{primitive::request::RequestBuilder, traits::WithClient, ErrorCode, LLMCompleteResponse, LLMCompleteResponseMetadata, LLMErrorResponse, LLMResponse};
+use super::types::VertexResponse;
+use crate::internal::llm_client::{
+    primitive::request::RequestBuilder, traits::WithClient, ErrorCode, LLMCompleteResponse,
+    LLMCompleteResponseMetadata, LLMErrorResponse, LLMResponse,
+};
 use anyhow::Context;
 use serde::Deserialize;
 use serde_json::Value;
@@ -23,11 +26,13 @@ pub fn parse_vertex_response<C: WithClient + RequestBuilder>(
     instant_now: web_time::Instant,
     model_name: Option<String>,
 ) -> LLMResponse {
-    let response = match VertexResponse::deserialize(&response_body).context(format!(
-        "Failed to parse into a response accepted by {}: {}",
-        std::any::type_name::<VertexResponse>(),
-        response_body
-    )).map_err(|e| LLMErrorResponse {
+    let response = match VertexResponse::deserialize(&response_body)
+        .context(format!(
+            "Failed to parse into a response accepted by {}: {}",
+            std::any::type_name::<VertexResponse>(),
+            response_body
+        ))
+        .map_err(|e| LLMErrorResponse {
             client: client.context().name.to_string(),
             model: model_name.clone(),
             prompt: to_prompt(prompt),
@@ -36,12 +41,10 @@ pub fn parse_vertex_response<C: WithClient + RequestBuilder>(
             latency: instant_now.elapsed(),
             message: format!("{:?}", e),
             code: ErrorCode::Other(2),
-        })
-    {
+        }) {
         Ok(response) => response,
         Err(e) => return LLMResponse::LLMFailure(e),
     };
-
 
     if response.candidates.len() != 1 {
         return LLMResponse::LLMFailure(LLMErrorResponse {
@@ -89,10 +92,7 @@ pub fn parse_vertex_response<C: WithClient + RequestBuilder>(
         request_options: client.request_options().clone(),
         model: model_name.unwrap_or("<unknown>".to_string()),
         metadata: LLMCompleteResponseMetadata {
-            baml_is_complete: matches!(
-                response.candidates[0].finish_reason,
-                Some(FinishReason::Stop)
-            ),
+            baml_is_complete: response.candidates[0].finish_reason == Some("STOP".to_string()),
             finish_reason: response.candidates[0]
                 .finish_reason
                 .as_ref()
@@ -112,7 +112,6 @@ fn content_part(model_name: &str) -> usize {
     }
 }
 
-
 pub fn scan_vertex_response_stream(
     client_name: &str,
     request_options: &baml_types::BamlMap<String, serde_json::Value>,
@@ -126,14 +125,16 @@ pub fn scan_vertex_response_stream(
     let inner = match accumulated {
         Ok(accumulated) => accumulated,
         // We'll just keep the first error and return it
-        Err(e) => return Ok(())
+        Err(e) => return Ok(()),
     };
 
-    let event = match VertexResponse::deserialize(&event_body).context(format!(
-        "Failed to parse into a response accepted by {}: {}",
-        std::any::type_name::<VertexResponse>(),
-        event_body
-    )).map_err(|e| LLMErrorResponse {
+    let event = match VertexResponse::deserialize(&event_body)
+        .context(format!(
+            "Failed to parse into a response accepted by {}: {}",
+            std::any::type_name::<VertexResponse>(),
+            event_body
+        ))
+        .map_err(|e| LLMErrorResponse {
             client: client_name.to_string(),
             model: model_name.clone(),
             prompt: prompt.clone(),
@@ -142,13 +143,17 @@ pub fn scan_vertex_response_stream(
             latency: instant_now.elapsed(),
             message: format!("{:?}", e),
             code: ErrorCode::Other(2),
-        })
-    {
+        }) {
         Ok(response) => response,
         Err(e) => return Err(e),
     };
     if let Some(choice) = event.candidates.get(0) {
-        let part_index = content_part(model_name.as_ref().map(|s| s.as_str()).unwrap_or("<unknown>"));
+        let part_index = content_part(
+            model_name
+                .as_ref()
+                .map(|s| s.as_str())
+                .unwrap_or("<unknown>"),
+        );
         if let Some(content) = choice
             .content
             .as_ref()
@@ -157,11 +162,112 @@ pub fn scan_vertex_response_stream(
             inner.content += &content.text;
         }
         inner.metadata.finish_reason = choice.finish_reason.as_ref().map(|r| r.to_string());
-        if let Some(FinishReason::Stop) = choice.finish_reason.as_ref() {
+        if choice.finish_reason == Some("STOP".to_string()) {
             inner.metadata.baml_is_complete = true;
         }
     }
 
     inner.latency = instant_now.elapsed();
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::internal::llm_client::primitive::tests::MockClient;
+
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use web_time::Duration;
+
+    const RESPONSE: &str = r#"
+{
+  "candidates": [
+    {
+      "content": {
+        "parts": [
+          {
+            "text": "**AccountIssue** \n\nThe input clearly describes a problem with accessing an account and a failure in the password reset process.  This falls squarely into account-related issues. \n"
+          }
+        ],
+        "role": "model"
+      },
+      "finishReason": "STOP",
+      "index": 0,
+      "safetyRatings": [
+        {
+          "category": "HARM_CATEGORY_SEXUALLY_EXPLICIT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HATE_SPEECH",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_HARASSMENT",
+          "probability": "NEGLIGIBLE"
+        },
+        {
+          "category": "HARM_CATEGORY_DANGEROUS_CONTENT",
+          "probability": "NEGLIGIBLE"
+        }
+      ]
+    }
+  ],
+  "usageMetadata": {
+    "promptTokenCount": 79,
+    "candidatesTokenCount": 35,
+    "totalTokenCount": 114,
+    "promptTokensDetails": [
+      {
+        "modality": "TEXT",
+        "tokenCount": 79
+      }
+    ]
+  },
+  "modelVersion": "gemini-1.5-pro-001"
+}
+    "#;
+
+    #[test]
+    fn test_parse_vertex_response() {
+        let client = MockClient::new();
+        let prompt = vec![];
+        let response_body = serde_json::from_str(RESPONSE.trim()).unwrap();
+        let system_now = web_time::SystemTime::now();
+        let instant_now = web_time::Instant::now();
+        let model_name = "gpt-4o-mini".to_string();
+
+        let result = parse_vertex_response(
+            &client,
+            either::Right(prompt.as_slice()),
+            response_body,
+            system_now,
+            instant_now,
+            Some(model_name.clone()),
+        );
+
+        let expected = LLMCompleteResponse {
+            client: "mock".to_string(),
+            prompt: internal_baml_jinja::RenderedPrompt::Chat(vec![]),
+            content: "**AccountIssue** \n\nThe input clearly describes a problem with accessing an account and a failure in the password reset process.  This falls squarely into account-related issues. \n".to_string(),
+            start_time: system_now,
+            latency: Duration::ZERO,
+            model: model_name,
+            request_options: client.request_options().clone(),
+            metadata: LLMCompleteResponseMetadata {
+                baml_is_complete: true,
+                finish_reason: Some("STOP".to_string()),
+                prompt_tokens: Some(79),
+                output_tokens: Some(35),
+                total_tokens: Some(114),
+            },
+        };
+
+        if let LLMResponse::Success(mut actual_result) = result {
+            actual_result.latency = Duration::ZERO;
+            assert_eq!(actual_result, expected);
+        } else {
+            panic!("Expected LLMResponse::Success, got {:?}", result);
+        }
+    }
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/response_handler.rs
@@ -96,7 +96,7 @@ pub fn parse_vertex_response<C: WithClient + RequestBuilder>(
             finish_reason: response.candidates[0]
                 .finish_reason
                 .as_ref()
-                .map(|r| serde_json::to_string(r).unwrap_or("".into())),
+                .map(|r| r.to_string()),
             prompt_tokens: usage_metadata.prompt_token_count,
             output_tokens: usage_metadata.candidates_token_count,
             total_tokens: usage_metadata.total_token_count,

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
@@ -233,7 +233,7 @@ pub enum HarmSeverity {
 pub struct Candidate {
     pub index: Option<i32>,
     pub content: Option<Content>,
-    pub finish_reason: Option<FinishReason>,
+    pub finish_reason: Option<String>,
     pub safety_ratings: Option<Vec<SafetyRating>>,
     pub citation_metadata: Option<CitationMetadata>,
     pub grounding_metadata: Option<GroundingMetadata>,
@@ -300,28 +300,6 @@ pub struct VideoMetadata {
 pub struct Duration {
     pub seconds: i64,
     pub nanos: i32,
-}
-
-#[derive(Serialize, Deserialize, Debug, strum_macros::Display)]
-pub enum FinishReason {
-    #[serde(rename = "FINISH_REASON_UNSPECIFIED")]
-    Unspecified,
-    #[serde(rename = "STOP")]
-    Stop,
-    #[serde(rename = "MAX_TOKENS")]
-    MaxTokens,
-    #[serde(rename = "SAFETY")]
-    Safety,
-    #[serde(rename = "RECITATION")]
-    Recitation,
-    #[serde(rename = "OTHER")]
-    Other,
-    #[serde(rename = "BLOCKLIST")]
-    Blocklist,
-    #[serde(rename = "PROHIBITED_CONTENT")]
-    ProhibitedContent,
-    #[serde(rename = "SPII")]
-    Spii,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -445,7 +423,7 @@ mod tests {
                         video_metadata: None,
                     }],
                 }),
-                finish_reason: Some(FinishReason::Stop),
+                finish_reason: Some("STOP".to_string()),
                 safety_ratings: Some(vec![
                     SafetyRating {
                         category: Some(HarmCategory::HateSpeech),

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
@@ -431,16 +431,70 @@ mod tests {
         "#;
 
         let parsed: Result<VertexResponse, Error> = serde_json::from_str(data);
+        let expected = VertexResponse {
+            candidates: vec![Candidate {
+                index: None,
+                content: Some(Content {
+                    role: Some("model".to_string()),
+                    parts: vec![Part {
+                        text: "The air in Donkey Kong's treehouse was thick with frustration. Scattered banana peels littered the floor, evidence of a temper tantrum of Kong-sized proportions. Donkey Kong himself sat slumped against a wall, his furry brow furrowed. Today was the annual Jungle Jamboree, and Donkey Kong, reigning champion of the Banana Eating Contest, couldn't participate. \n\nHis dentist, a nervous little monkey named Marvin, had fitted him with braces. \"No more chomping whole bananas for a while, big guy,\" Marvin had chirped, tapping a metal bracket. \"These babies need soft food.\"\n\nDonkey Kong sighed. Soft food. What was the point of a jungle jamboree if you couldn't even enjoy a proper banana?\n\nSuddenly, a sweet, nutty aroma wafted in from the open window. Donkey Kong's nose twitched. He followed the scent to find Diddy Kong, his little buddy, happily munching on something spread on a banana slice.\n\n\"What's that you got there, little buddy?\" Donkey Kong grumbled, trying not to sound too interested.\n\n\"Peanut butter sandwiches!\" chirped Diddy Kong, offering Donkey Kong a bite. \"Want one? It's the best thing ever!\"\n\nDonkey Kong hesitated. Could he? He took a tentative bite and his eyes widened. The creamy peanut butter coated his mouth, the salty-sweet taste a revelation. It was soft, delicious, and didn't require any chewing!\n\n\"Diddy,\" Donkey Kong said, a slow grin spreading across his face, \"You're a genius!\"\n\nThat afternoon, Donkey Kong entered the Jungle Jamboree, his head held high. He might not be the Banana Eating Champion this year, but he was determined to become the Peanut Butter Sandwich Eating Champion. And with a determined glint in his eye and a stack of peanut butter sandwiches, Donkey Kong knew he had this one in the bag. From then on, peanut butter became a staple in Donkey Kong's diet, braces or no braces. After all, who needed chomping when you had creamy, delicious peanut butter? \n".to_string(),
+                        inline_data: None,
+                        file_data: None,
+                        function_call: None,
+                        function_response: None,
+                        video_metadata: None,
+                    }],
+                }),
+                finish_reason: Some(FinishReason::Stop),
+                safety_ratings: Some(vec![
+                    SafetyRating {
+                        category: Some(HarmCategory::HateSpeech),
+                        probability: Some(HarmProbability::Negligible),
+                        probability_score: Some(0.12085322),
+                        severity: Some(HarmSeverity::Negligible),
+                        severity_score: Some(0.11616109),
+                        blocked: None,
+                    },
+                    SafetyRating {
+                        category: Some(HarmCategory::DangerousContent),
+                        probability: Some(HarmProbability::Negligible),
+                        probability_score: Some(0.07356305),
+                        severity: Some(HarmSeverity::Negligible),
+                        severity_score: Some(0.037750278),
+                        blocked: None,
+                    },
+                    SafetyRating {
+                        category: Some(HarmCategory::Harassment),
+                        probability: Some(HarmProbability::Negligible),
+                        probability_score: Some(0.24926445),
+                        severity: Some(HarmSeverity::Negligible),
+                        severity_score: Some(0.108566426),
+                        blocked: None,
+                    },
+                    SafetyRating {
+                        category: Some(HarmCategory::SexuallyExplicit),
+                        probability: Some(HarmProbability::Negligible),
+                        probability_score: Some(0.08137363),
+                        severity: Some(HarmSeverity::Negligible),
+                        severity_score: Some(0.1301748),
+                        blocked: None,
+                    },
+                ]),
+                citation_metadata: None,
+                grounding_metadata: None,
+                finish_message: None,
+            }],
+            prompt_feedback: None,
+            usage_metadata: Some(UsageMetaData {
+                prompt_token_count: Some(11),
+                candidates_token_count: Some(433),
+                total_token_count: Some(444),
+            }),
+        };
 
-        match parsed {
-            Ok(response) => println!("Parsed successfully: {:?}", response),
-            Err(e) => {
-                println!("Failed to parse: {}", e);
-                println!("Error line: {}", e.line());
-                println!("Error column: {}", e.column());
-                println!("Error cause: {:?}", e.classify());
-                panic!("Deserialization failed");
-            }
-        }
+        let parsed = parsed.expect("Failed to parse json");
+        let parsed_json = serde_json::to_string(&parsed).unwrap();
+        let expected_json = serde_json::to_string(&expected).unwrap();
+        assert_eq!(parsed_json, expected_json);
     }
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
@@ -12,7 +12,7 @@ use crate::{
     internal::llm_client::{
         primitive::{
             request::{make_parsed_request, make_request, RequestBuilder},
-            vertex::types::{FinishReason, VertexResponse},
+            vertex::types::VertexResponse,
         },
         traits::{
             SseResponseTrait, StreamResponse, WithChat, WithClient, WithNoCompletion,

--- a/tools/build
+++ b/tools/build
@@ -129,7 +129,8 @@ case "$_path" in
     if [ "$_test_mode" -eq 1 ]; then
       #command="wasm-pack test --chrome . --features=wasm"
       #command="wasm-pack test --node . --features=wasm"
-      command="cargo test --features=no_wasm,internal internal --verbose -- --nocapture"
+      # command="cargo test --features=no_wasm,internal internal --verbose -- --nocapture"
+      command="cargo test --features=internal internal -- --nocapture"
     else
       command="cargo build --features=wasm --target=wasm32-unknown-unknown"
       command="cargo build"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance request handling and response parsing for LLM clients, add tests, and update build script for `baml-runtime`.
> 
>   - **Behavior**:
>     - Add `PartialEq` and `Eq` to `LLMResponse`, `LLMErrorResponse`, `ErrorCode`, `LLMCompleteResponse`, and `LLMCompleteResponseMetadata` in `mod.rs`.
>     - Replace `StopReason` enum with `Option<String>` for `stop_reason` in `AnthropicMessageResponse` and `StreamStop` in `types.rs`.
>     - Modify `parse_anthropic_response()` and `scan_anthropic_response_stream()` in `response_handler.rs` to use `is_done()` for `stop_reason` checks.
>     - Update `parse_google_response()` and `scan_google_response_stream()` in `response_handler.rs` to handle `finish_reason` as `Option<String>`.
>     - Adjust `parse_openai_response()` and `scan_openai_response_stream()` in `response_handler.rs` to handle `choices` and `usage` correctly.
>     - Modify `parse_vertex_response()` and `scan_vertex_response_stream()` in `response_handler.rs` to handle `finish_reason` as `Option<String>`.
>   - **Tests**:
>     - Add tests for `parse_anthropic_response()`, `parse_google_response()`, `parse_openai_response()`, and `parse_vertex_response()` in respective `response_handler.rs` files.
>     - Add deserialization tests for `GoogleResponse` and `VertexResponse` in `types.rs`.
>   - **Build**:
>     - Update `tools/build` to change test command for `baml-runtime` to `cargo test --features=internal internal -- --nocapture`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 749b95c724d30ffec0863b428dafa73d7ffa3724. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->