### PR TITLE
Fix event handling in BamlStream to use non-blocking queue retrieval

### DIFF
--- a/engine/language_client_python/python_src/baml_py/stream.py
+++ b/engine/language_client_python/python_src/baml_py/stream.py
@@ -79,11 +79,14 @@ class BamlStream(Generic[PartialOutputType, FinalOutputType]):
         try:
             self.__drive_to_completion_in_bg()
             while True:
-                event = self.__event_queue.get()
-                if event is None:
-                    break
-                if event.is_ok():
-                    yield self.__partial_coerce(event)
+                try:
+                    event = self.__event_queue.get_nowait()
+                    if event is None:
+                        break
+                    if event.is_ok():
+                        yield self.__partial_coerce(event)
+                except queue.Empty:
+                    await asyncio.sleep(0.050)
         except Exception as e:
             raise e
         finally:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Modify `BamlStream.__aiter__` to use non-blocking queue retrieval with `get_nowait()` and handle empty queue with `asyncio.sleep()`.
> 
>   - **Behavior**:
>     - In `BamlStream.__aiter__`, change from blocking `queue.get()` to non-blocking `queue.get_nowait()`.
>     - Add `asyncio.sleep(0.050)` in `BamlStream.__aiter__` to handle `queue.Empty` exception, allowing for non-blocking event retrieval.
>   - **Misc**:
>     - No changes to `BamlSyncStream` or other parts of `stream.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ff8b656d30e07ed753a26b2a42e2aa1d9e7d2f3b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->