### PR TITLE
feat: set up RPC types for runtime/backend/frontend

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -998,6 +998,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "time",
+ "ts-rs",
  "type-safe-id",
  "uuid",
  "walkdir",
@@ -5236,6 +5237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5623,6 +5633,29 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ts-rs"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e640d9b0964e9d39df633548591090ab92f7a4567bc31d3891af23471a3365c6"
+dependencies = [
+ "lazy_static",
+ "thiserror 2.0.12",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9d8656589772eeec2cf7a8264d9cda40fb28b9bc53118ceb9e8c07f8f38730"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "termcolor",
+]
 
 [[package]]
 name = "type-safe-id"

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -145,6 +145,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "askama"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +961,48 @@ dependencies = [
  "tokio-util",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "baml-rpc"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "base64 0.22.1",
+ "bytes",
+ "console_log",
+ "derive_more",
+ "dissimilar",
+ "dunce",
+ "either",
+ "env_logger",
+ "eventsource-stream",
+ "expect-test",
+ "futures",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "indexmap 2.2.6",
+ "indoc",
+ "log",
+ "num",
+ "pretty_assertions",
+ "rand",
+ "regex",
+ "rstest",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "static_assertions",
+ "strsim 0.11.1",
+ "strum",
+ "strum_macros",
+ "time",
+ "type-safe-id",
+ "uuid",
+ "walkdir",
+ "wasm-bindgen-test",
+ "web-time",
 ]
 
 [[package]]
@@ -3994,7 +4042,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b55c4d17d994b637e2f4daf6e5dc5d660d209d5642377d675d7a1c3ab69fa579"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "typed-arena",
  "unicode-width",
 ]
@@ -5575,6 +5623,18 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "type-safe-id"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0f2333ec5a49706b6f29896d0e4cdba1665d2bf2d752d0c4f130634935d42f"
+dependencies = [
+ "arrayvec 0.7.6",
+ "rand",
+ "thiserror 2.0.12",
+ "uuid",
+]
 
 [[package]]
 name = "typed-arena"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "baml-lib/*",
+  "baml-rpc",
   "baml-runtime",
   "baml-schema-wasm",
   "bstd",
