### PR TITLE
fix docs for assert and deno

### DIFF
--- a/fern/01-guide/02-languages/typescript.mdx
+++ b/fern/01-guide/02-languages/typescript.mdx
@@ -58,7 +58,15 @@ To set up BAML with Typescript do the following:
     npx baml-cli generate
     ```
     ```bash deno
-    deno run -A npm:@boundaryml/baml/baml-cli generate
+    deno run --unstable-sloppy-imports -A npm:@boundaryml/baml/baml-cli generate
+    # Note: ESM is especially important for Deno, so you must explicitly
+    # allow our Node import style, with the `--unstable-sloppy-imports` flag
+    # and in your Deno VSCode configuration:
+    #
+    # {
+    #   "deno.unstable": ["sloppy-imports"] 
+    # }
+
     ```
 
     You can modify your `package.json` so you have a helper prefix in front of your build command.

--- a/fern/03-reference/baml/attributes/assert.mdx
+++ b/fern/03-reference/baml/attributes/assert.mdx
@@ -23,7 +23,7 @@ class Foo {
 ```baml BAML
 class MyClass {
   // @assert will be applied to each element in the array
-  my_field (string @assert(is_valid_email, {{ this.contains("@") }}))[]
+  my_field (string @assert(is_valid_email, {{ this|regex_match("@") }}))[]
 }
 ```
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update Deno setup with `--unstable-sloppy-imports` flag and refine BAML `@assert` email validation in documentation.
> 
>   - **Deno Setup**:
>     - Updated `typescript.mdx` to include `--unstable-sloppy-imports` flag for Deno in `deno run` command.
>     - Added note on ESM importance and Deno VSCode configuration for `sloppy-imports`.
>   - **BAML Assert**:
>     - Changed `@assert` usage in `assert.mdx` from `this.contains("@")` to `this|regex_match("@")` for email validation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 077b433c220f7f405d0fed16ce6e807133cfd426. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->