### PR TITLE
Parser for openai must have `created` as an optional field

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/types.rs
@@ -14,7 +14,7 @@ pub struct ChatCompletionGeneric<C> {
     /// A list of chat completion choices. Can be more than one if `n` is greater than 1.s
     pub choices: Vec<C>,
     /// The Unix timestamp (in seconds) of when the chat completion was created.
-    #[serde(deserialize_with = "deserialize_float_to_u32")]
+    #[serde(default, deserialize_with = "deserialize_float_to_u32")]
     pub created: Option<u32>,
     /// The model used for the chat completion.
     pub model: String,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Makes `created` field in `ChatCompletionGeneric` optional during deserialization to handle missing values in OpenAI responses.
> 
>   - **Deserialization**:
>     - Makes `created` field in `ChatCompletionGeneric` optional by adding `#[serde(default, ...)]`, allowing missing `created` in OpenAI responses to deserialize as `None`.
>   - **Scope**:
>     - Change is limited to `types.rs`, only affects `ChatCompletionGeneric` struct.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 81ef224677ff4a23113afd06047e9cb28c388d75. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->