### PR TITLE
fix doc typo

### DIFF
--- a/fern/01-guide/06-prompt-engineering/action-items.mdx
+++ b/fern/01-guide/06-prompt-engineering/action-items.mdx
@@ -1,4 +1,4 @@
-# Tutorial: Extracting Action Items from Meeting Transcripts
+# Extracting Action Items from Meeting Transcripts
 
 In this tutorial, you'll learn how to build a BAML function that automatically extracts structured action items from meeting transcripts. By the end, you'll have a working system that can identify tasks, assignees, priorities, subtasks, and dependencies.
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in `action-items.mdx` by removing "Tutorial:" from the document title.
> 
>   - **Documentation**:
>     - Fix typo in `action-items.mdx` by removing "Tutorial:" from the document title.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 34227a5289b036f24141063e68e06fd04cea8236. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->