### PR TITLE
chore: reduce warnings when compiling non-wasm

### DIFF
--- a/engine/baml-schema-wasm/src/lib.rs
+++ b/engine/baml-schema-wasm/src/lib.rs
@@ -1,3 +1,4 @@
+#[cfg(target_arch = "wasm32")]
 pub(crate) mod aws_cred_bridge;
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add conditional compilation for `aws_cred_bridge` in `lib.rs` to reduce non-WASM compile errors.
> 
>   - **Compilation**:
>     - Add `#[cfg(target_arch = "wasm32")]` to `aws_cred_bridge` module in `lib.rs` to prevent compile errors when not targeting WebAssembly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for bf9dbb4e846eeef21e170a33df5500ca56675d90. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->