### PR TITLE
fix: google-vertex docs

### DIFF
--- a/fern/snippets/client-constructor.mdx
+++ b/fern/snippets/client-constructor.mdx
@@ -11,7 +11,7 @@ The configuration modifies the URL request BAML runtime makes.
 | `google-ai`      | [Google AI](/docs/snippets/clients/providers/gemini)                |                                                            |
 | `openai`         | [OpenAI](/docs/snippets/clients/providers/openai)                   |                                                            |
 | `openai-generic` | [OpenAI (generic)](/docs/snippets/clients/providers/openai-generic) | Any model provider that supports an OpenAI-compatible API  |
-| `vertex-ai`      | [Vertex AI](/docs/snippets/clients/providers/vertex)                |                                                            |
+| `vertex-ai`      | [Vertex AI](/docs/snippets/clients/providers/google-vertex)         |                                                            |
 
 We also have some special providers that allow composing clients together:
 | Provider Name  | Docs                             | Notes                                                      |


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes link for `vertex-ai` provider in `client-constructor.mdx`.
> 
>   - **Documentation**:
>     - Fixes link for `vertex-ai` provider in `client-constructor.mdx` from `/docs/snippets/clients/providers/vertex` to `/docs/snippets/clients/providers/google-vertex`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f11c9b7486f9ddefc46695fddae223cfe4d582df. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->