### PR TITLE
[bug] Fix log level prints

### DIFF
--- a/engine/baml-lib/baml-log/src/logger.rs
+++ b/engine/baml-lib/baml-log/src/logger.rs
@@ -647,7 +647,7 @@ pub fn log_event_internal<T: Loggable>(
     .to_logger();
 
     // Skip if level is not enabled
-    if level.is_at_least(config.level) {
+    if !level.is_at_least(config.level) {
         return;
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes log level check in `log_event_internal()` in `logger.rs` to correctly skip logging if the level is not enabled.
> 
>   - **Bug Fix**:
>     - Fixes log level check in `log_event_internal()` in `logger.rs` to correctly skip logging if the level is not enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 9f3713c38cd8784cffcf35cdeada507431ab89e0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->