### PR TITLE
allow loading env vars lazily AFTER baml_client is imported

### DIFF
--- a/engine/language_client_codegen/src/python/templates/__init__.py.j2
+++ b/engine/language_client_codegen/src/python/templates/__init__.py.j2
@@ -9,7 +9,6 @@ from .async_client import b
 from .sync_client import b
 {% endif %}
 
-
 __all__ = [
   "b",
   "partial_types",

--- a/engine/language_client_codegen/src/python/templates/globals.py.j2
+++ b/engine/language_client_codegen/src/python/templates/globals.py.j2
@@ -23,4 +23,26 @@ def reset_baml_env_vars(env_vars: Dict[str, str]):
   else:
     raise BamlError("Cannot reset BAML environment variables while there are active BAML contexts.")
 
+
+try:
+    import dotenv
+    from unittest.mock import patch
+
+    # Monkeypatch load_dotenv to call reset_baml_env_vars after execution
+    original_load_dotenv = dotenv.load_dotenv
+
+    def patched_load_dotenv(*args, **kwargs):
+        result = original_load_dotenv(*args, **kwargs)
+        try:
+            reset_baml_env_vars(os.environ.copy())
+        except BamlError:
+            # swallow the error
+            pass
+        return result
+
+    patch('dotenv.load_dotenv', patched_load_dotenv).start()
+except ImportError:
+    # dotenv is not installed, so we do nothing
+    pass
+
 __all__ = []

--- a/engine/language_client_codegen/src/typescript/templates/globals.ts.j2
+++ b/engine/language_client_codegen/src/typescript/templates/globals.ts.j2
@@ -20,7 +20,7 @@ export function resetBamlEnvVars(envVars: Record<string, string | undefined>) {
   }
 }
 
