### PR TITLE
add fern check strict link checks to CI

### DIFF
--- a/.github/workflows/fern-check.yml
+++ b/.github/workflows/fern-check.yml
@@ -14,4 +14,5 @@ jobs:
       - name: Install fern
         run: npm install -g fern-api
       - name: fern check
-        run: fern check
+        working-directory: ./fern
+        run: fern check --strict-broken-links

--- a/fern/01-guide/02-languages/python.mdx
+++ b/fern/01-guide/02-languages/python.mdx
@@ -181,4 +181,4 @@ This auto-reload approach works best if you're only making changes to the prompt
 
 </Steps>
 
-You're all set! Continue on to the [Deployment Guides](/docs/get-started/deploying) for your language to learn how to deploy your BAML code or check out the [Interactive Examples](https://baml-examples.vercel.app/) to see more examples.
+You're all set! Continue on to the [Deployment Guides](/guide/development/deploying/docker) for your language to learn how to deploy your BAML code or check out the [Interactive Examples](https://baml-examples.vercel.app/) to see more examples.

--- a/fern/01-guide/02-languages/rest.mdx
+++ b/fern/01-guide/02-languages/rest.mdx
@@ -12,7 +12,7 @@ BAML allows you to expose your BAML functions as RESTful APIs:
 
 <img src="/assets/languages/baml-to-rest.png" />
 