@@ -14,6 +15,7 @@ members = [
 ]
 default-members = [
   "baml-lib/*",
+  "baml-rpc",
   "baml-runtime",
   # Disabled by default: --features no_wasm and --features wasm are mutually exclusive
   # Building baml-schema-wasm in combination with everything else triggers feature unification,

--- a/engine/baml-rpc/.gitignore
+++ b/engine/baml-rpc/.gitignore
@@ -1,0 +1,1 @@
+bindings

--- a/engine/baml-rpc/Cargo.toml
+++ b/engine/baml-rpc/Cargo.toml
@@ -40,6 +40,7 @@ strsim = "0.11.1"
 strum.workspace = true
 strum_macros.workspace = true
 time.workspace = true
+ts-rs = "10.1"
 type-safe-id = "0.3.2"
 uuid = { version = "1.8.0", features = ["v4", "serde"] }
 web-time.workspace = true

--- a/engine/baml-rpc/Cargo.toml
+++ b/engine/baml-rpc/Cargo.toml
@@ -1,0 +1,64 @@
+[package]
+edition = "2021"
+name = "baml-rpc"
+version = "0.0.1"
+authors.workspace = true
+description = "RPC types for BAML backends"
+license-file.workspace = true
+
+[package.metadata.rustflags]
+RSTEST_TIMEOUT = "10"
+
+[lints.rust]
+dead_code = "deny"
+elided_named_lifetimes = "deny"
+unused_imports = "deny"
+unused_variables = "deny"
+
+[dependencies]
+anyhow.workspace = true
+base64.workspace = true
+bytes.workspace = true
+derive_more.workspace = true
+dunce = "1.0.4"
+either.workspace = true
+env_logger.workspace = true
+eventsource-stream = "0.2.3"
+futures.workspace = true
+http.workspace = true
+http-body.workspace = true
+indexmap.workspace = true
+indoc.workspace = true
+log.workspace = true
+num = "0.4"
+rand.workspace = true
+regex.workspace = true
+scopeguard.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+strsim = "0.11.1"
+strum.workspace = true
+strum_macros.workspace = true
+time.workspace = true
+type-safe-id = "0.3.2"
+uuid = { version = "1.8.0", features = ["v4", "serde"] }
+web-time.workspace = true
+static_assertions.workspace = true
+
+
+[features]
+defaults = []
+internal = []
+skip-integ-tests = []
+
+[dev-dependencies]
+assert_cmd = "2"
+console_log = "1"
+dissimilar = "1.0.4"
+expect-test = "1.1.0"
+indoc.workspace = true
+pretty_assertions.workspace = true
+either = "1.8.1"
+rstest = "0.22.0"
+wasm-bindgen-test = "0.3.42"
+walkdir = "2.5.0"

--- a/engine/baml-rpc/src/ast.rs
+++ b/engine/baml-rpc/src/ast.rs
@@ -1,0 +1,149 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ast_node_id::AstNodeId;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct BamlTypeId(pub AstNodeId);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct BamlFunctionId(pub AstNodeId);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BamlMediaType {
+    Image,
+    Audio,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize, Serialize)]
+pub enum TypeValue {
+    String,
+    Int,
+    Float,
+    Bool,
+    Null,
+    Media(BamlMediaType),
+}
+
+/// Subset of [`crate::BamlValue`] allowed for literal type definitions.
+#[derive(serde::Serialize, Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[allow(dead_code)]
+pub enum LiteralValue {
+    String(String),
+    Int(i64),
+    Bool(bool),
+}
+/// FieldType represents the type of either a class field or a function arg.
+#[derive(serde::Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[allow(dead_code)]
+pub enum FieldType {
+    Primitive(TypeValue),
+    Enum(String),
+    Literal(LiteralValue),
+    Class(String),
+    List(Box<FieldType>),
+    Map(Box<FieldType>, Box<FieldType>),
+    Union(Vec<FieldType>),
+    Tuple(Vec<FieldType>),
+    Optional(Box<FieldType>),
+    RecursiveTypeAlias(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BamlTypeReference {
+    Null,
+    Int,
+    Bool,
+    Float,
+    String,
+    Media(BamlMediaType),
+    Class {
+        type_id: String,
+    },
+    Enum {
+        type_id: String,
+    },
+    TypeAlias {
+        type_id: String,
+    },
+    Array {
+        items: Box<BamlTypeReference>,
+    },
+    Map {
+        key: Box<BamlTypeReference>,
+        value: Box<BamlTypeReference>,
+    },
+    // Optionals are unions
+    Union {
+        #[serde(rename = "anyOf")]
+        any_of: Vec<BamlTypeReference>,
+    },
+    Tuple {
+        items: Vec<BamlTypeReference>,
+    },
+    Literal(BamlLiteralTypeReference),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(tag = "literal_type", content = "literal", rename_all = "snake_case")]
+pub enum BamlLiteralTypeReference {
+    String(String),
+    Int(i64),
+    Bool(bool),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum BamlTypeDefinition {
+    Class(BamlClassDefinition),
+    Enum(BamlEnumDefinition),
+    TypeAlias(BamlTypeAliasDefinition),
+}
+
+impl BamlTypeDefinition {
+    pub fn type_id(&self) -> &BamlTypeId {
+        match self {
+            BamlTypeDefinition::Class(definition) => &definition.type_id,
+            BamlTypeDefinition::Enum(definition) => &definition.type_id,
+            BamlTypeDefinition::TypeAlias(definition) => &definition.type_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BamlClassDefinition {
+    pub type_id: BamlTypeId,
+    pub fields: Vec<BamlClassField>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BamlClassField {
+    pub name: String,
+    pub r#type: BamlTypeReference,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BamlEnumDefinition {
+    pub type_id: BamlTypeId,
+    pub values: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BamlTypeAliasDefinition {
+    pub type_id: BamlTypeId,
+    pub type_reference: BamlTypeReference,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BamlFunctionDefinition {
+    pub function_id: BamlFunctionId,
+    pub inputs: Vec<BamlFunctionInput>,
+    pub output: BamlTypeReference,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BamlFunctionInput {
+    pub name: String,
+    pub value: BamlTypeReference,
+}

--- a/engine/baml-rpc/src/ast_node_id.rs
+++ b/engine/baml-rpc/src/ast_node_id.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(into = "String", from = "String")]
+pub struct AstNodeId {
+    pub type_name: String,
+    pub name: String,
+    pub interface_hash: Option<u64>,
+    pub impl_hash: Option<u64>,
+}
+
+impl std::fmt::Display for AstNodeId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}##{}##{}##{}",
+            self.type_name,
+            self.name,
+            self.interface_hash.unwrap_or(0),
+            self.impl_hash.unwrap_or(0)
+        )
+    }
+}
+
+impl std::str::FromStr for AstNodeId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts = s.split("##").collect::<Vec<_>>();
+        if parts.len() != 4 {
+            return Err(anyhow::anyhow!("Invalid unique id: {}", s));
+        }
+        Ok(AstNodeId {
+            type_name: parts[0].to_string(),
+            name: parts[1].to_string(),
+            interface_hash: parts[2].parse().ok(),
+            impl_hash: parts[3].parse().ok(),
+        })
+    }
+}
+
+impl From<AstNodeId> for String {
+    fn from(value: AstNodeId) -> Self {
+        value.to_string()
+    }
+}
+
+impl From<String> for AstNodeId {
+    fn from(value: String) -> Self {
+        value
+            .parse()
+            .expect("Failed to parse AstNodeId from string")
+    }
+}

--- a/engine/baml-rpc/src/baml_src_upload.rs
+++ b/engine/baml-rpc/src/baml_src_upload.rs
@@ -1,0 +1,56 @@
+use serde::{Deserialize, Serialize};
+
+use crate::ast::{BamlFunctionDefinition, BamlTypeDefinition};
+use crate::ast_node_id::AstNodeId;
+use crate::rpc::ApiEndpoint;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum BamlSrcUploadStatus {
+    DoesNotExist,
+    Exists,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetBamlSrcUploadStatusRequest {
+    pub project_id: String,
+    pub baml_src_id: AstNodeId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetBamlSrcUploadStatusResponse {
+    pub project_id: String,
+    pub baml_src_id: AstNodeId,
+    pub status: BamlSrcUploadStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateBamlSrcUploadRequest {
+    pub project_id: String,
+    pub baml_src_id: AstNodeId,
+    pub function_definitions: Vec<BamlFunctionDefinition>,
+    pub type_definitions: Vec<BamlTypeDefinition>,
+}
+
+impl CreateBamlSrcUploadRequest {
+    pub fn to_get_baml_src_upload_status_request(&self) -> GetBamlSrcUploadStatusRequest {
+        GetBamlSrcUploadStatusRequest {
+            project_id: self.project_id.clone(),
+            baml_src_id: self.baml_src_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateBamlSrcUploadResponse {
+    pub project_id: String,
+    pub baml_src_id: AstNodeId,
+}
+
+pub struct CreateBamlSrcUpload;
+
+/// POST /v1/baml-src/upload
+impl ApiEndpoint for CreateBamlSrcUpload {
+    type Request = CreateBamlSrcUploadRequest;
+    type Response = CreateBamlSrcUploadResponse;
+
+    const PATH: &'static str = "/v1/baml-src/upload";
+}

--- a/engine/baml-rpc/src/base.rs
+++ b/engine/baml-rpc/src/base.rs
@@ -30,32 +30,8 @@ impl<'de> Deserialize<'de> for EpochMsTimestamp {
     }
 }
 
-// pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<time::OffsetDateTime>, D::Error>
-// where
-//     D: Deserializer<'de>,
-// {
-//     let formatted: Option<u64> = serde::Deserialize::deserialize(deserializer)?;
-//     match formatted {
-//         Some(epoch_ms) => {
-//             let v = OffsetDateTime::from_unix_timestamp_nanos(
-//                 Duration::from_millis(epoch_ms).as_nanos() as i128,
-//             )
-//             .map_err(serde::de::Error::custom)?;
-//             Ok(Some(v))
-//         }
-//         None => Ok(None),
-//     }
-// }
-
-// pub fn serialize<S>(v: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
-// where
-//     S: Serializer,
-// {
-//     match v {
-//         Some(v) => {
-//             let epoch_millis = Duration::from_nanos(v.unix_timestamp_nanos() as u64).as_millis();
-//             serializer.serialize_u64(epoch_millis as u64)
-//         }
-//         None => serializer.serialize_none(),
-//     }
-// }
+impl Into<time::OffsetDateTime> for EpochMsTimestamp {
+    fn into(self) -> time::OffsetDateTime {
+        self.0
+    }
+}

--- a/engine/baml-rpc/src/base.rs
+++ b/engine/baml-rpc/src/base.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+use serde::{Deserializer, Serializer};
+use std::time::Duration;
+use time::OffsetDateTime;
+
+#[derive(Debug)]
+pub struct EpochMsTimestamp(time::OffsetDateTime);
+
+impl Serialize for EpochMsTimestamp {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let epoch_millis = Duration::from_nanos(self.0.unix_timestamp_nanos() as u64).as_millis();
+        serializer.serialize_u64(epoch_millis as u64)
+    }
+}
+
+impl<'de> Deserialize<'de> for EpochMsTimestamp {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let epoch_ms: u64 = serde::Deserialize::deserialize(deserializer)?;
+        let v = OffsetDateTime::from_unix_timestamp_nanos(
+            Duration::from_millis(epoch_ms).as_nanos() as i128,
+        )
+        .map_err(serde::de::Error::custom)?;
+        Ok(EpochMsTimestamp(v))
+    }
+}
+
+// pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<time::OffsetDateTime>, D::Error>
+// where
+//     D: Deserializer<'de>,
+// {
+//     let formatted: Option<u64> = serde::Deserialize::deserialize(deserializer)?;
+//     match formatted {
+//         Some(epoch_ms) => {
+//             let v = OffsetDateTime::from_unix_timestamp_nanos(
+//                 Duration::from_millis(epoch_ms).as_nanos() as i128,
+//             )
+//             .map_err(serde::de::Error::custom)?;
+//             Ok(Some(v))
+//         }
+//         None => Ok(None),
+//     }
+// }
+
+// pub fn serialize<S>(v: &Option<OffsetDateTime>, serializer: S) -> Result<S::Ok, S::Error>
+// where
+//     S: Serializer,
+// {
+//     match v {
+//         Some(v) => {
+//             let epoch_millis = Duration::from_nanos(v.unix_timestamp_nanos() as u64).as_millis();
+//             serializer.serialize_u64(epoch_millis as u64)
+//         }
+//         None => serializer.serialize_none(),
+//     }
+// }

--- a/engine/baml-rpc/src/define_id.rs
+++ b/engine/baml-rpc/src/define_id.rs
@@ -1,0 +1,43 @@
+use type_safe_id::{StaticType, TypeSafeId};
+
+macro_rules! define_id {
+    ($name:ident, $inner_name:ident, $type_str:expr) => {
+        #[derive(Default, Clone)]
+        struct $inner_name;
+
+        impl StaticType for $inner_name {
+            const TYPE: &'static str = $type_str;
+        }
+
+        #[derive(Debug, Clone)]
+        pub struct $name(TypeSafeId<$inner_name>);
+
+        impl serde::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                self.0.to_string().serialize(serializer)
+            }
+        }
+
+        // Add Deserialize implementation
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let s = String::deserialize(deserializer)?;
+                match s.parse() {
+                    Ok(id) => Ok($name(id)),
+                    Err(e) => Err(serde::de::Error::custom(e.to_string())),
+                }
+            }
+        }
+    };
+}
+
+// Example usage:
+define_id!(SpanId, Span_, "bspan");
+define_id!(TraceEventId, TraceEvent_, "bevent");
+define_id!(HttpRequestId, HttpRequest_, "breq");

--- a/engine/baml-rpc/src/define_id.rs
+++ b/engine/baml-rpc/src/define_id.rs
@@ -12,6 +12,12 @@ macro_rules! define_id {
         #[derive(Debug, Clone)]
         pub struct $name(TypeSafeId<$inner_name>);
 
+        impl $name {
+            pub fn new() -> Self {
+                Self(TypeSafeId::<$inner_name>::new())
+            }
+        }
+
         impl serde::Serialize for $name {
             fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
             where
@@ -34,10 +40,16 @@ macro_rules! define_id {
                 }
             }
         }
+
+        impl ToString for $name {
+            fn to_string(&self) -> String {
+                self.0.to_string()
+            }
+        }
     };
 }
 
