### PR TITLE
Macos reduce host target

### DIFF
--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -2,9 +2,6 @@ name: BAML Release - Build Typescript
 
 on:
   workflow_call: {}
-  push:
-    branches:
-      - glibc3
 
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow
@@ -85,7 +82,7 @@ jobs:
 
       # Check GLIBC version for Linux targets
       - name: Check GLIBC version
-        if: contains(matrix._.target, 'linux') || contains(matrix._.target, 'darwin')
+        if: contains(matrix._.target, 'linux')
         run: |
           ldd --version
           

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -2,7 +2,9 @@ name: BAML Release - Build Typescript
 
 on:
   workflow_call: {}
-
+  push:
+    branches:
+      - glibc3
 
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow
@@ -34,7 +36,7 @@ jobs:
             cargo_args: -p baml-typescript-ffi -p baml-python-ffi
 
           - target: x86_64-apple-darwin
-            host: macos-latest
+            host: macos-14
             node_build: pnpm build:napi-release --target x86_64-apple-darwin
 
           - target: x86_64-pc-windows-msvc
@@ -83,7 +85,7 @@ jobs:
 
       # Check GLIBC version for Linux targets
       - name: Check GLIBC version
-        if: contains(matrix._.target, 'linux')
+        if: contains(matrix._.target, 'linux') || contains(matrix._.target, 'darwin')
         run: |
           ldd --version
           


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Change macOS host version to `macos-14` for `x86_64-apple-darwin` target in GitHub Actions workflow.
> 
>   - **Workflow Changes**:
>     - In `.github/workflows/build-typescript-release.reusable.yaml`, change macOS host version from `macos-latest` to `macos-14` for `x86_64-apple-darwin` target.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 55bbbc6f28b194aff3b17636d9968ee1a6736a35. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->