### PR TITLE
hellovai/remove default params

### DIFF
--- a/engine/language_client_codegen/src/python/mod.rs
+++ b/engine/language_client_codegen/src/python/mod.rs
@@ -248,11 +248,7 @@ impl TryFrom<(&'_ IntermediateRepr, &'_ crate::GeneratorArgs)> for PythonClient 
                                 .inputs()
                                 .iter()
                                 .map(|(name, r#type)| {
-                                    (
-                                        name.to_string(),
-                                        r#type.to_type_ref(ir, false),
-                                        default_value_for_parameter_type(r#type),
-                                    )
+                                    (name.to_string(), r#type.to_type_ref(ir, false), None)
                                 })
                                 .collect(),
                         })

--- a/integ-tests/python/baml_client/async_client.py
+++ b/integ-tests/python/baml_client/async_client.py
@@ -291,7 +291,7 @@ class BamlAsyncClient:
     
     async def AliasedInputList(
         self,
-        input: List[types.AliasedEnum] = [],
+        input: List[types.AliasedEnum],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -399,7 +399,7 @@ class BamlAsyncClient:
     
     async def BuildLinkedList(
         self,
-        input: List[int] = [],
+        input: List[int],
         baml_options: BamlCallOptions = {},
     ) -> types.LinkedList:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -858,7 +858,7 @@ class BamlAsyncClient:
     
     async def DynamicListInputOutput(
         self,
-        input: List[types.DynInputOutput] = [],
+        input: List[types.DynInputOutput],
         baml_options: BamlCallOptions = {},
     ) -> List[types.DynInputOutput]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1047,7 +1047,7 @@ class BamlAsyncClient:
     
     async def ExtractResume(
         self,
-        resume: str,img: Optional[baml_py.Image] = None,
+        resume: str,img: Optional[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> types.Resume:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1263,7 +1263,7 @@ class BamlAsyncClient:
     
     async def FnNamedArgsSingleStringOptional(
         self,
-        myString: Optional[str] = None,
+        myString: Optional[str],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1722,7 +1722,7 @@ class BamlAsyncClient:
     
     async def InOutEnumMapKey(
         self,
-        i1: Dict[types.MapKey, str] = {},i2: Dict[types.MapKey, str] = {},
+        i1: Dict[types.MapKey, str],i2: Dict[types.MapKey, str],
         baml_options: BamlCallOptions = {},
     ) -> Dict[types.MapKey, str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1749,7 +1749,7 @@ class BamlAsyncClient:
     
     async def InOutLiteralStringUnionMapKey(
         self,
-        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},
+        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],
         baml_options: BamlCallOptions = {},
     ) -> Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1776,7 +1776,7 @@ class BamlAsyncClient:
     
     async def InOutSingleLiteralStringMapKey(
         self,
-        m: Dict[Literal["key"], str] = {},
+        m: Dict[Literal["key"], str],
         baml_options: BamlCallOptions = {},
     ) -> Dict[Literal["key"], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1938,7 +1938,7 @@ class BamlAsyncClient:
     
     async def MapAlias(
         self,
-        m: Dict[str, List[str]] = {},
+        m: Dict[str, List[str]],
         baml_options: BamlCallOptions = {},
     ) -> Dict[str, List[str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3396,7 +3396,7 @@ class BamlAsyncClient:
     
     async def TestFnNamedArgsSingleEnumList(
         self,
-        myArg: List[types.NamedArgsSingleEnumList] = [],
+        myArg: List[types.NamedArgsSingleEnumList],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3477,7 +3477,7 @@ class BamlAsyncClient:
     
     async def TestFnNamedArgsSingleMapStringToClass(
         self,
-        myMap: Dict[str, types.StringToClassEntry] = {},
+        myMap: Dict[str, types.StringToClassEntry],
         baml_options: BamlCallOptions = {},
     ) -> Dict[str, types.StringToClassEntry]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3504,7 +3504,7 @@ class BamlAsyncClient:
     
     async def TestFnNamedArgsSingleMapStringToMap(
         self,
-        myMap: Dict[str, Dict[str, str]] = {},
+        myMap: Dict[str, Dict[str, str]],
         baml_options: BamlCallOptions = {},
     ) -> Dict[str, Dict[str, str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3531,7 +3531,7 @@ class BamlAsyncClient:
     
     async def TestFnNamedArgsSingleMapStringToString(
         self,
-        myMap: Dict[str, str] = {},
+        myMap: Dict[str, str],
         baml_options: BamlCallOptions = {},
     ) -> Dict[str, str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3585,7 +3585,7 @@ class BamlAsyncClient:
     
     async def TestFnNamedArgsSingleStringArray(
         self,
-        myStringArray: List[str] = [],
+        myStringArray: List[str],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3612,7 +3612,7 @@ class BamlAsyncClient:
     
     async def TestFnNamedArgsSingleStringList(
         self,
-        myArg: List[str] = [],
+        myArg: List[str],
         baml_options: BamlCallOptions = {},
     ) -> List[str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3801,7 +3801,7 @@ class BamlAsyncClient:
     
     async def TestImageListInput(
         self,
-        imgs: List[baml_py.Image] = [],
+        imgs: List[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -4827,7 +4827,7 @@ class BamlStreamClient:
     
     def AliasedInputList(
         self,
-        input: List[types.AliasedEnum] = [],
+        input: List[types.AliasedEnum],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -4959,7 +4959,7 @@ class BamlStreamClient:
     
     def BuildLinkedList(
         self,
-        input: List[int] = [],
+        input: List[int],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[partial_types.LinkedList, types.LinkedList]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -5524,7 +5524,7 @@ class BamlStreamClient:
     
     def DynamicListInputOutput(
         self,
-        input: List[types.DynInputOutput] = [],
+        input: List[types.DynInputOutput],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[List[partial_types.DynInputOutput], List[types.DynInputOutput]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -5755,7 +5755,7 @@ class BamlStreamClient:
     
     def ExtractResume(
         self,
-        resume: str,img: Optional[baml_py.Image] = None,
+        resume: str,img: Optional[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[partial_types.Resume, types.Resume]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6020,7 +6020,7 @@ class BamlStreamClient:
     
     def FnNamedArgsSingleStringOptional(
         self,
-        myString: Optional[str] = None,
+        myString: Optional[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6581,7 +6581,7 @@ class BamlStreamClient:
     
     def InOutEnumMapKey(
         self,
-        i1: Dict[types.MapKey, str] = {},i2: Dict[types.MapKey, str] = {},
+        i1: Dict[types.MapKey, str],i2: Dict[types.MapKey, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Dict[types.MapKey, Optional[str]], Dict[types.MapKey, str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6615,7 +6615,7 @@ class BamlStreamClient:
     
     def InOutLiteralStringUnionMapKey(
         self,
-        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},
+        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], Optional[str]], Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6649,7 +6649,7 @@ class BamlStreamClient:
     
     def InOutSingleLiteralStringMapKey(
         self,
-        m: Dict[Literal["key"], str] = {},
+        m: Dict[Literal["key"], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Dict[Literal["key"], Optional[str]], Dict[Literal["key"], str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6844,7 +6844,7 @@ class BamlStreamClient:
     
     def MapAlias(
         self,
-        m: Dict[str, List[str]] = {},
+        m: Dict[str, List[str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Dict[str, List[Optional[str]]], Dict[str, List[str]]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8628,7 +8628,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleEnumList(
         self,
-        myArg: List[types.NamedArgsSingleEnumList] = [],
+        myArg: List[types.NamedArgsSingleEnumList],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8727,7 +8727,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleMapStringToClass(
         self,
-        myMap: Dict[str, types.StringToClassEntry] = {},
+        myMap: Dict[str, types.StringToClassEntry],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Dict[str, partial_types.StringToClassEntry], Dict[str, types.StringToClassEntry]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8760,7 +8760,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleMapStringToMap(
         self,
-        myMap: Dict[str, Dict[str, str]] = {},
+        myMap: Dict[str, Dict[str, str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Dict[str, Dict[str, Optional[str]]], Dict[str, Dict[str, str]]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8793,7 +8793,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleMapStringToString(
         self,
-        myMap: Dict[str, str] = {},
+        myMap: Dict[str, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Dict[str, Optional[str]], Dict[str, str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8859,7 +8859,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleStringArray(
         self,
-        myStringArray: List[str] = [],
+        myStringArray: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8892,7 +8892,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleStringList(
         self,
-        myArg: List[str] = [],
+        myArg: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[List[Optional[str]], List[str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -9122,7 +9122,7 @@ class BamlStreamClient:
     
     def TestImageListInput(
         self,
-        imgs: List[baml_py.Image] = [],
+        imgs: List[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}

--- a/integ-tests/python/baml_client/async_request.py
+++ b/integ-tests/python/baml_client/async_request.py
@@ -200,7 +200,7 @@ class AsyncHttpRequest:
     
     async def AliasedInputList(
         self,
-        input: List[types.AliasedEnum] = [],
+        input: List[types.AliasedEnum],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -292,7 +292,7 @@ class AsyncHttpRequest:
     
     async def BuildLinkedList(
         self,
-        input: List[int] = [],
+        input: List[int],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -687,7 +687,7 @@ class AsyncHttpRequest:
     
     async def DynamicListInputOutput(
         self,
-        input: List[types.DynInputOutput] = [],
+        input: List[types.DynInputOutput],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -848,7 +848,7 @@ class AsyncHttpRequest:
     
     async def ExtractResume(
         self,
-        resume: str,img: Optional[baml_py.Image] = None,
+        resume: str,img: Optional[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1033,7 +1033,7 @@ class AsyncHttpRequest:
     
     async def FnNamedArgsSingleStringOptional(
         self,
-        myString: Optional[str] = None,
+        myString: Optional[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1424,7 +1424,7 @@ class AsyncHttpRequest:
     
     async def InOutEnumMapKey(
         self,
-        i1: Dict[types.MapKey, str] = {},i2: Dict[types.MapKey, str] = {},
+        i1: Dict[types.MapKey, str],i2: Dict[types.MapKey, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1448,7 +1448,7 @@ class AsyncHttpRequest:
     
     async def InOutLiteralStringUnionMapKey(
         self,
-        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},
+        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1472,7 +1472,7 @@ class AsyncHttpRequest:
     
     async def InOutSingleLiteralStringMapKey(
         self,
-        m: Dict[Literal["key"], str] = {},
+        m: Dict[Literal["key"], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1607,7 +1607,7 @@ class AsyncHttpRequest:
     
     async def MapAlias(
         self,
-        m: Dict[str, List[str]] = {},
+        m: Dict[str, List[str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -2851,7 +2851,7 @@ class AsyncHttpRequest:
     
     async def TestFnNamedArgsSingleEnumList(
         self,
-        myArg: List[types.NamedArgsSingleEnumList] = [],
+        myArg: List[types.NamedArgsSingleEnumList],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -2920,7 +2920,7 @@ class AsyncHttpRequest:
     
     async def TestFnNamedArgsSingleMapStringToClass(
         self,
-        myMap: Dict[str, types.StringToClassEntry] = {},
+        myMap: Dict[str, types.StringToClassEntry],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -2943,7 +2943,7 @@ class AsyncHttpRequest:
     
     async def TestFnNamedArgsSingleMapStringToMap(
         self,
-        myMap: Dict[str, Dict[str, str]] = {},
+        myMap: Dict[str, Dict[str, str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -2966,7 +2966,7 @@ class AsyncHttpRequest:
     
     async def TestFnNamedArgsSingleMapStringToString(
         self,
-        myMap: Dict[str, str] = {},
+        myMap: Dict[str, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -3012,7 +3012,7 @@ class AsyncHttpRequest:
     
     async def TestFnNamedArgsSingleStringArray(
         self,
-        myStringArray: List[str] = [],
+        myStringArray: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -3035,7 +3035,7 @@ class AsyncHttpRequest:
     
     async def TestFnNamedArgsSingleStringList(
         self,
-        myArg: List[str] = [],
+        myArg: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -3195,7 +3195,7 @@ class AsyncHttpRequest:
     
     async def TestImageListInput(
         self,
-        imgs: List[baml_py.Image] = [],
+        imgs: List[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4031,7 +4031,7 @@ class AsyncHttpStreamRequest:
     
     async def AliasedInputList(
         self,
-        input: List[types.AliasedEnum] = [],
+        input: List[types.AliasedEnum],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4123,7 +4123,7 @@ class AsyncHttpStreamRequest:
     
     async def BuildLinkedList(
         self,
-        input: List[int] = [],
+        input: List[int],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4518,7 +4518,7 @@ class AsyncHttpStreamRequest:
     
     async def DynamicListInputOutput(
         self,
-        input: List[types.DynInputOutput] = [],
+        input: List[types.DynInputOutput],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4679,7 +4679,7 @@ class AsyncHttpStreamRequest:
     
     async def ExtractResume(
         self,
-        resume: str,img: Optional[baml_py.Image] = None,
+        resume: str,img: Optional[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4864,7 +4864,7 @@ class AsyncHttpStreamRequest:
     
     async def FnNamedArgsSingleStringOptional(
         self,
-        myString: Optional[str] = None,
+        myString: Optional[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -5255,7 +5255,7 @@ class AsyncHttpStreamRequest:
     
     async def InOutEnumMapKey(
         self,
-        i1: Dict[types.MapKey, str] = {},i2: Dict[types.MapKey, str] = {},
+        i1: Dict[types.MapKey, str],i2: Dict[types.MapKey, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -5279,7 +5279,7 @@ class AsyncHttpStreamRequest:
     
     async def InOutLiteralStringUnionMapKey(
         self,
-        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},
+        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -5303,7 +5303,7 @@ class AsyncHttpStreamRequest:
     
     async def InOutSingleLiteralStringMapKey(
         self,
-        m: Dict[Literal["key"], str] = {},
+        m: Dict[Literal["key"], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -5438,7 +5438,7 @@ class AsyncHttpStreamRequest:
     
     async def MapAlias(
         self,
-        m: Dict[str, List[str]] = {},
+        m: Dict[str, List[str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6682,7 +6682,7 @@ class AsyncHttpStreamRequest:
     
     async def TestFnNamedArgsSingleEnumList(
         self,
-        myArg: List[types.NamedArgsSingleEnumList] = [],
+        myArg: List[types.NamedArgsSingleEnumList],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6751,7 +6751,7 @@ class AsyncHttpStreamRequest:
     
     async def TestFnNamedArgsSingleMapStringToClass(
         self,
-        myMap: Dict[str, types.StringToClassEntry] = {},
+        myMap: Dict[str, types.StringToClassEntry],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6774,7 +6774,7 @@ class AsyncHttpStreamRequest:
     
     async def TestFnNamedArgsSingleMapStringToMap(
         self,
-        myMap: Dict[str, Dict[str, str]] = {},
+        myMap: Dict[str, Dict[str, str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6797,7 +6797,7 @@ class AsyncHttpStreamRequest:
     
     async def TestFnNamedArgsSingleMapStringToString(
         self,
-        myMap: Dict[str, str] = {},
+        myMap: Dict[str, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6843,7 +6843,7 @@ class AsyncHttpStreamRequest:
     
     async def TestFnNamedArgsSingleStringArray(
         self,
-        myStringArray: List[str] = [],
+        myStringArray: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6866,7 +6866,7 @@ class AsyncHttpStreamRequest:
     
     async def TestFnNamedArgsSingleStringList(
         self,
-        myArg: List[str] = [],
+        myArg: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -7026,7 +7026,7 @@ class AsyncHttpStreamRequest:
     
     async def TestImageListInput(
         self,
-        imgs: List[baml_py.Image] = [],
+        imgs: List[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)

--- a/integ-tests/python/baml_client/sync_client.py
+++ b/integ-tests/python/baml_client/sync_client.py
@@ -289,7 +289,7 @@ class BamlSyncClient:
     
     def AliasedInputList(
         self,
-        input: List[types.AliasedEnum] = [],
+        input: List[types.AliasedEnum],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -397,7 +397,7 @@ class BamlSyncClient:
     
     def BuildLinkedList(
         self,
-        input: List[int] = [],
+        input: List[int],
         baml_options: BamlCallOptions = {},
     ) -> types.LinkedList:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -856,7 +856,7 @@ class BamlSyncClient:
     
     def DynamicListInputOutput(
         self,
-        input: List[types.DynInputOutput] = [],
+        input: List[types.DynInputOutput],
         baml_options: BamlCallOptions = {},
     ) -> List[types.DynInputOutput]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1045,7 +1045,7 @@ class BamlSyncClient:
     
     def ExtractResume(
         self,
-        resume: str,img: Optional[baml_py.Image] = None,
+        resume: str,img: Optional[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> types.Resume:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1261,7 +1261,7 @@ class BamlSyncClient:
     
     def FnNamedArgsSingleStringOptional(
         self,
-        myString: Optional[str] = None,
+        myString: Optional[str],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1720,7 +1720,7 @@ class BamlSyncClient:
     
     def InOutEnumMapKey(
         self,
-        i1: Dict[types.MapKey, str] = {},i2: Dict[types.MapKey, str] = {},
+        i1: Dict[types.MapKey, str],i2: Dict[types.MapKey, str],
         baml_options: BamlCallOptions = {},
     ) -> Dict[types.MapKey, str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1747,7 +1747,7 @@ class BamlSyncClient:
     
     def InOutLiteralStringUnionMapKey(
         self,
-        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},
+        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],
         baml_options: BamlCallOptions = {},
     ) -> Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1774,7 +1774,7 @@ class BamlSyncClient:
     
     def InOutSingleLiteralStringMapKey(
         self,
-        m: Dict[Literal["key"], str] = {},
+        m: Dict[Literal["key"], str],
         baml_options: BamlCallOptions = {},
     ) -> Dict[Literal["key"], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -1936,7 +1936,7 @@ class BamlSyncClient:
     
     def MapAlias(
         self,
-        m: Dict[str, List[str]] = {},
+        m: Dict[str, List[str]],
         baml_options: BamlCallOptions = {},
     ) -> Dict[str, List[str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3394,7 +3394,7 @@ class BamlSyncClient:
     
     def TestFnNamedArgsSingleEnumList(
         self,
-        myArg: List[types.NamedArgsSingleEnumList] = [],
+        myArg: List[types.NamedArgsSingleEnumList],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3475,7 +3475,7 @@ class BamlSyncClient:
     
     def TestFnNamedArgsSingleMapStringToClass(
         self,
-        myMap: Dict[str, types.StringToClassEntry] = {},
+        myMap: Dict[str, types.StringToClassEntry],
         baml_options: BamlCallOptions = {},
     ) -> Dict[str, types.StringToClassEntry]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3502,7 +3502,7 @@ class BamlSyncClient:
     
     def TestFnNamedArgsSingleMapStringToMap(
         self,
-        myMap: Dict[str, Dict[str, str]] = {},
+        myMap: Dict[str, Dict[str, str]],
         baml_options: BamlCallOptions = {},
     ) -> Dict[str, Dict[str, str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3529,7 +3529,7 @@ class BamlSyncClient:
     
     def TestFnNamedArgsSingleMapStringToString(
         self,
-        myMap: Dict[str, str] = {},
+        myMap: Dict[str, str],
         baml_options: BamlCallOptions = {},
     ) -> Dict[str, str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3583,7 +3583,7 @@ class BamlSyncClient:
     
     def TestFnNamedArgsSingleStringArray(
         self,
-        myStringArray: List[str] = [],
+        myStringArray: List[str],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3610,7 +3610,7 @@ class BamlSyncClient:
     
     def TestFnNamedArgsSingleStringList(
         self,
-        myArg: List[str] = [],
+        myArg: List[str],
         baml_options: BamlCallOptions = {},
     ) -> List[str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -3799,7 +3799,7 @@ class BamlSyncClient:
     
     def TestImageListInput(
         self,
-        imgs: List[baml_py.Image] = [],
+        imgs: List[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> str:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -4833,7 +4833,7 @@ class BamlStreamClient:
     
     def AliasedInputList(
         self,
-        input: List[types.AliasedEnum] = [],
+        input: List[types.AliasedEnum],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -4969,7 +4969,7 @@ class BamlStreamClient:
     
     def BuildLinkedList(
         self,
-        input: List[int] = [],
+        input: List[int],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[partial_types.LinkedList, types.LinkedList]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -5551,7 +5551,7 @@ class BamlStreamClient:
     
     def DynamicListInputOutput(
         self,
-        input: List[types.DynInputOutput] = [],
+        input: List[types.DynInputOutput],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[List[partial_types.DynInputOutput], List[types.DynInputOutput]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -5789,7 +5789,7 @@ class BamlStreamClient:
     
     def ExtractResume(
         self,
-        resume: str,img: Optional[baml_py.Image] = None,
+        resume: str,img: Optional[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[partial_types.Resume, types.Resume]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6062,7 +6062,7 @@ class BamlStreamClient:
     
     def FnNamedArgsSingleStringOptional(
         self,
-        myString: Optional[str] = None,
+        myString: Optional[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6640,7 +6640,7 @@ class BamlStreamClient:
     
     def InOutEnumMapKey(
         self,
-        i1: Dict[types.MapKey, str] = {},i2: Dict[types.MapKey, str] = {},
+        i1: Dict[types.MapKey, str],i2: Dict[types.MapKey, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Dict[types.MapKey, Optional[str]], Dict[types.MapKey, str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6675,7 +6675,7 @@ class BamlStreamClient:
     
     def InOutLiteralStringUnionMapKey(
         self,
-        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},
+        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], Optional[str]], Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6710,7 +6710,7 @@ class BamlStreamClient:
     
     def InOutSingleLiteralStringMapKey(
         self,
-        m: Dict[Literal["key"], str] = {},
+        m: Dict[Literal["key"], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Dict[Literal["key"], Optional[str]], Dict[Literal["key"], str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -6911,7 +6911,7 @@ class BamlStreamClient:
     
     def MapAlias(
         self,
-        m: Dict[str, List[str]] = {},
+        m: Dict[str, List[str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Dict[str, List[Optional[str]]], Dict[str, List[str]]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8749,7 +8749,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleEnumList(
         self,
-        myArg: List[types.NamedArgsSingleEnumList] = [],
+        myArg: List[types.NamedArgsSingleEnumList],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8851,7 +8851,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleMapStringToClass(
         self,
-        myMap: Dict[str, types.StringToClassEntry] = {},
+        myMap: Dict[str, types.StringToClassEntry],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Dict[str, partial_types.StringToClassEntry], Dict[str, types.StringToClassEntry]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8885,7 +8885,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleMapStringToMap(
         self,
-        myMap: Dict[str, Dict[str, str]] = {},
+        myMap: Dict[str, Dict[str, str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Dict[str, Dict[str, Optional[str]]], Dict[str, Dict[str, str]]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8919,7 +8919,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleMapStringToString(
         self,
-        myMap: Dict[str, str] = {},
+        myMap: Dict[str, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Dict[str, Optional[str]], Dict[str, str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -8987,7 +8987,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleStringArray(
         self,
-        myStringArray: List[str] = [],
+        myStringArray: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -9021,7 +9021,7 @@ class BamlStreamClient:
     
     def TestFnNamedArgsSingleStringList(
         self,
-        myArg: List[str] = [],
+        myArg: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[List[Optional[str]], List[str]]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}
@@ -9258,7 +9258,7 @@ class BamlStreamClient:
     
     def TestImageListInput(
         self,
-        imgs: List[baml_py.Image] = [],
+        imgs: List[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.BamlSyncStream[Optional[str], str]:
       options: BamlCallOptions = {**self.__baml_options, **(baml_options or {})}

--- a/integ-tests/python/baml_client/sync_request.py
+++ b/integ-tests/python/baml_client/sync_request.py
@@ -200,7 +200,7 @@ class HttpRequest:
     
     def AliasedInputList(
         self,
-        input: List[types.AliasedEnum] = [],
+        input: List[types.AliasedEnum],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -292,7 +292,7 @@ class HttpRequest:
     
     def BuildLinkedList(
         self,
-        input: List[int] = [],
+        input: List[int],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -683,7 +683,7 @@ class HttpRequest:
     
     def DynamicListInputOutput(
         self,
-        input: List[types.DynInputOutput] = [],
+        input: List[types.DynInputOutput],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -844,7 +844,7 @@ class HttpRequest:
     
     def ExtractResume(
         self,
-        resume: str,img: Optional[baml_py.Image] = None,
+        resume: str,img: Optional[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1028,7 +1028,7 @@ class HttpRequest:
     
     def FnNamedArgsSingleStringOptional(
         self,
-        myString: Optional[str] = None,
+        myString: Optional[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1419,7 +1419,7 @@ class HttpRequest:
     
     def InOutEnumMapKey(
         self,
-        i1: Dict[types.MapKey, str] = {},i2: Dict[types.MapKey, str] = {},
+        i1: Dict[types.MapKey, str],i2: Dict[types.MapKey, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1442,7 +1442,7 @@ class HttpRequest:
     
     def InOutLiteralStringUnionMapKey(
         self,
-        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},
+        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1465,7 +1465,7 @@ class HttpRequest:
     
     def InOutSingleLiteralStringMapKey(
         self,
-        m: Dict[Literal["key"], str] = {},
+        m: Dict[Literal["key"], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -1603,7 +1603,7 @@ class HttpRequest:
     
     def MapAlias(
         self,
-        m: Dict[str, List[str]] = {},
+        m: Dict[str, List[str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -2845,7 +2845,7 @@ class HttpRequest:
     
     def TestFnNamedArgsSingleEnumList(
         self,
-        myArg: List[types.NamedArgsSingleEnumList] = [],
+        myArg: List[types.NamedArgsSingleEnumList],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -2914,7 +2914,7 @@ class HttpRequest:
     
     def TestFnNamedArgsSingleMapStringToClass(
         self,
-        myMap: Dict[str, types.StringToClassEntry] = {},
+        myMap: Dict[str, types.StringToClassEntry],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -2937,7 +2937,7 @@ class HttpRequest:
     
     def TestFnNamedArgsSingleMapStringToMap(
         self,
-        myMap: Dict[str, Dict[str, str]] = {},
+        myMap: Dict[str, Dict[str, str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -2960,7 +2960,7 @@ class HttpRequest:
     
     def TestFnNamedArgsSingleMapStringToString(
         self,
-        myMap: Dict[str, str] = {},
+        myMap: Dict[str, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -3006,7 +3006,7 @@ class HttpRequest:
     
     def TestFnNamedArgsSingleStringArray(
         self,
-        myStringArray: List[str] = [],
+        myStringArray: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -3029,7 +3029,7 @@ class HttpRequest:
     
     def TestFnNamedArgsSingleStringList(
         self,
-        myArg: List[str] = [],
+        myArg: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -3190,7 +3190,7 @@ class HttpRequest:
     
     def TestImageListInput(
         self,
-        imgs: List[baml_py.Image] = [],
+        imgs: List[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4029,7 +4029,7 @@ class HttpStreamRequest:
     
     def AliasedInputList(
         self,
-        input: List[types.AliasedEnum] = [],
+        input: List[types.AliasedEnum],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4121,7 +4121,7 @@ class HttpStreamRequest:
     
     def BuildLinkedList(
         self,
-        input: List[int] = [],
+        input: List[int],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4512,7 +4512,7 @@ class HttpStreamRequest:
     
     def DynamicListInputOutput(
         self,
-        input: List[types.DynInputOutput] = [],
+        input: List[types.DynInputOutput],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4673,7 +4673,7 @@ class HttpStreamRequest:
     
     def ExtractResume(
         self,
-        resume: str,img: Optional[baml_py.Image] = None,
+        resume: str,img: Optional[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -4857,7 +4857,7 @@ class HttpStreamRequest:
     
     def FnNamedArgsSingleStringOptional(
         self,
-        myString: Optional[str] = None,
+        myString: Optional[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -5248,7 +5248,7 @@ class HttpStreamRequest:
     
     def InOutEnumMapKey(
         self,
-        i1: Dict[types.MapKey, str] = {},i2: Dict[types.MapKey, str] = {},
+        i1: Dict[types.MapKey, str],i2: Dict[types.MapKey, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -5271,7 +5271,7 @@ class HttpStreamRequest:
     
     def InOutLiteralStringUnionMapKey(
         self,
-        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str] = {},
+        i1: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],i2: Dict[Union[Literal["one"], Literal["two"], Union[Literal["three"], Literal["four"]]], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -5294,7 +5294,7 @@ class HttpStreamRequest:
     
     def InOutSingleLiteralStringMapKey(
         self,
-        m: Dict[Literal["key"], str] = {},
+        m: Dict[Literal["key"], str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -5432,7 +5432,7 @@ class HttpStreamRequest:
     
     def MapAlias(
         self,
-        m: Dict[str, List[str]] = {},
+        m: Dict[str, List[str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6674,7 +6674,7 @@ class HttpStreamRequest:
     
     def TestFnNamedArgsSingleEnumList(
         self,
-        myArg: List[types.NamedArgsSingleEnumList] = [],
+        myArg: List[types.NamedArgsSingleEnumList],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6743,7 +6743,7 @@ class HttpStreamRequest:
     
     def TestFnNamedArgsSingleMapStringToClass(
         self,
-        myMap: Dict[str, types.StringToClassEntry] = {},
+        myMap: Dict[str, types.StringToClassEntry],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6766,7 +6766,7 @@ class HttpStreamRequest:
     
     def TestFnNamedArgsSingleMapStringToMap(
         self,
-        myMap: Dict[str, Dict[str, str]] = {},
+        myMap: Dict[str, Dict[str, str]],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6789,7 +6789,7 @@ class HttpStreamRequest:
     
     def TestFnNamedArgsSingleMapStringToString(
         self,
-        myMap: Dict[str, str] = {},
+        myMap: Dict[str, str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6835,7 +6835,7 @@ class HttpStreamRequest:
     
     def TestFnNamedArgsSingleStringArray(
         self,
-        myStringArray: List[str] = [],
+        myStringArray: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -6858,7 +6858,7 @@ class HttpStreamRequest:
     
     def TestFnNamedArgsSingleStringList(
         self,
-        myArg: List[str] = [],
+        myArg: List[str],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)
@@ -7019,7 +7019,7 @@ class HttpStreamRequest:
     
     def TestImageListInput(
         self,
-        imgs: List[baml_py.Image] = [],
+        imgs: List[baml_py.Image],
         baml_options: BamlCallOptions = {},
     ) -> baml_py.HTTPRequest:
       __tb__ = baml_options.get("tb", None)


### PR DESCRIPTION
- **Revert adding default params**
- **generated code fixes!**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed default parameter values from functions in `async_client.py`, `sync_client.py`, `async_request.py`, and `sync_request.py` to prevent unintended side effects from mutable defaults.
> 
>   - **Behavior**:
>     - Removed default parameter values in functions across `async_client.py`, `sync_client.py`, and `sync_request.py`.
>     - Functions now require explicit parameter values, preventing unintended side effects from mutable defaults.
>   - **Code Generation**:
>     - Updated `mod.rs` to set default parameter values to `None` during code generation.
>   - **Affected Functions**:
>     - Changes in `AliasedInputList`, `BuildLinkedList`, `DynamicListInputOutput`, `ExtractResume`, `FnNamedArgsSingleStringOptional`, `InOutEnumMapKey`, `InOutLiteralStringUnionMapKey`, `InOutSingleLiteralStringMapKey`, `MapAlias`, `TestFnNamedArgsSingleEnumList`, `TestFnNamedArgsSingleMapStringToClass`, `TestFnNamedArgsSingleMapStringToMap`, `TestFnNamedArgsSingleMapStringToString`, `TestFnNamedArgsSingleStringArray`, `TestFnNamedArgsSingleStringList`, `TestImageListInput` in `async_client.py` and `sync_client.py`.
>     - Similar changes in `async_request.py` and `sync_request.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 28edef1900567d3fb124578eec84113853b532c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->