### PR TITLE
Fix partial recursive aliases codegen

### DIFF
--- a/engine/language_client_codegen/src/python/generate_types.rs
+++ b/engine/language_client_codegen/src/python/generate_types.rs
@@ -51,6 +51,7 @@ struct PythonTypeAlias<'ir> {
 #[template(path = "partial_types.py.j2", escape = "none")]
 pub(crate) struct PythonStreamTypes<'ir> {
     partial_classes: Vec<PartialPythonClass<'ir>>,
+    structural_recursive_alias_cycles: Vec<PythonTypeAlias<'ir>>,
 }
 
 /// The Python class corresponding to Partial<TypeDefinedInBaml>
@@ -165,6 +166,14 @@ impl<'ir> TryFrom<(&'ir IntermediateRepr, &'_ crate::GeneratorArgs)> for PythonS
                 .walk_classes()
                 .map(PartialPythonClass::from)
                 .collect::<Vec<_>>(),
+            structural_recursive_alias_cycles: {
+                let mut cycles = ir
+                    .walk_alias_cycles()
+                    .map(PythonTypeAlias::from)
+                    .collect::<Vec<_>>();
+                cycles.sort_by_key(|alias| alias.name.clone());
+                cycles
+            },
         })
     }
 }
@@ -391,9 +400,9 @@ impl ToTypeReferenceInTypeDefinition for FieldType {
             }
             FieldType::RecursiveTypeAlias(name) => {
                 if wrapped {
-                    format!("types.{name}")
+                    format!("\"{name}\"")
                 } else {
-                    format!("Optional[types.{name}]")
+                    format!("Optional[\"{name}\"]")
                 }
             }
             FieldType::Literal(value) => {

--- a/engine/language_client_codegen/src/python/templates/partial_types.py.j2
+++ b/engine/language_client_codegen/src/python/templates/partial_types.py.j2
@@ -2,6 +2,7 @@
 import baml_py
 from enum import Enum
 from pydantic import BaseModel, ConfigDict
+from typing_extensions import TypeAlias
 from typing import Dict, Generic, List, Optional, TypeVar, Union, Literal
 
 from . import types
@@ -29,11 +30,16 @@ class {{cls.name}}(BaseModel):
     model_config = ConfigDict(extra='allow')
     {%- endif %}
     {%- if cls.fields.is_empty() && !cls.dynamic %}pass{% endif %}
-    
+
     {%- for (name, partial_type, m_docstring) in cls.fields %}
     {{name}}: {{partial_type}}
     {%- if let Some(docstring) = m_docstring %}
     {{ docstring }}
     {%- endif %}
     {%- endfor %}
+{% endfor %}
+
+{#- Type Aliases -#}
+{% for alias in structural_recursive_alias_cycles %}
+{{alias.name}}: TypeAlias = {{alias.target}}
 {% endfor %}

--- a/integ-tests/python/baml_client/partial_types.py
+++ b/integ-tests/python/baml_client/partial_types.py
@@ -16,6 +16,7 @@
 import baml_py
 from enum import Enum
 from pydantic import BaseModel, ConfigDict
+from typing_extensions import TypeAlias
 from typing import Dict, Generic, List, Optional, TypeVar, Union, Literal
 
 from . import types
@@ -343,7 +344,7 @@ class Recipe(BaseModel):
     recipe_type: Optional[Union[Literal["breakfast"], Literal["dinner"]]] = None
 
 class RecursiveAliasDependency(BaseModel):
-    value: Optional[types.JsonValue] = None
+    value: Optional["JsonValue"] = None
 
 class Resume(BaseModel):
     name: Optional[str] = None
@@ -442,3 +443,23 @@ class UniverseQuestionInput(BaseModel):
 class WithReasoning(BaseModel):
     value: Optional[str] = None
     reasoning: Optional[str] = None
+
+JsonArray: TypeAlias = List["JsonValue"]
+
+JsonEntry: TypeAlias = Union["SimpleTag", "JsonTemplate"]
+
+JsonObject: TypeAlias = Dict[str, "JsonValue"]
+
+JsonTemplate: TypeAlias = Dict[str, "JsonEntry"]
+
+JsonValue: TypeAlias = Union[int, str, bool, float, "JsonObject", "JsonArray"]
+
+RecAliasOne: TypeAlias = "RecAliasTwo"
+
+RecAliasThree: TypeAlias = List["RecAliasOne"]
+
+RecAliasTwo: TypeAlias = "RecAliasThree"
+
+RecursiveListAlias: TypeAlias = List["RecursiveListAlias"]
+
+RecursiveMapAlias: TypeAlias = Dict[str, "RecursiveMapAlias"]


### PR DESCRIPTION
Fix issue #1588 and PR #1598
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes recursive type alias handling in Python code generation by updating `generate_types.rs` and `partial_types.py.j2`.
> 
>   - **Behavior**:
>     - Fixes handling of recursive type aliases in `generate_types.rs` by adding `structural_recursive_alias_cycles` to `PythonStreamTypes`.
>     - Updates `FieldType::RecursiveTypeAlias` in `ToTypeReferenceInTypeDefinition` to use `Optional["{name}"]` format.
>   - **Templates**:
>     - Adds `TypeAlias` for recursive aliases in `partial_types.py.j2`.
>   - **Tests**:
>     - Updates `partial_types.py` to reflect changes in recursive alias handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 4845b9a56d7fbb76f5f57deb00391d709c56d181. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->