### PR TITLE
fix: make vscode proxy work again

### DIFF
--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
@@ -29,28 +29,19 @@ import { motion } from 'motion/react'
 
 const envVarVisibilityAtom = atom<Record<string, boolean>>({})
 
-const REQUIRED_ENV_VAR_UNSET_WARNING = 'Your BAML clients may fail if this is not set'
+const REQUIRED_ENV_VAR_UNSET_WARNING = 'Clients may fail if this is not set'
 
-interface EnvVarEntry {
-  key: string
-  value: string | undefined
-  required: boolean
-  hidden: boolean
-}
-
-const renderedEnvVarsAtom = atom<EnvVarEntry[]>((get) => {
-  const envVars = get(envVarsAtom) as Record<string, string>
+const renderedEnvVarsAtom = atom((get) => {
+  const envVars = get(envVarsAtom)
   const requiredEnvVars = get(requiredEnvVarsAtom)
   const visibility = get(envVarVisibilityAtom)
 
-  const vars: EnvVarEntry[] = Object.entries(envVars)
-    .filter(([key]) => key !== 'BOUNDARY_PROXY_URL')
-    .map(([key, value]) => ({
-      key,
-      value,
-      required: requiredEnvVars.includes(key),
-      hidden: visibility[key] !== false, // hidden by default unless explicitly set to false
-    }))
+  const vars = Object.entries(envVars).map(([key, value]) => ({
+    key,
+    value,
+    required: requiredEnvVars.includes(key),
+    hidden: visibility[key] !== false, // hidden by default unless explicitly set to false
+  }))
 
   const missingVars = requiredEnvVars.filter((envVar) => !(envVar in envVars))
 
@@ -96,41 +87,7 @@ const unescapeValue = (value: string): string => {
   })
 }
 
-function EnvVarStatus({ value, required }: { value?: string; required: boolean }) {
-  if (!value || value === '') {
-    return (
-      <TooltipProvider delayDuration={300}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <AlertTriangle className='h-4 w-4 text-orange-500 flex-shrink-0' />
-          </TooltipTrigger>
-          <TooltipContent side='top' className='text-xs'>
-            {value ? 'Click to edit' : REQUIRED_ENV_VAR_UNSET_WARNING}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    )
-  }
-
-  if (required) {
-    return (
-      <TooltipProvider delayDuration={300}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Check className='h-4 w-4 text-green-500 flex-shrink-0' />
-          </TooltipTrigger>
-          <TooltipContent side='top' className='text-xs'>
-            Used by one of your BAML clients
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
-    )
-  }
-
-  return <div />
-}
-
-export const EnvironmentVariablesPanel: React.FC = () => {
+export default function EnvVariablesManager() {
   const envVars = useAtomValue(renderedEnvVarsAtom)
   const setEnvVars = useSetAtom(envVarsAtom)
   const setVisibility = useSetAtom(envVarVisibilityAtom)
@@ -246,6 +203,9 @@ export const EnvironmentVariablesPanel: React.FC = () => {
               VSCode proxy is <b>{proxySettings.proxyEnabled ? 'enabled' : 'disabled'}</b>
             </p>
             <Checkbox
+              // This is, under the hood, powered by a DAG of atoms derived from bamlConfig
+              // vscode.setProxySettings eventually updates the workspace setting baml.enablePlaygroundProxy
+              // In WebviewPanelHost, we listen for changes to baml settings and push them into the bamlConfig atom
               checked={proxySettings.proxyEnabled}
               onCheckedChange={() => {
                 vscode.setProxySettings(!proxySettings.proxyEnabled)
@@ -259,84 +219,99 @@ export const EnvironmentVariablesPanel: React.FC = () => {
       <div className='space-y-1'>
         <table className='w-full'>
           <tbody>
-            {envVars.map((env, index) => (
-              <motion.tr
-                initial={{ opacity: 0, y: 2 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: index * 0.001, duration: 0.05 }}
-                key={env.key}
-                className='relative hover:bg-accent/50 rounded-md'
-              >
-                <td className='pl-2 pr-0.5 py-0.5'>
-                  <div className='flex items-center gap-2 justify-between'>
-                    <code className='font-mono text-xs text-muted-foreground'>{env.key}</code>
-                    <EnvVarStatus value={env.value} required={env.required} />
-                  </div>
-                </td>
-                <td className='px-0.5 py-0.5'>
-                  <TooltipProvider key={env.key} delayDuration={300}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Input
-                          type={env.hidden ? 'password' : 'text'}
-                          value={typeof env.value === 'string' ? escapeValue(env.value) : ''}
-                          onChange={(e) => updateEnvVar(index, unescapeValue(e.target.value))}
-                          className='h-6 text-xs font-mono placeholder:font-sans min-w-32'
-                          placeholder={env.required && !env.value ? '<unset>' : undefined}
-                          autoComplete='off'
-                          data-1p-ignore
-                        />
-                      </TooltipTrigger>
-                      <TooltipContent side='top' className='text-xs'>
-                        {env.value ? 'Click to edit' : REQUIRED_ENV_VAR_UNSET_WARNING}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                </td>
-                <td className='pl-0.5 pr-2 py-0.5 text-right'>
-                  <div className='flex gap-1 justify-end'>
-                    <TooltipProvider delayDuration={300}>
+            {envVars
+              .filter(({ key }) => key !== 'BOUNDARY_PROXY_URL')
+              .map((env, index) => (
+                <motion.tr
+                  initial={{ opacity: 0, y: 2 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ delay: index * 0.001, duration: 0.05 }}
+                  key={env.key}
+                  className='relative hover:bg-accent/50 rounded-md'
+                >
+                  <td className='pl-2 pr-0.5 py-0.5'>
+                    <div className='flex items-center gap-2 justify-between'>
+                      <code className='font-mono text-xs text-muted-foreground'>{env.key}</code>
+                      {!env.value || env.value === '' ? (
+                        <TooltipProvider key={env.key} delayDuration={300}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <AlertTriangle className='h-4 w-4 text-orange-500 flex-shrink-0' />
+                            </TooltipTrigger>
+                            <TooltipContent side='top' className='text-xs'>
+                              {env.value ? 'Click to edit' : REQUIRED_ENV_VAR_UNSET_WARNING}
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
+                      ) : (
+                        <div />
+                      )}
+                    </div>
+                  </td>
+                  <td className='px-0.5 py-0.5'>
+                    <TooltipProvider key={env.key} delayDuration={300}>
                       <Tooltip>
                         <TooltipTrigger asChild>
-                          <Button
-                            variant='ghost'
-                            size='sm'
-                            className='p-0.5 w-5 h-5'
-                            onClick={() => toggleVisibility(index)}
-                          >
-                            {env.hidden ? (
-                              <EyeOff className='w-4 h-4 text-muted-foreground hover:text-primary' />
-                            ) : (
-                              <Eye className='w-4 h-4 text-muted-foreground hover:text-primary' />
-                            )}
-                          </Button>
+                          <Input
+                            type={env.hidden ? 'password' : 'text'}
+                            value={typeof env.value === 'string' ? escapeValue(env.value) : ''}
+                            onChange={(e) => updateEnvVar(index, unescapeValue(e.target.value))}
+                            className='h-6 text-xs font-mono placeholder:font-sans'
+                            placeholder={env.required && !env.value ? '<unset>' : undefined}
+                            autoComplete='off'
+                            data-1p-ignore
+                          />
                         </TooltipTrigger>
                         <TooltipContent side='top' className='text-xs'>
-                          {env.hidden ? 'Click to show value' : 'Click to hide value'}
+                          {env.value ? 'Click to edit' : REQUIRED_ENV_VAR_UNSET_WARNING}
                         </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
-                    <TooltipProvider delayDuration={300}>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <Button
-                            variant='ghost'
-                            size='sm'
-                            className='p-0.5 w-5 h-5'
-                            onClick={() => deleteEnvVar(index)}
-                          >
-                            <Trash2 className='w-4 h-4 text-muted-foreground hover:text-destructive' />
-                          </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side='top' className='text-xs'>
-                          Delete environment variable
-                        </TooltipContent>
-                      </Tooltip>
-                    </TooltipProvider>
-                  </div>
-                </td>
-              </motion.tr>
-            ))}
+                  </td>
+                  <td className='pl-0.5 pr-2 py-0.5 text-right'>
+                    <div className='flex gap-1 justify-end'>
+                      <TooltipProvider delayDuration={300}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant='ghost'
+                              size='sm'
+                              className='p-0.5 w-5 h-5'
+                              onClick={() => toggleVisibility(index)}
+                            >
+                              {env.hidden ? (
+                                <EyeOff className='w-4 h-4 text-muted-foreground hover:text-primary' />
+                              ) : (
+                                <Eye className='w-4 h-4 text-muted-foreground hover:text-primary' />
+                              )}
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side='top' className='text-xs'>
+                            {env.hidden ? 'Click to show value' : 'Click to hide value'}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                      <TooltipProvider delayDuration={300}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              variant='ghost'
+                              size='sm'
+                              className='p-0.5 w-5 h-5'
+                              onClick={() => deleteEnvVar(index)}
+                            >
+                              <Trash2 className='w-4 h-4 text-muted-foreground hover:text-destructive' />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side='top' className='text-xs'>
+                            Delete environment variable
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    </div>
+                  </td>
+                </motion.tr>
+              ))}
             <motion.tr
               initial={{ opacity: 0, y: 2 }}
               animate={{ opacity: 1, y: 0 }}
@@ -402,18 +377,5 @@ export const EnvironmentVariablesPanel: React.FC = () => {
         </DialogContent>
       </Dialog>
     </div>
-  )
-}
-
-export const EnvironmentVariablesDialog: React.FC<{
-  showEnvDialog: boolean
-  setShowEnvDialog: (show: boolean) => void
-}> = ({ showEnvDialog, setShowEnvDialog }) => {
-  return (
-    <Dialog open={showEnvDialog} onOpenChange={setShowEnvDialog}>
-      <DialogContent className='mt-12 max-h-[80vh] overflow-y-auto sm:max-w-none w-fit'>
-        <EnvironmentVariablesPanel />
-      </DialogContent>
-    </Dialog>
   )
 }

--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/side-bar/env-vars.tsx
@@ -29,14 +29,21 @@ import { motion } from 'motion/react'
 
 const envVarVisibilityAtom = atom<Record<string, boolean>>({})
 
-const REQUIRED_ENV_VAR_UNSET_WARNING = 'Clients may fail if this is not set'
+const REQUIRED_ENV_VAR_UNSET_WARNING = 'Your BAML clients may fail if this is not set'
 
-const renderedEnvVarsAtom = atom((get) => {
-  const envVars = get(envVarsAtom)
+interface EnvVarEntry {
+  key: string
+  value: string | undefined
+  required: boolean
+  hidden: boolean
+}
+
+const renderedEnvVarsAtom = atom<EnvVarEntry[]>((get) => {
+  const envVars = get(envVarsAtom) as Record<string, string>
   const requiredEnvVars = get(requiredEnvVarsAtom)
   const visibility = get(envVarVisibilityAtom)
 
-  const vars = Object.entries(envVars).map(([key, value]) => ({
+  const vars: EnvVarEntry[] = Object.entries(envVars).map(([key, value]) => ({
     key,
     value,
     required: requiredEnvVars.includes(key),
@@ -87,7 +94,41 @@ const unescapeValue = (value: string): string => {
   })
 }
 
-export default function EnvVariablesManager() {
+function EnvVarStatus({ value, required }: { value?: string; required: boolean }) {
+  if (!value || value === '') {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <AlertTriangle className='h-4 w-4 text-orange-500 flex-shrink-0' />
+          </TooltipTrigger>
+          <TooltipContent side='top' className='text-xs'>
+            {value ? 'Click to edit' : REQUIRED_ENV_VAR_UNSET_WARNING}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
+
+  if (required) {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Check className='h-4 w-4 text-green-500 flex-shrink-0' />
+          </TooltipTrigger>
+          <TooltipContent side='top' className='text-xs'>
+            Used by one of your BAML clients
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    )
+  }
+
+  return <div />
+}
+
+export const EnvironmentVariablesPanel: React.FC = () => {
   const envVars = useAtomValue(renderedEnvVarsAtom)
   const setEnvVars = useSetAtom(envVarsAtom)
   const setVisibility = useSetAtom(envVarVisibilityAtom)
@@ -203,9 +244,6 @@ export default function EnvVariablesManager() {
               VSCode proxy is <b>{proxySettings.proxyEnabled ? 'enabled' : 'disabled'}</b>
             </p>
             <Checkbox
-              // This is, under the hood, powered by a DAG of atoms derived from bamlConfig
-              // vscode.setProxySettings eventually updates the workspace setting baml.enablePlaygroundProxy
-              // In WebviewPanelHost, we listen for changes to baml settings and push them into the bamlConfig atom
               checked={proxySettings.proxyEnabled}
               onCheckedChange={() => {
                 vscode.setProxySettings(!proxySettings.proxyEnabled)
@@ -232,20 +270,7 @@ export default function EnvVariablesManager() {
                   <td className='pl-2 pr-0.5 py-0.5'>
                     <div className='flex items-center gap-2 justify-between'>
                       <code className='font-mono text-xs text-muted-foreground'>{env.key}</code>
-                      {!env.value || env.value === '' ? (
-                        <TooltipProvider key={env.key} delayDuration={300}>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <AlertTriangle className='h-4 w-4 text-orange-500 flex-shrink-0' />
-                            </TooltipTrigger>
-                            <TooltipContent side='top' className='text-xs'>
-                              {env.value ? 'Click to edit' : REQUIRED_ENV_VAR_UNSET_WARNING}
-                            </TooltipContent>
-                          </Tooltip>
-                        </TooltipProvider>
-                      ) : (
-                        <div />
-                      )}
+                      <EnvVarStatus value={env.value} required={env.required} />
                     </div>
                   </td>
                   <td className='px-0.5 py-0.5'>
@@ -256,7 +281,7 @@ export default function EnvVariablesManager() {
                             type={env.hidden ? 'password' : 'text'}
                             value={typeof env.value === 'string' ? escapeValue(env.value) : ''}
                             onChange={(e) => updateEnvVar(index, unescapeValue(e.target.value))}
-                            className='h-6 text-xs font-mono placeholder:font-sans'
+                            className='h-6 text-xs font-mono placeholder:font-sans min-w-32'
                             placeholder={env.required && !env.value ? '<unset>' : undefined}
                             autoComplete='off'
                             data-1p-ignore
@@ -377,5 +402,18 @@ export default function EnvVariablesManager() {
         </DialogContent>
       </Dialog>
     </div>
+  )
+}
+
+export const EnvironmentVariablesDialog: React.FC<{
+  showEnvDialog: boolean
+  setShowEnvDialog: (show: boolean) => void
+}> = ({ showEnvDialog, setShowEnvDialog }) => {
+  return (
+    <Dialog open={showEnvDialog} onOpenChange={setShowEnvDialog}>
+      <DialogContent className='mt-12 max-h-[80vh] overflow-y-auto sm:max-w-none w-fit'>
+        <EnvironmentVariablesPanel />
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/typescript/vscode-ext/packages/vscode/src/panels/WebviewPanelHost.ts
+++ b/typescript/vscode-ext/packages/vscode/src/panels/WebviewPanelHost.ts
@@ -355,7 +355,9 @@ export class WebviewPanelHost {
             ;(async () => {
               try {
                 const profile = vscodeMessage.profile
-                const credentialProvider = fromIni({ profile: profile ?? undefined })
+                const credentialProvider = fromIni({
+                  profile: profile ?? undefined,
+                })
                 const awsCreds = await credentialProvider()
                 this._panel.webview.postMessage({
                   rpcId: message.rpcId,

--- a/typescript/vscode-ext/packages/vscode/src/panels/WebviewPanelHost.ts
+++ b/typescript/vscode-ext/packages/vscode/src/panels/WebviewPanelHost.ts
@@ -27,6 +27,7 @@ import { dirname, join } from 'path'
 import * as dotenv from 'dotenv'
 import * as fs from 'fs'
 import { AwsCredentialIdentity } from '@smithy/types'
+import { refreshBamlConfigSingleton } from '../plugins/language-server/bamlConfig'
 // import { CredentialsProviderError } from '@aws-sdk/credential-providers'
 const customConfig: Config = {
   dictionaries: [adjectives, colors, animals],
@@ -198,6 +199,8 @@ export class WebviewPanelHost {
    * @param context A reference to the extension context
    */
   private _setWebviewMessageListener(webview: Webview) {
+    console.log('_setWebviewMessageListener')
+
     const addProject = async () => {
       await requestDiagnostics()
       console.log('last opened func', openPlaygroundConfig.lastOpenedFunction)
@@ -208,6 +211,12 @@ export class WebviewPanelHost {
       this.postMessage('baml_cli_version', bamlConfig.cliVersion)
       this.postMessage('baml_settings_updated', bamlConfig)
     }
+
+    vscode.workspace.onDidChangeConfiguration((event) => {
+      if (event.affectsConfiguration('baml')) {
+        this.postMessage('baml_settings_updated', refreshBamlConfigSingleton())
+      }
+    })
 
     webview.onDidReceiveMessage(
       async (
@@ -346,9 +355,7 @@ export class WebviewPanelHost {
             ;(async () => {
               try {
                 const profile = vscodeMessage.profile
-                const credentialProvider = fromIni({
-                  profile: profile ?? undefined,
-                })
+                const credentialProvider = fromIni({ profile: profile ?? undefined })
                 const awsCreds = await credentialProvider()
                 this._panel.webview.postMessage({
                   rpcId: message.rpcId,

--- a/typescript/vscode-ext/packages/vscode/src/plugins/language-server/bamlConfig.ts
+++ b/typescript/vscode-ext/packages/vscode/src/plugins/language-server/bamlConfig.ts
@@ -18,17 +18,18 @@ export const bamlConfigSchema = z
   .partial()
 type BamlConfig = z.infer<typeof bamlConfigSchema>
 
-export const bamlConfig: { config: BamlConfig | null; cliVersion: string | null } = {
+export const BAML_CONFIG_SINGLETON: { config: BamlConfig | null; cliVersion: string | null } = {
   config: null,
   cliVersion: null,
 }
 
-export const getConfig = () => {
+export const refreshBamlConfigSingleton = () => {
   try {
     console.log('getting config')
     const configResponse = workspace.getConfiguration('baml')
     console.log('configResponse ' + JSON.stringify(configResponse, null, 2))
-    bamlConfig.config = bamlConfigSchema.parse(configResponse)
+    BAML_CONFIG_SINGLETON.config = bamlConfigSchema.parse(configResponse)
+    return BAML_CONFIG_SINGLETON
   } catch (e: any) {
     if (e instanceof Error) {
       console.log('Error getting config' + e.message + ' ' + e.stack)

--- a/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
+++ b/typescript/vscode-ext/packages/vscode/src/plugins/language-server/index.ts
@@ -23,9 +23,9 @@ import type { BamlVSCodePlugin } from '../types'
 import { URI } from 'vscode-uri'
 import StatusBarPanel from '../../panels/StatusBarPanel'
 import { getCurrentOpenedFile } from '../../helpers/get-open-file'
-import { bamlConfig, getConfig } from './bamlConfig'
+import { BAML_CONFIG_SINGLETON, refreshBamlConfigSingleton } from './bamlConfig'
 
-export { bamlConfig }
+export { BAML_CONFIG_SINGLETON as bamlConfig }
 const packageJson = require('../../../../package.json') // eslint-disable-line
 let clientReady = false
 
@@ -62,7 +62,7 @@ export const requestBamlCLIVersion = async () => {
       return
     }
     console.log('Got BAML CLI version', version)
-    bamlConfig.cliVersion = version as string
+    BAML_CONFIG_SINGLETON.cliVersion = version as string
   } catch (e) {
     console.error('Failed to get BAML CLI version', e)
   }
@@ -136,7 +136,7 @@ const activateClient = (
   serverOptions: ServerOptions,
   clientOptions: LanguageClientOptions,
 ) => {
-  getConfig()
+  refreshBamlConfigSingleton()
   console.log('Starting language server with options', JSON.stringify(serverOptions, null, 2))
 
   // Create the language client
@@ -236,11 +236,11 @@ const activateClient = (
         }
       })
 
-      client.onRequest('baml_settings_updated', (config: typeof bamlConfig) => {
+      client.onRequest('baml_settings_updated', (config: typeof BAML_CONFIG_SINGLETON) => {
         console.log('baml_settings_updated', config)
-        bamlConfig.config = config.config
-        bamlConfig.cliVersion = config.cliVersion
-        WebviewPanelHost.currentPanel?.postMessage('baml_settings_updated', bamlConfig)
+        BAML_CONFIG_SINGLETON.config = config.config
+        BAML_CONFIG_SINGLETON.cliVersion = config.cliVersion
+        WebviewPanelHost.currentPanel?.postMessage('baml_settings_updated', BAML_CONFIG_SINGLETON)
       })
 
       // Handler for both notifications and requests of type "runtime_updated".
@@ -279,11 +279,11 @@ const activateClient = (
         handleRuntimeUpdated(params)
       })
 
-      client.onRequest('baml_settings_updated', (config: typeof bamlConfig) => {
+      client.onRequest('baml_settings_updated', (config: typeof BAML_CONFIG_SINGLETON) => {
         console.log('baml_settings_updated', config)
-        bamlConfig.config = config.config
-        bamlConfig.cliVersion = config.cliVersion
-        WebviewPanelHost.currentPanel?.postMessage('baml_settings_updated', bamlConfig)
+        BAML_CONFIG_SINGLETON.config = config.config
+        BAML_CONFIG_SINGLETON.cliVersion = config.cliVersion
+        WebviewPanelHost.currentPanel?.postMessage('baml_settings_updated', BAML_CONFIG_SINGLETON)
       })
 
       // this will fail otherwise in dev mode if the config where the baml path is hasnt been picked up yet. TODO: pass the config to the server to avoid this.


### PR DESCRIPTION
Clicking the "proxy enabled" toggle in vscode playground settings propagates the change to vscode workspace settings baml.enablePlaygroundProxy correctly, but the other direction used to be indirectly through the language-server. Since that language-server has now been rewritten in Rust, we need a new way to sync that setting change back into the webview.

In addition, BOUNDARY_PROXY_URL was not being managed correctly in the env vars panel: it was being filtered from the actual set settings, instead of just being filtered from the UI.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes VSCode proxy setting sync and corrects `BOUNDARY_PROXY_URL` handling in environment variables UI.
> 
>   - **Behavior**:
>     - Syncs `baml.enablePlaygroundProxy` setting directly in `WebviewPanelHost.ts` using `vscode.workspace.onDidChangeConfiguration`.
>     - Filters `BOUNDARY_PROXY_URL` from UI display in `env-vars.tsx`, but not from actual settings.
>   - **Configuration**:
>     - Replaces `bamlConfig` with `BAML_CONFIG_SINGLETON` in `bamlConfig.ts` and `index.ts`.
>     - Adds `refreshBamlConfigSingleton()` to update configuration in `bamlConfig.ts` and `WebviewPanelHost.ts`.
>   - **Misc**:
>     - Renames `bamlConfig` to `BAML_CONFIG_SINGLETON` in `index.ts` and `bamlConfig.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for fc19571fc8c0c23d0a78c434c163cd97260b328d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->