### PR TITLE
Allow multiple unique block-level attributes

### DIFF
--- a/engine/baml-lib/baml/tests/validation_files/class/attributes.baml
+++ b/engine/baml-lib/baml/tests/validation_files/class/attributes.baml
@@ -14,3 +14,29 @@ class HasTwoBlockAttributes {
   @@description("A test")
   @@alias("AKAHasTwo")
 }
+
+class HasThreeBlockAttributes {
+  name string
+  @@description("A test")
+  @@alias("AKAHasTwo")
+  @@description("A second description")
+}
+
+// error: Attribute "@description" can only be defined once.
+//   -->  class/attributes.baml:20
+//    | 
+// 19 |   name string
+// 20 |   @@description("A test")
+//    | 
+// error: Attribute "@description" can only be defined once.
+//   -->  class/attributes.baml:22
+//    | 
+// 21 |   @@alias("AKAHasTwo")
+// 22 |   @@description("A second description")
+//    | 
+// error: Attribute "@description" can only be defined once.
+//   -->  class/attributes.baml:20
+//    | 
+// 19 |   name string
+// 20 |   @@description("A test")
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/class/attributes.baml
+++ b/engine/baml-lib/baml/tests/validation_files/class/attributes.baml
@@ -8,3 +8,9 @@ class TestClassAlias {
   key3 string @alias("key with space")
   key4 string @alias("key.with.punctuation/123")
 }
+
+class HasTwoBlockAttributes {
+  name string
+  @@description("A test")
+  @@alias("AKAHasTwo")
+}

--- a/engine/baml-lib/parser-database/src/attributes/mod.rs
+++ b/engine/baml-lib/parser-database/src/attributes/mod.rs
@@ -162,9 +162,9 @@ fn resolve_type_exp_block_attributes<'db>(
             // Now validate the class attributes.
             ctx.assert_all_attributes_processed(type_id.into());
 
-            for _ in 0..ast_typexpr.attributes.len() {
-                let attrs = to_string_attribute::visit(ctx, &span, true);
-                class_attributes.extend_serializer(&attrs);
+            // Process all attributes, including multiple block comments
+            while let Some(attrs) = to_string_attribute::visit(ctx, &span, true) {
+                class_attributes.extend_serializer(&Some(attrs));
             }
             ctx.validate_visited_attributes();
             ctx.types.class_attributes.insert(type_id, class_attributes);

--- a/engine/baml-lib/parser-database/src/context/mod.rs
+++ b/engine/baml-lib/parser-database/src/context/mod.rs
@@ -151,13 +151,18 @@ impl<'db> Context<'db> {
                     attr.name.name(),
                     attr.span.clone(),
                 ));
-                assert!(self.attributes.unused_attributes.remove(&idx));
+                if !self.attributes.unused_attributes.remove(&idx) {
+                    return false; // Attribute was already processed.
+                }
             }
 
             return false; // stop validation in this case
         }
 
-        assert!(self.attributes.unused_attributes.remove(&first_idx));
+        // Only try to remove if it's still in the unused_attributes set
+        if !self.attributes.unused_attributes.remove(&first_idx) {
+            return false; // Attribute was already processed
+        }
         drop(attrs);
         self.set_attribute(first_idx, first)
     }
@@ -196,7 +201,7 @@ impl<'db> Context<'db> {
     /// This must be called at the end of arguments validation. It will report errors for each argument that was not used by the validators. The Drop impl will helpfully panic
     /// otherwise.
     pub(crate) fn validate_visited_arguments(&mut self) {
-        let attr = if let Some(attrid) = self.attributes.attribute {
+        let attr: &Attribute = if let Some(attrid) = self.attributes.attribute {
             &self.ast[attrid]
         } else {
             panic!("State error: missing attribute in validate_visited_arguments.")

--- a/flake.nix
+++ b/flake.nix
@@ -112,9 +112,9 @@
             };
             LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
             BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin then
-              "-I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/headers "
+              "-I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/headers -I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include"
             else
-              "-isystem ${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include -isystem ${pkgs.glibc.dev}/include";
+              "-isystem ${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include -isystem ${pkgs.llvmPackages_19.libclang.lib}/include -isystem ${pkgs.glibc.dev}/include";
 
             cargoLock = { lockFile = ./engine/Cargo.lock; outputHashes = {
               "pyo3-asyncio-0.21.0" = "sha256-5ZLzWkxp3e2u0B4+/JJTwO9SYKhtmBpMBiyIsTCW5Zw=";
@@ -143,6 +143,10 @@
             inherit buildInputs;
             PATH="${clang}/bin:$PATH";
             LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
+            BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin then
+              "-I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/headers -I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include"
+            else
+              "-isystem ${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include -isystem ${pkgs.llvmPackages_19.libclang.lib}/include -isystem ${pkgs.glibc.dev}/include";
           };
         }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -112,7 +112,7 @@
             };
             LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
             BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin then
-              "-I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/headers -I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include"
+              "" # Rely on default includes provided by stdenv.cc + libclang
             else
               "-isystem ${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include -isystem ${pkgs.llvmPackages_19.libclang.lib}/include -isystem ${pkgs.glibc.dev}/include";
 
@@ -144,7 +144,7 @@
             PATH="${clang}/bin:$PATH";
             LIBCLANG_PATH = pkgs.libclang.lib + "/lib/";
             BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin then
-              "-I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/headers -I${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include"
+              "" # Rely on default includes provided by stdenv.cc + libclang
             else
               "-isystem ${pkgs.llvmPackages_19.libclang.lib}/lib/clang/19/include -isystem ${pkgs.llvmPackages_19.libclang.lib}/include -isystem ${pkgs.glibc.dev}/include";
           };


### PR DESCRIPTION
Fixes #1638 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Allow multiple unique block-level attributes in BAML classes and update attribute processing logic and build configuration.
> 
>   - **Behavior**:
>     - Allow multiple unique block-level attributes in BAML classes in `attributes.baml`.
>     - Update error messages for duplicate attributes in `attributes.baml`.
>   - **Attribute Processing**:
>     - Modify `resolve_type_exp_block_attributes()` in `mod.rs` to process multiple block attributes.
>     - Update `visit_optional_single_attr()` in `context/mod.rs` to handle already processed attributes.
>   - **Build Configuration**:
>     - Adjust `BINDGEN_EXTRA_CLANG_ARGS` in `flake.nix` for non-Darwin systems to include additional paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 969a61e254c1f4db90b466a7218ee5e240abaaa8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->