-// Example usage:
 define_id!(SpanId, Span_, "bspan");
 define_id!(TraceEventId, TraceEvent_, "bevent");
 define_id!(HttpRequestId, HttpRequest_, "breq");
+define_id!(ProjectId, Project_, "proj");

--- a/engine/baml-rpc/src/lib.rs
+++ b/engine/baml-rpc/src/lib.rs
@@ -1,0 +1,21 @@
+mod ast;
+mod ast_node_id;
+mod baml_src_upload;
+mod base;
+mod define_id;
+mod rpc;
+mod trace;
+mod trace_event_upload;
+mod ui_control_plane_orgs;
+mod ui_control_plane_projects;
+mod ui_dashboard;
+mod ui_function_spans;
+
+pub use rpc::{ApiEndpoint, GetEndpoint};
+
+pub use baml_src_upload::{
+    CreateBamlSrcUpload, CreateBamlSrcUploadRequest, CreateBamlSrcUploadResponse,
+};
+pub use trace_event_upload::{
+    CreateTraceEventUpload, CreateTraceEventUploadRequest, CreateTraceEventUploadResponse,
+};

--- a/engine/baml-rpc/src/lib.rs
+++ b/engine/baml-rpc/src/lib.rs
@@ -11,11 +11,29 @@ mod ui_control_plane_projects;
 mod ui_dashboard;
 mod ui_function_spans;
 
