### PR TITLE
[bug-fix] Fixed issue with enums not rendering in the prompt for some types

### DIFF
--- a/engine/baml-lib/jinja-runtime/src/output_format/types.rs
+++ b/engine/baml-lib/jinja-runtime/src/output_format/types.rs
@@ -157,7 +157,7 @@ pub(crate) enum MapStyle {
     ObjectLiteral,
 }
 
-pub(crate) struct RenderOptions {
+pub struct RenderOptions {
     prefix: RenderSetting<String>,
     pub(crate) or_splitter: String,
     enum_value_prefix: RenderSetting<String>,
@@ -599,10 +599,7 @@ impl OutputFormatContent {
         })
     }
 
-    pub(crate) fn render(
-        &self,
-        options: RenderOptions,
-    ) -> Result<Option<String>, minijinja::Error> {
+    pub fn render(&self, options: RenderOptions) -> Result<Option<String>, minijinja::Error> {
         let prefix = self.prefix(&options);
 
         let mut render_state = RenderState {
@@ -631,11 +628,6 @@ impl OutputFormatContent {
                 message = Some(class.to_owned());
             }
         }
-
-        let enum_definitions = Vec::from_iter(render_state.hoisted_enums.iter().map(|e| {
-            let enm = self.enums.get(e).expect("Enum not found"); // TODO: Jinja Err
-            self.enum_to_string(enm, &options)
-        }));
 
         let mut class_definitions = Vec::new();
         let mut type_alias_definitions = Vec::new();
@@ -671,6 +663,13 @@ impl OutputFormatContent {
                 _ => format!("{alias} = {recursive_pointer}"),
             });
         }
+
+        // once render_state.hoisted_enums is used, we shouldn't write to it again, hence why into_iter() over iter().
+        // We want a compile-time error if render_state.hoisted_enums is used again.
+        let enum_definitions = Vec::from_iter(render_state.hoisted_enums.into_iter().map(|e| {
+            let enm = self.enums.get(&e).expect("Enum not found"); // TODO: Jinja Err
+            self.enum_to_string(enm, &options)
+        }));
 
         let mut output = String::new();
 

--- a/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
+++ b/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
@@ -447,10 +447,12 @@ fn relevant_data_models<'a>(
 mod tests {
     use std::collections::HashMap;
 
+    use internal_baml_jinja::types::RenderOptions;
+
     use super::*;
     use crate::BamlRuntime;
 
-    #[test]
+    #[test_log::test]
     fn skipped_variants_are_not_rendered() {
         let files = vec![(
             "test-file.baml",
@@ -474,5 +476,199 @@ mod tests {
         let foo_enum = render_output.find_enum("Foo").unwrap();
         assert_eq!(foo_enum.values[0].0.real_name(), "Bar".to_string());
         assert_eq!(foo_enum.values.len(), 1);
+    }
+
+    #[test]
+    fn test_render_output_format_aliases() {
+        let files = vec![(
+            "test-file.baml",
+            r#"
+enum Month {
+  January
+  February
+  March
+  April
+  May
+  June
+  July
+  August
+  September
+  October
+  November
+  December
+}
+
+class Date {
+  day int
+  month Month
+  year Date?
+}
+
+type DateAlias = Date
+
+class Education {
+  from_date DateAlias
+  to_date DateAlias | "current"
+  school string
+  description string
+}
+
+class Resume {
+  education Education[]
+}
+
+            "#,
+        )]
+        .into_iter()
+        .collect();
+        let env_vars: HashMap<&str, &str> = HashMap::new();
+        let baml_runtime = BamlRuntime::from_file_content(".", &files, env_vars).unwrap();
+        let ctx_manager = baml_runtime.create_ctx_manager(BamlValue::Null, None);
+        let ctx: RuntimeContext = ctx_manager.create_ctx(None, None, None).unwrap();
+
+        let field_type = FieldType::class("Resume");
+        let render_output =
+            render_output_format(baml_runtime.inner.ir.as_ref(), &ctx, &field_type).unwrap();
+
+        let rendered = render_output
+            .render(RenderOptions::default())
+            .unwrap()
+            .unwrap();
+        println!("{}", rendered);
+
+        assert_eq!(
+            rendered,
+            r#"
+Month
+----
+- January
+- February
+- March
+- April
+- May
+- June
+- July
+- August
+- September
+- October
+- November
+- December
+
+Date {
+  day: int,
+  month: Month,
+  year: Date or null,
+}
+
+Answer in JSON using this schema:
+{
+  education: [
+    {
+      from_date: Date,
+      to_date: Date or "current",
+      school: string,
+      description: string,
+    }
+  ],
+}
+        "#
+            .trim()
+        )
+    }
+
+    #[test]
+    fn test_render_output_format() {
+        let files = vec![(
+            "test-file.baml",
+            r#"
+enum Month {
+  January
+  February
+  March
+  April
+  May
+  June
+  July
+  August
+  September
+  October
+  November
+  December
+}
+
+class Date {
+  day int
+  month Month
+  year int
+}
+
+class Education {
+  from_date Date
+  to_date Date | "current"
+  school string
+  description string
+}
+
+class Resume {
+  education Education[]
+}
+
+            "#,
+        )]
+        .into_iter()
+        .collect();
+        let env_vars: HashMap<&str, &str> = HashMap::new();
+        let baml_runtime = BamlRuntime::from_file_content(".", &files, env_vars).unwrap();
+        let ctx_manager = baml_runtime.create_ctx_manager(BamlValue::Null, None);
+        let ctx: RuntimeContext = ctx_manager.create_ctx(None, None, None).unwrap();
+
+        let field_type = FieldType::class("Resume");
+        let render_output =
+            render_output_format(baml_runtime.inner.ir.as_ref(), &ctx, &field_type).unwrap();
+
+        let rendered = render_output
+            .render(RenderOptions::default())
+            .unwrap()
+            .unwrap();
+        println!("{}", rendered);
+
+        assert_eq!(
+            rendered,
+            r#"
+Month
+----
+- January
+- February
+- March
+- April
+- May
+- June
+- July
+- August
+- September
+- October
+- November
+- December
+
+Date {
+  day: int,
+  month: Month,
+  year: int,
+}
+
+Answer in JSON using this schema:
+{
+  education: [
+    {
+      from_date: Date,
+      to_date: Date or "current",
+      school: string,
+      description: string,
+    }
+  ],
+}
+        "#
+            .trim()
+        )
     }
 }


### PR DESCRIPTION
* Added more unit tests for render_prompt and ctx.output_format

Fixes Definition of required field absent in generated prompt #1737

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes enum rendering issue in `OutputFormatContent` and adds unit tests to validate the fix.
> 
>   - **Behavior**:
>     - Fixes enum rendering in `render()` in `OutputFormatContent` by ensuring enums are hoisted and rendered correctly.
>     - Adjusts handling of `render_state.hoisted_enums` to prevent further writes after use.
>   - **Tests**:
>     - Adds unit tests `test_render_output_format_aliases` and `test_render_output_format` in `render_output_format.rs` to validate enum rendering.
>     - Modifies `skipped_variants_are_not_rendered` test to use `#[test_log::test]` for better logging.
>   - **Misc**:
>     - Changes `RenderOptions` visibility to public in `types.rs` to allow external access.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 782fb59af007f4b3772b91666b951c01d9c24362. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->