### PR TITLE
Parse ints from floats in openai generic

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/types.rs
@@ -35,13 +35,13 @@ where
     #[derive(Deserialize)]
     #[serde(untagged)]
     enum FloatOrInt {
-        Float(f64),
         Int(u32),
+        Float(f64),
     }
 
     match Option::<FloatOrInt>::deserialize(deserializer)? {
-        Some(FloatOrInt::Float(f)) => Ok(Some(f.floor() as u32)),
         Some(FloatOrInt::Int(i)) => Ok(Some(i)),
+        Some(FloatOrInt::Float(f)) => Ok(Some(f.floor() as u32)),
         None => Ok(None),
     }
 }

--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/types.rs
@@ -1,3 +1,4 @@
+use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 
 pub type CompletionResponse = ChatCompletionGeneric<CompletionChoice>;
@@ -13,6 +14,7 @@ pub struct ChatCompletionGeneric<C> {
     /// A list of chat completion choices. Can be more than one if `n` is greater than 1.s
     pub choices: Vec<C>,
     /// The Unix timestamp (in seconds) of when the chat completion was created.
+    #[serde(deserialize_with = "deserialize_float_to_u32")]
     pub created: Option<u32>,
     /// The model used for the chat completion.
     pub model: String,
@@ -24,6 +26,24 @@ pub struct ChatCompletionGeneric<C> {
     /// The object type, which is `chat.completion` for non-streaming chat completion, `chat.completion.chunk` for streaming chat completion.
     pub object: Option<String>,
     pub usage: Option<CompletionUsage>,
+}
+
+fn deserialize_float_to_u32<'de, D>(deserializer: D) -> Result<Option<u32>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum FloatOrInt {
+        Float(f64),
+        Int(u32),
+    }
+
+    match Option::<FloatOrInt>::deserialize(deserializer)? {
+        Some(FloatOrInt::Float(f)) => Ok(Some(f.floor() as u32)),
+        Some(FloatOrInt::Int(i)) => Ok(Some(i)),
+        None => Ok(None),
+    }
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]


### PR DESCRIPTION
The SambaNova provider returns a float for the `"completed"` field of the Completions generic API. This PR makes the Completions parser more flexible, accepting both ints and floats, but always returning ints.

I have tested this locally - SambaNova and OpenAI requests now parse correctly. I didn't check in the testing code, because we don't necessarily want to mention lots of providers in our test suite.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `ChatCompletionGeneric` to accept both int and float for `created` field, ensuring consistent int return using `deserialize_float_to_u32`.
> 
>   - **Behavior**:
>     - `ChatCompletionGeneric` now accepts both `int` and `float` for `created` field, always returning `int`.
>     - Adds `deserialize_float_to_u32` function to handle deserialization of `created` field.
>   - **Code**:
>     - Adds `deserialize_float_to_u32` function in `types.rs` to convert floats to integers using `floor()`.
>     - Updates `ChatCompletionGeneric` struct to use `deserialize_float_to_u32` for `created` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0d334bd809913f72ceaa1169ddc97b60f0b9fe67. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->