### PR TITLE
lower glibc for 2 more platforms

### DIFF
--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -48,7 +48,7 @@ jobs:
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-gnu --use-napi-cross
 
           - target: x86_64-unknown-linux-musl
-            host: ubuntu-latest
+            host: ubuntu-20.04
             before: |
               curl -LO https://musl.cc/x86_64-linux-musl-cross.tgz
               tar -xzf x86_64-linux-musl-cross.tgz
@@ -63,7 +63,7 @@ jobs:
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-musl --use-napi-cross
 
           - target: aarch64-unknown-linux-musl
-            host: ubuntu-latest
+            host: ubuntu-20.04
             before: |
               curl -LO https://musl.cc/aarch64-linux-musl-cross.tgz
               tar -xzf aarch64-linux-musl-cross.tgz


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `host` to `ubuntu-20.04` for two musl targets in GitHub Actions workflow to ensure glibc compatibility.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/build-typescript-release.reusable.yaml`, change `host` from `ubuntu-latest` to `ubuntu-20.04` for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for e8d24b9bae125191f225cfbcc9508b13c025aab3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->