### PR TITLE
Use `AnyValue: {}` for the `any` type in OpenAPI

### DIFF
--- a/engine/language_client_codegen/src/openapi.rs
+++ b/engine/language_client_codegen/src/openapi.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::{Context, Result};
 use baml_types::{BamlMediaType, FieldType, LiteralValue, TypeValue};
@@ -558,7 +558,9 @@ impl<'ir> ToTypeReferenceInTypeDefinition<'ir> for FieldType {
                     r#const: None,
                     nullable: false,
                 },
-                type_spec: TypeSpec::AnyValue { any_of: vec![] },
+                type_spec: TypeSpec::AnyValue {
+                    any_value: HashMap::new(),
+                },
             },
             FieldType::Literal(v) => TypeSpecWithMeta {
                 meta: TypeMetadata {
@@ -682,7 +684,9 @@ impl<'ir> ToTypeReferenceInTypeDefinition<'ir> for FieldType {
                 }
                 None => base.to_type_spec(_ir)?,
             },
-            FieldType::Arrow(_) => todo!("Arrow types should not be used in generated type definitions"),
+            FieldType::Arrow(_) => {
+                todo!("Arrow types should not be used in generated type definitions")
+            }
         })
     }
 }
@@ -732,9 +736,11 @@ enum TypeSpec {
         #[serde(rename = "oneOf", alias = "oneOf")]
         one_of: Vec<TypeSpecWithMeta>,
     },
+    // Any Type in OpenAPI version 3.
+    // https://swagger.io/docs/specification/v3_0/data-models/data-types/#any-type
     AnyValue {
-        #[serde(rename = "anyOf", alias = "anyOf")]
-        any_of: Vec<TypeSpecWithMeta>,
+        #[serde(rename = "AnyValue", alias = "AnyValue")]
+        any_value: HashMap<String, TypeSpecWithMeta>,
     },
 }
 

--- a/integ-tests/openapi/baml_client/openapi.yaml
+++ b/integ-tests/openapi/baml_client/openapi.yaml
@@ -917,7 +917,7 @@ paths:
             application/json:
               schema:
                 title: JsonTypeAliasCycleResponse
-                anyOf: []
+                AnyValue: {}
       operationId: JsonTypeAliasCycle
   /call/LiteralUnionsTest:
     post:
@@ -1259,7 +1259,7 @@ paths:
             application/json:
               schema:
                 title: RecursiveAliasCycleResponse
-                anyOf: []
+                AnyValue: {}
       operationId: RecursiveAliasCycle
   /call/RecursiveClassWithAliasIndirection:
     post:
@@ -1326,7 +1326,7 @@ paths:
             application/json:
               schema:
                 title: ReturnJsonEntryResponse
-                anyOf: []
+                AnyValue: {}
       operationId: ReturnJsonEntry
   /call/ReturnMalformedConstraints:
     post:
@@ -1365,7 +1365,7 @@ paths:
             application/json:
               schema:
                 title: SimpleRecursiveListAliasResponse
-                anyOf: []
+                AnyValue: {}
       operationId: SimpleRecursiveListAlias
   /call/SimpleRecursiveMapAlias:
     post:
@@ -1378,7 +1378,7 @@ paths:
             application/json:
               schema:
                 title: SimpleRecursiveMapAliasResponse
-                anyOf: []
+                AnyValue: {}
       operationId: SimpleRecursiveMapAlias
   /call/StreamBigNumbers:
     post:
@@ -3452,7 +3452,7 @@ components:
             type: object
             properties:
               input:
-                anyOf: []
+                AnyValue: {}
               __baml_options__:
                 nullable: true
                 $ref: '#/components/schemas/BamlOptions'
@@ -3816,7 +3816,7 @@ components:
             type: object
             properties:
               input:
-                anyOf: []
+                AnyValue: {}
               __baml_options__:
                 nullable: true
                 $ref: '#/components/schemas/BamlOptions'
@@ -3928,7 +3928,7 @@ components:
             type: object
             properties:
               input:
-                anyOf: []
+                AnyValue: {}
               __baml_options__:
                 nullable: true
                 $ref: '#/components/schemas/BamlOptions'
@@ -3944,7 +3944,7 @@ components:
             type: object
             properties:
               input:
-                anyOf: []
+                AnyValue: {}
               __baml_options__:
                 nullable: true
                 $ref: '#/components/schemas/BamlOptions'
@@ -6345,7 +6345,7 @@ components:
       type: object
       properties:
         value:
-          anyOf: []
+          AnyValue: {}
       required:
       - value
       additionalProperties: false


### PR DESCRIPTION
Recursive type aliases [are broken](https://discord.com/channels/1119368998161752075/1359498024790917231) in OpenAPI. Use the [Any Type](https://swagger.io/docs/specification/v3_0/data-models/data-types/#any-type) to fix them.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `anyOf` with `AnyValue` in OpenAPI to fix recursive type alias handling, updating both code generation and integration tests.
> 
>   - **Behavior**:
>     - Replaces `anyOf: []` with `AnyValue: {}` in `openapi.rs` and `openapi.yaml` to handle recursive type aliases in OpenAPI.
>     - Updates `TypeSpec::AnyValue` in `openapi.rs` to use `HashMap` for `any_value`.
>   - **Code Changes**:
>     - Modifies `ToTypeReferenceInTypeDefinition` for `FieldType::RecursiveTypeAlias` in `openapi.rs` to use `AnyValue`.
>     - Updates `TypeSpec` enum in `openapi.rs` to include `AnyValue` with `HashMap`.
>   - **Tests**:
>     - Updates `openapi.yaml` in `baml_client` integration tests to reflect changes from `anyOf` to `AnyValue` for various paths.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 8da98aa3e7c2b3a65e2abca0fb5ed787cd365a98. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->