### PR TITLE
Add create-baml-app script to work with pnpm workspace

### DIFF
--- a/typescript/create-baml-app/README.md
+++ b/typescript/create-baml-app/README.md
@@ -1,0 +1,100 @@
+# Create BAML App 🐑
+
+<p align="center">
+<img src="https://github.com/ashayas/create-baml-app/raw/master/.github/assets/lamb.png" width="250" alt="Create BAML App"/>
+</p>
+
+<p align="center">
+<a href="https://www.npmjs.com/package/create-baml-app"><img src="https://img.shields.io/npm/v/create-baml-app.svg" alt="npm version"></a>
+<a href="https://www.npmjs.com/package/create-baml-app"><img src="https://img.shields.io/npm/dm/create-baml-app.svg" alt="npm downloads"></a>
+<img src="https://img.shields.io/badge/license-ISC-blue" alt="ISC License">
+</p>
+
+A CLI tool to set up a BAML project with your preferred language and package manager.
+
+
+## Installation & Usage 🚀
+
+Create a new BAML project using npx:
+
+```bash
+# Create a new project with interactive prompts
+npx create-baml-app
+
+# Create a new project in a specific directory
+npx create-baml-app my-baml-app
+
+# Create a new project in the current directory
+npx create-baml-app my-baml-app --use-current-dir
+# or
+npx create-baml-app my-baml-app -.
+
+# Show help menu
+npx create-baml-app --help
+```
+
+When using the interactive prompts:
+- Enter your project name (defaults to 'my-app')
+- Use "." to create the project in the current directory
+- Or enter a name to create a new directory
+
+The CLI will then:
+1. Create a new directory for your project (unless "." or --use-current-dir is specified)
+2. Help you select a programming language (Python, TypeScript, Ruby)
+3. Choose your preferred package manager
+4. Set up a complete BAML project structure
+
+## Supported Languages and Package Managers 🛠️
+
+### Python
+- **pip**: Standard Python package manager
+  - Requires: Python installed on your system
+- **poetry**: Modern Python dependency management
+  - Requires: [Poetry](https://python-poetry.org/docs/#installation) installed
+- **uv**: Fast Python package installer
+  - Requires: [uv](https://github.com/astral-sh/uv) installed
+
+### TypeScript
+- **npm**: Standard Node.js package manager
+  - Requires: [Node.js](https://nodejs.org/) installed
+- **pnpm**: Fast, disk space efficient package manager
+  - Requires: [pnpm](https://pnpm.io/installation) installed
+- **yarn**: Alternative Node.js package manager
+  - Requires: [Yarn](https://yarnpkg.com/getting-started/install) installed
+- **deno**: Secure runtime for JavaScript and TypeScript
+  - Requires: [Deno](https://deno.land/manual/getting_started/installation) installed
+  - Note: For Deno in VSCode, add `{ "deno.unstable": ["sloppy-imports"] }` to your settings
+- **bun**: Fast, disk space efficient package manager
+  - Requires: [bun](https://bun.sh/docs/installation) installed
+
+### Ruby
+- **bundle**: Ruby's package manager
+  - Requires: [Ruby](https://www.ruby-lang.org/en/documentation/installation/) and [Bundler](https://bundler.io/) installed
+
+## Project Structure 📁
+
+After running `create-baml-app`, you'll have a basic BAML project with:
+
+- The BAML CLI installed
+- Basic project structure with configuration files
+- Initial BAML source files
+
+## Development Workflow 🧑‍💻
+
+1. Write BAML function definitions in `.baml` files
+2. Generate client code with `baml-cli generate`
+3. Import and use the generated code in your application
+
+## Resources 📚
+
+- [BAML Documentation](https://docs.boundaryml.com/)
+- [BAML GitHub Repository](https://github.com/BoundaryML/baml)
+- [Boundary ML Website](https://www.boundaryml.com/)
+
+## Contributing 🤝
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License 📄
+
+This project is licensed under the ISC License. See the [LICENSE](LICENSE) file for details.

--- a/typescript/create-baml-app/index.js
+++ b/typescript/create-baml-app/index.js
@@ -1,0 +1,345 @@
+#!/usr/bin/env node
+
+import inquirer from 'inquirer';
+import chalk from 'chalk';
+import { execa } from 'execa';
+import { existsSync, mkdirSync } from 'fs';
+import { join, resolve } from 'path';
+import fs from 'fs';
+
+function showHelp() {
+  console.log(chalk.bold.magenta('\nCreate BAML App 🦙'));
+  console.log('\nUsage:');
+  console.log('  npx create-baml-app [project-name] [options]');
+  console.log('\nOptions:');
+  console.log('  -h, --help              Show this help message');
+  console.log('  --use-current-dir, -.   Use current directory instead of creating a new one');
+  console.log('\nExamples:');
+  console.log('  npx create-baml-app my-baml-app');
+  console.log('  npx create-baml-app my-baml-app --use-current-dir');
+  console.log('  npx create-baml-app my-baml-app -.');
+  console.log('\nSupported Package Managers:');
+  console.log('  - Python: pip, poetry, uv');
+  console.log('  - TypeScript: npm, pnpm, yarn, deno, bun');
+  console.log('  - Ruby: bundle');
+  process.exit(0);
+}
+
+async function runCommand(command, args, description, options = {}) {
+  console.log(chalk.cyan(`\nRunning: ${description}...`));
+  try {
+    const { stdout } = await execa(command, args, { stdio: 'inherit', ...options });
+    console.log(chalk.green('✓ Success!'));
+    return stdout;
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      console.error(chalk.red(`Error: Command '${command}' not found. Please make sure it is installed and available in your PATH.`));
+    } else {
+      console.error(chalk.red(`Error: ${error.message}`));
+    }
+    process.exit(1);
+  }
+}
+
+// Check if a command is available without exiting if not
+async function checkCommandAvailable(command) {
+  try {
+    await execa(command, ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+async function main() {
+  console.log(chalk.bold.magenta('\nWelcome to create-baml-app! 🦙'));
+  
+  // Handle command line arguments
+  const args = process.argv.slice(2);
+  
+  // Show help if requested
+  if (args.includes('-h') || args.includes('--help')) {
+    showHelp();
+  }
+
+  // Get project name from arguments or prompt
+  let projectName = args[0];
+  if (!projectName) {
+    const response = await inquirer.prompt([
+      {
+        type: 'input',
+        name: 'projectName',
+        message: 'What is your project named? (Use "." to create in current directory)',
+        default: 'my-app',
+        validate: (input) => {
+          if (input === '.') return true;
+          if (!/^[a-zA-Z0-9-_]+$/.test(input)) {
+            return 'Project name can only contain letters, numbers, dashes and underscores';
+          }
+          return true;
+        }
+      }
+    ]);
+    projectName = response.projectName;
+  }
+
+  // Determine target directory
+  const useCurrentDir = projectName === '.' || args.includes('--use-current-dir') || args.includes('-.');
+  const targetDir = useCurrentDir ? process.cwd() : resolve(projectName);
+
+  console.log(chalk.yellow("\nLet's set up your BAML project...\n"));
+
+  // Step 1: Select Language
+  const { language } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'language',
+      message: chalk.blue('Which language would you like to use?'),
+      choices: ['Python', 'TypeScript', 'Ruby'],
+    },
+  ]);
+
+  // Step 2: Select Package Manager based on Language
+  let packageManagerChoices;
+  switch (language) {
+    case 'Python':
+      packageManagerChoices = ['pip', 'poetry', 'uv'];
+      break;
+    case 'TypeScript':
+      packageManagerChoices = ['npm', 'pnpm', 'yarn', 'deno', 'bun'];
+      break;
+    case 'Ruby':
+      packageManagerChoices = ['bundle'];
+      break;
+  }
+
+  const { packageManager } = await inquirer.prompt([
+    {
+      type: 'list',
+      name: 'packageManager',
+      message: chalk.blue(`Which package manager would you like to use for ${language}?`),
+      choices: packageManagerChoices,
+    },
+  ]);
+
+  // Check if the package manager is available before creating directories
+  let isPackageManagerAvailable = await checkCommandAvailable(packageManager);
+  
+  // For npm/pnpm/yarn, we might need to check node instead
+  if (!isPackageManagerAvailable && ['npm', 'pnpm', 'yarn'].includes(packageManager)) {
+    isPackageManagerAvailable = await checkCommandAvailable('node');
+  }
+  
+  if (!isPackageManagerAvailable) {
+    console.log(chalk.red(`\nError: ${packageManager} is not installed or not available in PATH`));
+    console.log(chalk.yellow(`Please install ${packageManager} first.`));
+    
+    let installLink = '';
+    switch (packageManager) {
+      case 'pip':
+        installLink = 'https://pip.pypa.io/en/stable/installation/';
+        break;
+      case 'poetry':
+        installLink = 'https://python-poetry.org/docs/#installation';
+        break;
+      case 'uv':
+        installLink = 'https://github.com/astral-sh/uv#installation';
+        break;
+      case 'npm':
+        installLink = 'https://docs.npmjs.com/downloading-and-installing-node-js-and-npm';
+        break;
+      case 'pnpm':
+        installLink = 'https://pnpm.io/installation';
+        break;
+      case 'yarn':
+        installLink = 'https://classic.yarnpkg.com/en/docs/install';
+        break;
+      case 'deno':
+        installLink = 'https://deno.land/#installation';
+        break;
+      case 'bundle':
+        installLink = 'https://bundler.io/#getting-started';
+        break;
+      case 'bun':
+        installLink = 'https://bun.sh/docs/installation';
+        break;
+    }
+    
+    console.log(chalk.gray(`${installLink}\n`));
+    process.exit(1);
+  }
+  
+  // Only check if directory is empty if using current directory
+  if (useCurrentDir && existsSync(targetDir) && fs.readdirSync(targetDir).length > 0) {
+    console.error(chalk.red('\nError: Current directory is not empty. Please use a new directory or empty the current one.'));
+    process.exit(1);
+  }
+
+  // Create directory if not using current directory
+  if (!useCurrentDir) {
+    if (existsSync(targetDir)) {
+      console.error(chalk.red(`\nError: Directory ${projectName} already exists. Please choose a different name or use --use-current-dir to use an existing directory.`));
+      process.exit(1);
+    }
+    
+    console.log(chalk.cyan(`\nCreating a new BAML app in ${chalk.green(targetDir)}`));
+    try {
+      mkdirSync(targetDir, { recursive: true });
+    } catch (error) {
+      console.error(chalk.red(`Error creating directory: ${error.message}`));
+      process.exit(1);
+    }
+  }
+
+  // Change to target directory
+  try {
+    process.chdir(targetDir);
+  } catch (error) {
+    console.error(chalk.red(`Error changing to directory: ${error.message}`));
+    process.exit(1);
+  }
+
+  // Step 3: Execute Commands
+  console.log(chalk.magenta(`\nSetting up your ${language} BAML project with ${packageManager}...\n`));
+
+  if (language === 'Python') {
+    if (packageManager === 'pip') {
+      // Initialize requirements.txt if it doesn't exist
+      if (!existsSync('requirements.txt')) {
+        console.log(chalk.yellow('\nInitializing new Python project with pip...'));
+        await runCommand('touch', ['requirements.txt'], 'Creating requirements.txt');
+      }
+      
+      // Continue with the rest of the installation
+      await runCommand('pip', ['install', 'baml-py'], 'Installing baml-py');
+      await runCommand('baml-cli', ['init'], 'Initializing BAML');
+      await runCommand('baml-cli', ['generate'], 'Generating BAML files');
+    } else if (packageManager === 'poetry') {
+      // Initialize poetry project if pyproject.toml doesn't exist
+      if (!existsSync('pyproject.toml')) {
+        console.log(chalk.yellow('\nInitializing new Python project with Poetry...'));
+        await runCommand('poetry', ['init', '--name=baml-project', '--description=A BAML project', '--author=', '--python=^3.8', '--no-interaction'], 'Creating Poetry project');
+      }
+      await runCommand('poetry', ['add', 'baml-py'], 'Adding baml-py');
+      await runCommand('poetry', ['run', 'baml-cli', 'init'], 'Initializing BAML');
+      await runCommand('poetry', ['run', 'baml-cli', 'generate'], 'Generating BAML files');
+    } else if (packageManager === 'uv') {
+      // Initialize pyproject.toml properly with uv init if it doesn't exist
+      if (!existsSync('pyproject.toml')) {
+        console.log(chalk.yellow('\nInitializing new Python project with uv...'));
+        await runCommand('uv', ['init'], 'Initializing uv project');
+      }
+      await runCommand('uv', ['add', 'baml-py'], 'Adding baml-py');
+      await runCommand('uv', ['run', 'baml-cli', 'init'], 'Initializing BAML');
+      await runCommand('uv', ['run', 'baml-cli', 'generate'], 'Generating BAML files');
+    }
+  } else if (language === 'TypeScript') {
+    // Install TypeScript first based on package manager (except for Deno)
+    if (packageManager !== 'deno' && packageManager !== 'bun') {
+      switch (packageManager) {
+        case 'npm':
+          await runCommand('npm', ['install', 'typescript', '--save-dev'], 'Installing TypeScript');
+          break;
+        case 'pnpm':
+          await runCommand('pnpm', ['add', 'typescript', '-D'], 'Installing TypeScript');
+          break;
+        case 'yarn':
+          await runCommand('yarn', ['add', 'typescript', '--dev'], 'Installing TypeScript');
+          break;
+      }
+    } else if (packageManager === 'bun') {
+      await runCommand('bun', ['add', 'typescript', '--dev'], 'Installing TypeScript');
+    }
+
+    // Create tsconfig.json if it doesn't exist
+    if (!existsSync('tsconfig.json')) {
+      try {
+        switch (packageManager) {
+          case 'npm':
+            await runCommand('npx', ['tsc', '--init'], 'Creating tsconfig.json');
+            break;
+          case 'pnpm':
+            await runCommand('pnpm', ['exec', 'tsc', '--init'], 'Creating tsconfig.json');
+            break;
+          case 'yarn':
+            await runCommand('yarn', ['tsc', '--init'], 'Creating tsconfig.json');
+            break;
+          case 'bun':
+            await runCommand('bun', ['x', 'tsc', '--init'], 'Creating tsconfig.json');
+            break;
+          case 'deno':
+            // For Deno, we'll create a basic tsconfig.json directly
+            console.log(chalk.cyan('\nCreating tsconfig.json for Deno...'));
+            const denoConfig = {
+              "compilerOptions": {
+                "target": "ES2022",
+                "lib": ["ES2022", "DOM"],
+                "module": "ES2022",
+                "moduleResolution": "node",
+                "esModuleInterop": true,
+                "strict": true,
+                "skipLibCheck": true
+              }
+            };
+            fs.writeFileSync('tsconfig.json', JSON.stringify(denoConfig, null, 2));
+            console.log(chalk.green('✓ Success!'));
+            break;
+        }
+      } catch (error) {
+        console.error(chalk.red(`Error creating tsconfig.json: ${error.message}`));
+        process.exit(1);
+      }
+    }
+
+    if (packageManager === 'npm') {
+      await runCommand('npm', ['install', '@boundaryml/baml'], 'Installing @boundaryml/baml');
+      await runCommand('npx', ['baml-cli', 'init'], 'Initializing BAML');
+      await runCommand('npx', ['baml-cli', 'generate'], 'Generating BAML files');
+    } else if (packageManager === 'pnpm') {
+      await runCommand('pnpm', ['add', '@boundaryml/baml'], 'Adding @boundaryml/baml');
+      await runCommand('pnpm', ['exec', 'baml-cli', 'init'], 'Initializing BAML');
+      await runCommand('pnpm', ['exec', 'baml-cli', 'generate'], 'Generating BAML files');
+    } else if (packageManager === 'yarn') {
+      await runCommand('yarn', ['add', '@boundaryml/baml'], 'Adding @boundaryml/baml');
+      await runCommand('yarn', ['baml-cli', 'init'], 'Initializing BAML');
+      await runCommand('yarn', ['baml-cli', 'generate'], 'Generating BAML files');
+    } else if (packageManager === 'deno') {
+      // For Deno, create deno.json if it doesn't exist
+      if (!existsSync('deno.json')) {
+        console.log(chalk.yellow('\nInitializing new Deno project...'));
+        await runCommand('deno', ['init'], 'Creating deno.json');
+      }
+      await runCommand('deno', ['install', 'npm:@boundaryml/baml'], 'Installing @boundaryml/baml');
+      await runCommand('deno', ['run', '-A', 'npm:@boundaryml/baml/baml-cli', 'init'], 'Initializing BAML');
+      await runCommand('deno', ['run', '--unstable-sloppy-imports', '-A', 'npm:@boundaryml/baml/baml-cli', 'generate'], 'Generating BAML files');
+      console.log(chalk.yellow('\nNote: As per BAML docs, for Deno in VSCode, add this to your config:'));
+      console.log(chalk.gray('{\n  "deno.unstable": ["sloppy-imports"]\n}'));
+    } else if (packageManager === 'bun') {
+      // For Bun, create package.json if it doesn't exist
+      if (!existsSync('package.json')) {
+        console.log(chalk.yellow('\nInitializing new Bun project...'));
+        await runCommand('bun', ['init', '-y'], 'Creating package.json', { cwd: targetDir });
+      }
+      await runCommand('bun', ['install', '@boundaryml/baml'], 'Installing @boundaryml/baml', { cwd: targetDir });
+      await runCommand('bun', ['x', 'baml-cli', 'init'], 'Initializing BAML', { cwd: targetDir });
+      await runCommand('bun', ['x', 'baml-cli', 'generate'], 'Generating BAML files', { cwd: targetDir });
+    }
+  } else if (language === 'Ruby') {
+    // Initialize Gemfile if it doesn't exist
+    if (!existsSync('Gemfile')) {
+      console.log(chalk.yellow('\nInitializing new Ruby project...'));
+      await runCommand('bundle', ['init'], 'Creating Gemfile');
+    }
+    await runCommand('bundle', ['add', 'baml', 'sorbet-runtime'], 'Adding baml and sorbet-runtime');
+    await runCommand('bundle', ['exec', 'baml-cli', 'init'], 'Initializing BAML');
+    await runCommand('bundle', ['exec', 'baml-cli', 'generate'], 'Generating BAML files');
+  }
+
+  console.log(chalk.bold.green('\n🚀 All done! Your BAML project is ready.'));
+  console.log(chalk.cyan('Next steps: Check your project directory and start coding!'));
+}
+
+main().catch((error) => {
+  console.error(chalk.red('An unexpected error occurred:', error.message));
+  process.exit(1);
+});

--- a/typescript/create-baml-app/package.json
+++ b/typescript/create-baml-app/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "create-baml-app",
+    "version": "1.1.0",
+    "type": "module",
+    "main": "index.js",
+    "description": "A CLI tool to set up a BAML app",
+    "packageManager": "pnpm@9.12.0",
+    "bin": {
+      "create-baml-app": "./index.js" 
+  },
+    "scripts": {
+      "start": "node index.js",
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "keywords": ["baml", "cli", "setup"],
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+      "chalk": "^5.4.1",
+      "execa": "^9.5.2",
+      "inquirer": "^12.5.0"
+    }
+  }
+  

--- a/typescript/pnpm-workspace.yaml
+++ b/typescript/pnpm-workspace.yaml
@@ -8,3 +8,4 @@ packages:
   - 'playground-common'
   - 'fiddle-frontend'
   - 'codemirror-lang-baml'
+  - 'create-baml-app'


### PR DESCRIPTION
- Migrated code over from http://github.com/ashayas/create-baml-app 
- Usage instructions in README
- `npm`, `pnpm`, `yarn`, `deno`, `bun`, `pip`, `poetry`, `uv`, `ruby` support
- Will add Go (can even preemptively add it if I know the instructions) 

- Testing suite for this is interesting: I could maybe do a bunch of docker containers that have the various package managers 
- I did do tests with / without package managers
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `create-baml-app` CLI tool for setting up BAML projects with support for multiple languages and package managers.
> 
>   - **New Feature**:
>     - Adds `create-baml-app` CLI tool for setting up BAML projects with support for Python, TypeScript, and Ruby.
>     - Supports package managers: `pip`, `poetry`, `uv`, `npm`, `pnpm`, `yarn`, `deno`, `bun`, `bundle`.
>   - **Files**:
>     - `index.js`: Main script for handling user input and project setup.
>     - `package.json`: Defines dependencies (`chalk`, `execa`, `inquirer`) and scripts for the CLI tool.
>     - `pnpm-workspace.yaml`: Adds `create-baml-app` to the workspace packages.
>   - **Documentation**:
>     - `README.md`: Provides installation and usage instructions for the CLI tool.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 630bede1a548827cd24544f7695186ef3757d263. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->