### PR TITLE
Revert "Use maps for captures instead of lists in tmGrammar (#1767)"

### DIFF
--- a/typescript/vscode-ext/packages/syntaxes/jinja.tmLanguage.json
+++ b/typescript/vscode-ext/packages/syntaxes/jinja.tmLanguage.json
@@ -26,11 +26,11 @@
     },
     {
       "begin": "{{-?",
-      "captures": {
-        "1": {
+      "captures": [
+        {
           "name": "storage.type.jinja.delimiter"
         }
-      },
+      ],
       "end": "-?}}",
       "name": "variable.meta.scope.jinja",
       "patterns": [
@@ -41,11 +41,11 @@
     },
     {
       "begin": "{%-?",
-      "captures": {
-        "1": {
+      "captures": [
+        {
           "name": "storage.type.jinja.delimiter"
         }
-      },
+      ],
       "end": "-?%}",
       "name": "meta.scope.jinja.tag",
       "patterns": [
@@ -58,11 +58,11 @@
   "repository": {
     "comments": {
       "begin": "{#-?",
-      "captures": {
-        "1": {
+      "captures": [
+        {
           "name": "storage.type.jinja.delimiter"
         }
-      },
+      ],
       "end": "-?#}",
       "name": "comment.block.jinja",
       "patterns": [
@@ -176,11 +176,11 @@
         },
         {
           "begin": "\\[",
-          "captures": {
-            "1": {
+          "captures": [
+            {
               "name": "punctuation.other.jinja"
             }
-          },
+          ],
           "end": "\\]",
           "patterns": [
             {
@@ -190,11 +190,11 @@
         },
         {
           "begin": "\\(",
-          "captures": {
-            "1": {
+          "captures": [
+            {
               "name": "punctuation.other.jinja"
             }
-          },
+          ],
           "end": "\\)",
           "patterns": [
             {
@@ -204,11 +204,11 @@
         },
         {
           "begin": "\\{",
-          "captures": {
-            "1": {
+          "captures": [
+            {
               "name": "punctuation.other.jinja"
             }
-          },
+          ],
           "end": "\\}",
           "patterns": [
             {
@@ -230,17 +230,17 @@
         },
         {
           "begin": "\"",
-          "beginCaptures": {
-            "1": {
+          "beginCaptures": [
+            {
               "name": "punctuation.definition.string.begin.jinja"
             }
-          },
+          ],
           "end": "\"",
-          "endCaptures": {
-            "1": {
+          "endCaptures": [
+            {
               "name": "punctuation.definition.string.end.jinja"
             }
-          },
+          ],
           "name": "string.quoted.double.jinja",
           "patterns": [
             {
@@ -250,17 +250,17 @@
         },
         {
           "begin": "'",
-          "beginCaptures": {
-            "1": {
+          "beginCaptures": [
+            {
               "name": "punctuation.definition.string.begin.jinja"
             }
-          },
+          ],
           "end": "'",
-          "endCaptures": {
-            "1": {
+          "endCaptures": [
+            {
               "name": "punctuation.definition.string.end.jinja"
             }
-          },
+          ],
           "name": "string.quoted.single.jinja",
           "patterns": [
             {
@@ -270,17 +270,17 @@
         },
         {
           "begin": "@/",
-          "beginCaptures": {
-            "1": {
+          "beginCaptures": [
+            {
               "name": "punctuation.definition.regexp.begin.jinja"
             }
-          },
+          ],
           "end": "/",
-          "endCaptures": {
-            "1": {
+          "endCaptures": [
+            {
               "name": "punctuation.definition.regexp.end.jinja"
             }
-          },
+          ],
           "name": "string.regexp.jinja",
           "patterns": [
             {


### PR DESCRIPTION
This reverts commit 929e0b646594562edcfee14b4195c04187d68adc.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts `jinja.tmLanguage.json` to use lists instead of maps for captures, affecting Jinja syntax patterns.
> 
>   - **Revert Change**:
>     - Reverts commit `929e0b646594562edcfee14b4195c04187d68adc` in `jinja.tmLanguage.json`.
>     - Changes `captures` from maps back to lists for various patterns, including `{{-?`, `{%-?`, `{#-?`, and others.
>   - **Patterns Affected**:
>     - Affects patterns for delimiters, comments, and expressions in Jinja syntax.
>     - Specific patterns include `"`, `'`, `@/`, and others for string and regex handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7fcc1151dec1a08e6f49e2a015f3b810c8b20f99. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->