### PR TITLE
docs(dynamic-types.mdx): Fix unstable_features.add_json_schema section

### DIFF
--- a/fern/01-guide/05-baml-advanced/dynamic-types.mdx
+++ b/fern/01-guide/05-baml-advanced/dynamic-types.mdx
@@ -357,63 +357,13 @@ tb.add_baml("
 
 ### Building dynamic types from JSON schema
 
-We have a working implementation of this, but are waiting for a concrete use case to merge it.
-Please chime in on [the GitHub issue](https://github.com/BoundaryML/baml/issues/771) if this is
-something you'd like to use.
+JSON Schema is a declarative language for validating JSON data structures, often derived from language-native type definitions such as Python classes, TypeScript interfaces, or Java classes.
 
-<CodeBlocks>
+BAML supports converting JSON schemas into dynamic BAML types, allowing you to automatically use your existing data models with BAML's LLM functions. This feature enables seamless integration between your application's type system and BAML's structured output capabilities.
 
-```python Python
-import pydantic
-from baml_client import b
+We have a working implementation of this feature, but are waiting for concrete use cases to merge it into the main codebase. For a detailed explanation of this functionality, see our [article on dynamic JSON schemas](https://www.boundaryml.com/blog/dynamic-json-schemas). You can also explore the [source code and examples](https://github.com/BoundaryML/baml-examples/tree/main/json-schema-to-baml) to understand how to implement this in your projects.
 
-class Person(pydantic.BaseModel):
-    last_name: list[str]
-    height: Optional[float] = pydantic.Field(description="Height in meters")
-
-tb = TypeBuilder()
-tb.unstable_features.add_json_schema(Person.model_json_schema())
-
-res = await b.ExtractPeople(
-    "My name is Harrison. My hair is black and I'm 6 feet tall. I'm pretty good around the hoop. I like giraffes.",
-    {"tb": tb},
-)
-```
-
-```typescript TypeScript
-import 'z' from zod
-import 'zodToJsonSchema' from zod-to-json-schema
-import { b } from '../baml_client'
-
-const personSchema = z.object({
-  animalLiked: z.object({
-    animal: z.string().describe('The animal mentioned, in singular form.'),
-  }),
-  hobbies: z.enum(['chess', 'sports', 'music', 'reading']).array(),
-  height: z.union([z.string(), z.number().int()]).describe('Height in meters'),
-})
-
-let tb = new TypeBuilder()
-tb.unstableFeatures.addJsonSchema(zodToJsonSchema(personSchema, 'Person'))
-
-const res = await b.ExtractPeople(
-  "My name is Harrison. My hair is black and I'm 6 feet tall. I'm pretty good around the hoop. I like giraffes.",
-  { tb },
-)
-```
-
-```ruby Ruby
-tb = Baml::TypeBuilder.new
-tb.unstable_features.add_json_schema(...)
-
-res = Baml::Client.extract_people(
-  input: "My name is Harrison. My hair is black and I'm 6 feet tall. I'm pretty good around the hoop. I like giraffes.",
-  baml_options: { tb: tb }
-)
-
-puts res
-```
-</CodeBlocks>
+Please chime in on [the GitHub issue](https://github.com/BoundaryML/baml/issues/771) if this is something you'd like to use.
 
 ### Testing dynamic types in BAML
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updated `dynamic-types.mdx` to clarify `add_json_schema` feature, removing code examples and adding detailed descriptions.
> 
>   - **Documentation Update**:
>     - In `dynamic-types.mdx`, revised the `unstable_features.add_json_schema` section.
>     - Removed Python, TypeScript, and Ruby code examples.
>     - Added detailed explanation of JSON Schema and its integration with BAML.
>     - Encouraged user feedback via GitHub issue link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 97e08be88f0aeaae3e2ddc9e86d4f8914277ec05. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->