### PR TITLE
docs(prompt-caching.mdx): fix typo 'messges'

### DIFF
--- a/fern/01-guide/05-baml-advanced/prompt-caching.mdx
+++ b/fern/01-guide/05-baml-advanced/prompt-caching.mdx
@@ -29,7 +29,7 @@ curl https://api.anthropic.com/v1/messages \
 This is nearly the same as this BAML code, minus the `cache_control` metadata:
 
 
-Let's add the `cache-control` metadata to each of our messges in BAML now.
+Let's add the `cache-control` metadata to each of our messages in BAML now.
 There's just 2 steps:
 
 <Steps>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in `prompt-caching.mdx`, changing 'messges' to 'messages'.
> 
>   - **Documentation**:
>     - Fix typo in `prompt-caching.mdx`, changing 'messges' to 'messages'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for aedf2a0b2da823e8ac468228abc46be7e93cd0d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->