### PR TITLE
feat: vertex auth should log when a given strategy fails

### DIFF
--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -2,8 +2,6 @@ name: BAML Release - Build Python
 
 on:
   workflow_call: {}
-  push:
-    branches: [sam/gcp-auth-nope]
 
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -2,8 +2,6 @@ name: BAML Release - Build Typescript
 
 on:
   workflow_call: {}
-  push:
-    branches: [sam/alpine-warnings, aaron-fix]
 
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/std_auth.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/std_auth.rs
@@ -59,9 +59,8 @@ impl VertexAuth {
                     Err(e) => {
                         log::error!(
                             "{:?}",
-                            anyhow::Error::from(e).context(
-                                "Failed to auth using MetadataServiceAccount strategy"
-                            )
+                            anyhow::Error::from(e)
+                                .context("Failed to auth using MetadataServiceAccount strategy")
                         );
                     }
                 }
@@ -73,10 +72,11 @@ impl VertexAuth {
                     Err(e) => {
                         log::error!(
                             "{:?}",
-                            anyhow::Error::from(e).context(
-                                "Failed to auth using GCloudAuthorizedUser strategy"
-                            )
+                            anyhow::Error::from(e)
+                                .context("Failed to auth using GCloudAuthorizedUser strategy")
                         );
+                    }
+                }
                 anyhow::bail!(
                     "Failed to auth - system_default strategy did not resolve successfully"
                 )

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/std_auth.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/std_auth.rs
@@ -34,22 +34,49 @@ impl VertexAuth {
                 Ok(VertexAuth::CustomServiceAccount(authz_user))
             }
             ResolvedGcpAuthStrategy::SystemDefault => {
-                log::debug!("Attempting to auth using SystemDefault strategy");
-                if let Ok(authz_user) = gcp_auth::ConfigDefaultCredentials::new().await {
-                    log::debug!(
-                        "Successful auth using GcloudApplicationDefaultCredentials strategy"
-                    );
-                    return Ok(VertexAuth::ConfigDefaultCredentials(authz_user));
+                log::debug!("Attempting to auth using SystemDefault strategy (local mods)");
+                match gcp_auth::ConfigDefaultCredentials::new().await {
+                    Ok(authz_user) => {
+                        log::debug!(
+                            "Successful auth using GcloudApplicationDefaultCredentials strategy"
+                        );
+                        return Ok(VertexAuth::ConfigDefaultCredentials(authz_user));
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "{:?}",
+                            anyhow::Error::from(e).context(
+                                "Failed to auth using GcloudApplicationDefaultCredentials strategy"
+                            )
+                        );
+                    }
                 }
-                if let Ok(authz_user) = gcp_auth::MetadataServiceAccount::new().await {
-                    log::debug!("Successful auth using MetadataServiceAccount strategy");
-                    return Ok(VertexAuth::MetadataServiceAccount(authz_user));
+                match gcp_auth::MetadataServiceAccount::new().await {
+                    Ok(authz_user) => {
+                        log::debug!("Successful auth using MetadataServiceAccount strategy");
+                        return Ok(VertexAuth::MetadataServiceAccount(authz_user));
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "{:?}",
+                            anyhow::Error::from(e).context(
+                                "Failed to auth using MetadataServiceAccount strategy"
+                            )
+                        );
+                    }
                 }
-                if let Ok(authz_user) = gcp_auth::GCloudAuthorizedUser::new().await {
-                    log::debug!("Successful auth using GCloudAuthorizedUser strategy");
-                    return Ok(VertexAuth::GCloudAuthorizedUser(authz_user));
-                }
-
+                match gcp_auth::GCloudAuthorizedUser::new().await {
+                    Ok(authz_user) => {
+                        log::debug!("Successful auth using GCloudAuthorizedUser strategy");
+                        return Ok(VertexAuth::GCloudAuthorizedUser(authz_user));
+                    }
+                    Err(e) => {
+                        log::error!(
+                            "{:?}",
+                            anyhow::Error::from(e).context(
+                                "Failed to auth using GCloudAuthorizedUser strategy"
+                            )
+                        );
                 anyhow::bail!(
                     "Failed to auth - system_default strategy did not resolve successfully"
                 )

--- a/engine/language_client_typescript/package.json
+++ b/engine/language_client_typescript/package.json
@@ -60,7 +60,7 @@
     "build": "pnpm build:napi-release && pnpm build:ts_build",
     "build:debug": "pnpm build:napi-debug && pnpm build:ts_build",
     "build:napi-release": "pnpm build:napi-debug --release",
-    "build:napi-debug": "napi build --js ./native.js --dts ./native.d.ts --platform",
+    "build:napi-debug": "napi build --js ./native.js --dts ./native.d.ts --target x86_64-unknown-linux-gnu",
     "build:ts_build": "tsc ./typescript_src/*.ts --outDir ./ --module nodenext --module nodenext --allowJs --declaration true --declarationMap true || true",
     "format": "run-p format:biome format:rs format:toml",
     "format:biome": "biome --write .",

--- a/engine/language_client_typescript/package.json
+++ b/engine/language_client_typescript/package.json
@@ -60,7 +60,7 @@
     "build": "pnpm build:napi-release && pnpm build:ts_build",
     "build:debug": "pnpm build:napi-debug && pnpm build:ts_build",
     "build:napi-release": "pnpm build:napi-debug --release",
-    "build:napi-debug": "napi build --js ./native.js --dts ./native.d.ts --target x86_64-unknown-linux-gnu",
+    "build:napi-debug": "napi build --js ./native.js --dts ./native.d.ts --platform",
     "build:ts_build": "tsc ./typescript_src/*.ts --outDir ./ --module nodenext --module nodenext --allowJs --declaration true --declarationMap true || true",
     "format": "run-p format:biome format:rs format:toml",
     "format:biome": "biome --write .",


### PR DESCRIPTION
vertex-ai system-default auth attempts 3 strategies in sequence: default app credentials, metadata service, and finally the gcloud cli fallback. We assumed that the logging inside gcp-auth would be useful enough to figure out what's going on, and swallowed errors on our side.

That turns out to not be true: because we don't bundle certs in our builds, users must provide their own certs (e.g. by installing ca-certificates). When they don't, the gcp-auth crate can't actually initiate credential exchanges and consequently fails when attempting to use either default app credentials or the metadata service. Unfortunately, since we swallow these errors, users have no way to realize that they just need to install ca-certificates to fix the error.

Adding logging enables fixing this.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds error logging for failed authentication attempts in `VertexAuth` and removes unused branches from workflow files.
> 
>   - **Behavior**:
>     - Adds error logging for failed authentication attempts in `VertexAuth::new()` in `std_auth.rs` for `SystemDefault` strategy.
>     - Logs errors for `ConfigDefaultCredentials`, `MetadataServiceAccount`, and `GCloudAuthorizedUser` strategies.
>   - **Workflows**:
>     - Removes unused branches from `build-python-release.reusable.yaml` and `build-typescript-release.reusable.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for a56b5a315be31c1c1ad3088c37afcc1a15816895. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->