+pub use ast::{BamlClassDefinition, BamlFunctionDefinition, BamlTypeDefinition, BamlTypeReference};
+pub use ast_node_id::AstNodeId;
 pub use rpc::{ApiEndpoint, GetEndpoint};
 
 pub use baml_src_upload::{
-    CreateBamlSrcUpload, CreateBamlSrcUploadRequest, CreateBamlSrcUploadResponse,
+    BamlSrcUploadStatus, CreateBamlSrcUpload, CreateBamlSrcUploadRequest,
+    CreateBamlSrcUploadResponse, GetBamlSrcUploadStatusRequest, GetBamlSrcUploadStatusResponse,
 };
+pub use define_id::{HttpRequestId, ProjectId, SpanId, TraceEventId};
+pub use trace::{TraceData, TraceEvent, TraceEventBatch};
 pub use trace_event_upload::{
     CreateTraceEventUpload, CreateTraceEventUploadRequest, CreateTraceEventUploadResponse,
+};
+
+pub use ui_control_plane_orgs::{
+    CreateOrganization, CreateOrganizationRequest, CreateOrganizationResponse, GetOrganization,
+    GetOrganizationRequest, GetOrganizationResponse, Organization, UpdateOrganization,
+    UpdateOrganizationRequest, UpdateOrganizationResponse,
+};
+pub use ui_control_plane_projects::{
+    CreateProject, CreateProjectRequest, CreateProjectResponse, ListProjects, ListProjectsRequest,
+    ListProjectsResponse, Project, UpdateProject, UpdateProjectRequest, UpdateProjectResponse,
+};
+pub use ui_function_spans::{
+    ListFunctionSpans, ListFunctionSpansRequest, ListFunctionSpansResponse,
 };

--- a/engine/baml-rpc/src/rpc.rs
+++ b/engine/baml-rpc/src/rpc.rs
@@ -19,8 +19,8 @@ pub trait ApiEndpoint {
     const PATH: &'static str;
 
     /// Returns the endpoint path (e.g., "/users/42").
-    fn path(&self) -> String {
+    fn path() -> &'static str {
         debug_assert!(Self::PATH.starts_with('/'));
-        Self::PATH.to_string()
+        Self::PATH
     }
 }

--- a/engine/baml-rpc/src/rpc.rs
+++ b/engine/baml-rpc/src/rpc.rs
@@ -1,0 +1,26 @@
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Trait for GET endpoints (no request body).
+pub trait GetEndpoint {
+    type Response: DeserializeOwned;
+    const PATH: &'static str;
+
+    /// Returns the endpoint path (e.g., "/users/42").
+    fn path(&self) -> String {
+        debug_assert!(Self::PATH.starts_with('/'));
+        Self::PATH.to_string()
+    }
+}
+
+/// Trait for POST endpoints that have an associated request body and response.
+pub trait ApiEndpoint {
+    type Request: Serialize;
+    type Response: DeserializeOwned;
+    const PATH: &'static str;
+
+    /// Returns the endpoint path (e.g., "/users/42").
+    fn path(&self) -> String {
+        debug_assert!(Self::PATH.starts_with('/'));
+        Self::PATH.to_string()
+    }
+}

