### PR TITLE
feat: add stripe and propel webhook types

### DIFF
--- a/engine/baml-rpc/src/define_id.rs
+++ b/engine/baml-rpc/src/define_id.rs
@@ -2,17 +2,18 @@ use type_safe_id::{StaticType, TypeSafeId};
 
 macro_rules! define_id {
     ($name:ident, $inner_name:ident, $type_str:expr) => {
-        #[derive(Default, Clone)]
+        #[derive(Default, Clone, PartialEq, Eq, Hash)]
         struct $inner_name;
 
         impl StaticType for $inner_name {
             const TYPE: &'static str = $type_str;
         }
 
-        #[derive(Debug, Clone)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
         pub struct $name(TypeSafeId<$inner_name>);
 
         impl $name {
+            #[allow(dead_code)]
             pub fn new() -> Self {
                 Self(TypeSafeId::<$inner_name>::new())
             }
@@ -53,3 +54,4 @@ define_id!(SpanId, Span_, "bspan");
 define_id!(TraceEventId, TraceEvent_, "bevent");
 define_id!(HttpRequestId, HttpRequest_, "breq");
 define_id!(ProjectId, Project_, "proj");
+define_id!(TraceBatchId, TraceBatch_, "tracebatch");

--- a/engine/baml-rpc/src/lib.rs
+++ b/engine/baml-rpc/src/lib.rs
@@ -4,6 +4,7 @@ mod baml_src_upload;
 mod base;
 mod define_id;
 mod rpc;
+mod s3;
 mod trace;
 mod trace_event_upload;
 mod ui_control_plane_orgs;
@@ -14,12 +15,13 @@ mod ui_function_spans;
 pub use ast::{BamlClassDefinition, BamlFunctionDefinition, BamlTypeDefinition, BamlTypeReference};
 pub use ast_node_id::AstNodeId;
 pub use rpc::{ApiEndpoint, GetEndpoint};
+pub use s3::S3UploadMetadata;
 
 pub use baml_src_upload::{
     BamlSrcUploadStatus, CreateBamlSrcUpload, CreateBamlSrcUploadRequest,
     CreateBamlSrcUploadResponse, GetBamlSrcUploadStatusRequest, GetBamlSrcUploadStatusResponse,
 };
-pub use define_id::{HttpRequestId, ProjectId, SpanId, TraceEventId};
+pub use define_id::{HttpRequestId, ProjectId, SpanId, TraceBatchId, TraceEventId};
 pub use trace::{TraceData, TraceEvent, TraceEventBatch};
 pub use trace_event_upload::{
     CreateTraceEventUpload, CreateTraceEventUploadRequest, CreateTraceEventUploadResponse,

--- a/engine/baml-rpc/src/lib.rs
+++ b/engine/baml-rpc/src/lib.rs
@@ -27,6 +27,7 @@ pub use define_id::{HttpRequestId, ProjectId, SpanId, TraceBatchId, TraceEventId
 pub use trace::{TraceData, TraceEvent, TraceEventBatch};
 pub use trace_event_upload::{
     CreateTraceEventUpload, CreateTraceEventUploadRequest, CreateTraceEventUploadResponse,
+    CreateTraceEventUploadUrl, CreateTraceEventUploadUrlRequest, CreateTraceEventUploadUrlResponse,
 };
 
 pub use ui_control_plane_orgs::{

--- a/engine/baml-rpc/src/lib.rs
+++ b/engine/baml-rpc/src/lib.rs
@@ -11,6 +11,8 @@ mod ui_control_plane_orgs;
 mod ui_control_plane_projects;
 mod ui_dashboard;
 mod ui_function_spans;
+mod ui_webhook_propelauth;
+mod ui_webhook_stripe;
 
 pub use ast::{BamlClassDefinition, BamlFunctionDefinition, BamlTypeDefinition, BamlTypeReference};
 pub use ast_node_id::AstNodeId;
@@ -39,3 +41,8 @@ pub use ui_control_plane_projects::{
 pub use ui_function_spans::{
     ListFunctionSpans, ListFunctionSpansRequest, ListFunctionSpansResponse,
 };
+
+pub use ui_webhook_propelauth::{
+    PropelAuthWebhook, PropelAuthWebhookRequest, PropelAuthWebhookResponse,
+};
+pub use ui_webhook_stripe::{StripeWebhook, StripeWebhookRequest, StripeWebhookResponse};

--- a/engine/baml-rpc/src/s3.rs
+++ b/engine/baml-rpc/src/s3.rs
@@ -1,0 +1,57 @@
+use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
+
+use crate::ProjectId;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct S3UploadMetadata {
+    pub project_id: ProjectId,
+    pub api_key_name: String,
+    pub env_name: String,
+}
+
+impl S3UploadMetadata {
+    pub fn to_map(&self) -> IndexMap<String, String> {
+        let mut map = IndexMap::new();
+        map.insert("project_id".to_string(), self.project_id.to_string());
+        map.insert("api_key_name".to_string(), self.api_key_name.clone());
+        map.insert("env_name".to_string(), self.env_name.clone());
+        map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::{self, json};
+
+    #[test]
+    fn test_s3_upload_metadata_deserialization() {
+        let project_id = ProjectId::new();
+        let example = json!({
+            "project_id": project_id.to_string(),
+            "api_key_name": "test-api-key",
+            "env_name": "test-env"
+        });
+
+        let metadata: S3UploadMetadata = serde_json::from_value(example).unwrap();
+
+        assert_eq!(metadata.project_id, project_id);
+        assert_eq!(metadata.api_key_name, "test-api-key");
+        assert_eq!(metadata.env_name, "test-env");
+    }
+
+    #[test]
+    fn test_s3_upload_metadata_to_map() {
+        let metadata = S3UploadMetadata {
+            project_id: ProjectId::new(),
+            api_key_name: "test-api-key".to_string(),
+            env_name: "test-env".to_string(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(metadata.to_map()).unwrap(),
+            serde_json::to_value(metadata).unwrap()
+        );
+    }
+}

--- a/engine/baml-rpc/src/s3.rs
+++ b/engine/baml-rpc/src/s3.rs
@@ -23,10 +23,11 @@ impl S3UploadMetadata {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Result;
     use serde_json::{self, json};
 
     #[test]
-    fn test_s3_upload_metadata_deserialization() {
+    fn test_s3_upload_metadata_deserialization() -> Result<()> {
         let project_id = ProjectId::new();
         let example = json!({
             "project_id": project_id.to_string(),
@@ -34,15 +35,17 @@ mod tests {
             "env_name": "test-env"
         });
 
-        let metadata: S3UploadMetadata = serde_json::from_value(example).unwrap();
+        let metadata: S3UploadMetadata = serde_json::from_value(example)?;
 
         assert_eq!(metadata.project_id, project_id);
         assert_eq!(metadata.api_key_name, "test-api-key");
         assert_eq!(metadata.env_name, "test-env");
+
+        Ok(())
     }
 
     #[test]
-    fn test_s3_upload_metadata_to_map() {
+    fn test_s3_upload_metadata_to_map() -> Result<()> {
         let metadata = S3UploadMetadata {
             project_id: ProjectId::new(),
             api_key_name: "test-api-key".to_string(),
@@ -50,8 +53,10 @@ mod tests {
         };
 
         assert_eq!(
-            serde_json::to_value(metadata.to_map()).unwrap(),
-            serde_json::to_value(metadata).unwrap()
+            serde_json::to_value(metadata.to_map())?,
+            serde_json::to_value(metadata)?
         );
+
+        Ok(())
     }
 }

--- a/engine/baml-rpc/src/trace_event_upload.rs
+++ b/engine/baml-rpc/src/trace_event_upload.rs
@@ -1,7 +1,28 @@
 use serde::{Deserialize, Serialize};
 
 use crate::rpc::ApiEndpoint;
+use crate::s3::S3UploadMetadata;
 use crate::trace::TraceEvent;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateTraceEventUploadUrlRequest {
+    pub upload_metadata: S3UploadMetadata,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CreateTraceEventUploadUrlResponse {
+    pub upload_url: String,
+}
+
+pub struct CreateTraceEventUploadUrl;
+
+// POST /v1/baml-trace/create-upload-url
+impl ApiEndpoint for CreateTraceEventUploadUrl {
+    type Request = CreateTraceEventUploadUrlRequest;
+    type Response = CreateTraceEventUploadUrlResponse;
+
+    const PATH: &'static str = "/v1/baml-trace/create-upload-url";
+}
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CreateTraceEventUploadRequest {

--- a/engine/baml-rpc/src/ui_control_plane_orgs.rs
+++ b/engine/baml-rpc/src/ui_control_plane_orgs.rs
@@ -10,6 +10,7 @@ pub struct Organization {
     pub org_display_name: String,
     pub stripe_customer_id: Option<String>,
     pub stripe_subscription_id: Option<String>,
+    pub stripe_subscription_status: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -43,6 +44,7 @@ pub struct UpdateOrganizationRequest {
     pub org_display_name: Option<String>,
     pub stripe_customer_id: Option<String>,
     pub stripe_subscription_id: Option<String>,
+    pub stripe_subscription_status: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]

--- a/engine/baml-rpc/src/ui_control_plane_projects.rs
+++ b/engine/baml-rpc/src/ui_control_plane_projects.rs
@@ -1,11 +1,12 @@
-use crate::rpc::ApiEndpoint;
+use crate::{rpc::ApiEndpoint, ProjectId};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct Project {
-    pub project_id: String,
+    #[ts(type = "string")]
+    pub project_id: ProjectId,
     pub project_slug: String,
     pub org_id: String,
     pub environments: Vec<String>,
@@ -60,7 +61,8 @@ impl ApiEndpoint for CreateProject {
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct UpdateProjectRequest {
-    pub project_id: String,
+    #[ts(type = "string")]
+    pub project_id: ProjectId,
     pub project_slug: Option<String>,
     pub environments: Option<Vec<String>>,
 }

--- a/engine/baml-rpc/src/ui_webhook_propelauth.rs
+++ b/engine/baml-rpc/src/ui_webhook_propelauth.rs
@@ -1,0 +1,26 @@
+use crate::rpc::ApiEndpoint;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct PropelAuthWebhookRequest {
+    // PropelAuth webhooks typically send a JSON payload
+    #[ts(type = "any")]
+    payload: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct PropelAuthWebhookResponse {
+    received: bool,
+}
+
+pub struct PropelAuthWebhook;
+
+impl ApiEndpoint for PropelAuthWebhook {
+    type Request = PropelAuthWebhookRequest;
+    type Response = PropelAuthWebhookResponse;
+
+    const PATH: &'static str = "/v1/webhooks/propelauth";
+}

--- a/engine/baml-rpc/src/ui_webhook_stripe.rs
+++ b/engine/baml-rpc/src/ui_webhook_stripe.rs
@@ -1,0 +1,25 @@
+use crate::rpc::ApiEndpoint;
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct StripeWebhookRequest {
+    #[ts(type = "any")]
+    event: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct StripeWebhookResponse {
+    received: bool,
+}
+
+pub struct StripeWebhook;
+
+impl ApiEndpoint for StripeWebhook {
+    type Request = StripeWebhookRequest;
+    type Response = StripeWebhookResponse;
+
+    const PATH: &'static str = "/v1/webhooks/stripe";
+}

--- a/engine/rust-toolchain.toml
+++ b/engine/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.86.0"
+profile = "default"

--- a/engine/rust-toolchain.toml
+++ b/engine/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.86.0"
+targets = ["wasm32-unknown-unknown"]
 profile = "default"


### PR DESCRIPTION
Also bump our Rust toolchain version to 1.86.0.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Stripe and PropelAuth webhook types, update Rust toolchain, and enhance S3 and trace event upload functionalities.
> 
>   - **Webhooks**:
>     - Add `StripeWebhook` and `PropelAuthWebhook` modules with request and response structs in `ui_webhook_stripe.rs` and `ui_webhook_propelauth.rs`.
>     - Implement `ApiEndpoint` for both webhooks with paths `/v1/webhooks/stripe` and `/v1/webhooks/propelauth`.
>   - **S3 Upload**:
>     - Add `S3UploadMetadata` struct in `s3.rs` with serialization and deserialization support.
>     - Add `to_map()` method and corresponding tests.
>   - **Trace Event Upload**:
>     - Add `CreateTraceEventUploadUrl` struct and implement `ApiEndpoint` in `trace_event_upload.rs`.
>     - Add request and response structs for `CreateTraceEventUploadUrl`.
>   - **Organization and Project Updates**:
>     - Add `stripe_subscription_status` to `Organization` and `UpdateOrganizationRequest` in `ui_control_plane_orgs.rs`.
>     - Change `project_id` type to `ProjectId` in `Project` and `UpdateProjectRequest` in `ui_control_plane_projects.rs`.
>   - **Misc**:
>     - Add `TraceBatchId` to `define_id.rs`.
>     - Update Rust toolchain to version 1.86.0 in `rust-toolchain.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0c43564fefcf3e99ffbce2064bc3208f9bca9e5a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->