### PR TITLE
Maintain attribute information when combining fields

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -453,83 +453,85 @@ fn to_ir_attributes(
     db: &ParserDatabase,
     maybe_ast_attributes: Option<&Attributes>,
 ) -> (IndexMap<String, UnresolvedValue<()>>, Vec<Constraint>) {
-    let null_result = (IndexMap::new(), Vec::new());
-    maybe_ast_attributes.map_or(null_result, |attributes| {
-        let Attributes {
-            description,
-            alias,
-            dynamic_type,
-            skip,
-            constraints,
-            streaming_done,
-            streaming_needed,
-            streaming_state,
-        } = attributes;
+    let Some(attributes) = maybe_ast_attributes else {
+        return (IndexMap::new(), Vec::new());
+    };
 
-        let description = description
-            .as_ref()
-            .map(|d| ("description".to_string(), d.without_meta()));
+    let Attributes {
+        description,
+        alias,
+        dynamic_type,
+        skip,
+        constraints,
+        streaming_done,
+        streaming_needed,
+        streaming_state,
+    } = attributes;
 
-        let alias = alias
-            .as_ref()
-            .map(|v| ("alias".to_string(), v.without_meta()));
+    let description = description
+        .as_ref()
+        .map(|d| ("description".to_string(), d.without_meta()));
 
-        let dynamic_type = dynamic_type.as_ref().and_then(|v| {
-            if *v {
-                Some(("dynamic_type".to_string(), UnresolvedValue::Bool(true, ())))
-            } else {
-                None
-            }
-        });
-        let skip = skip.as_ref().and_then(|v| {
-            if *v {
-                Some(("skip".to_string(), UnresolvedValue::Bool(true, ())))
-            } else {
-                None
-            }
-        });
-        let streaming_done = streaming_done.as_ref().and_then(|v| {
-            if *v {
-                Some(("stream.done".to_string(), UnresolvedValue::Bool(true, ())))
-            } else {
-                None
-            }
-        });
-        let streaming_needed = streaming_needed.as_ref().and_then(|v| {
-            if *v {
-                Some((
-                    "stream.not_null".to_string(),
-                    UnresolvedValue::Bool(true, ()),
-                ))
-            } else {
-                None
-            }
-        });
-        let streaming_state = streaming_state.as_ref().and_then(|v| {
-            if *v {
-                Some((
-                    "stream.with_state".to_string(),
-                    UnresolvedValue::Bool(true, ()),
-                ))
-            } else {
-                None
-            }
-        });
+    let alias = alias
+        .as_ref()
+        .map(|v| ("alias".to_string(), v.without_meta()));
 
-        let meta = vec![
-            description,
-            alias,
-            dynamic_type,
-            skip,
-            streaming_done,
-            streaming_needed,
-            streaming_state,
-        ]
-        .into_iter()
-        .filter_map(|s| s)
-        .collect();
-        (meta, constraints.clone())
-    })
+    let dynamic_type = dynamic_type.as_ref().and_then(|v| {
+        if *v {
+            Some(("dynamic_type".to_string(), UnresolvedValue::Bool(true, ())))
+        } else {
+            None
+        }
+    });
+    let skip = skip.as_ref().and_then(|v| {
+        if *v {
+            Some(("skip".to_string(), UnresolvedValue::Bool(true, ())))
+        } else {
+            None
+        }
+    });
+    let streaming_done = streaming_done.as_ref().and_then(|v| {
+        if *v {
+            Some(("stream.done".to_string(), UnresolvedValue::Bool(true, ())))
+        } else {
+            None
+        }
+    });
+    let streaming_needed = streaming_needed.as_ref().and_then(|v| {
+        if *v {
+            Some((
+                "stream.not_null".to_string(),
+                UnresolvedValue::Bool(true, ()),
+            ))
+        } else {
+            None
+        }
+    });
+    let streaming_state = streaming_state.as_ref().and_then(|v| {
+        if *v {
+            Some((
+                "stream.with_state".to_string(),
+                UnresolvedValue::Bool(true, ()),
+            ))
+        } else {
+            None
+        }
+    });
+
+    let meta = vec![
+        description,
+        alias,
+        dynamic_type,
+        skip,
+        streaming_done,
+        streaming_needed,
+        streaming_state,
+    ]
+    .into_iter()
+    .filter_map(|s| s)
+    .collect();
+
+    (meta, constraints.clone())
 }
 
 /// Nodes allow attaching metadata to a given IR entity: attributes, source location, etc

