### PR TITLE
Disable formatting in LSP due to incorrect behavior

### DIFF
--- a/engine/language_server/src/server/api/requests/format.rs
+++ b/engine/language_server/src/server/api/requests/format.rs
@@ -20,56 +20,57 @@ impl SyncRequestHandler for DocumentFormatting {
         _requester: &mut Requester,
         params: DocumentFormattingParams,
     ) -> Result<Option<Vec<lsp_types::TextEdit>>> {
-        let url = &params.text_document.uri;
-        let path = url
-            .to_file_path()
-            .internal_error_msg("Could not convert URL to path")?;
-        session
-            .ensure_project_db_for_baml_file(url)
-            .internal_error()?;
-        let project = session
-            .project_db_for_path_mut(path)
-            .expect("Ensured that a project db exists");
-        let document_key = DocumentKey::from_url(
-            &PathBuf::from(project.lock().unwrap().baml_project.root_dir_name.clone()),
-            &url,
-        )
-        .internal_error()?;
-        let doc_contents = match project
-            .lock()
-            .unwrap()
-            .baml_project
-            .files
-            .get(&document_key)
-        {
-            None => {
-                tracing::warn!("Failed to find doc {:?}", url);
-                Err(anyhow::anyhow!(
-                    "File {} was not present in the project",
-                    url
-                ))
-            }
-            Some(text_document) => Ok(text_document.contents.clone()),
-        }
-        .internal_error()?;
-        format_schema(
-            &doc_contents,
-            FormatOptions {
-                indent_width: 2,
-                fail_on_unhandled_rule: false,
-            },
-        )
-        .map(|new_contents| {
-            Ok(Some(vec![TextEdit {
-                range: full_document_range(&doc_contents),
-                new_text: new_contents,
-            }]))
-        })
-        .unwrap_or_else(|e| {
-            notifier
-                .notify_baml_error(e.to_string().as_str())
-                .internal_error()?;
-            Ok(None)
-        })
+        // let url = &params.text_document.uri;
+        // let path = url
+        //     .to_file_path()
+        //     .internal_error_msg("Could not convert URL to path")?;
+        // session
+        //     .ensure_project_db_for_baml_file(url)
+        //     .internal_error()?;
+        // let project = session
+        //     .project_db_for_path_mut(path)
+        //     .expect("Ensured that a project db exists");
+        // let document_key = DocumentKey::from_url(
+        //     &PathBuf::from(project.lock().unwrap().baml_project.root_dir_name.clone()),
+        //     &url,
+        // )
+        // .internal_error()?;
+        // let doc_contents = match project
+        //     .lock()
+        //     .unwrap()
+        //     .baml_project
+        //     .files
+        //     .get(&document_key)
+        // {
+        //     None => {
+        //         tracing::warn!("Failed to find doc {:?}", url);
+        //         Err(anyhow::anyhow!(
+        //             "File {} was not present in the project",
+        //             url
+        //         ))
+        //     }
+        //     Some(text_document) => Ok(text_document.contents.clone()),
+        // }
+        // .internal_error()?;
+        // format_schema(
+        //     &doc_contents,
+        //     FormatOptions {
+        //         indent_width: 2,
+        //         fail_on_unhandled_rule: false,
+        //     },
+        // )
+        // .map(|new_contents| {
+        //     Ok(Some(vec![TextEdit {
+        //         range: full_document_range(&doc_contents),
+        //         new_text: new_contents,
+        //     }]))
+        // })
+        // .unwrap_or_else(|e| {
+        //     notifier
+        //         .notify_baml_error(e.to_string().as_str())
+        //         .internal_error()?;
+        //     Ok(None)
+        // })
+        Ok(None)
     }
 }


### PR DESCRIPTION
We dont apply unsaved changes to the files so stuff gets reverted to how it was before saving.