### PR TITLE
Use maps for captures instead of lists in tmGrammar

### DIFF
--- a/typescript/vscode-ext/packages/syntaxes/jinja.tmLanguage.json
+++ b/typescript/vscode-ext/packages/syntaxes/jinja.tmLanguage.json
@@ -26,11 +26,11 @@
     },
     {
       "begin": "{{-?",
-      "captures": [
-        {
+      "captures": {
+        "1": {
           "name": "storage.type.jinja.delimiter"
         }
-      ],
+      },
       "end": "-?}}",
       "name": "variable.meta.scope.jinja",
       "patterns": [
@@ -41,11 +41,11 @@
     },
     {
       "begin": "{%-?",
-      "captures": [
-        {
+      "captures": {
+        "1": {
           "name": "storage.type.jinja.delimiter"
         }
-      ],
+      },
       "end": "-?%}",
       "name": "meta.scope.jinja.tag",
       "patterns": [
@@ -58,11 +58,11 @@
   "repository": {
     "comments": {
       "begin": "{#-?",
-      "captures": [
-        {
+      "captures": {
+        "1": {
           "name": "storage.type.jinja.delimiter"
         }
-      ],
+      },
       "end": "-?#}",
       "name": "comment.block.jinja",
       "patterns": [
@@ -176,11 +176,11 @@
         },
         {
           "begin": "\\[",
-          "captures": [
-            {
+          "captures": {
+            "1": {
               "name": "punctuation.other.jinja"
             }
-          ],
+          },
           "end": "\\]",
           "patterns": [
             {
@@ -190,11 +190,11 @@
         },
         {
           "begin": "\\(",
-          "captures": [
-            {
+          "captures": {
+            "1": {
               "name": "punctuation.other.jinja"
             }
-          ],
+          },
           "end": "\\)",
           "patterns": [
             {
@@ -204,11 +204,11 @@
         },
         {
           "begin": "\\{",
-          "captures": [
-            {
+          "captures": {
+            "1": {
               "name": "punctuation.other.jinja"
             }
-          ],
+          },
           "end": "\\}",
           "patterns": [
             {
@@ -230,17 +230,17 @@
         },
         {
           "begin": "\"",
-          "beginCaptures": [
-            {
+          "beginCaptures": {
+            "1": {
               "name": "punctuation.definition.string.begin.jinja"
             }
-          ],
+          },
           "end": "\"",
-          "endCaptures": [
-            {
+          "endCaptures": {
+            "1": {
               "name": "punctuation.definition.string.end.jinja"
             }
-          ],
+          },
           "name": "string.quoted.double.jinja",
           "patterns": [
             {
@@ -250,17 +250,17 @@
         },
         {
           "begin": "'",
-          "beginCaptures": [
-            {
+          "beginCaptures": {
+            "1": {
               "name": "punctuation.definition.string.begin.jinja"
             }
-          ],
+          },
           "end": "'",
-          "endCaptures": [
-            {
+          "endCaptures": {
+            "1": {
               "name": "punctuation.definition.string.end.jinja"
             }
-          ],
+          },
           "name": "string.quoted.single.jinja",
           "patterns": [
             {
@@ -270,17 +270,17 @@
         },
         {
           "begin": "@/",
-          "beginCaptures": [
-            {
+          "beginCaptures": {
+            "1": {
               "name": "punctuation.definition.regexp.begin.jinja"
             }
-          ],
+          },
           "end": "/",
-          "endCaptures": [
-            {
+          "endCaptures": {
+            "1": {
               "name": "punctuation.definition.regexp.end.jinja"
             }
-          ],
+          },
           "name": "string.regexp.jinja",
           "patterns": [
             {


### PR DESCRIPTION
When adding baml as a language in the github-linguist project, their linter complained that our `captures`  are a list, rather than a map whose keys are indices.

This PR fixes that issue in our textmate grammar.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `captures` from list to map in `jinja.tmLanguage.json` to comply with GitHub Linguist linter.
> 
>   - **Behavior**:
>     - Change `captures` from list to map with indices as keys in `jinja.tmLanguage.json`.
>     - Affects patterns for delimiters, comments, strings, and regular expressions.
>   - **Patterns**:
>     - Updated `captures` for `begin` and `end` in patterns like `{{-?`, `{%-?`, `{#-?`, `"`, `'`, and `@/`.
>     - Ensures compliance with GitHub Linguist linter requirements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 722c5e198193fbccf9f3cb7c743e157cc4a185b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->