### PR TITLE
Attempt to fix fern width style

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -108,11 +108,7 @@ body, p, ul, h1, h2, h3, h4, h5, h6, span:not(a span) {
   width: 100% !important;
 }
 
-.fern-layout-guide {
-  max-width: 860px !important;
-  margin-left: 10px !important;
-  margin-right: 10px !important;
-}
+
 
 .fern-sidebar-link-container[data-state="active"] {
   background-color: var(--tag-primary) !important;

--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -105,6 +105,13 @@ body, p, ul, h1, h2, h3, h4, h5, h6, span:not(a span) {
 
 .w-content-width {
   max-width: 860px !important;
+  width: 100% !important;
+}
+
+.fern-layout-guide {
+  max-width: 860px !important;
+  margin-left: 10px !important;
+  margin-right: 10px !important;
 }
 
 .fern-sidebar-link-container[data-state="active"] {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `width: 100%` to `.w-content-width` in `styles.css` for full container width compliance.
> 
>   - **CSS Changes**:
>     - Add `width: 100% !important;` to `.w-content-width` in `styles.css` to ensure full width within container while respecting `max-width` constraint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for e9a3360b5419adaf2b81061c547ed4db68cb34fc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->