### PR TITLE
Support multiroot workspaces

### DIFF
--- a/engine/language_server/src/baml_project/file_utils.rs
+++ b/engine/language_server/src/baml_project/file_utils.rs
@@ -19,6 +19,11 @@ use lsp_types::{TextDocumentItem, Url};
 ///   or `None` otherwise.
 pub fn find_top_level_parent(file_path: &Path) -> Option<PathBuf> {
     let mut current = file_path;
+    if let Some(file_name) = current.file_name() {
+        if file_name == "baml_src" {
+            return Some(current.to_path_buf());
+        }
+    }
     while let Some(parent) = current.parent() {
         if let Some(dir_name) = parent.file_name() {
             if dir_name == "baml_src" {

--- a/engine/language_server/src/baml_project/mod.rs
+++ b/engine/language_server/src/baml_project/mod.rs
@@ -90,6 +90,15 @@ impl BamlProject {
         }
     }
 
+    pub fn list_functions(&mut self) -> Vec<BamlFunction> {
+        let runtime = self.runtime(HashMap::new());
+        if let Ok(runtime) = runtime {
+            runtime.list_functions()
+        } else {
+            vec![]
+        }
+    }
+
     pub fn check_version(
         &self,
         generator_config: &BamlGeneratorConfig,

--- a/engine/language_server/src/server.rs
+++ b/engine/language_server/src/server.rs
@@ -1,6 +1,9 @@
 //! Scheduling, I/O, and API endpoints.
 
 use log::info;
+use lsp_types::{
+    WorkspaceClientCapabilities, WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
+};
 use std::num::NonZeroUsize;
 // The new PanicInfoHook name requires MSRV >= 1.82
 #[allow(deprecated)]
@@ -98,6 +101,10 @@ impl Server {
             });
             (url, settings)
         };
+        tracing::info!(
+            "--- workspace folders: {:?}",
+            init_params.workspace_folders.clone()
+        );
 
         let workspaces = init_params
             .workspace_folders
@@ -123,10 +130,6 @@ impl Server {
                 anyhow::anyhow!("Failed to get the current working directory while creating a default workspace.")
             })?;
 
-        if workspaces.len() > 1 {
-            // TODO(dhruvmanila): Support multi-root workspaces
-            anyhow::bail!("Multi-root workspaces are not supported yet");
-        }
         // for some reason tracing logs are not available before this point
         tracing::info!("Starting server with {} worker threads", worker_threads);
 
@@ -337,6 +340,13 @@ impl Server {
                     ..Default::default()
                 },
             )),
+            workspace: Some(WorkspaceServerCapabilities {
+                workspace_folders: Some(WorkspaceFoldersServerCapabilities {
+                    supported: Some(true),
+                    change_notifications: Some(lsp_types::OneOf::Left(true)),
+                }),
+                ..Default::default()
+            }),
             ..Default::default()
         }
     }

