### PR TITLE
Fix ts build

### DIFF
--- a/engine/language_client_typescript/package.json
+++ b/engine/language_client_typescript/package.json
@@ -66,7 +66,7 @@
     "build": "pnpm build:napi-release && pnpm build:ts_build",
     "build:debug": "pnpm build:napi-debug && pnpm build:ts_build && pnpm napi create-npm-dirs && pnpm artifacts",
     "build:napi-release": "pnpm build:napi-debug --release",
-    "build:napi-debug": "napi build --js ./native.js --dts ./native.d.ts --platform && pnpm build:napi-debug-local",
+    "build:napi-debug": "napi build --js ./native.js --dts ./native.d.ts --platform",
     "build:ts_build": "tsc ./typescript_src/*.ts --outDir ./ --module nodenext --module nodenext --allowJs --declaration true --declarationMap true || true && pnpm build:ts_build_local",
     "build:napi-debug-local": "napi build -o ./artifacts --js ./native.js --dts ./native.d.ts --platform",
     "build:ts_build_local": "tsc ./typescript_src/*.ts --outDir ./artifacts --module nodenext --module nodenext --allowJs --declaration true --declarationMap true || true",


### PR DESCRIPTION
The pnpm napi-release pnpm script takes in arguments. We had added a `&& ....` to it, which seems to delete the actual target parameters from the github release script.