### PR TITLE
Need to await async call in docs

### DIFF
--- a/docs/old/docs/get-started/quickstart/python.mdx
+++ b/docs/old/docs/get-started/quickstart/python.mdx
@@ -70,7 +70,7 @@ To set up BAML in python do the following:
         print(msg) # This will be a PartialResume type
       
       # This will be a Resume type
-      final = stream.get_final_response()
+      final = await stream.get_final_response()
 
       return final
     ```
@@ -91,7 +91,7 @@ To set up BAML in python do the following:
         print(msg) # This will be a PartialResume type
       
       # This will be a Resume type
-      final = stream.get_final_response()
+      final = await stream.get_final_response()
 
       return final
     ```

--- a/fern/01-guide/02-languages/python.mdx
+++ b/fern/01-guide/02-languages/python.mdx
@@ -124,7 +124,7 @@ To set up BAML with Python do the following:
         print(msg) # This will be a PartialResume type
       
       # This will be a Resume type
-      final = stream.get_final_response()
+      final = await stream.get_final_response()
 
       return final
     ```


### PR DESCRIPTION
The example for async streaming has a minor error. The `get_final_response` is an asynchronous function and needs an `await` to be useful.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix async example in Python docs to use `await` with `stream.get_final_response()`.
> 
>   - **Documentation**:
>     - In `python.mdx` (both `docs/old/docs/get-started/quickstart` and `fern/01-guide/02-languages`), corrected the example code to use `await` with `stream.get_final_response()` in async functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 114ee35bbb97420eb66d0728a101cb3691b18e11. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->