-We integrate with [OpenAPI](openapi) (universal API definitions), so you can get typesafe client libraries for free!
+We integrate with [OpenAPI](https://www.openapis.org/) (universal API definitions), so you can get typesafe client libraries for free!
 
 <Steps>
   ### Install BAML VSCode Extension
@@ -502,3 +502,4 @@ async fn main() {
 [openapi-feedback-github-issue]: https://github.com/BoundaryML/baml/issues/892
 [npx-windows-issue]: https://github.com/nodejs/node/issues/53538
 [openapi-client-types]: https://github.com/OpenAPITools/openapi-generator#overview
+[openapi]: https://www.openapis.org/

--- a/fern/01-guide/03-development/deploying/openapi.mdx
+++ b/fern/01-guide/03-development/deploying/openapi.mdx
@@ -118,7 +118,6 @@ curl http://localhost:2024/_debug/ping
 
 Update your code to use `BOUNDARY_ENDPOINT`, if set, as the endpoint for your BAML functions. 
 
-If you plan to use [Boundary Cloud](/ref/cloud/functions/get-started) to host your BAML functions, you should also update it to use `BOUNDARY_API_KEY`.
 
 <Markdown src="../../../snippets/openapi-howto-rely-on-envvars.mdx" />
 

--- a/fern/01-guide/06-prompt-engineering/tools.mdx
+++ b/fern/01-guide/06-prompt-engineering/tools.mdx
@@ -99,7 +99,7 @@ function UseTool(user_message: string) -> WeatherAPI | MyOtherAPI {
 }
 ```
 
-<Tip>If you use [VSCode Playground](/guides/installation-editors/vs-code-extension), you can see what we inject into the prompt, with full transparency.</Tip>
+<Tip>If you use [VSCode Playground](/guide/installation-editors/vs-code-extension), you can see what we inject into the prompt, with full transparency.</Tip>
 
 Call the function like this:
 

--- a/fern/01-guide/07-observability/studio.mdx
+++ b/fern/01-guide/07-observability/studio.mdx
@@ -119,7 +119,6 @@ This allows us to see each function invocation, as well as all its children in t
 
 <img src="/assets/studio/dashboard-test-pic.png" width="auto" />
 
-See [running tests](/running-tests) for more information on how to run this test.
 
 ### Adding custom tags
 

--- a/fern/01-guide/09-comparisons/pydantic.mdx
+++ b/fern/01-guide/09-comparisons/pydantic.mdx
@@ -339,7 +339,7 @@ Here's all the BAML code you need to solve the Extract Resume problem from earli
 <img src="/assets/vscode/extract-resume-prompt-preview.png" />
 
 <Note>
-Here we use a "GPT4" client, but you can use any model. See [client docs](/docs/syntax/client/client)
+Here we use a "GPT4" client, but you can use any model. See [client docs](/ref/llm-client-providers/open-ai)
 </Note>
 {/* 
 ```baml
@@ -398,7 +398,7 @@ In this image we change the types and BAML automatically updates the prompt, par
 
 
 
-Adding retries or resilience requires just [a couple of modifications](/docs/syntax/client/retry). And best of all, **you can test things instantly, without leaving your VSCode**.
+Adding retries or resilience requires just [a couple of modifications](/ref/llm-client-strategies/retry-policy). And best of all, **you can test things instantly, without leaving your VSCode**.
 
 ### Conclusion
 We built BAML because writing a Python library was just not powerful enough to do everything we envisioned, as we have just explored.

--- a/fern/03-reference/baml-cli/init.mdx
+++ b/fern/03-reference/baml-cli/init.mdx
@@ -75,4 +75,3 @@ For a full list of supported OpenAPI client types, refer to the [OpenAPI Generat
 - The command attempts to infer the OpenAPI generator command based on what's available in your system PATH. It checks for `openapi-generator`, `openapi-generator-cli`, or falls back to using `npx @openapitools/openapi-generator-cli`.
 - After initialization, follow the instructions provided in the console output for language-specific setup steps.
 
-For more information on getting started with BAML, visit the [BAML documentation](https://docs.boundaryml.com/docs/get-started/quickstart).

--- a/fern/03-reference/baml/attributes/check.mdx
+++ b/fern/03-reference/baml/attributes/check.mdx
@@ -25,4 +25,4 @@ class Bar {
 - **Non-Intrusive Validation**: Allows for validation checks without interrupting the flow of data processing.
 - **Runtime Inspection**: Enables inspection of validation results at runtime.
 
-See more in [validations guide](/guide/baml-advanced/validations).
+See more in [validations guide](/guide/baml-advanced/checks-and-asserts).

--- a/fern/03-reference/baml/class.mdx
+++ b/fern/03-reference/baml/class.mdx
@@ -100,7 +100,7 @@ Property names must follow these rules:
 - Must be unique within the class
 - classes cannot be self-referential (cannot have a property of the same type as the class itself)
 
-The type of a property can be any [supported type](supported-types)
+The type of a property can be any [supported type](/ref/baml/types)
 
 ### Default values
 

--- a/fern/03-reference/baml/comments.mdx
+++ b/fern/03-reference/baml/comments.mdx
@@ -36,7 +36,7 @@ Multiline comments are denoted via `{//` and `//}`.
  
 ## Comments in block strings
 
-See [Block Strings](./values/string#block-strings) for more information.
+See [Block Strings](/ref/baml/general-baml-syntax/string#block-strings) for more information.
 
 ```jinja
 #"

--- a/fern/03-reference/baml/types.mdx
+++ b/fern/03-reference/baml/types.mdx
@@ -35,8 +35,8 @@ See [Union(|)](#union-) for more details.
 
 
 ## Multimodal Types
-See [calling a function with multimodal types](/docs/snippets/calling-baml/multi-modal)
-and [testing image inputs](/docs/snippets/test-cases#images)
+See [calling a function with multimodal types](/guide/baml-basics/multi-modal)
+and [testing image inputs](/guide/baml-basics/testing-functions#test-image-inputs-in-the-playground)
 
 <Accordion title="Implementation details: runtime and security considerations">
   BAML's multimodal types are designed for ease of use: we have deliberately made it

--- a/fern/03-reference/baml_client/errors/baml-validation-error.mdx
+++ b/fern/03-reference/baml_client/errors/baml-validation-error.mdx
@@ -62,5 +62,5 @@ if (error instanceof BamlValidationError) {
 
 ## Related Errors
 
-- [BamlClientFinishReasonError](./baml-client-finish-reason-error)
-- [BamlClientError](./baml-client-error)
+- [BamlClientFinishReasonError](/ref/baml_client/errors/baml-client-finish-reason-error)
+- [BamlClientError](/ref/baml_client/errors/baml-client-finish-reason-error)

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "boundary",
-  "version": "0.51.37"
+  "version": "0.56.13"
 }

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -1,2 +1,3 @@
 api:
-  path: ./openapi/openapi.yaml
+  specs:
+    - openapi: ./openapi/openapi.yaml


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add strict link checking to CI and update documentation links and OpenAPI configuration.
> 
>   - **CI/CD**:
>     - Update `.github/workflows/fern-check.yml` to use `fern check --strict-broken-links` with `working-directory: ./fern`.
>   - **Documentation**:
>     - Corrects links in `python.mdx`, `rest.mdx`, `tools.mdx`, `pydantic.mdx`, `check.mdx`, `class.mdx`, `comments.mdx`, `types.mdx`, `baml-validation-error.mdx` to point to the correct paths.
>     - Removes outdated references in `openapi.mdx` and `studio.mdx`.
>   - **Configuration**:
>     - Update `generators.yml` to use `specs` for OpenAPI configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for fd0ee828e404a4722c23a5bf794b9753143ad941. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->