### PR TITLE
[docs] Fixed links client<llm> page

### DIFF
--- a/fern/01-guide/05-baml-advanced/client-registry.mdx
+++ b/fern/01-guide/05-baml-advanced/client-registry.mdx
@@ -146,7 +146,7 @@ A function to add an LLM client to the registry.
 <Markdown src="/snippets/client-constructor.mdx" />
 
 <ParamField path="retry_policy" type="string">
-The name of a retry policy that is already defined in a .baml file. See [Retry Policies](/docs/snippets/clients/retry).
+The name of a retry policy that is already defined in a .baml file. See [Retry Policies](/ref/llm-client-strategies/retry-policy).
 </ParamField>
 
 ### set_primary / setPrimary

--- a/fern/03-reference/baml/client-llm.mdx
+++ b/fern/03-reference/baml/client-llm.mdx
@@ -50,5 +50,5 @@ different model.
 
 <ParamField path="retry_policy">
   The name of the retry policy. See [Retry
-  Policy](/ref/client-strategies/retry-policy).
+  Policy](/ref/llm-client-strategies/retry-policy).
 </ParamField>

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -516,7 +516,7 @@ navigation:
             path: 03-reference/baml/clients/strategy/fallback.mdx
           - page: "Round Robin"
             path: 03-reference/baml/clients/strategy/round-robin.mdx
-  
+
       - section: Prompt Syntax
         contents:
           - page: What is jinja?
@@ -734,7 +734,7 @@ redirects:
   - source: "/docs/snippets/clients/providers/azure"
     destination: "/ref/llm-client-providers/open-ai-from-azure"
   - source: "/docs/snippets/clients/providers/gemini"
-    destination: "/ref/llm-client-providers/google-ai-studio"
+    destination: "/ref/llm-client-providers/google-ai-gemini"
   - source: "/docs/snippets/clients/providers/groq"
     destination: "/ref/llm-client-providers/openai-generic-groq"
   - source: "/docs/snippets/clients/providers/huggingface"
@@ -745,6 +745,8 @@ redirects:
     destination: "/ref/llm-client-providers/open-ai"
   - source: "/docs/snippets/clients/providers/openai-generic"
     destination: "/ref/llm-client-providers/openai-generic"
+  - source: "/docs/snippets/clients/providers/google-vertex"
+    destination: "/ref/llm-client-providers/google-vertex"
   - source: "/docs/snippets/clients/providers/openrouter"
     destination: "/ref/llm-client-providers/openai-generic-open-router"
   - source: "/docs/snippets/clients/providers/together"

--- a/fern/snippets/client-constructor.mdx
+++ b/fern/snippets/client-constructor.mdx
@@ -5,19 +5,19 @@ The configuration modifies the URL request BAML runtime makes.
 
 | Provider Name    | Docs                                                                | Notes                                                      |
 | ---------------- | ------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `anthropic`      | [Anthropic](/docs/snippets/clients/providers/anthropic)             |                                                            |
-| `aws-bedrock`    | [AWS Bedrock](/docs/snippets/clients/providers/aws-bedrock)         |                                                            |
-| `azure-openai`   | [Azure OpenAI](/docs/snippets/clients/providers/azure)              |                                                            |
-| `google-ai`      | [Google AI](/docs/snippets/clients/providers/gemini)                |                                                            |
-| `openai`         | [OpenAI](/docs/snippets/clients/providers/openai)                   |                                                            |
-| `openai-generic` | [OpenAI (generic)](/docs/snippets/clients/providers/openai-generic) | Any model provider that supports an OpenAI-compatible API  |
-| `vertex-ai`      | [Vertex AI](/docs/snippets/clients/providers/google-vertex)         |                                                            |
+| `anthropic`      | [Anthropic](/ref/llm-client-providers/anthropic)             |                                                            |
+| `aws-bedrock`    | [AWS Bedrock](/ref/llm-client-providers/aws-bedrock)         |                                                            |
+| `azure-openai`   | [Azure OpenAI](/ref/llm-client-providers/open-ai-from-azure)              |                                                            |
+| `google-ai`      | [Google AI](/ref/llm-client-providers/google-ai-gemini)                |                                                            |
+| `openai`         | [OpenAI](/ref/llm-client-providers/open-ai)                   |                                                            |
+| `openai-generic` | [OpenAI (generic)](/ref/llm-client-providers/openai-generic) | Any model provider that supports an OpenAI-compatible API  |
+| `vertex-ai`      | [Vertex AI](/ref/llm-client-providers/google-vertex)         |                                                            |
 
 We also have some special providers that allow composing clients together:
 | Provider Name  | Docs                             | Notes                                                      |
 | -------------- | -------------------------------- | ---------------------------------------------------------- |
-| `fallback`     | [Fallback](/docs/snippets/clients/fallback)             | Used to chain models conditional on failures               |
-| `round-robin`  | [Round Robin](/docs/snippets/clients/round-robin)       | Used to load balance                                       |
+| `fallback`     | [Fallback](/ref/llm-client-strategies/fallback)             | Used to chain models conditional on failures               |
+| `round-robin`  | [Round Robin](/ref/llm-client-strategies/round-robin)       | Used to load balance                                       |
 
 </ParamField>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes broken links in documentation for LLM client strategies and providers, ensuring correct navigation and references.
> 
>   - **Documentation Links**:
>     - Fix link to "Retry Policies" in `client-registry.mdx` to `/ref/llm-client-strategies/retry-policy`.
>     - Fix link to "Retry Policy" in `client-llm.mdx` to `/ref/llm-client-strategies/retry-policy`.
>     - Update provider links in `client-constructor.mdx` to use `/ref/llm-client-providers/` paths.
>   - **Redirects**:
>     - Update redirect for `/docs/snippets/clients/providers/gemini` to `/ref/llm-client-providers/google-ai-gemini` in `docs.yml`.
>     - Add redirect for `/docs/snippets/clients/providers/google-vertex` to `/ref/llm-client-providers/google-vertex` in `docs.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 1631ca1348db7b28fe181420375e4d351c13a754. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->