### PR TITLE
feat: add explicit handling for newlines in env vars

### DIFF
--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
@@ -59,6 +59,36 @@ const renderedEnvVarsAtom = atom((get) => {
   return sortBy(vars, [(v) => v.key])
 })
 
+const escapeValue = (value: string): string => {
+  return value.replace(/[\n\r\t]/g, (match) => {
+    switch (match) {
+      case '\n':
+        return '\\n'
+      case '\r':
+        return '\\r'
+      case '\t':
+        return '\\t'
+      default:
+        return match
+    }
+  })
+}
+
+const unescapeValue = (value: string): string => {
+  return value.replace(/\\[nrt]/g, (match) => {
+    switch (match) {
+      case '\\n':
+        return '\n'
+      case '\\r':
+        return '\r'
+      case '\\t':
+        return '\t'
+      default:
+        return match
+    }
+  })
+}
+
 export default function EnvVariablesManager() {
   const envVars = useAtomValue(renderedEnvVarsAtom)
   const setEnvVars = useSetAtom(envVarsAtom)
@@ -221,8 +251,8 @@ export default function EnvVariablesManager() {
                       <TooltipTrigger asChild>
                         <Input
                           type={env.hidden ? 'password' : 'text'}
-                          value={typeof env.value === 'string' ? env.value : ''}
-                          onChange={(e) => updateEnvVar(index, e.target.value)}
+                          value={typeof env.value === 'string' ? escapeValue(env.value) : ''}
+                          onChange={(e) => updateEnvVar(index, unescapeValue(e.target.value))}
                           className='h-6 text-xs font-mono placeholder:font-sans'
                           placeholder={env.required && !env.value ? '<unset>' : undefined}
                           autoComplete='off'

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
@@ -70,25 +70,6 @@ export default function EnvVariablesManager() {
   const [envFileContent, setEnvFileContent] = useState('')
   const { toast } = useToast()
 
-  // Local state for environment variables
-  const [inMemoryEnvVars, setInMemoryEnvVars] = useState<Record<string, string>>(currentEnvVars)
-
-  // // Sync local state with atom on mount and when atom changes
-  // useEffect(() => {
-  //   setInMemoryEnvVars(currentEnvVars)
-  // }, [currentEnvVars])
-
-  // Sync atom with local state whenever local state changes
-  useEffect(() => {
-    // Schedule the update to run on the next animation frame
-    const timeoutId = requestAnimationFrame(() => {
-      setEnvVars(inMemoryEnvVars)
-    })
-
-    // Cleanup the scheduled update if the effect re-runs before it executes
-    return () => cancelAnimationFrame(timeoutId)
-  }, [inMemoryEnvVars, setEnvVars])
-
   // Toggle visibility of an environment variable
   const toggleVisibility = (index: number) => {
     const envVar = envVars[index]
@@ -101,30 +82,26 @@ export default function EnvVariablesManager() {
   // Update an environment variable immediately
   const updateEnvVar = (index: number, value: string) => {
     const envVar = envVars[index]
-    setInMemoryEnvVars((prev) => ({
-      ...prev,
-      [envVar.key]: value,
-    }))
+    const newVars = { ...currentEnvVars }
+    newVars[envVar.key] = value
+    setEnvVars(newVars)
   }
 
   // Delete an environment variable
   const deleteEnvVar = (index: number) => {
     const { key } = envVars[index]
-    setInMemoryEnvVars((prev) => {
-      const newVars = { ...prev }
-      delete newVars[key]
-      return newVars
-    })
+    const newVars = { ...currentEnvVars }
+    delete newVars[key]
+    setEnvVars(newVars)
   }
 
   // Add a new environment variable
   const addEnvVar = () => {
     if (newKey.trim() === '') return
 
-    setInMemoryEnvVars((prev) => ({
-      ...prev,
-      [newKey]: newValue,
-    }))
+    const newVars = { ...currentEnvVars }
+    newVars[newKey] = newValue
+    setEnvVars(newVars)
 
     // Reset form
     setNewKey('')
@@ -132,13 +109,14 @@ export default function EnvVariablesManager() {
   }
 
   // Parse and import environment variables from .env file
-  const parseEnvFile = () => {
+  const parseAndSaveEnvFile = () => {
     try {
       const parsed = parseDotenv(envFileContent)
-      setInMemoryEnvVars((prev) => ({
-        ...prev,
-        ...parsed,
-      }))
+      const newVars = { ...currentEnvVars }
+      Object.entries(parsed).forEach(([key, value]) => {
+        newVars[key] = value
+      })
+      setEnvVars(newVars)
       setEnvFileContent('')
       toast({
         title: 'Environment variables imported',
@@ -360,7 +338,7 @@ export default function EnvVariablesManager() {
               <Button variant='outline'>Cancel</Button>
             </DialogClose>
             <DialogClose asChild>
-              <Button onClick={parseEnvFile}>Import</Button>
+              <Button onClick={parseAndSaveEnvFile}>Import</Button>
             </DialogClose>
           </DialogFooter>
         </DialogContent>

--- a/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
+++ b/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
@@ -1,12 +1,13 @@
 import { expect } from '@storybook/test'
 import { DevTools } from 'jotai-devtools'
 import 'jotai-devtools/styles.css'
-import { atom, createStore, useAtomValue } from 'jotai'
+import { atom, createStore, useAtomValue, useSetAtom } from 'jotai'
 import { default as EnvVars } from '../shared/baml-project-panel/playground-panel/side-bar/env-vars'
 import { Provider as JotaiProvider } from 'jotai'
 import { ThemeProvider } from 'next-themes'
 import '../App.css'
 import { envVarsAtom } from '../shared/baml-project-panel/atoms'
+import { useState } from 'react'
 
 interface JotaiProviderProps {
   envVars: Record<string, string>
@@ -19,27 +20,27 @@ const JotaiStorybookProvider: React.FC<JotaiProviderProps> = ({ envVars, childre
   return <JotaiProvider store={storybookStore}>{children}</JotaiProvider>
 }
 
+const WrappedEnvVars: React.FC = () => {
+  const envVars = useAtomValue(envVarsAtom)
+  return (
+    <div>
+      <ThemeProvider attribute='class' defaultTheme='dark' enableSystem={false} disableTransitionOnChange={true}>
+        <div className='flex gap-8 items-start'>
+          <EnvVars />
+          <div className='p-4 bg-[#1e1e1e] rounded-lg min-w-[300px]'>
+            <h3 className='mb-2 text-sm font-mono'>JSON.stringify(useAtomValue(envVarsAtom))</h3>
+            <pre className='text-xs'>{JSON.stringify(envVars, null, 2)}</pre>
+          </div>
+        </div>
+      </ThemeProvider>
+    </div>
+  )
+}
+
 export default {
   title: 'EnvVars',
-  component: EnvVars,
-  decorators: [
-    (Story: React.FC) => {
-      const envVars = useAtomValue(envVarsAtom)
-      return (
-        <div>
-          <ThemeProvider attribute='class' defaultTheme='dark' enableSystem={false} disableTransitionOnChange={true}>
-            <div className='flex gap-8 items-start'>
-              <Story />
-              <div className='p-4 bg-[#1e1e1e] rounded-lg min-w-[300px]'>
-                <h3 className='mb-2 text-sm font-mono'>JSON.stringify(useAtomValue(envVarsAtom))</h3>
-                <pre className='text-xs'>{JSON.stringify(envVars, null, 2)}</pre>
-              </div>
-            </div>
-          </ThemeProvider>
-        </div>
-      )
-    },
-  ],
+  component: WrappedEnvVars,
+  decorators: [],
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
     layout: 'centered',
@@ -51,7 +52,13 @@ export const NoRequiredEnvVarsAreSet = {
   decorators: [
     (Story: React.FC) => (
       <JotaiStorybookProvider envVars={{}}>
-        <Story />
+        <div>
+          <ThemeProvider attribute='class' defaultTheme='dark' enableSystem={false} disableTransitionOnChange={true}>
+            <div className='flex gap-8 items-start'>
+              <Story />
+            </div>
+          </ThemeProvider>
+        </div>
       </JotaiStorybookProvider>
     ),
   ],
@@ -68,7 +75,13 @@ export const SomeRequiredEnvVarsAreSet = {
           OPENAI_API_KEY: '',
         }}
       >
-        <Story />
+        <div>
+          <ThemeProvider attribute='class' defaultTheme='dark' enableSystem={false} disableTransitionOnChange={true}>
+            <div className='flex gap-8 items-start'>
+              <Story />
+            </div>
+          </ThemeProvider>
+        </div>
       </JotaiStorybookProvider>
     ),
   ],

--- a/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
+++ b/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
@@ -1,7 +1,7 @@
 import { expect } from '@storybook/test'
 import { DevTools } from 'jotai-devtools'
 import 'jotai-devtools/styles.css'
-import { atom, createStore } from 'jotai'
+import { atom, createStore, useAtomValue } from 'jotai'
 import { default as EnvVars } from '../shared/baml-project-panel/playground-panel/side-bar/env-vars'
 import { Provider as JotaiProvider } from 'jotai'
 import { ThemeProvider } from 'next-themes'
@@ -23,13 +23,22 @@ export default {
   title: 'EnvVars',
   component: EnvVars,
   decorators: [
-    (Story: React.FC) => (
-      <div>
-        <ThemeProvider attribute='class' defaultTheme='dark' enableSystem={false} disableTransitionOnChange={true}>
-          <Story />
-        </ThemeProvider>
-      </div>
-    ),
+    (Story: React.FC) => {
+      const envVars = useAtomValue(envVarsAtom)
+      return (
+        <div>
+          <ThemeProvider attribute='class' defaultTheme='dark' enableSystem={false} disableTransitionOnChange={true}>
+            <div className='flex gap-8 items-start'>
+              <Story />
+              <div className='p-4 bg-[#1e1e1e] rounded-lg min-w-[300px]'>
+                <h3 className='mb-2 text-sm font-mono'>JSON.stringify(useAtomValue(envVarsAtom))</h3>
+                <pre className='text-xs'>{JSON.stringify(envVars, null, 2)}</pre>
+              </div>
+            </div>
+          </ThemeProvider>
+        </div>
+      )
+    },
   ],
   parameters: {
     // More on how to position stories at: https://storybook.js.org/docs/configure/story-layout
@@ -38,7 +47,7 @@ export default {
 }
 
 // More on component testing: https://storybook.js.org/docs/writing-tests/component-testing
-export const WithNoRequired = {
+export const NoRequiredEnvVarsAreSet = {
   decorators: [
     (Story: React.FC) => (
       <JotaiStorybookProvider envVars={{}}>
@@ -49,7 +58,7 @@ export const WithNoRequired = {
 }
 
 // ANTHROPIC_API_KEY and OPENAI_API_KEY are required by default
-export const WithSomeRequiredAndMore = {
+export const SomeRequiredEnvVarsAreSet = {
   decorators: [
     (Story: React.FC) => (
       <JotaiStorybookProvider
@@ -66,7 +75,7 @@ export const WithSomeRequiredAndMore = {
 }
 
 // ANTHROPIC_API_KEY and OPENAI_API_KEY are required by default
-export const WithAllRequiredAndMore = {
+export const AllRequiredEnvVarsAreSet = {
   decorators: [
     (Story: React.FC) => (
       <JotaiStorybookProvider
@@ -82,8 +91,24 @@ export const WithAllRequiredAndMore = {
   ],
 }
 
+export const EnvVarContainsNewlines = {
+  decorators: [
+    (Story: React.FC) => (
+      <JotaiStorybookProvider
+        envVars={{
+          ANTHROPIC_API_KEY: 'line1\nline2\nline3',
+          COHERE_API_KEY: 'sk-coh789',
+          OPENAI_API_KEY: 'sk-test123',
+        }}
+      >
+        <Story />
+      </JotaiStorybookProvider>
+    ),
+  ],
+}
+
 // ANTHROPIC_API_KEY and OPENAI_API_KEY are required by default
-export const With100EnvVars = {
+export const TableWith100EnvVars = {
   decorators: [
     (Story: React.FC) => (
       <JotaiStorybookProvider


### PR DESCRIPTION
This will not allow copy-pasting values with newlines into a given env var input, but you can do that using the "import a .env file" field. I could use textarea but don't yet want to compromise on accessibility / hand-rolling input type=password with that, and am not sure what npm packages exist for that.