### PR TITLE
feat: BAML gem supports ruby 3.4

### DIFF
--- a/.github/workflows/build-ruby-release.reusable.yaml
+++ b/.github/workflows/build-ruby-release.reusable.yaml
@@ -48,7 +48,7 @@ jobs:
       - uses: oxidize-rb/actions/setup-ruby-and-rust@main
         with:
           rubygems: latest
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: false
           cargo-cache: false
           cargo-vendor: false
@@ -105,7 +105,7 @@ jobs:
             --platform ${{ matrix._.platform }} \
             --mount-toolchains \
             --directory language_client_ruby \
-            --ruby-versions 3.3,3.2,3.1 \
+            --ruby-versions 3.4,3.3,3.2,3.1 \
             --build \
             -- ${{ matrix._.rb-sys-dock-setup }}
 

--- a/engine/language_client_ruby/Gemfile.lock
+++ b/engine/language_client_ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    baml (0.78.0)
+    baml (0.84.3)
 
 GEM
   remote: https://rubygems.org/

--- a/engine/language_client_ruby/test/runtime_test.rb
+++ b/engine/language_client_ruby/test/runtime_test.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-require_relative "../lib/baml"
+require_relative '../lib/baml'
 
 require 'minitest/autorun'
 require 'minitest/reporters'
 
-describe "runtime sanity check" do
-  it "can build runtime" do
-    baml = Baml::Ffi::BamlRuntime.from_directory("/Users/sam/baml/integ-tests/baml_src", {})
+describe 'runtime sanity check' do
+  it 'can build runtime' do
+    # Construct the path relative to the current file's directory (__dir__)
+    # Go up three levels to the project root, then into integ-tests/baml_src
+    baml_src_dir = File.expand_path('../../../integ-tests/baml_src', __dir__)
+    Baml::Ffi::BamlRuntime.from_directory(baml_src_dir, {})
     # assert_equal(baml.always_error("input"), "0.1.0")
-
   end
 end
 

--- a/engine/language_client_ruby/test/sorbet_test.rb
+++ b/engine/language_client_ruby/test/sorbet_test.rb
@@ -28,7 +28,7 @@ end
 module Baml
   module Serializable
     def serialize
-      Baml::Ffi::serialize(Baml::Types, self)
+      Baml::Ffi::serialize(Baml::Types, Baml::Types, false, self)
     end
   end
 


### PR DESCRIPTION
`baml` gem now supports ruby 3.4

1. Update runtime_test.rb to find integ-tests relative to file instead of hardcoded path.
2. Update github workflow to include ruby 3.4. Currently suffers from the same pinning issue, will follow up with another PR to have it be unpinned to 3.4. But at least this unblocks ruby 3.4.
3. bump Gemfile.lock to latest baml gem
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for Ruby 3.4 in `baml` gem by updating GitHub workflow, test paths, and `Gemfile.lock`.
> 
>   - **Ruby 3.4 Support**:
>     - Update `.github/workflows/build-ruby-release.reusable.yaml` to include Ruby 3.4 in the build matrix.
>     - Modify `runtime_test.rb` to use relative paths for `integ-tests` directory.
>   - **Gem Updates**:
>     - Update `Gemfile.lock` to latest `baml` gem version.
>   - **Misc**:
>     - Adjust `serialize` method in `sorbet_test.rb` to include additional parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ddd2873b4d4716f6d6884dcae582bc42411ec168. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->