### PR TITLE
[bug] fix downloader for go binary

### DIFF
--- a/engine/language_client_go/baml_go/lib.go
+++ b/engine/language_client_go/baml_go/lib.go
@@ -334,29 +334,50 @@ func getCacheDir() (string, error) {
 
 func getTargetLibFilename() (string, error) {
 	goos, goarch := runtime.GOOS, runtime.GOARCH
-	libName, tag := "libbaml", "v"+VERSION
-	var ext, arch string
+	libName := "libbaml_cffi"
+	var ext, targetTriple string
 	switch goos {
 	case "linux":
 		ext = "so"
+		if isMusl() {
+			if goarch == "amd64" {
+				targetTriple = "x86_64-unknown-linux-musl"
+			} else if goarch == "arm64" {
+				targetTriple = "aarch64-unknown-linux-musl"
+			} else {
+				return "", fmt.Errorf("%w: unsupported architecture %s", ErrNotSupportedPlatform, goarch)
+			}
+		} else {
+			if goarch == "amd64" {
+				targetTriple = "x86_64-unknown-linux-gnu"
+			} else if goarch == "arm64" {
+				targetTriple = "aarch64-unknown-linux-gnu"
+			} else {
+				return "", fmt.Errorf("%w: unsupported architecture %s", ErrNotSupportedPlatform, goarch)
+			}
+		}
 	case "darwin":
 		ext = "dylib"
+		if goarch == "amd64" {
+			targetTriple = "x86_64-apple-darwin"
+		} else if goarch == "arm64" {
+			targetTriple = "aarch64-apple-darwin"
+		} else {
+			return "", fmt.Errorf("%w: unsupported architecture %s", ErrNotSupportedPlatform, goarch)
+		}
 	default:
 		return "", fmt.Errorf("%w: unsupported OS %s", ErrNotSupportedPlatform, goos)
 	}
-	switch goarch {
-	case "amd64":
-		arch = "x86_64"
-	case "arm64":
-		arch = "aarch64"
-	default:
-		return "", fmt.Errorf("%w: unsupported architecture %s", ErrNotSupportedPlatform, goarch)
-	}
-	return fmt.Sprintf("%s-%s-%s-%s.%s", libName, tag, goos, arch, ext), nil
+	return fmt.Sprintf("%s-%s.%s", libName, targetTriple, ext), nil
+}
+
+func isMusl() bool {
+	// TODO: Implement this
+	return false
 }
 
 func downloadBamlLibrary(destDir string, filename string) error {
-	tag := "v" + VERSION
+	tag := VERSION
 	downloadURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s", githubRepo, tag, filename)
 	checksumURL := fmt.Sprintf("https://github.com/%s/releases/download/%s/%s.sha256", githubRepo, tag, filename)
 	destPath := filepath.Join(destDir, filename)
@@ -388,7 +409,7 @@ func downloadBamlLibrary(destDir string, filename string) error {
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
 		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("%w: library file not found at %s (HTTP 404). Check release tag '%s' and filename '%s'", ErrDownloadFailed, downloadURL, tag, filename)
+			return fmt.Errorf("%w: library file not found at %s (HTTP 404). Check release tag 'v%s' and filename '%s'", ErrDownloadFailed, downloadURL, tag, filename)
 		}
 		return fmt.Errorf("%w: unexpected HTTP status %d fetching %s. Server response: %s", ErrDownloadFailed, resp.StatusCode, downloadURL, string(bodyBytes))
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix downloader for Go binaries by updating library filename format and handling OS/architecture specifics in `lib.go`.
> 
>   - **Behavior**:
>     - Update `getTargetLibFilename()` in `lib.go` to use `libbaml_cffi` and format filenames with `targetTriple` for different OS and architectures.
>     - Add `isMusl()` function in `lib.go` to determine musl libc usage (not yet implemented).
>     - Modify error message in `downloadBamlLibrary()` in `lib.go` to include 'v' prefix in version tag for 404 errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 0e7c34ba0b942287b651fc07bccd8d14ee2aad34. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->