### PR TITLE
Fix tutorial icon

### DIFF
--- a/fern/01-guide/06-prompt-engineering/action-items.mdx
+++ b/fern/01-guide/06-prompt-engineering/action-items.mdx
@@ -1,4 +1,4 @@
-# Tutorial: Extracting Action Items from Meeting Transcripts
+# Extracting Action Items from Meeting Transcripts
 
 In this tutorial, you'll learn how to build a BAML function that automatically extracts structured action items from meeting transcripts. By the end, you'll have a working system that can identify tasks, assignees, priorities, subtasks, and dependencies.
 

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -220,7 +220,7 @@ navigation:
             icon: fa-regular fa-adjust
             path: 01-guide/06-prompt-engineering/symbol-tuning.mdx
           - page: PII Data Extraction / Scrubbing
-            icon: fa-regular fa-shield
+            icon: fa-regular fa-user-cog
             path: 01-guide/06-prompt-engineering/pii-data-extraction.mdx
           - page: Action Item Extraction
             icon: fa-regular fa-list-check


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes tutorial title and updates icon for PII Data Extraction in documentation.
> 
>   - **Documentation**:
>     - Change tutorial title in `action-items.mdx` from "Tutorial: Extracting Action Items from Meeting Transcripts" to "Extracting Action Items from Meeting Transcripts".
>     - Update icon for "PII Data Extraction / Scrubbing" in `docs.yml` from `fa-regular fa-shield` to `fa-regular fa-user-cog`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 4c552956a21cd0c039bde03b0cdd687251693a62. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->