### PR TITLE
nit: Remove redundant model for RAG example

### DIFF
--- a/fern/01-guide/06-prompt-engineering/rag.mdx
+++ b/fern/01-guide/06-prompt-engineering/rag.mdx
@@ -10,16 +10,12 @@ The most common way to implement RAG is to use a vector store that contains embe
 the data. First, let's define our BAML model for RAG.
 
 ```baml rag.baml
-class Query {
-  query string
-}
-
-class Answer {
+class Response {
   question string
   answer string
 }
 
-function RAG(question: string, context: string) -> Answer {
+function RAG(question: string, context: string) -> Response {
   client "openai/gpt-4o-mini"
   prompt #"
     Answer the question in full sentences using the provided context.
@@ -148,7 +144,8 @@ if __name__ == "__main__":
 
     for question in questions:
         context = vector_store.retrieve_context(question)
-        print(f"{b.RAG(question, context)}")
+        response = b.RAG(question, context)
+        print(response)
         print("-" * 10)
 ```
 


### PR DESCRIPTION
The earlier version had an unnecessary class `Query` that doesn't serve the purpose of this example (it's unused). This PR removes the redundant class from the BAML file.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unused `Query` class and rename `Answer` to `Response` in `rag.mdx` for code simplification.
> 
>   - **Code Simplification**:
>     - Remove unused `Query` class from BAML model in `rag.mdx`.
>     - Rename `Answer` class to `Response` in `rag.mdx`.
>     - Update `RAG` function to return `Response` instead of `Answer` in `rag.mdx`.
>   - **Python Code**:
>     - Update `rag.py` to use `Response` class for output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 90c759fae8cdae284882442d65d996ba1e06bb66. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->