### PR TITLE
Fix ambiguous literal string parsing

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_literal.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_literal.rs
@@ -1,7 +1,7 @@
 use std::vec;
 
 use anyhow::Result;
-use baml_types::LiteralValue;
+use baml_types::{CompletionState, LiteralValue};
 use internal_baml_core::ir::FieldType;
 use internal_baml_jinja::CompletionOptions;
 
@@ -54,9 +54,14 @@ impl TypeCoercer for LiteralValue {
                 let (key, inner_value) = obj.iter().next().unwrap();
                 // only extract value if it's a primitive (not an object or array, hoping to god its fixed)
                 match inner_value {
-                    jsonish::Value::Number(_, _) | jsonish::Value::Boolean(_) | jsonish::Value::String(_, _) => {
+                    jsonish::Value::Number(_, _)
+                    | jsonish::Value::Boolean(_)
+                    | jsonish::Value::String(_, _) => {
                         let mut result = self.coerce(ctx, target, Some(&inner_value))?;
-                        result.add_flag(Flag::ObjectToPrimitive(jsonish::Value::Object(obj.clone(), completion_state.clone())));
+                        result.add_flag(Flag::ObjectToPrimitive(jsonish::Value::Object(
+                            obj.clone(),
+                            completion_state.clone(),
+                        )));
                         return Ok(result);
                     }
                     _ => {}
@@ -96,6 +101,17 @@ impl TypeCoercer for LiteralValue {
                 let candidates = vec![(literal_str.as_str(), vec![literal_str.clone()])];
 
                 let literal_match = match_string(ctx, target, Some(value), &candidates)?;
+
+                // Fix ambiguous literal parsing:
+                //
+                // value "pay" | "pay_with_card"
+                //
+                // Something like this can't be disambiguated:
+                //
+                // { "value": "pay
+                if value.completion_state() == &CompletionState::Incomplete {
+                    return Err(ctx.incomplete_literal_string(literal_str, value));
+                }
 
                 Ok(BamlValueWithFlags::String(literal_match))
             }

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_literal.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_literal.rs
@@ -1,7 +1,7 @@
 use std::vec;
 
 use anyhow::Result;
-use baml_types::{CompletionState, LiteralValue};
+use baml_types::LiteralValue;
 use internal_baml_core::ir::FieldType;
 use internal_baml_jinja::CompletionOptions;
 
@@ -101,17 +101,6 @@ impl TypeCoercer for LiteralValue {
                 let candidates = vec![(literal_str.as_str(), vec![literal_str.clone()])];
 
                 let literal_match = match_string(ctx, target, Some(value), &candidates)?;
-
-                // Fix ambiguous literal parsing:
-                //
-                // value "pay" | "pay_with_card"
-                //
-                // Something like this can't be disambiguated:
-                //
-                // { "value": "pay
-                if value.completion_state() == &CompletionState::Incomplete {
-                    return Err(ctx.incomplete_literal_string(literal_str, value));
-                }
 
                 Ok(BamlValueWithFlags::String(literal_match))
             }

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
@@ -198,18 +198,6 @@ impl ParsingContext<'_> {
         }
     }
 
-    pub(crate) fn incomplete_literal_string(
-        &self,
-        expected: &str,
-        got: &jsonish::Value,
-    ) -> ParsingError {
-        ParsingError {
-            reason: format!("Can't parse incomplete literal string '{got}' into '{expected}'.",),
-            scope: self.scope.clone(),
-            causes: vec![],
-        }
-    }
-
     pub(crate) fn error_internal<T: std::fmt::Display>(&self, error: T) -> ParsingError {
         ParsingError {
             reason: format!("Internal error: {}", error),

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
@@ -198,6 +198,18 @@ impl ParsingContext<'_> {
         }
     }
 
+    pub(crate) fn incomplete_literal_string(
+        &self,
+        expected: &str,
+        got: &jsonish::Value,
+    ) -> ParsingError {
+        ParsingError {
+            reason: format!("Can't parse incomplete literal string '{got}' into '{expected}'.",),
+            scope: self.scope.clone(),
+            causes: vec![],
+        }
+    }
+
     pub(crate) fn error_internal<T: std::fmt::Display>(&self, error: T) -> ParsingError {
         ParsingError {
             reason: format!("Internal error: {}", error),

--- a/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
@@ -46,7 +46,7 @@ pub fn validate_streaming_state(
         ir,
         baml_value_with_streaming_state_and_behavior,
         allow_partials,
-        0
+        0,
     )?;
     Ok(top_level_node)
 }
@@ -91,15 +91,15 @@ fn process_node(
         BamlValueWithMeta::Int(i, _) => Ok(BamlValueWithMeta::Int(i, new_meta)),
         BamlValueWithMeta::Float(f, _) => Ok(BamlValueWithMeta::Float(f, new_meta)),
         BamlValueWithMeta::Bool(b, _) => Ok(BamlValueWithMeta::Bool(b, new_meta)),
-        BamlValueWithMeta::List(items, _) => {
-            Ok(BamlValueWithMeta::List(
+        BamlValueWithMeta::List(items, _) => Ok(BamlValueWithMeta::List(
             items
                 .into_iter()
-                .filter_map(|item| process_node(ir, item, allow_partials_in_sub_nodes, depth+1).ok())
+                .filter_map(|item| {
+                    process_node(ir, item, allow_partials_in_sub_nodes, depth + 1).ok()
+                })
                 .collect(),
             new_meta,
-        ))
-    },
+        )),
         BamlValueWithMeta::Class(ref class_name, value_fields, _) => {
             let value_field_names: IndexSet<String> = value_fields
                 .keys()
@@ -157,7 +157,7 @@ fn process_node(
                         .as_ref()
                         .map_or(false, |b| b.state);
                     let completion_state = field_value.meta().0.clone();
-                    match process_node(ir, field_value, allow_partials_in_sub_nodes, depth+1) {
+                    match process_node(ir, field_value, allow_partials_in_sub_nodes, depth + 1) {
                         Ok(res) => Some((field_name, res)),
                         _ => {
                             let state = Completion {
@@ -218,7 +218,7 @@ fn process_node(
             let new_kvs = kvs
                 .into_iter()
                 .filter_map(|(k, v)| {
-                    process_node(ir, v, allow_partials_in_sub_nodes, depth+1)
+                    process_node(ir, v, allow_partials_in_sub_nodes, depth + 1)
                         .ok()
                         .map(|v| (k, v))
                 })
@@ -330,7 +330,9 @@ fn required_done(ir: &IntermediateRepr, field_type: &FieldType) -> bool {
         FieldType::Tuple(_) => false,
         FieldType::RecursiveTypeAlias(_) => false,
         FieldType::Class(_) => false,
-        FieldType::Union(_) => false,
+        // TODO: This rule is pretty aggressive. For example in the case of
+        // Class | Enum it would not allow classes to be streamed.
+        FieldType::Union(options) => options.iter().any(|option| required_done(ir, option)),
         FieldType::WithMetadata { .. } => {
             unreachable!("distribute_metadata always consumes `WithMetadata`.")
         }
@@ -343,10 +345,7 @@ fn completion_state(flags: &Vec<Flag>) -> CompletionState {
     if flags.iter().any(|f| matches!(f, Flag::Pending)) {
         CompletionState::Pending
     } else {
-        if flags
-            .iter()
-            .any(|f| matches!(f, Flag::Incomplete))
-        {
+        if flags.iter().any(|f| matches!(f, Flag::Incomplete)) {
             CompletionState::Incomplete
         } else {
             CompletionState::Complete

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser.rs
@@ -1,8 +1,8 @@
 mod json_collection;
 mod json_parse_state;
 
-use baml_types::CompletionState;
 use crate::jsonish::{value::Fixes, Value};
+use baml_types::CompletionState;
 
 use self::json_parse_state::JsonParseState;
 
@@ -72,7 +72,7 @@ pub fn parse(str: &str, _options: &ParseOptions) -> Result<Vec<(Value, Vec<Fixes
                                 Value::FixedJson(f.1.into(), f.2)
                             })
                             .collect(),
-                        CompletionState::Incomplete // TODO: Is it complete?
+                        CompletionState::Incomplete, // TODO: Is it complete?
                     ),
                     vec![Fixes::InferredArray],
                 )])

--- a/engine/baml-lib/jsonish/src/tests/macros.rs
+++ b/engine/baml-lib/jsonish/src/tests/macros.rs
@@ -155,7 +155,7 @@ macro_rules! test_partial_deserializer_streaming_failure {
     ($name:ident, $file_content:expr, $raw_string:expr, $target_type:expr) => {
         #[test_log::test]
         fn $name() {
-            let ir = load_test_ir($file_content);
+            let ir = crate::helpers::load_test_ir($file_content);
             let target =
                 crate::helpers::render_output_format(&ir, &$target_type, &Default::default())
                     .unwrap();

--- a/engine/baml-lib/jsonish/src/tests/test_literals.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_literals.rs
@@ -269,6 +269,31 @@ test_deserializer!(
     "THREE"
 );
 
+test_deserializer!(
+    test_ambiguous_literal_string_complete_string,
+    EMPTY_FILE,
+    r#"
+        "pay"
+    "#,
+    FieldType::Union(vec![
+        FieldType::Literal(LiteralValue::String("pay".into())),
+        FieldType::Literal(LiteralValue::String("pay_without_credit_card".into())),
+    ]),
+    "pay"
+);
+
+test_failing_deserializer!(
+    test_ambiguous_literal_string,
+    EMPTY_FILE,
+    r#"
+        "pay
+    "#,
+    FieldType::Union(vec![
+        FieldType::Literal(LiteralValue::String("pay".into())),
+        FieldType::Literal(LiteralValue::String("pay_without_credit_card".into())),
+    ])
+);
+
 // Test with object that has multiple keys (should fail)
 test_failing_deserializer!(
     test_union_literal_with_multiple_types_from_multi_key_object,

--- a/engine/baml-lib/jsonish/src/tests/test_literals.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_literals.rs
@@ -282,7 +282,7 @@ test_deserializer!(
     "pay"
 );
 
-test_failing_deserializer!(
+test_partial_deserializer_streaming_failure!(
     test_ambiguous_literal_string,
     EMPTY_FILE,
     r#"


### PR DESCRIPTION
Fix #1192 

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes ambiguous literal string parsing by refining deserialization logic and adding relevant test cases.
> 
>   - **Behavior**:
>     - Fixes ambiguous literal string parsing in `coerce_literal.rs` by refining the handling of primitive values within objects.
>     - Updates `process_node()` in `semantic_streaming.rs` to handle `FieldType::Union` more accurately, allowing classes to be streamed.
>   - **Tests**:
>     - Adds `test_ambiguous_literal_string_complete_string` and `test_ambiguous_literal_string` in `test_literals.rs` to verify handling of ambiguous strings.
>     - Modifies `test_partial_deserializer_streaming_failure!` macro in `macros.rs` to test failure cases for partial deserialization.
>   - **Misc**:
>     - Minor formatting and comment adjustments in `fixing_parser.rs` and `semantic_streaming.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 8ca9b2e27e620f6ebc6f506b7aa4695e14f81063. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->