--- a/engine/baml-rpc/src/trace.rs
+++ b/engine/baml-rpc/src/trace.rs
@@ -17,6 +17,11 @@ pub enum TraceLevel {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub struct TraceEventBatch {
+    pub events: Vec<TraceEvent>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TraceEvent {
     /*
      * (span_id, content_span_id) is a unique identifier for a log event

--- a/engine/baml-rpc/src/trace.rs
+++ b/engine/baml-rpc/src/trace.rs
@@ -1,0 +1,209 @@
+use crate::base::EpochMsTimestamp;
+use crate::define_id::{HttpRequestId, SpanId, TraceEventId};
+use anyhow::Result;
+use serde::{Deserialize, Serialize, Serializer};
+
+pub type TraceTags = serde_json::Map<String, serde_json::Value>;
+
+#[repr(usize)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum TraceLevel {
+    Trace = 100,
+    Debug = 200,
+    Info = 300,
+    Warn = 400,
+    Error = 500,
+    Fatal = 600,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TraceEvent {
+    /*
+     * (span_id, content_span_id) is a unique identifier for a log event
+     * The query (span_id, *) gets all logs for a function call
+     */
+    pub span_id: SpanId,
+    // a unique identifier for this particular content
+    pub event_id: TraceEventId,
+
+    // The content of the log
+    pub content: TraceData,
+
+    // The chain of spans that lead to this log event
+    // Includes span_id at the last position (content_span_id is not included)
+    pub span_chain: Vec<SpanId>,
+
+    // The timestamp of the log
+    #[serde(rename = "timestamp_epoch_ms")]
+    pub timestamp: EpochMsTimestamp,
+
+    /// human-readable callsite identifier, e.g. "ExtractResume" or "openai/gpt-4o/chat"
+    pub callsite: String,
+
+    /// verbosity level
+    #[serde(with = "level_serde")]
+    pub verbosity: TraceLevel,
+
+    pub tags: TraceTags,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", content = "data")]
+pub enum TraceData {
+    FunctionStart(FunctionStart),
+    FunctionEnd(FunctionEnd),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BamlOptions {
+    pub type_builder: Option<serde_json::Value>,
+    pub client_registry: Option<serde_json::Value>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FunctionStart {
+    pub function_id: SpanId,
+    pub function_display_name: String,
+    pub args: Vec<(String, serde_json::Value)>,
+    pub options: (),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FunctionEnd {
+    pub function_id: SpanId,
+    pub function_display_name: String,
+    #[serde(deserialize_with = "deserialize_ok", serialize_with = "serialize_ok")]
+    pub result: Result<serde_json::Value, anyhow::Error>,
+    // Everything below is duplicated from the start event
+    // to deal with the case where the log is dropped.
+    // P2: as we can for now assume logs are not dropped,
+
+    // pub name: String,
+    // pub start_timestamp: web_time::Instant,
+    // pub start_args: Vec<BamlValue>,
+}
+
+// LLM specific events
+
+// TODO: fix this.
+pub type Prompt = serde_json::Value;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LoggedLLMRequest {
+    pub request_id: HttpRequestId,
+    pub client_name: String,
+    pub client_provider: String,
+    pub params: serde_json::Value,
+    pub prompt: Prompt,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HTTPRequest {
+    // since LLM requests could be made in parallel, we need to match the response to the request
+    pub request_id: HttpRequestId,
+    pub url: String,
+    pub method: String,
+    pub headers: serde_json::Value,
+    pub body: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct HTTPResponse {
+    // since LLM requests could be made in parallel, we need to match the response to the request
+    pub request_id: HttpRequestId,
+    pub status: u16,
+    pub headers: serde_json::Value,
+    pub body: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LoggedLLMResponse {
+    /// Since LLM requests could be made in parallel, we need to match the response to the request.
+    pub request_id: HttpRequestId,
+
+    /// If available, fully qualified model name. None in failure cases or unknown state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    /// If available, a textual finish reason from the LLM. None in errors or unknown state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<String>,
+
+    /// If available, usage information from the LLM. None if usage data is unavailable or in error states.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<LLMUsage>,
+
+    /// If available, the accumulated text output after retrieving chunks from LLM. None in error states.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_text_output: Option<String>,
+
+    /// If an error occurred, store the message here. None if the request was successful.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LLMUsage {
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub total_tokens: Option<u64>,
+}
+
+/// -------------------------------------------------------------------------
+///
+/// Helper deserializer for our Result types.
+///
+/// This assumes that the incoming JSON always represents the Ok variant.
+/// (If you need to support error variants, you will have to expand this logic.)
+///
+use serde::Deserializer;
+fn deserialize_ok<'de, D, T>(deserializer: D) -> Result<Result<T, anyhow::Error>, D::Error>
+where
+    D: Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    T::deserialize(deserializer).map(Ok)
+}
+
+fn serialize_ok<S, T>(value: &Result<T, anyhow::Error>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+    T: Serialize,
+{
+    match value {
+        Ok(v) => v.serialize(serializer),
+        Err(err) => Err(serde::ser::Error::custom(format!("Error: {}", err))),
+    }
+}
+
+// Add this helper module for tracing::Level serialization
+mod level_serde {
+    use super::TraceLevel;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S>(level: &TraceLevel, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u32(*level as u32)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<TraceLevel, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let level_num: u32 = serde::Deserialize::deserialize(deserializer)?;
+        match level_num {
+            100 => Ok(TraceLevel::Trace),
+            200 => Ok(TraceLevel::Debug),
+            300 => Ok(TraceLevel::Info),
+            400 => Ok(TraceLevel::Warn),
+            500 => Ok(TraceLevel::Error),
+            600 => Ok(TraceLevel::Fatal),
+            _ => Err(serde::de::Error::custom(format!(
+                "Invalid trace level: {}",
+                level_num
+            ))),
+        }
+    }
+}

--- a/engine/baml-rpc/src/trace_event_upload.rs
+++ b/engine/baml-rpc/src/trace_event_upload.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+use crate::rpc::ApiEndpoint;
+use crate::trace::TraceEvent;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateTraceEventUploadRequest {
+    pub trace_event_batch: Vec<TraceEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateTraceEventUploadResponse {
+    pub project_id: String,
+}
+
+pub struct CreateTraceEventUpload;
+
+// POST /v1/baml-trace
+impl ApiEndpoint for CreateTraceEventUpload {
+    type Request = CreateTraceEventUploadRequest;
+    type Response = CreateTraceEventUploadResponse;
+
+    const PATH: &'static str = "/v1/baml-trace";
+}

--- a/engine/baml-rpc/src/ui_control_plane_orgs.rs
+++ b/engine/baml-rpc/src/ui_control_plane_orgs.rs
@@ -1,7 +1,9 @@
 use crate::rpc::ApiEndpoint;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct Organization {
     pub org_id: String,
     pub org_slug: String,
@@ -10,14 +12,16 @@ pub struct Organization {
     pub stripe_subscription_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct CreateOrganizationRequest {
     pub org_id: String,
     pub org_slug: String,
     pub org_display_name: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct CreateOrganizationResponse {
     pub org: Organization,
 }
@@ -31,7 +35,8 @@ impl ApiEndpoint for CreateOrganization {
     const PATH: &'static str = "/v1/create-organization";
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct UpdateOrganizationRequest {
     pub org_id: String,
     pub org_slug: Option<String>,
@@ -40,7 +45,8 @@ pub struct UpdateOrganizationRequest {
     pub stripe_subscription_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct UpdateOrganizationResponse {
     pub org: Organization,
 }
@@ -54,12 +60,14 @@ impl ApiEndpoint for UpdateOrganization {
     const PATH: &'static str = "/v1/update-organization";
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct GetOrganizationRequest {
     pub org_id: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct GetOrganizationResponse {
     pub org: Organization,
 }

--- a/engine/baml-rpc/src/ui_control_plane_orgs.rs
+++ b/engine/baml-rpc/src/ui_control_plane_orgs.rs
@@ -17,7 +17,7 @@ pub struct Organization {
 pub struct CreateOrganizationRequest {
     pub org_id: String,
     pub org_slug: String,
-    pub org_display_name: Option<String>,
+    pub org_display_name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -26,7 +26,7 @@ pub struct CreateOrganizationResponse {
     pub org: Organization,
 }
 
-struct CreateOrganization;
+pub struct CreateOrganization;
 
 impl ApiEndpoint for CreateOrganization {
     type Request = CreateOrganizationRequest;
@@ -51,7 +51,7 @@ pub struct UpdateOrganizationResponse {
     pub org: Organization,
 }
 
-struct UpdateOrganization;
+pub struct UpdateOrganization;
 
 impl ApiEndpoint for UpdateOrganization {
     type Request = UpdateOrganizationRequest;
@@ -72,7 +72,7 @@ pub struct GetOrganizationResponse {
     pub org: Organization,
 }
 
-struct GetOrganization;
+pub struct GetOrganization;
 
 impl ApiEndpoint for GetOrganization {
     type Request = GetOrganizationRequest;

--- a/engine/baml-rpc/src/ui_control_plane_orgs.rs
+++ b/engine/baml-rpc/src/ui_control_plane_orgs.rs
@@ -1,0 +1,74 @@
+use crate::rpc::ApiEndpoint;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Organization {
+    pub org_id: String,
+    pub org_slug: String,
+    pub org_display_name: String,
+    pub stripe_customer_id: Option<String>,
+    pub stripe_subscription_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateOrganizationRequest {
+    pub org_id: String,
+    pub org_slug: String,
+    pub org_display_name: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateOrganizationResponse {
+    pub org: Organization,
+}
+
+struct CreateOrganization;
+
+impl ApiEndpoint for CreateOrganization {
+    type Request = CreateOrganizationRequest;
+    type Response = CreateOrganizationResponse;
+
+    const PATH: &'static str = "/v1/create-organization";
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateOrganizationRequest {
+    pub org_id: String,
+    pub org_slug: Option<String>,
+    pub org_display_name: Option<String>,
+    pub stripe_customer_id: Option<String>,
+    pub stripe_subscription_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateOrganizationResponse {
+    pub org: Organization,
+}
+
+struct UpdateOrganization;
+
+impl ApiEndpoint for UpdateOrganization {
+    type Request = UpdateOrganizationRequest;
+    type Response = UpdateOrganizationResponse;
+
+    const PATH: &'static str = "/v1/update-organization";
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetOrganizationRequest {
+    pub org_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetOrganizationResponse {
+    pub org: Organization,
+}
+
+struct GetOrganization;
+
+impl ApiEndpoint for GetOrganization {
+    type Request = GetOrganizationRequest;
+    type Response = GetOrganizationResponse;
+
+    const PATH: &'static str = "/v1/get-organization";
+}

--- a/engine/baml-rpc/src/ui_control_plane_projects.rs
+++ b/engine/baml-rpc/src/ui_control_plane_projects.rs
@@ -1,19 +1,23 @@
 use crate::rpc::ApiEndpoint;
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct Project {
     pub project_id: String,
     pub short_name: String,
     pub environments: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct ListProjectsRequest {
     org_slug: String,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct ListProjectsResponse {
     projects: Vec<Project>,
     total_project_count: i64,
@@ -28,14 +32,16 @@ impl ApiEndpoint for ListProjects {
     const PATH: &'static str = "/v1/list-projects";
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct CreateProjectRequest {
     short_name: String,
     org_id: String,
     environments: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct CreateProjectResponse {
     project: Project,
 }
@@ -50,14 +56,16 @@ impl ApiEndpoint for CreateProject {
 }
 
 // TODO: fill in partial fields
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct UpdateProjectRequest {
     pub project_id: String,
     pub short_name: String,
     pub environments: Vec<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct UpdateProjectResponse {
     pub project: Project,
 }

--- a/engine/baml-rpc/src/ui_control_plane_projects.rs
+++ b/engine/baml-rpc/src/ui_control_plane_projects.rs
@@ -6,24 +6,25 @@ use ts_rs::TS;
 #[ts(export)]
 pub struct Project {
     pub project_id: String,
-    pub short_name: String,
+    pub project_slug: String,
+    pub org_id: String,
     pub environments: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct ListProjectsRequest {
-    org_slug: String,
+    pub org_id: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct ListProjectsResponse {
-    projects: Vec<Project>,
-    total_project_count: i64,
+    pub projects: Vec<Project>,
+    pub total_project_count: i64,
 }
 
-struct ListProjects;
+pub struct ListProjects;
 
 impl ApiEndpoint for ListProjects {
     type Request = ListProjectsRequest;
@@ -35,18 +36,18 @@ impl ApiEndpoint for ListProjects {
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct CreateProjectRequest {
-    short_name: String,
-    org_id: String,
-    environments: Vec<String>,
+    pub project_slug: String,
+    pub org_id: String,
+    pub environments: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct CreateProjectResponse {
-    project: Project,
+    pub project: Project,
 }
 
-struct CreateProject;
+pub struct CreateProject;
 
 impl ApiEndpoint for CreateProject {
     type Request = CreateProjectRequest;
@@ -60,8 +61,8 @@ impl ApiEndpoint for CreateProject {
 #[ts(export)]
 pub struct UpdateProjectRequest {
     pub project_id: String,
-    pub short_name: String,
-    pub environments: Vec<String>,
+    pub project_slug: Option<String>,
+    pub environments: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -70,7 +71,7 @@ pub struct UpdateProjectResponse {
     pub project: Project,
 }
 
-struct UpdateProject;
+pub struct UpdateProject;
 
 impl ApiEndpoint for UpdateProject {
     type Request = UpdateProjectRequest;

--- a/engine/baml-rpc/src/ui_control_plane_projects.rs
+++ b/engine/baml-rpc/src/ui_control_plane_projects.rs
@@ -1,0 +1,72 @@
+use crate::rpc::ApiEndpoint;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Project {
+    pub project_id: String,
+    pub short_name: String,
+    pub environments: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListProjectsRequest {
+    org_slug: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListProjectsResponse {
+    projects: Vec<Project>,
+    total_project_count: i64,
+}
+
+struct ListProjects;
+
+impl ApiEndpoint for ListProjects {
+    type Request = ListProjectsRequest;
+    type Response = ListProjectsResponse;
+
+    const PATH: &'static str = "/v1/list-projects";
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateProjectRequest {
+    short_name: String,
+    org_id: String,
+    environments: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateProjectResponse {
+    project: Project,
+}
+
+struct CreateProject;
+
+impl ApiEndpoint for CreateProject {
+    type Request = CreateProjectRequest;
+    type Response = CreateProjectResponse;
+
+    const PATH: &'static str = "/v1/create-project";
+}
+
+// TODO: fill in partial fields
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateProjectRequest {
+    pub project_id: String,
+    pub short_name: String,
+    pub environments: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpdateProjectResponse {
+    pub project: Project,
+}
+
+struct UpdateProject;
+
+impl ApiEndpoint for UpdateProject {
+    type Request = UpdateProjectRequest;
+    type Response = UpdateProjectResponse;
+
+    const PATH: &'static str = "/v1/update-project";
+}

--- a/engine/baml-rpc/src/ui_dashboard.rs
+++ b/engine/baml-rpc/src/ui_dashboard.rs
@@ -1,0 +1,146 @@
+use crate::base::EpochMsTimestamp;
+use crate::rpc::ApiEndpoint;
+use serde::{Deserialize, Serialize};
+
+/**
+ * interface Expression<T> {
+    operator: "gt" | "lt" | "lte" | "gte" | "eq" | "ne" | "in" | "contains" | "regex" | "exists";
+    unary_operator?: "length"
+    value: T;
+}
+
+interface DashboardQueryParams {
+  filter?: {
+    personId?: string;
+    apiKey?: string;
+    provider?: string, // openai
+    clientId?: string; // client##MyFallbackClient##{interface_hash}##{impl_hash}
+    clientName?: string; // MyFallbackClient -> 4o // o1
+    functionId?: string; // function##MyFunction##{hash}..
+    functionName?: string; // MyFunction
+    functionSpanId?: string; // specific to uuid / cuid etc
+    sessionId?: string;
+    callType?: "async" | "sync";
+    startAt?: string; // ISO8601
+    endAt?: string;   // ISO8601
+    relativeTime?: number(minutes|hours|days|weeks|months|years); // e.x. 7d for 7 days
+    streamed?: boolean;
+    status?: Expression<"success" | "error" | "running">
+    input?: {
+      [flatJsonPath: string]: Expression<any> // flatJsonPath = company.name
+    };
+    output?: {
+      [flatJsonPath: string]: Expression<any> // company[0].name = Amazon
+    };
+    tags?: {
+     [tagKey: string]: Expression<number, boolean, string>
+    };
+  };
+  graphs?: {
+    [graphName: string]: {
+      query: "cost" | "counts" | "latency_ms" | "errors"
+      groupBy?: | "personId" | "sessionId"
+                          | "clientId" | "functionId"
+                          | "clientName" | "functionName"
+                          | "call_type";
+      format: "number" | "percentage";
+      time_tick: "day" | "hour" | "week";
+      metric: "sum" | "average" | "p50" | "p90" | "p95" | "p99" | "min" | "max";
+    };
+  };
+  //comparison?: "current" | "previous" | "week-over-week" | "month-over-month" | "year-over-year";
+}
+ */
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum FilterOperation {
+    PersonId(UnaryBooleanOperator<String>),
+    ApiKeyName(UnaryBooleanOperator<String>),
+    Provider(UnaryBooleanOperator<String>),
+    ClientId(UnaryBooleanOperator<String>),
+    ClientName(UnaryBooleanOperator<String>),
+    FunctionId(UnaryBooleanOperator<String>),
+    FunctionName(UnaryBooleanOperator<String>),
+    SessionId(UnaryBooleanOperator<String>),
+    CallType(UnaryBooleanOperator<String>),
+    StartAtEpochMs(UnaryBooleanOperator<u64>),
+    EndAtEpochMs(UnaryBooleanOperator<u64>),
+    RelativeTime(UnaryBooleanOperator<u64>),
+    Streamed(UnaryBooleanOperator<bool>),
+    Status(UnaryBooleanOperator<String>),
+    Input {
+        path: String,
+        op: UnaryBooleanOperator<String>,
+    },
+    Output {
+        path: String,
+        op: UnaryBooleanOperator<String>,
+    },
+    Tags {
+        key: String,
+        op: UnaryBooleanOperator<String>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UnaryBooleanOperator<T> {
+    pub operator: String,
+    pub value: T,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ChartMetric {
+    TotalTokenCount,
+    LatencyMs,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChartParameters {
+    pub chart_name: String,
+    pub chart_metric: ChartMetric,
+    pub group_by: Vec<String>,
+    pub filters: Vec<FilterOperation>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChartDefinition {
+    pub chart_name: String,
+    pub chart_params: ChartParameters,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetDashboardDataRequest {
+    pub charts: Vec<ChartDefinition>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChartDataSeries {
+    pub series_name: String,
+    /// If there are no data points for a given time window, the value will be None.
+    /// The frontend can decide whether to show a gap or a zero.
+    pub data: Vec<(EpochMsTimestamp, Option<f64>)>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ChartData {
+    pub chart_name: String,
+    pub chart_params: ChartParameters,
+    /// There is one data series per member of the group_by set,
+    /// e.g. if group_by = ["personId", "functionId"], there will be one
+    /// data series per (personId, functionId) pair.
+    pub chart_data: Vec<ChartDataSeries>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetDashboardDataResponse {
+    pub charts: Vec<ChartData>,
+}
+
+struct GetDashboardData;
+
+impl ApiEndpoint for GetDashboardData {
+    type Request = GetDashboardDataRequest;
+    type Response = GetDashboardDataResponse;
+
+    const PATH: &'static str = "/v1/dashboard";
+}

--- a/engine/baml-rpc/src/ui_function_spans.rs
+++ b/engine/baml-rpc/src/ui_function_spans.rs
@@ -3,17 +3,22 @@ use crate::{
     rpc::ApiEndpoint,
 };
 use serde::{Deserialize, Serialize};
+use ts_rs::TS;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct ListFunctionSpansRequest {
     project_id: String,
     function_call_id: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
 pub struct ListFunctionSpansResponse {
     function_spans: Vec<api::FunctionSpan>,
+    #[ts(type = "any")]
     function_definitions: Vec<BamlFunctionDefinition>,
+    #[ts(type = "any")]
     type_definitions: Vec<BamlTypeDefinition>,
 }
 
@@ -28,28 +33,37 @@ impl ApiEndpoint for ListFunctionSpans {
 
 pub mod api {
     use serde::{Deserialize, Serialize};
+    use ts_rs::TS;
 
     use crate::base::EpochMsTimestamp;
 
-    #[derive(Debug, Deserialize, Serialize)]
+    #[derive(Debug, Serialize, Deserialize, TS)]
+    #[ts(export)]
     pub struct FunctionSpan {
         pub function_span_id: String,
         pub source: String,
         pub function_id: String,
         #[serde(rename = "start_epoch_ms")]
+        #[ts(type = "number | null")]
         pub start_time: Option<EpochMsTimestamp>,
         #[serde(rename = "end_epoch_ms")]
+        #[ts(type = "number | null")]
         pub end_time: Option<EpochMsTimestamp>,
+        #[ts(type = "any")]
         pub baml_options: serde_json::Value,
         pub inputs: Vec<FunctionInput>,
+        #[ts(type = "any")]
         pub output: serde_json::Value,
         pub status: String,
+        #[ts(type = "any")]
         pub error: serde_json::Value,
     }
 
-    #[derive(Debug, Deserialize, Serialize)]
+    #[derive(Debug, Deserialize, Serialize, TS)]
+    #[ts(export)]
     pub struct FunctionInput {
         pub field: String,
+        #[ts(type = "any")]
         pub value: serde_json::Value,
     }
 }

--- a/engine/baml-rpc/src/ui_function_spans.rs
+++ b/engine/baml-rpc/src/ui_function_spans.rs
@@ -22,7 +22,7 @@ pub struct ListFunctionSpansResponse {
     type_definitions: Vec<BamlTypeDefinition>,
 }
 
-struct ListFunctionSpans;
+pub struct ListFunctionSpans;
 
 impl ApiEndpoint for ListFunctionSpans {
     type Request = ListFunctionSpansRequest;

--- a/engine/baml-rpc/src/ui_function_spans.rs
+++ b/engine/baml-rpc/src/ui_function_spans.rs
@@ -1,0 +1,55 @@
+use crate::{
+    ast::{BamlFunctionDefinition, BamlTypeDefinition},
+    rpc::ApiEndpoint,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListFunctionSpansRequest {
+    project_id: String,
+    function_call_id: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ListFunctionSpansResponse {
+    function_spans: Vec<api::FunctionSpan>,
+    function_definitions: Vec<BamlFunctionDefinition>,
+    type_definitions: Vec<BamlTypeDefinition>,
+}
+
+struct ListFunctionSpans;
+
+impl ApiEndpoint for ListFunctionSpans {
+    type Request = ListFunctionSpansRequest;
+    type Response = ListFunctionSpansResponse;
+
+    const PATH: &'static str = "/v1/function-spans";
+}
+
+pub mod api {
+    use serde::{Deserialize, Serialize};
+
+    use crate::base::EpochMsTimestamp;
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct FunctionSpan {
+        pub function_span_id: String,
+        pub source: String,
+        pub function_id: String,
+        #[serde(rename = "start_epoch_ms")]
+        pub start_time: Option<EpochMsTimestamp>,
+        #[serde(rename = "end_epoch_ms")]
+        pub end_time: Option<EpochMsTimestamp>,
+        pub baml_options: serde_json::Value,
+        pub inputs: Vec<FunctionInput>,
+        pub output: serde_json::Value,
+        pub status: String,
+        pub error: serde_json::Value,
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    pub struct FunctionInput {
+        pub field: String,
+        pub value: serde_json::Value,
+    }
+}

--- a/tools/build
+++ b/tools/build
@@ -162,7 +162,7 @@ case "$_path" in
         --ext rs,hb,hbs,j2,toml \
         --watch "${_repo_root}/engine" \
         --ignore 'target/**' \
-        --exec "${command}" --verbose
+        --exec "${command}"
     else
       eval "${command}"
     fi


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Introduces `baml-rpc` module with RPC types and endpoints for BAML backends, including new data structures, API endpoints, and utilities.
> 
>   - **New Module**:
>     - Introduces `baml-rpc` module with RPC types for BAML backends.
>     - Adds `baml-rpc` to `Cargo.toml` and `Cargo.lock`.
>   - **API Endpoints**:
>     - Defines `ApiEndpoint` and `GetEndpoint` traits in `rpc.rs`.
>     - Implements endpoints for organization, project, and function span management in `ui_control_plane_orgs.rs`, `ui_control_plane_projects.rs`, and `ui_function_spans.rs`.
>     - Adds trace event upload endpoint in `trace_event_upload.rs`.
>   - **Data Structures**:
>     - Defines `AstNodeId`, `BamlTypeId`, `BamlFunctionId`, and related types in `ast.rs` and `ast_node_id.rs`.
>     - Implements `EpochMsTimestamp` for time handling in `base.rs`.
>     - Adds `TraceEvent`, `TraceData`, and related types in `trace.rs`.
>   - **Utilities**:
>     - Macro `define_id!` in `define_id.rs` for creating type-safe IDs.
>     - Adds `baml_src_upload.rs` for handling BAML source uploads.
>   - **Miscellaneous**:
>     - Updates `tools/build` script to remove verbose flag from `nodemon` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 357b680b2f3daea87afde3bc70524dc4e8bd51e3. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->