### PR TITLE
Fix partial recursive aliases and broken Python integ test

### DIFF
--- a/engine/language_client_codegen/src/python/generate_types.rs
+++ b/engine/language_client_codegen/src/python/generate_types.rs
@@ -391,9 +391,9 @@ impl ToTypeReferenceInTypeDefinition for FieldType {
             }
             FieldType::RecursiveTypeAlias(name) => {
                 if wrapped {
-                    format!("\"{name}\"")
+                    format!("types.{name}")
                 } else {
-                    format!("Optional[\"{name}\"]")
+                    format!("Optional[types.{name}]")
                 }
             }
             FieldType::Literal(value) => {

--- a/integ-tests/python/baml_client/partial_types.py
+++ b/integ-tests/python/baml_client/partial_types.py
@@ -343,7 +343,7 @@ class Recipe(BaseModel):
     recipe_type: Optional[Union[Literal["breakfast"], Literal["dinner"]]] = None
 
 class RecursiveAliasDependency(BaseModel):
-    value: Optional["JsonValue"] = None
+    value: Optional[types.JsonValue] = None
 
 class Resume(BaseModel):
     name: Optional[str] = None

--- a/integ-tests/python/tests/memory_test.py
+++ b/integ-tests/python/tests/memory_test.py
@@ -2,7 +2,7 @@ import json
 import time
 from typing import Any, Callable, List, TypedDict
 import psutil
-from baml_client import b  # Assuming similar client structure
+from ..baml_client import b  # Assuming similar client structure
 import asyncio
 from typing import TypeVar, Dict
 import tracemalloc


### PR DESCRIPTION
#1588 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix partial recursive types in `generate_types.rs` and correct import path in `memory_test.py`.
> 
>   - **Type Reference Fixes**:
>     - In `generate_types.rs`, update `FieldType::RecursiveTypeAlias` to use `types.{name}` instead of `"{name}"`.
>     - Update `Optional["{name}"]` to `Optional[types.{name}]` for `FieldType::RecursiveTypeAlias`.
>   - **Integration Test Fix**:
>     - In `partial_types.py`, change `value: Optional["JsonValue"]` to `value: Optional[types.JsonValue]` in `RecursiveAliasDependency`.
>     - Fix import path in `memory_test.py` from `from baml_client import b` to `from ..baml_client import b`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 2cd3821d4edd9f3385571e96038d00190096fb83. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->