--- a/engine/language_server/src/server/api.rs
+++ b/engine/language_server/src/server/api.rs
@@ -9,7 +9,7 @@ use lsp_types::{
     DidChangeTextDocumentParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
     FullDocumentDiagnosticReport, RelatedFullDocumentDiagnosticReport,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use url::Url;
 
 mod diagnostics;
@@ -32,6 +32,19 @@ use super::{
     Result,
 };
 
+#[derive(serde::Serialize, serde::Deserialize)]
+struct BamlFunctionSpan {
+    file_path: String,
+    start: usize,
+    end: usize,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
+struct BamlFunctionResult {
+    name: String,
+    span: BamlFunctionSpan,
+}
+
+struct BamlFunctionArg {}
 // --- Add debounce duration constant ---
 const DID_CHANGE_DEBOUNCE_DURATION: Duration = Duration::from_millis(250);
 
@@ -68,6 +81,51 @@ pub(super) fn request<'a>(req: lsp_server::Request) -> Task<'a> {
                 BackgroundSchedule::LatencySensitive,
             )
         }
+        "getBAMLFunctions" => {
+            tracing::info!("getBAMLFunctions");
+            return Task::local(move |session, notifier, requester, responder| {
+                let result: anyhow::Result<(serde_json::Value,)> = (|| {
+                    let mut all_functions = Vec::new();
+                    let projects = session.baml_src_projects.lock().unwrap();
+
+                    for (_, project) in projects.iter() {
+                        let functions = project
+                            .lock()
+                            .unwrap()
+                            .baml_project
+                            .list_functions()
+                            .iter()
+                            .map(|f| BamlFunctionResult {
+                                name: f.name.clone(),
+                                span: BamlFunctionSpan {
+                                    file_path: f.span.file_path.clone(),
+                                    start: f.span.start,
+                                    end: f.span.end,
+                                },
+                            })
+                            .collect::<Vec<BamlFunctionResult>>();
+
+                        all_functions.extend(functions);
+                    }
+
+                    let result = serde_json::to_value(all_functions);
+                    if let Ok(result) = result {
+                        Ok((result,))
+                    } else {
+                        Err(anyhow::anyhow!(
+                            "Failed to serialize functions: {:?}",
+                            result
+                        ))
+                    }
+                })();
+                if let Ok((result,)) = result {
+                    responder.respond(id, Ok(result)).unwrap();
+                } else {
+                    // no action
+                    // responder.respond(id, Err(result.unwrap_err())).unwrap();
+                }
+            });
+        }
         "requestDiagnostics" => {
             tracing::info!("---- requestDiagnostics");
             return Task::local(move |session, notifier, requester, responder| {
@@ -78,10 +136,8 @@ pub(super) fn request<'a>(req: lsp_server::Request) -> Task<'a> {
                         .map_err(|e| anyhow::anyhow!("Failed to parse JSON: {e}"))?;
                     let url = Url::parse(&params.project_id)
                         .map_err(|e| anyhow::anyhow!("Failed to parse URL: {e}"))?;
-                    session.ensure_project_db_for_baml_file(&url)?;
-                    // tracing::info!("url: {:?}", url);
                     let project = session
-                        .project_db_for_path(url.to_file_path().unwrap())
+                        .get_or_create_project(&url.to_file_path().unwrap())
                         .expect("Already checked for project's existence");
                     project.lock().unwrap().update_runtime(Some(notifier))?;
 
@@ -228,9 +284,9 @@ fn background_request_task<'a, R: traits::BackgroundDocumentRequestHandler>(
         };
         info!(
             "session.projects.len(): {:?}",
-            session.projects_by_workspace_folder.lock().unwrap().len()
+            session.baml_src_projects.lock().unwrap().len()
         );
-        let _db = session.project_db_for_path(path).clone();
+        let _db = session.get_or_create_project(&path).clone();
         if _db.is_none() {
             tracing::error!("Could not find project for path");
             return Box::new(|_, _| {});

--- a/engine/language_server/src/server/api/diagnostics.rs
+++ b/engine/language_server/src/server/api/diagnostics.rs
@@ -87,13 +87,8 @@ pub fn publish_session_lsp_diagnostics(
 ) -> Result<()> {
     // let keys = session.index().documents.keys();
     let path = file_url.to_file_path().unwrap_or(PathBuf::new());
-    let _ = session
-        .ensure_project_db_for_baml_file(file_url)
-        .map_err(|e| {
-            tracing::error!("Failed to ensure project db for baml file: {}", e);
-        });
     let project = session
-        .project_db_for_path_mut(path)
+        .get_or_create_project(&path)
         .expect("We just ensured the session is valid");
 
     let diagnostics = project_diagnostics(project.clone());

--- a/engine/language_server/src/server/api/notifications/did_change.rs
+++ b/engine/language_server/src/server/api/notifications/did_change.rs
@@ -24,22 +24,24 @@ impl SyncNotificationHandler for DidChangeTextDocumentHandler {
         _requester: &mut Requester,
         params: DidChangeTextDocumentParams,
     ) -> Result<()> {
-        tracing::info!("------- DidChangeTextDocumentHandler");
+        tracing::info!("DidChangeTextDocumentHandler");
         let start_time_total = Instant::now();
 
         let url = params.text_document.uri;
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-        session
-            .ensure_project_db_for_baml_file(&url)
-            .internal_error()?;
 
-        let project = session
-            .project_db_for_path_mut(path)
-            .expect("We ensured above that the project exists");
+        // Get or create the project using the unified method
+        let project = session.get_or_create_project(&path);
+        if project.is_none() {
+            tracing::error!("Failed to get or create project for path: {:?}", path);
+            show_err_msg!("Failed to get or create project for path: {:?}", path);
+        }
+
+        let project = project.unwrap();
         let document_key =
-            DocumentKey::from_url(project.lock().unwrap().root_path(), &url).internal_error()?;
+            DocumentKey::from_url(&project.lock().unwrap().root_path(), &url).internal_error()?;
 
         session
             .update_text_document(
@@ -52,11 +54,7 @@ impl SyncNotificationHandler for DidChangeTextDocumentHandler {
 
         tracing::info!("publishing diagnostics");
 
-        publish_diagnostics(
-            &notifier,
-            project.clone(),
-            Some(params.text_document.version),
-        )?;
+        publish_diagnostics(&notifier, project, Some(params.text_document.version))?;
 
         let elapsed = start_time_total.elapsed();
         tracing::info!("didchange total took {:?}ms", elapsed.as_millis());

--- a/engine/language_server/src/server/api/notifications/did_change_configuration.rs
+++ b/engine/language_server/src/server/api/notifications/did_change_configuration.rs
@@ -17,7 +17,6 @@ impl super::SyncNotificationHandler for DidChangeConfiguration {
         _requester: &mut Requester,
         _params: types::DidChangeConfigurationParams,
     ) -> Result<()> {
-        // TODO(jane): get this wired up after the pre-release
         Ok(())
     }
 }

--- a/engine/language_server/src/server/api/notifications/did_close.rs
+++ b/engine/language_server/src/server/api/notifications/did_close.rs
@@ -33,7 +33,7 @@ impl SyncNotificationHandler for DidCloseTextDocumentHandler {
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
 
-        match session.project_db_for_path(path) {
+        match session.get_or_create_project(&path) {
             None => {}
             Some(project) => {
                 let document_key = DocumentKey::from_url(

--- a/engine/language_server/src/server/api/notifications/did_open.rs
+++ b/engine/language_server/src/server/api/notifications/did_open.rs
@@ -24,9 +24,14 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
         tracing::info!("DidOpenTextDocumentHandler");
 
         let url = params.text_document.uri;
-        session
-            .ensure_project_db_for_baml_file(&url)
-            .internal_error()?;
+        let file_path = url.to_file_path().internal_error()?;
+
+        let project = session.get_or_create_project(&file_path);
+        if project.is_none() {
+            tracing::error!("Failed to get or create project for path: {:?}", file_path);
+            show_err_msg!("Failed to get or create project for path: {:?}", file_path);
+        }
+
         session.reload(Some(notifier.clone())).internal_error()?;
 
         publish_session_lsp_diagnostics(&notifier, session, &url)?;

--- a/engine/language_server/src/server/api/notifications/did_save_text_document.rs
+++ b/engine/language_server/src/server/api/notifications/did_save_text_document.rs
@@ -28,10 +28,7 @@ impl super::SyncNotificationHandler for DidSaveTextDocument {
         session.reload(Some(notifier.clone())).internal_error()?;
         tracing::info!("About to run generator. URL path: {:?}", path);
         session
-            .ensure_project_db_for_baml_file(&url)
-            .internal_error()?;
-        session
-            .project_db_for_path_mut(path)
+            .get_or_create_project(&path)
             .expect("Ensured that a project db exists")
             .lock()
             .unwrap()

--- a/engine/language_server/src/server/api/requests/code_lens.rs
+++ b/engine/language_server/src/server/api/requests/code_lens.rs
@@ -30,12 +30,9 @@ impl SyncRequestHandler for CodeLens {
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
 
-        session
-            .ensure_project_db_for_baml_file(&params.text_document.uri)
-            .internal_error()?;
         // session.reload(Some(notifier)).internal_error()?;
         let project = session
-            .project_db_for_path_mut(path)
+            .get_or_create_project(&path)
             .expect("Ensured that a project db exists");
         let fake_env = HashMap::new();
         let baml_diagnostics = match project.lock().unwrap().baml_project.runtime(fake_env) {

--- a/engine/language_server/src/server/api/requests/completion.rs
+++ b/engine/language_server/src/server/api/requests/completion.rs
@@ -24,12 +24,12 @@ impl SyncRequestHandler for Completion {
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-        session
-            .ensure_project_db_for_baml_file(&url)
-            .internal_error()?;
+
+        // Use the unified method to get or create the project
         let project = session
-            .project_db_for_path(path)
-            .expect("Ensured that a project db exists");
+            .get_or_create_project(&path)
+            .expect("Failed to get or create project");
+
         let guard = project.lock().unwrap();
         let document_key =
             DocumentKey::from_url(&PathBuf::from(guard.root_path()), &url).internal_error()?;

--- a/engine/language_server/src/server/api/requests/diagnostic.rs
+++ b/engine/language_server/src/server/api/requests/diagnostic.rs
@@ -52,12 +52,9 @@ impl SyncRequestHandler for DocumentDiagnosticRequestHandler {
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
 
-        session
-            .ensure_project_db_for_baml_file(&params.text_document.uri)
-            .internal_error()?;
         let project = session
-            .project_db_for_path_mut(path)
-            .expect("Just ensured it exists");
+            .get_or_create_project(&path)
+            .expect("Project should exist");
 
         let diagnostics = file_diagnostics(project, &url);
         // diagnostics

--- a/engine/language_server/src/server/api/requests/go_to_definition.rs
+++ b/engine/language_server/src/server/api/requests/go_to_definition.rs
@@ -32,13 +32,8 @@ impl SyncRequestHandler for GotoDefinition {
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-        session
-            .ensure_project_db_for_baml_file(
-                &params.text_document_position_params.text_document.uri,
-            )
-            .internal_error()?;
         let project = session
-            .project_db_for_path_mut(path)
+            .get_or_create_project(&path)
             .expect("Ensured that a project db exists");
         project
             .lock()

--- a/engine/language_server/src/server/api/requests/hover.rs
+++ b/engine/language_server/src/server/api/requests/hover.rs
@@ -22,11 +22,8 @@ impl SyncRequestHandler for Hover {
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-        session
-            .ensure_project_db_for_baml_file(url)
-            .internal_error()?;
         let project = session
-            .project_db_for_path_mut(path)
+            .get_or_create_project(&path)
             .expect("Ensured that a project db exists");
         let document_key =
             DocumentKey::from_url(project.lock().unwrap().root_path(), &url).internal_error()?;

--- a/engine/language_server/src/server/api/requests/rename.rs
+++ b/engine/language_server/src/server/api/requests/rename.rs
@@ -29,11 +29,8 @@ impl SyncRequestHandler for Rename {
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-        session
-            .ensure_project_db_for_baml_file(&url)
-            .internal_error()?;
         let project = session
-            .project_db_for_path(path)
+            .get_or_create_project(&path)
             .expect("Ensured that a project db exists");
 
         let res = {

--- a/engine/language_server/src/session.rs
+++ b/engine/language_server/src/session.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use index::DocumentController;
 use itertools::any;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -37,8 +37,8 @@ pub struct Session {
     /// Used to retrieve information about open documents and settings.
     pub index: Arc<Mutex<index::Index>>,
 
-    /// Maps workspace folders to their respective project databases.
-    pub projects_by_workspace_folder: Arc<Mutex<BTreeMap<PathBuf, Arc<Mutex<Project>>>>>,
+    /// Maps baml_src directories to their respective project databases.
+    pub baml_src_projects: Arc<Mutex<HashMap<PathBuf, Arc<Mutex<Project>>>>>,
 
     /// The global position encoding, negotiated during LSP initialization.
     pub position_encoding: PositionEncoding,
@@ -50,7 +50,7 @@ impl Clone for Session {
     fn clone(&self) -> Self {
         Self {
             index: self.index.clone(),
-            projects_by_workspace_folder: self.projects_by_workspace_folder.clone(),
+            baml_src_projects: self.baml_src_projects.clone(),
             position_encoding: self.position_encoding.clone(),
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
         }
@@ -64,7 +64,7 @@ impl Session {
         global_settings: ClientSettings,
         workspace_folders: &[(Url, ClientSettings)],
     ) -> anyhow::Result<Self> {
-        let mut workspaces = BTreeMap::new();
+        let mut projects = HashMap::new();
         let index = index::Index::new(global_settings);
 
         for (url, _) in workspace_folders {
@@ -72,20 +72,29 @@ impl Session {
                 .to_file_path()
                 .map_err(|()| anyhow!("Workspace URL is not a file or directory: {:?}", url))?;
 
-            workspaces.insert(
-                workspace_path.clone(),
-                Arc::new(Mutex::new(Project::new(BamlProject {
-                    root_dir_name: workspace_path,
-                    files: HashMap::new(),
-                    unsaved_files: HashMap::new(),
-                    cached_runtime: None,
-                }))),
-            );
+            // Try to find the baml_src directory
+            if let Some(baml_src) = find_top_level_parent(&workspace_path) {
+                projects.insert(
+                    baml_src.clone(),
+                    Arc::new(Mutex::new(Project::new(BamlProject {
+                        root_dir_name: baml_src.clone(),
+                        files: HashMap::new(),
+                        unsaved_files: HashMap::new(),
+                        cached_runtime: None,
+                    }))),
+                );
+                tracing::info!(
+                    "Session::new: Added initial project for baml_src path: {:?}",
+                    baml_src
+                );
+            } else {
+                tracing::info!("Session::new: No baml_src found yet {:?}", workspace_path);
+            }
         }
 
         Ok(Self {
             position_encoding,
-            projects_by_workspace_folder: Arc::new(Mutex::new(workspaces)),
+            baml_src_projects: Arc::new(Mutex::new(projects)),
             index: Arc::new(Mutex::new(index)),
             resolved_client_capabilities: Arc::new(ResolvedClientCapabilities::new(
                 client_capabilities,
@@ -93,65 +102,73 @@ impl Session {
         })
     }
 
-    /// Returns a reference to the project's [`ProjectDatabase`] corresponding to the given path, if
-    /// any.
-    pub(crate) fn project_db_for_path(
+    /// Gets or creates a project for the given path.
+    ///
+    /// This is the primary method for working with projects, replacing the multiple
+    /// previous methods. It handles both lookup and creation in a single method.
+    ///
+    /// Returns:
+    /// - Some(Arc<Mutex<Project>>) if a project was found or created
+    /// - None if no baml_src directory could be found for the path
+    pub fn get_or_create_project(
         &self,
         path: impl AsRef<Path> + std::fmt::Debug,
     ) -> Option<Arc<Mutex<Project>>> {
-        let guard = self.projects_by_workspace_folder.lock().unwrap();
-        guard
-            .range(..=path.as_ref().to_path_buf())
-            .next_back()
-            .map(|(_, db)| db.clone())
-    }
+        // Try to find the baml_src directory
+        let baml_src = find_top_level_parent(path.as_ref())?;
 
-    /// Returns a mutable reference to the project [`ProjectDatabase`] corresponding to the given
-    /// path, if any.
-    pub(crate) fn project_db_for_path_mut(
-        &mut self,
-        path: impl AsRef<Path> + std::fmt::Debug,
-    ) -> Option<Arc<Mutex<Project>>> {
-        let guard = self.projects_by_workspace_folder.lock().unwrap();
-        guard
-            .range(..=path.as_ref().to_path_buf())
-            .next_back()
-            .map(|(_, db)| db.clone())
-    }
+        // Lock once and perform all operations within this scope
+        let mut projects = self.baml_src_projects.lock().unwrap();
 
-    /// Ensures that a project database exists for the given BAML file,
-    /// creating one if it doesn't exist.
-    pub fn ensure_project_db_for_baml_file(&mut self, url: &Url) -> anyhow::Result<()> {
-        let baml_src = find_top_level_parent(&PathBuf::from(
-            url.to_file_path()
-                .map_err(|_| anyhow::anyhow!("Failed to convert URL to path"))?,
-        ))
-        .context("Failed to find top level parent 2")?;
-        match self.project_db_for_path(&baml_src) {
-            Some(_) => Ok(()),
-            None => {
-                self.projects_by_workspace_folder.lock().unwrap().insert(
-                    baml_src.clone(),
-                    Arc::new(Mutex::new(Project::new(BamlProject {
-                        root_dir_name: baml_src,
-                        files: HashMap::new(),
-                        unsaved_files: HashMap::new(),
-                        cached_runtime: None,
-                    }))),
-                );
-                Ok(())
-            }
+        // If project exists, return it
+        if let Some(project) = projects.get(&baml_src) {
+            return Some(project.clone());
         }
+
+        // Create a new project if needed
+        tracing::info!("Creating new project for baml_src path: {:?}", baml_src);
+        let new_project = Arc::new(Mutex::new(Project::new(BamlProject {
+            root_dir_name: baml_src.clone(),
+            files: HashMap::new(),
+            unsaved_files: HashMap::new(),
+            cached_runtime: None,
+        })));
+
+        // Insert and return the new project
+        projects.insert(baml_src, new_project.clone());
+        Some(new_project)
+    }
+
+    pub fn print_baml_projects(&self) {
+        let projects = self.baml_src_projects.lock().unwrap();
+
+        let info_string = projects
+            .iter()
+            .map(|(key, project)| {
+                format!(
+                    "{}: {:?}",
+                    key.display(),
+                    project.lock().unwrap().root_path()
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        tracing::info!(
+            "{} projects_by_workspace_folder: {:?}",
+            projects.len(),
+            info_string
+        );
     }
 
     pub fn reload(&mut self, notifier: Option<Notifier>) -> anyhow::Result<()> {
-        tracing::info!("---- Reloading session");
+        tracing::info!("Reloading session");
         let project_updates: Vec<HashMap<_, _>> = self
-            .projects_by_workspace_folder
+            .baml_src_projects
             .lock()
             .unwrap()
             .iter_mut()
-            .map(|(_projet_root, project)| {
+            .map(|(_project_root, project)| {
                 let files_map = project.lock().unwrap().baml_project.load_files()?;
                 project
                     .lock()
@@ -164,22 +181,22 @@ impl Session {
                 Ok(files_map)
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
+
         let files: Vec<(DocumentKey, String)> = project_updates
             .into_iter()
-            .map(|project_files| {
+            .flat_map(|project_files| {
                 project_files
                     .into_iter()
                     .map(|(key, text_document)| (key, text_document.contents))
                     .collect::<Vec<_>>()
             })
-            .flatten()
             .collect();
 
         // Index all the files, except for the ones with unsaved changes.
         files.iter().for_each(|(file_url, file_contents)| {
             let text_document = TextDocument::new(file_contents.clone(), 0);
             let document_is_unsaved = any(
-                self.projects_by_workspace_folder.lock().unwrap().iter(),
+                self.baml_src_projects.lock().unwrap().iter(),
                 |(_, project)| {
                     project
                         .lock()
@@ -193,26 +210,29 @@ impl Session {
                 self.open_text_document(file_url.clone(), text_document);
             }
         });
-        log::info!("--- Reloaded {} files", files.len());
+        log::info!("Reloaded {} files", files.len());
 
         Ok(())
     }
+
     pub fn clear_unsaved_files(&mut self) {
         tracing::info!("Clearing unsaved files");
-        for (_folder, project) in self.projects_by_workspace_folder.lock().unwrap().iter_mut() {
+        for (_folder, project) in self.baml_src_projects.lock().unwrap().iter_mut() {
             project.lock().unwrap().baml_project.unsaved_files.clear();
         }
     }
 
     /// Creates a document snapshot with the URL referencing the document to snapshot.
     pub fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
-        // let key = self.key_from_url(url);
-        let project = self.project_db_for_path(url.to_file_path().ok()?)?;
+        let file_path = url.to_file_path().ok()?;
+        let project = self.get_or_create_project(&file_path)?;
+
         let document_key = DocumentKey::from_url(
             &PathBuf::from(project.lock().unwrap().baml_project.root_dir_name.clone()),
             &url,
         )
         .ok()?;
+
         Some(DocumentSnapshot {
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
             document_ref: self.index.lock().unwrap().make_document_ref(document_key)?,
@@ -241,7 +261,7 @@ impl Session {
                 )
             }
         };
-        for (_folder, project) in self.projects_by_workspace_folder.lock().unwrap().iter_mut() {
+        for (_folder, project) in self.baml_src_projects.lock().unwrap().iter_mut() {
             let text_document = TextDocument::new(new_contents.clone(), 0);
             project
                 .lock()
@@ -280,10 +300,10 @@ impl Session {
             };
             text_document.contents().to_string()
         };
-        let elapsed = start_time.elapsed();
+        let _elapsed = start_time.elapsed();
 
         let start_time = Instant::now();
-        self.projects_by_workspace_folder
+        self.baml_src_projects
             .lock()
             .unwrap()
             .iter_mut()
@@ -303,14 +323,14 @@ impl Session {
                         .baml_project
                         .unsaved_files
                         .insert(doc_key.clone(), text_document);
-                    let elapsed = start_time.elapsed();
+                    let _elapsed = start_time.elapsed();
 
                     project
                         .lock()
                         .unwrap()
                         .update_runtime(notifier.clone())
                         .map_err(|e| anyhow::anyhow!("Could not update runtime: {e}"))?;
-                    let elapsed = start_time.elapsed();
+                    let _elapsed = start_time.elapsed();
                 }
                 Ok::<(), anyhow::Error>(())
             })?;
@@ -355,7 +375,83 @@ impl DocumentSnapshot {
     }
 
     pub(crate) fn project(&self) -> Option<Arc<Mutex<Project>>> {
-        self.session
-            .project_db_for_path(self.document_ref.file_url().to_file_path().unwrap())
+        let file_path = self.document_ref.file_url().to_file_path().ok()?;
+        self.session.get_or_create_project(&file_path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*; // Import items from outer module (Session, Project, etc.)
+    use crate::baml_project::{BamlProject, Project};
+    use crate::logging::{init_logging, LogLevel};
+    use crate::session::settings::ClientSettings;
+    use crate::PositionEncoding;
+    use lsp_types::ClientCapabilities;
+    use std::path::PathBuf;
+    use std::sync::{Arc, Mutex};
+
+    // Minimal setup for Session::new
+    fn create_test_session() -> Session {
+        // Use default/empty capabilities and settings for simplicity
+        let client_capabilities = ClientCapabilities::default();
+        // Assuming UTF8 is a valid variant or default for PositionEncoding
+        let position_encoding = PositionEncoding::UTF8;
+        let global_settings = ClientSettings::default();
+        let workspace_folders = vec![]; // Start with empty workspace
+
+        Session::new(
+            &client_capabilities,
+            position_encoding,
+            global_settings,
+            &workspace_folders,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn test_get_or_create_project() {
+        init_logging(LogLevel::Info, None);
+
+        let mut session = create_test_session();
+
+        // Using paths similar to the logs
+        let path_str1 = "/Users/aaronvillalpando/Projects/baml-examples/ruby-starter/baml_src";
+        let path_str2 = "/Users/aaronvillalpando/Projects/next-app/my-app/baml_src";
+
+        let key1 = PathBuf::from(path_str1);
+        let key2 = PathBuf::from(path_str2);
+
+        // Create a project for key1
+        let project1 = session.get_or_create_project(&key1);
+        assert!(project1.is_some(), "Project should be created for key1");
+
+        // Verify that get_or_create_project returns the same project when called again
+        let project1_again = session.get_or_create_project(&key1);
+        assert!(project1_again.is_some(), "Project should be found for key1");
+
+        // Create a project for key2
+        let project2 = session.get_or_create_project(&key2);
+        assert!(project2.is_some(), "Project should be created for key2");
+
+        // Test with a file path inside key2
+        let file_path_in_key2 = key2.join("chat.baml");
+        let found_project = session.get_or_create_project(&file_path_in_key2);
+        assert!(
+            found_project.is_some(),
+            "Project should be found for file path within key2"
+        );
+
+        // Verify it's the same project
+        {
+            let unwrapped_project = found_project.unwrap();
+            let project_guard = unwrapped_project.lock().unwrap();
+            let found_root = project_guard.root_path();
+            assert_eq!(
+                found_root, key2,
+                "Expected root: {:?}, Found root: {:?}",
+                key2, found_root
+            );
+        }
     }
 }

--- a/engine/language_server/src/session/settings.rs
+++ b/engine/language_server/src/session/settings.rs
@@ -75,7 +75,7 @@ impl AllSettings {
             serde_json::from_value(options)
                 .map_err(|err| {
                     tracing::error!("Failed to deserialize initialization options: {err}. Falling back to default client settings...");
-                    show_err_msg!("Ruff received invalid client settings - falling back to default client settings.");
+                    show_err_msg!("Baml received invalid client settings - falling back to default client settings.");
                 })
                 .unwrap_or_default(),
         )
@@ -89,6 +89,8 @@ impl AllSettings {
                 workspace_settings,
             } => (global_settings, Some(workspace_settings)),
         };
+
+        tracing::info!("--- workspace_settings: {:?}", workspace_settings);
 
         Self {
             global_settings,


### PR DESCRIPTION
Simplifies a bunch of logic for keeping track of baml projects
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for multi-root workspaces by managing multiple `baml_src` directories in the language server.
> 
>   - **Behavior**:
>     - Support for multi-root workspaces by managing multiple `baml_src` directories in `Session`.
>     - Removed restriction on single workspace in `server.rs`.
>     - Added `get_or_create_project()` in `Session` to handle project lookup and creation.
>   - **API**:
>     - Added `getBAMLFunctions` request in `api.rs` to list functions from all projects.
>     - Updated `DidChangeTextDocumentHandler`, `DidOpenTextDocumentHandler`, and other notification handlers to use `get_or_create_project()`.
>     - Updated `CodeLens`, `Completion`, `GotoDefinition`, `Hover`, and `Rename` request handlers to support multi-root workspaces.
>   - **Diagnostics**:
>     - Updated `publish_diagnostics()` and `project_diagnostics()` in `diagnostics.rs` to handle diagnostics for multiple projects.
>   - **Misc**:
>     - Added tests for `get_or_create_project()` in `session.rs`.
>     - Minor logging improvements in `server.rs` and `session.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 967e24b974c11df4a6a94d7976c04d632fceae2f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->