### PR TITLE
feat: handle edge cases in env var rendering

### DIFF
--- a/typescript/playground-common/src/index.ts
+++ b/typescript/playground-common/src/index.ts
@@ -7,9 +7,5 @@ export { default as CustomErrorBoundary } from './utils/ErrorFallback'
 export { CodeMirrorViewer } from './shared/baml-project-panel/codemirror-panel/code-mirror-viewer'
 export { JotaiProvider } from './baml_wasm_web/JotaiProvider'
 export { PromptPreview }
-export {
-  EnvironmentVariablesDialog,
-  EnvironmentVariablesPanel,
-} from './shared/baml-project-panel/playground-panel/side-bar/env-vars'
 //wasm
 // export { default as lint, type LinterSourceFile, type LinterError, type LinterInput } from "./wasm/lint";

--- a/typescript/playground-common/src/index.ts
+++ b/typescript/playground-common/src/index.ts
@@ -7,6 +7,9 @@ export { default as CustomErrorBoundary } from './utils/ErrorFallback'
 export { CodeMirrorViewer } from './shared/baml-project-panel/codemirror-panel/code-mirror-viewer'
 export { JotaiProvider } from './baml_wasm_web/JotaiProvider'
 export { PromptPreview }
-export { default as EnvVars } from './shared/baml-project-panel/playground-panel/side-bar/env-vars'
+export {
+  EnvironmentVariablesDialog,
+  EnvironmentVariablesPanel,
+} from './shared/baml-project-panel/playground-panel/side-bar/env-vars'
 //wasm
 // export { default as lint, type LinterSourceFile, type LinterError, type LinterInput } from "./wasm/lint";

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/index.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/index.tsx
@@ -46,7 +46,7 @@ const PromptPreview = ({ isEmbed = false }: { isEmbed?: boolean }) => {
         style={{ minHeight: '530px' }}
       >
         <Dialog open={showEnvDialog} onOpenChange={setShowEnvDialog}>
-          <DialogContent className='mt-12 sm:max-w-[825px]'>
+          <DialogContent className='mt-12 max-h-[80vh] overflow-y-auto sm:max-w-none w-fit'>
             <EnvVars />
           </DialogContent>
         </Dialog>

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/index.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/index.tsx
@@ -13,8 +13,8 @@ import { ResizablePanel } from '@/components/ui/resizable'
 import { useAtom, useAtomValue } from 'jotai'
 import { areTestsRunningAtom, showEnvDialogAtom } from '../atoms'
 import { ThemeProvider } from '../../theme/ThemeProvider'
-import { Dialog, DialogContent } from '@/components/ui/dialog'
-import EnvVars from '../side-bar/env-vars'
+import { EnvironmentVariablesDialog } from '../side-bar/env-vars'
+
 const PromptPreview = ({ isEmbed = false }: { isEmbed?: boolean }) => {
   const areTestsRunning = useAtomValue(areTestsRunningAtom)
   const ref = useRef<ImperativePanelHandle>(null)
@@ -45,11 +45,7 @@ const PromptPreview = ({ isEmbed = false }: { isEmbed?: boolean }) => {
         className='flex overflow-x-auto flex-col justify-start items-start pr-2 w-full h-full'
         style={{ minHeight: '530px' }}
       >
-        <Dialog open={showEnvDialog} onOpenChange={setShowEnvDialog}>
-          <DialogContent className='mt-12 max-h-[80vh] overflow-y-auto sm:max-w-none w-fit'>
-            <EnvVars />
-          </DialogContent>
-        </Dialog>
+        <EnvironmentVariablesDialog showEnvDialog={showEnvDialog} setShowEnvDialog={setShowEnvDialog} />
         <ResizablePanelGroup autoSaveId={'prompt-preview'} direction='vertical' className='py-2 h-full'>
           <ResizablePanel defaultSize={areTestsRunning ? 40 : 80} className='flex flex-col gap-4 px-4'>
             <PreviewToolbar />

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
@@ -29,14 +29,21 @@ import { motion } from 'motion/react'
 
 const envVarVisibilityAtom = atom<Record<string, boolean>>({})
 
-const REQUIRED_ENV_VAR_UNSET_WARNING = 'Clients may fail if this is not set'
+const REQUIRED_ENV_VAR_UNSET_WARNING = 'Your BAML clients may fail if this is not set'
 
-const renderedEnvVarsAtom = atom((get) => {
-  const envVars = get(envVarsAtom)
+interface EnvVarEntry {
+  key: string
+  value: string | undefined
+  required: boolean
+  hidden: boolean
+}
+
+const renderedEnvVarsAtom = atom<EnvVarEntry[]>((get) => {
+  const envVars = get(envVarsAtom) as Record<string, string>
   const requiredEnvVars = get(requiredEnvVarsAtom)
   const visibility = get(envVarVisibilityAtom)
 
-  const vars = Object.entries(envVars)
+  const vars: EnvVarEntry[] = Object.entries(envVars)
     .filter(([key]) => key !== 'BOUNDARY_PROXY_URL')
     .map(([key, value]) => ({
       key,
@@ -113,7 +120,7 @@ function EnvVarStatus({ value, required }: { value?: string; required: boolean }
             <Check className='h-4 w-4 text-green-500 flex-shrink-0' />
           </TooltipTrigger>
           <TooltipContent side='top' className='text-xs'>
-            Required by one of your BAML clients
+            Used by one of your BAML clients
           </TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
@@ -89,6 +89,40 @@ const unescapeValue = (value: string): string => {
   })
 }
 
+function EnvVarStatus({ value, required }: { value?: string; required: boolean }) {
+  if (!value || value === '') {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <AlertTriangle className='h-4 w-4 text-orange-500 flex-shrink-0' />
+          </TooltipTrigger>
+          <TooltipContent side='top' className='text-xs'>
+            {value ? 'Click to edit' : REQUIRED_ENV_VAR_UNSET_WARNING}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
+
+  if (required) {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Check className='h-4 w-4 text-green-500 flex-shrink-0' />
+          </TooltipTrigger>
+          <TooltipContent side='top' className='text-xs'>
+            Required by one of your BAML clients
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
+
+  return <div />
+}
+
 export default function EnvVariablesManager() {
   const envVars = useAtomValue(renderedEnvVarsAtom)
   const setEnvVars = useSetAtom(envVarsAtom)
@@ -229,20 +263,7 @@ export default function EnvVariablesManager() {
                 <td className='pl-2 pr-0.5 py-0.5'>
                   <div className='flex items-center gap-2 justify-between'>
                     <code className='font-mono text-xs text-muted-foreground'>{env.key}</code>
-                    {!env.value || env.value === '' ? (
-                      <TooltipProvider key={env.key} delayDuration={300}>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <AlertTriangle className='h-4 w-4 text-orange-500 flex-shrink-0' />
-                          </TooltipTrigger>
-                          <TooltipContent side='top' className='text-xs'>
-                            {env.value ? 'Click to edit' : REQUIRED_ENV_VAR_UNSET_WARNING}
-                          </TooltipContent>
-                        </Tooltip>
-                      </TooltipProvider>
-                    ) : (
-                      <div />
-                    )}
+                    <EnvVarStatus value={env.value} required={env.required} />
                   </div>
                 </td>
                 <td className='px-0.5 py-0.5'>

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
@@ -130,7 +130,7 @@ function EnvVarStatus({ value, required }: { value?: string; required: boolean }
   return <div />
 }
 
-export default function EnvVariablesManager() {
+export const EnvironmentVariablesPanel: React.FC = () => {
   const envVars = useAtomValue(renderedEnvVarsAtom)
   const setEnvVars = useSetAtom(envVarsAtom)
   const setVisibility = useSetAtom(envVarVisibilityAtom)
@@ -402,5 +402,18 @@ export default function EnvVariablesManager() {
         </DialogContent>
       </Dialog>
     </div>
+  )
+}
+
+export const EnvironmentVariablesDialog: React.FC<{
+  showEnvDialog: boolean
+  setShowEnvDialog: (show: boolean) => void
+}> = ({ showEnvDialog, setShowEnvDialog }) => {
+  return (
+    <Dialog open={showEnvDialog} onOpenChange={setShowEnvDialog}>
+      <DialogContent className='mt-12 max-h-[80vh] overflow-y-auto sm:max-w-none w-fit'>
+        <EnvironmentVariablesPanel />
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
@@ -281,7 +281,7 @@ export const EnvironmentVariablesPanel: React.FC = () => {
                           type={env.hidden ? 'password' : 'text'}
                           value={typeof env.value === 'string' ? escapeValue(env.value) : ''}
                           onChange={(e) => updateEnvVar(index, unescapeValue(e.target.value))}
-                          className='h-6 text-xs font-mono placeholder:font-sans'
+                          className='h-6 text-xs font-mono placeholder:font-sans min-w-32'
                           placeholder={env.required && !env.value ? '<unset>' : undefined}
                           autoComplete='off'
                           data-1p-ignore

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/index.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/index.tsx
@@ -27,7 +27,7 @@ import {
 } from '../prompt-preview/test-panel/atoms'
 import { useRunBamlTests } from '../prompt-preview/test-panel/test-runner'
 import { getStatus } from '../prompt-preview/test-panel/testStateUtils'
-import EnvVars from './env-vars'
+import { EnvironmentVariablesDialog, EnvironmentVariablesPanel } from './env-vars'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { atomWithStorage } from 'jotai/utils'
 import { vscode } from '../../vscode'

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/index.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/index.tsx
@@ -1,9 +1,7 @@
 /* eslint-disable @typescript-eslint/no-floating-promises */
 import { Input } from '@/components/ui/input'
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 import { cn } from '@/lib/utils'
-import { Dialog, DialogContent } from '@radix-ui/react-dialog'
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
 import {
   AlertTriangle,
@@ -13,7 +11,6 @@ import {
   FlaskConical,
   Play,
   Search,
-  Settings,
   XCircle,
 } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
@@ -38,10 +35,6 @@ interface FunctionData {
   tests: string[]
 }
 
-interface SidepanelProps {
-  functions: FunctionData[]
-  searchTerm: string
-}
 const functionsAtom = atom((get) => {
   const runtimeState = get(runtimeStateAtom)
   if (runtimeState === undefined) {
@@ -150,12 +143,6 @@ export default function CustomSidebar({ isEmbed = false }: { isEmbed?: boolean }
               </div>
             </ScrollArea>
           </ResizablePanel>
-          {/* <ResizableHandle withHandle />
-          <ResizablePanel defaultSize={25}>
-            <ScrollArea className="h-full" type="always">
-              <EnvVars />
-            </ScrollArea>
-          </ResizablePanel> */}
         </ResizablePanelGroup>
       </div>
     </div>

--- a/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
+++ b/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
@@ -158,3 +158,19 @@ export const TableWith100EnvVarsInDialog = {
     ),
   ],
 }
+
+export const VeryLongEnvVarNameInDialog = {
+  decorators: [
+    (Story: React.FC) => (
+      <JotaiStorybookProvider
+        envVars={{
+          ANTHROPIC_API_KEY: 'line1\nline2\nline3',
+          LONG_ENV_VAR_NAME_THAT_EXCEEDS_MAX_WIDTH_OF_THE_TABLE_CELL: 'sk-test123',
+          OPENAI_API_KEY: 'sk-test123',
+        }}
+      >
+        <EnvironmentVariablesDialog showEnvDialog={true} setShowEnvDialog={() => {}} />
+      </JotaiStorybookProvider>
+    ),
+  ],
+}

--- a/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
+++ b/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
@@ -2,7 +2,10 @@ import { expect } from '@storybook/test'
 import { DevTools } from 'jotai-devtools'
 import 'jotai-devtools/styles.css'
 import { atom, createStore, useAtomValue, useSetAtom } from 'jotai'
-import { default as EnvVars } from '../shared/baml-project-panel/playground-panel/side-bar/env-vars'
+import {
+  EnvironmentVariablesDialog,
+  EnvironmentVariablesPanel,
+} from '../shared/baml-project-panel/playground-panel/side-bar/env-vars'
 import { Provider as JotaiProvider } from 'jotai'
 import { ThemeProvider } from 'next-themes'
 import '../App.css'
@@ -27,7 +30,7 @@ const WrappedEnvVars: React.FC = () => {
     <div>
       <ThemeProvider attribute='class' defaultTheme='dark' enableSystem={false} disableTransitionOnChange={true}>
         <div className='flex gap-8 items-start'>
-          <EnvVars />
+          <EnvironmentVariablesPanel />
           <div className='p-4 bg-[#1e1e1e] rounded-lg min-w-[300px]'>
             <h3 className='mb-2 text-sm font-mono'>JSON.stringify(useAtomValue(envVarsAtom))</h3>
             <pre className='text-xs'>{JSON.stringify(envVars, null, 2)}</pre>
@@ -150,11 +153,7 @@ export const TableWith100EnvVarsInDialog = {
           ...Object.fromEntries(Array.from({ length: 100 }, (_, i) => `VAR_${i}`).map((key) => [key, `value_${key}`])),
         }}
       >
-        <Dialog open={true} onOpenChange={() => {}}>
-          <DialogContent className='mt-12 max-h-[80vh] overflow-y-auto sm:max-w-none w-fit'>
-            <Story />
-          </DialogContent>
-        </Dialog>
+        <EnvironmentVariablesDialog showEnvDialog={true} setShowEnvDialog={() => {}} />
       </JotaiStorybookProvider>
     ),
   ],

--- a/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
+++ b/typescript/vscode-ext/packages/web-panel/src/stories/EnvVars.stories.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from 'next-themes'
 import '../App.css'
 import { envVarsAtom } from '../shared/baml-project-panel/atoms'
 import { useState } from 'react'
+import { Dialog, DialogContent } from '@/components/ui/dialog'
 
 interface JotaiProviderProps {
   envVars: Record<string, string>
@@ -133,6 +134,27 @@ export const TableWith100EnvVars = {
         }}
       >
         <Story />
+      </JotaiStorybookProvider>
+    ),
+  ],
+}
+
+export const TableWith100EnvVarsInDialog = {
+  decorators: [
+    (Story: React.FC) => (
+      <JotaiStorybookProvider
+        envVars={{
+          ANTHROPIC_API_KEY: 'sk-ant456',
+          COHERE_API_KEY: 'sk-coh789',
+          OPENAI_API_KEY: 'sk-test123',
+          ...Object.fromEntries(Array.from({ length: 100 }, (_, i) => `VAR_${i}`).map((key) => [key, `value_${key}`])),
+        }}
+      >
+        <Dialog open={true} onOpenChange={() => {}}>
+          <DialogContent className='mt-12 max-h-[80vh] overflow-y-auto sm:max-w-none w-fit'>
+            <Story />
+          </DialogContent>
+        </Dialog>
       </JotaiStorybookProvider>
     ),
   ],


### PR DESCRIPTION
- allow the dialog to scroll when there are a _lot_ of env vars
- set a min width when one of the env vars is super long
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances environment variable dialog UI to handle many variables and long names, refactoring components for better status handling.
> 
>   - **UI Enhancements**:
>     - `EnvironmentVariablesDialog` in `env-vars.tsx` now supports scrolling for dialogs with many environment variables and sets a minimum width for long variable names.
>     - Replaces `Dialog` and `DialogContent` with `EnvironmentVariablesDialog` in `prompt-preview/index.tsx` and `side-bar/index.tsx`.
>   - **Refactoring**:
>     - Introduces `EnvVarStatus` component in `env-vars.tsx` to handle status display of environment variables.
>     - Renames `EnvVars` to `EnvironmentVariablesPanel` and `EnvironmentVariablesDialog` in `env-vars.tsx`.
>   - **Storybook**:
>     - Updates `EnvVars.stories.tsx` to include scenarios for dialogs with many variables and long variable names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 3cda29324e9ea1089f5169f6c332c2355bed8e54. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->