### PR TITLE
chore: set gitconfig defaults for upstream management

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,3 +1,10 @@
 [merge "baml_client"]
         driver = true
+[checkout]
+        defaultRemote = origin
+[push]
+        autoSetupRemote = true
+[pull]
+        ff = only
+        rebase = true
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> .gitconfig updated to set default remote for checkout, auto-setup remote for push, and fast-forward/rebase for pull.
> 
>   - **.gitconfig defaults**:
>     - Sets `[checkout] defaultRemote = origin`.
>     - Sets `[push] autoSetupRemote = true`.
>     - Sets `[pull] ff = only` and `rebase = true`.
>   - No code or logic changes; only git configuration updated for upstream management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0a188aeb41f49eb0efa1441a9a7199e78039a51f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->