-const patchedLoad = (originalFn: any, ...args: any[]) => (...args: any[]) => {
+const patchedLoad = (originalFn: any) => (...args: any[]) => {
     const result = originalFn(...args);
     try {
         // Dont fail if env vars fail to reset

--- a/engine/language_client_codegen/src/typescript/templates/globals.ts.j2
+++ b/engine/language_client_codegen/src/typescript/templates/globals.ts.j2
@@ -10,11 +10,41 @@ export const DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME = Baml
 export const DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX = new BamlCtxManager(DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME)
 
 
-export function resetBamlEnvVars(envVars: Record<string, string>) {
+export function resetBamlEnvVars(envVars: Record<string, string | undefined>) {
   if (DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX.allowResets()) {
-    DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME.reset('baml_src', getBamlFiles(), envVars)
+    const envVarsToReset = Object.fromEntries(Object.entries(envVars).filter((kv): kv is [string, string] => kv[1] !== undefined));
+    DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME.reset('baml_src', getBamlFiles(), envVarsToReset)
     DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX.reset()
   } else {
     throw new Error('BamlError: Cannot reset BAML environment variables while there are active BAML contexts.')
   }
+}
+
+const patchedLoad = (originalFn: any, ...args: any[]) => (...args: any[]) => {
+    const result = originalFn(...args);
+    try {
+        // Dont fail if env vars fail to reset
+        resetBamlEnvVars(process.env);
+    } catch (e) {
+        console.error(e);
+    }
+    return result;
+};
+
+try {
+  const dotenv = require('dotenv');
+  // Monkeypatch load function to call resetBamlEnvVars after execution
+
+
+    // Apply the patch
+    dotenv.config = patchedLoad(dotenv.config);
+    dotenv.configDotenv = patchedLoad(dotenv.configDotenv);
+    dotenv.populate = patchedLoad(dotenv.populate);
+} catch (error) {
+  // dotenv is not installed, so we do nothing
+}
+
+// also patch process.loadEnvFile
+if (process.loadEnvFile) {
+    process.loadEnvFile = patchedLoad(process.loadEnvFile);
 }

--- a/integ-tests/python/baml_client/__init__.py
+++ b/integ-tests/python/baml_client/__init__.py
@@ -22,7 +22,6 @@ from .globals import reset_baml_env_vars
 from .async_client import b
 
 
-
 __all__ = [
   "b",
   "partial_types",

--- a/integ-tests/python/baml_client/globals.py
+++ b/integ-tests/python/baml_client/globals.py
@@ -38,4 +38,26 @@ def reset_baml_env_vars(env_vars: Dict[str, str]):
   else:
     raise BamlError("Cannot reset BAML environment variables while there are active BAML contexts.")
 
+
+try:
+    import dotenv
+    from unittest.mock import patch
+
+    # Monkeypatch load_dotenv to call reset_baml_env_vars after execution
+    original_load_dotenv = dotenv.load_dotenv
+
+    def patched_load_dotenv(*args, **kwargs):
+        result = original_load_dotenv(*args, **kwargs)
+        try:
+            reset_baml_env_vars(os.environ.copy())
+        except BamlError:
+            # swallow the error
+            pass
+        return result
+
+    patch('dotenv.load_dotenv', patched_load_dotenv).start()
+except ImportError:
+    # dotenv is not installed, so we do nothing
+    pass
+
 __all__ = []

--- a/integ-tests/python/run_tests.sh
+++ b/integ-tests/python/run_tests.sh
@@ -10,3 +10,5 @@ uv run baml-cli generate --from ../baml_src
 
 # test_functions.py is excluded because it requires credentials
 uv run pytest "$@" --ignore=tests/test_functions.py --ignore=tests/test_collector.py
+
+uv run ruff check .

--- a/integ-tests/react/baml_client/globals.ts
+++ b/integ-tests/react/baml_client/globals.ts
@@ -37,7 +37,7 @@ export function resetBamlEnvVars(envVars: Record<string, string | undefined>) {
   }
 }
 
-const patchedLoad = (originalFn: any, ...args: any[]) => (...args: any[]) => {
+const patchedLoad = (originalFn: any) => (...args: any[]) => {
     const result = originalFn(...args);
     try {
         // Dont fail if env vars fail to reset

--- a/integ-tests/react/baml_client/globals.ts
+++ b/integ-tests/react/baml_client/globals.ts
@@ -27,11 +27,41 @@ export const DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME = Baml
 export const DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX = new BamlCtxManager(DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME)
 
 
-export function resetBamlEnvVars(envVars: Record<string, string>) {
+export function resetBamlEnvVars(envVars: Record<string, string | undefined>) {
   if (DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX.allowResets()) {
-    DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME.reset('baml_src', getBamlFiles(), envVars)
+    const envVarsToReset = Object.fromEntries(Object.entries(envVars).filter((kv): kv is [string, string] => kv[1] !== undefined));
+    DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME.reset('baml_src', getBamlFiles(), envVarsToReset)
     DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX.reset()
   } else {
     throw new Error('BamlError: Cannot reset BAML environment variables while there are active BAML contexts.')
   }
+}
+
+const patchedLoad = (originalFn: any, ...args: any[]) => (...args: any[]) => {
+    const result = originalFn(...args);
+    try {
+        // Dont fail if env vars fail to reset
+        resetBamlEnvVars(process.env);
+    } catch (e) {
+        console.error(e);
+    }
+    return result;
+};
+
+try {
+  const dotenv = require('dotenv');
+  // Monkeypatch load function to call resetBamlEnvVars after execution
+
+
+    // Apply the patch
+    dotenv.config = patchedLoad(dotenv.config);
+    dotenv.configDotenv = patchedLoad(dotenv.configDotenv);
+    dotenv.populate = patchedLoad(dotenv.populate);
+} catch (error) {
+  // dotenv is not installed, so we do nothing
+}
+
+// also patch process.loadEnvFile
+if (process.loadEnvFile) {
+    process.loadEnvFile = patchedLoad(process.loadEnvFile);
 }

--- a/integ-tests/typescript/baml_client/globals.ts
+++ b/integ-tests/typescript/baml_client/globals.ts
@@ -37,7 +37,7 @@ export function resetBamlEnvVars(envVars: Record<string, string | undefined>) {
   }
 }
 
-const patchedLoad = (originalFn: any, ...args: any[]) => (...args: any[]) => {
+const patchedLoad = (originalFn: any) => (...args: any[]) => {
     const result = originalFn(...args);
     try {
         // Dont fail if env vars fail to reset

--- a/integ-tests/typescript/baml_client/globals.ts
+++ b/integ-tests/typescript/baml_client/globals.ts
@@ -27,11 +27,41 @@ export const DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME = Baml
 export const DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX = new BamlCtxManager(DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME)
 
 
-export function resetBamlEnvVars(envVars: Record<string, string>) {
+export function resetBamlEnvVars(envVars: Record<string, string | undefined>) {
   if (DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX.allowResets()) {
-    DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME.reset('baml_src', getBamlFiles(), envVars)
+    const envVarsToReset = Object.fromEntries(Object.entries(envVars).filter((kv): kv is [string, string] => kv[1] !== undefined));
+    DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME.reset('baml_src', getBamlFiles(), envVarsToReset)
     DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX.reset()
   } else {
     throw new Error('BamlError: Cannot reset BAML environment variables while there are active BAML contexts.')
   }
+}
+
+const patchedLoad = (originalFn: any, ...args: any[]) => (...args: any[]) => {
+    const result = originalFn(...args);
+    try {
+        // Dont fail if env vars fail to reset
+        resetBamlEnvVars(process.env);
+    } catch (e) {
+        console.error(e);
+    }
+    return result;
+};
+
+try {
+  const dotenv = require('dotenv');
+  // Monkeypatch load function to call resetBamlEnvVars after execution
+
+
+    // Apply the patch
+    dotenv.config = patchedLoad(dotenv.config);
+    dotenv.configDotenv = patchedLoad(dotenv.configDotenv);
+    dotenv.populate = patchedLoad(dotenv.populate);
+} catch (error) {
+  // dotenv is not installed, so we do nothing
+}
+
+// also patch process.loadEnvFile
+if (process.loadEnvFile) {
+    process.loadEnvFile = patchedLoad(process.loadEnvFile);
 }

--- a/integ-tests/typescript/package.json
+++ b/integ-tests/typescript/package.json
@@ -9,7 +9,7 @@
     "build": "cd ../../engine/language_client_typescript && npm run build && cd - && pnpm i",
     "integ-tests:ci": "pnpm tsc && infisical run --env=test -- pnpm test -- --ci --silent false --testTimeout 30000 --verbose=false --reporters=jest-junit",
     "integ-tests": "pnpm tsc && infisical run --env=test -- pnpm test -- --silent false --testTimeout 30000",
-    "integ-tests:dotenv": "pnpm tsc && dotenv -e ../.env -- pnpm test -- --silent false --testTimeout 30000",
+    "integ-tests:dotenv": "pnpm tsc && pnpm test -- --silent false --testTimeout 30000",
     "generate": "baml-cli generate --from ../baml_src",
     "memory-test": "BAML_LOG=info infisical run --env=test -- pnpm test -- --silent false --testTimeout 60000 -t 'memory'"
   },

--- a/integ-tests/typescript/tests/dynamic-types.test.ts
+++ b/integ-tests/typescript/tests/dynamic-types.test.ts
@@ -114,8 +114,8 @@ describe('Dynamic Type Tests', () => {
       let tb = new TypeBuilder()
       tb.addBaml(`
         class ExtraPersonInfo {
-            height int
-            weight int
+            height int @description("in feet")
+            weight int @description("in pounds")
         }
 
         enum Job {

--- a/integ-tests/typescript/tests/env_vars.ts
+++ b/integ-tests/typescript/tests/env_vars.ts
@@ -1,0 +1,41 @@
+import { resetBamlEnvVars, traceAsync, traceSync } from "../baml_client"
+import { b } from "./test-setup"
+
+describe('Env Vars Tests', () => {
+    it('should reset environment variables correctly', async () => {
+        const envVars = {
+            OPENAI_API_KEY: 'sk-1234567890',
+    }
+    resetBamlEnvVars(envVars)
+
+    const topLevelSyncTracing = traceSync('name', () => {
+      resetBamlEnvVars(envVars)
+    })
+
+    const atopLevelAsyncTracing = traceAsync('name', async () => {
+      resetBamlEnvVars(envVars)
+    })
+
+    await expect(async () => {
+      topLevelSyncTracing()
+    }).rejects.toThrow('BamlError')
+
+    await expect(async () => {
+      await atopLevelAsyncTracing()
+    }).rejects.toThrow('BamlError')
+
+    await expect(async () => {
+      await b.ExtractPeople(
+        "My name is Harrison. My hair is black and I'm 6 feet tall. I'm pretty good around the hoop.",
+      )
+    }).rejects.toThrow('BamlClientHttpError')
+
+    resetBamlEnvVars(
+      Object.fromEntries(Object.entries(process.env).filter(([_, v]) => v !== undefined)) as Record<string, string>,
+    )
+    const people = await b.ExtractPeople(
+      "My name is Harrison. My hair is black and I'm 6 feet tall. I'm pretty good around the hoop.",
+        )
+        expect(people.length).toBeGreaterThan(0)
+    })
+})

--- a/integ-tests/typescript/tests/load.test.ts
+++ b/integ-tests/typescript/tests/load.test.ts
@@ -1,13 +1,7 @@
-import { b } from "../baml_client"
-// import { ChartJSNodeCanvas } from 'chartjs-node-canvas';
-// import { Chart, registerables } from 'chart.js';
+import { b } from "./test-setup"
 import fs from 'fs';
 
 // BAML_LOG=info infisical run --env=test -- npx tsx tests/load.test.ts
-
-// Register Chart.js components
-// Chart.register(...registerables);
-
 
 
 type MemoryEvent = {

--- a/integ-tests/typescript/tests/test-setup.ts
+++ b/integ-tests/typescript/tests/test-setup.ts
@@ -6,10 +6,9 @@ import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME, resetBaml
 import { ReadableStream, ReadableStreamDefaultController } from 'stream/web';
 import { TextEncoder, TextDecoder } from 'util';
 
-config()
 
 beforeAll(() => {
-  // Add any global setup here
+  config({ path: "../.env" })
 })
 
 afterAll(() => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enable lazy loading of environment variables post `baml_client` import by monkey-patching `dotenv` in Python and TypeScript.
> 
>   - **Behavior**:
>     - Monkeypatch `dotenv.load_dotenv` in `globals.py.j2` and `globals.ts.j2` to call `reset_baml_env_vars` after execution.
>     - Handle `ImportError` if `dotenv` is not installed.
>     - Update `resetBamlEnvVars` to filter out undefined values in `globals.ts.j2`.
>   - **Tests**:
>     - Add `env_vars.ts` to test environment variable reset behavior in TypeScript.
>     - Update `test-setup.ts` to configure dotenv path.
>     - Modify `run_tests.sh` to include `ruff` check.
>   - **Misc**:
>     - Remove `dotenv` usage from `package.json` in `integ-tests/typescript`.
>     - Minor updates to `dynamic-types.test.ts` and `load.test.ts` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 13c409f12b5c069d7591b5e3b34b2f7773f58ea4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->