--- a/engine/baml-lib/schema-ast/src/parser/parse_field.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_field.rs
@@ -54,7 +54,7 @@ pub(crate) fn parse_value_expr(
         _ => Err(DatamodelError::new_model_validation_error(
             "This field declaration is invalid. It is either missing a name or a type.",
             container_type,
-            model_name.as_ref().map_or("<unknown>", |f| f.name()),
+            model_name.as_ref().map_or("<unknown>", Identifier::name),
             diagnostics.span(pair_span),
         )),
     }
@@ -219,13 +219,21 @@ fn combine_field_types(types: Vec<FieldType>) -> Option<FieldType> {
 
     let mut seen_types = vec![combined_type.clone()];
 
+    // In a union, use the attributes associated with the last type as the
+    // attributes of the union. Example:
+    //
+    // field: string? | int @alias("hello")
+    //
+    // The alias is part of the union.
+    let last_field_attrs = types.last().map(|t| t.attributes().to_vec());
+
     let mut earliest_start = combined_type.span().start;
     let mut latest_end = combined_type.span().end;
 
     for next_type in types.into_iter().skip(1) {
-        seen_types.push(next_type.clone());
+        let span = next_type.span().to_owned();
+        seen_types.push(next_type);
 
-        let span = next_type.span();
         if span.start < earliest_start {
             earliest_start = span.start;
         }
@@ -243,6 +251,11 @@ fn combine_field_types(types: Vec<FieldType>) -> Option<FieldType> {
             },
             None,
         );
+    }
+
+    // We know it's a union because it was assigned above in the for loop.
+    if let FieldType::Union(_, _, _, attrs) = &mut combined_type {
+        *attrs = last_field_attrs;
     }
 
     Some(combined_type)
@@ -531,9 +544,9 @@ mod tests {
             name: (value, Span::fake()).into(),
             parenthesized: false,
             arguments: ArgumentsList {
-                arguments: Vec::new()
+                arguments: Vec::new(),
             },
-            span: Span::fake()
+            span: Span::fake(),
         }
     }
 }

--- a/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
+++ b/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
@@ -29,6 +29,7 @@ pub fn render_output_format(
         .build())
 }
 
+#[derive(Debug)]
 enum OverridableValue<T> {
     Unset,
     SetEmpty,

--- a/engine/baml-runtime/tests/test_runtime.rs
+++ b/engine/baml-runtime/tests/test_runtime.rs
@@ -1007,4 +1007,30 @@ test RecursiveAliasCycle {
             "##,
         })
     }
+
+    #[test]
+    fn test_class_property_alias() -> anyhow::Result<()> {
+        run_type_builder_block_test(TypeBuilderBlockTest {
+            function_name: "Fn",
+            test_name: "Test",
+            baml: r##"
+              class PropertyAlias {
+                  property string? | int @alias("hello")
+              }
+
+              function Fn() -> PropertyAlias {
+                  client "openai/gpt-4o"
+                  prompt #"
+                      {{ctx.output_format}}
+                  "#
+              }
+
+              test Test {
+                functions [Fn]
+                args {
+                }
+              }
+            "##,
+        })
+    }
 }


### PR DESCRIPTION
Fix #1256 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Maintain attribute information in union types by associating attributes from the last type in the union.
> 
>   - **Behavior**:
>     - `combine_field_types` in `parse_field.rs` now retains attributes from the last type in a union.
>     - Handles union types like `string? | int @alias("hello")` by associating the alias with the union.
>   - **Tests**:
>     - Adds `test_class_property_alias` in `test_runtime.rs` to verify alias handling in union types.
>     - Updates existing tests in `parse_field.rs` to reflect changes in attribute handling.
>   - **Misc**:
>     - Minor refactoring in `repr.rs` to simplify attribute extraction logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 67a35497bef5a2c97c2459787e13ebe0719611d0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->