### PR TITLE
Make TS compatible with glibc 2.31+

### DIFF
--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -2,6 +2,9 @@ name: BAML Release - Build Typescript
 
 on:
   workflow_call: {}
+  push:
+    branches:
+      - glibc-ts
 
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow
@@ -76,6 +79,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Check GLIBC version for Linux targets
+      - name: Check GLIBC version
+        if: contains(matrix._.target, 'linux')
+        run: |
+          ldd --version
+          
       # Install common toolchain dependencies
       # NOTE: we can't use mise here because it doesn't support Windows
       - uses: pnpm/action-setup@v4

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -44,8 +44,8 @@ jobs:
             cargo_args: -p baml-typescript-ffi -p baml-python-ffi
 
           - target: x86_64-unknown-linux-gnu
-            host: ubuntu-20.04
-            # container: quay.io/pypa/manylinux2014_x86_64:latest
+            host: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64:latest
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
 
           - target: x86_64-unknown-linux-musl

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -110,7 +110,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: engine
-          shared-key: engine-${{ github.job }}-${{ matrix._.target }}
+          prefix-key: engine-${{ github.job }}-${{ matrix._.target }}
+          # shared-key: engine-${{ github.job }}-${{ matrix._.target }}
           cache-on-failure: true
 
       - name: PNPM Install

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -25,6 +25,7 @@ jobs:
             node_build: pnpm build:napi-release --target aarch64-apple-darwin
 
           - target: aarch64-unknown-linux-gnu
+            # Do not use -latest, since it uses a different glibc version!
             host: ubuntu-20.04
             # from https://github.com/PyO3/maturin-action?tab=readme-ov-file#manylinux-docker-container
             # need a new version of manylinux to build crates on arm64-linux
@@ -42,6 +43,7 @@ jobs:
             cargo_args: -p baml-typescript-ffi -p baml-python-ffi
 
           - target: x86_64-unknown-linux-gnu
+            # Do not use -latest, since it uses a newer glibc version!
             host: ubuntu-20.04
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
 

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -45,7 +45,7 @@ jobs:
 
           - target: x86_64-unknown-linux-gnu
             host: ubuntu-20.04
-            container: quay.io/pypa/manylinux2014_x86_64:latest
+            # container: quay.io/pypa/manylinux2014_x86_64:latest
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
 
           - target: x86_64-unknown-linux-musl

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -45,7 +45,7 @@ jobs:
 
           - target: x86_64-unknown-linux-gnu
             host: ubuntu-20.04
-            # container: quay.io/pypa/manylinux2014_x86_64:latest
+            container: quay.io/pypa/manylinux2014_x86_64:latest
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
 
           - target: x86_64-unknown-linux-musl

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -77,6 +77,8 @@ jobs:
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.host }}
     container: ${{ matrix._.container }}
+    env:
+      ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -44,10 +44,10 @@ jobs:
             cargo_args: -p baml-typescript-ffi -p baml-python-ffi
 
           - target: x86_64-unknown-linux-gnu
-            host: ubuntu-latest
-            container: quay.io/pypa/manylinux_2_28_x86_64:latest
+            host: ubuntu-20.04
+            # container: quay.io/pypa/manylinux_2_28_x86_64:latest
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
-            cargo_args: -p baml-typescript-ffi -p baml-python-ffi
+            # cargo_args: -p baml-typescript-ffi -p baml-python-ffi
 
           - target: x86_64-unknown-linux-musl
             host: ubuntu-latest

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -27,7 +27,7 @@ jobs:
             node_build: pnpm build:napi-release --target aarch64-apple-darwin
 
           - target: aarch64-unknown-linux-gnu
-            host: ubuntu-latest
+            host: ubuntu-20.04
             # from https://github.com/PyO3/maturin-action?tab=readme-ov-file#manylinux-docker-container
             # need a new version of manylinux to build crates on arm64-linux
             container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
@@ -45,9 +45,7 @@ jobs:
 
           - target: x86_64-unknown-linux-gnu
             host: ubuntu-20.04
-            # container: quay.io/pypa/manylinux_2_28_x86_64:latest
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
-            # cargo_args: -p baml-typescript-ffi -p baml-python-ffi
 
           - target: x86_64-unknown-linux-musl
             host: ubuntu-latest

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -2,9 +2,7 @@ name: BAML Release - Build Typescript
 
 on:
   workflow_call: {}
-  push:
-    branches:
-      - glibc-ts
+
 
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -45,6 +45,7 @@ jobs:
 
           - target: x86_64-unknown-linux-gnu
             host: ubuntu-latest
+            container: quay.io/pypa/manylinux2014_x86_64:latest
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
 
           - target: x86_64-unknown-linux-musl

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -47,6 +47,7 @@ jobs:
             host: ubuntu-latest
             container: quay.io/pypa/manylinux_2_28_x86_64:latest
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
+            cargo_args: -p baml-typescript-ffi -p baml-python-ffi
 
           - target: x86_64-unknown-linux-musl
             host: ubuntu-latest

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -44,8 +44,8 @@ jobs:
             cargo_args: -p baml-typescript-ffi -p baml-python-ffi
 
           - target: x86_64-unknown-linux-gnu
-            host: ubuntu-latest
-            container: quay.io/pypa/manylinux2014_x86_64:latest
+            host: ubuntu-20.04
+            # container: quay.io/pypa/manylinux2014_x86_64:latest
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
 
           - target: x86_64-unknown-linux-musl


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add GLIBC version check and change host to `ubuntu-20.04` for specific Linux targets in GitHub Actions workflow.
> 
>   - **Workflow Changes**:
>     - Add step to check GLIBC version using `ldd --version` for Linux targets in `build-typescript-release.reusable.yaml`.
>     - Change host from `ubuntu-latest` to `ubuntu-20.04` for `aarch64-unknown-linux-gnu` and `x86_64-unknown-linux-gnu` targets to ensure consistent GLIBC versions.
>   - **Caching**:
>     - Modify cache key from `shared-key` to `prefix-key` in `build-typescript-release.reusable.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 6ed42ed2f438ee4ef486234c42c4b242381b2249. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->