### PR TITLE
Superficial streaming for workflows

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -171,10 +171,6 @@ impl WithRepr<ExprFunction> for ExprFnWalker<'_> {
     }
 }
 
-fn weird_default() -> FieldType {
-    FieldType::Primitive(TypeValue::Null)
-}
-
 impl WithRepr<Function> for ExprFnWalker<'_> {
     fn repr(&self, db: &ParserDatabase) -> Result<Function> {
         // TODO: Drop weird default (replace by better validation).
@@ -626,10 +622,10 @@ impl IntermediateRepr {
         repr.retry_policies
             .sort_by(|a, b| a.elem.name.0.cmp(&b.elem.name.0));
 
-        // TODO: Necessary?
+        let mut typing_context = initial_typing_context(&repr);
         for expr_fn in repr.expr_fns.iter_mut() {
             let expr = expr_fn.elem.expr.clone();
-            let inferred_expr = infer_types_in_context(&mut HashMap::new(), Arc::new(expr));
+            let inferred_expr = infer_types_in_context(&mut typing_context, Arc::new(expr));
             expr_fn.elem.expr = Arc::unwrap_or_clone(inferred_expr);
         }
 
@@ -1562,10 +1558,6 @@ impl ExprFunction {
                             annotate_variable(target, r#type.clone(), body)
                         });
                 let res = Expr::Lambda(*arity, Arc::new(new_body), meta.clone());
-                eprintln!(
-                    "ASSIGN_PARAM_TYPES_TO_BODY_VARIABLES input:\n{:?}\nresult:\n{:?}",
-                    self.expr, res
-                );
                 res
             }
             // TODO: Handle other cases - traverse the tree.
@@ -2139,6 +2131,13 @@ pub fn initial_context(ir: &IntermediateRepr) -> HashMap<Name, Expr<ExprMetadata
         );
     }
     ctx
+}
+
+pub fn initial_typing_context(ir: &IntermediateRepr) -> HashMap<Name, FieldType> {
+    let ctx = initial_context(ir);
+    ctx.into_iter()
+        .filter_map(|(name, expr)| expr.meta().1.as_ref().map(|t| (name, t.clone())))
+        .collect()
 }
 
 #[cfg(test)]

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
@@ -157,95 +157,18 @@ pub fn typecheck_in_context(
                     }
                 }
                 x => {
-                    eprintln!("TYPECHECKING APP: UNEXPECTED ARGS: {:?} {:?}", f, x);
+                    eprintln!(
+                        "TYPECHECKING APP: UNEXPECTED ARGS: ({}: {:?} ) {:?}",
+                        f.dump_str(),
+                        f.meta()
+                            .1
+                            .as_ref()
+                            .map_or("?".to_string(), |t| t.to_string()),
+                        x
+                    );
                 }
             }
             Ok(())
-
-            // TODO: What was this? Bring it back?
-            // match (f.as_ref(), xs.as_ref(), maybe_app_type) {
-            //     (
-            //         _, // Expr::Lambda(params, body, (lambda_span, _)),
-            //         Expr::ArgsTuple(args, (args_span, args_type)),
-            //         _,
-            //     ) => {
-            //         // First, check that the arguments are the right type
-            //         // for the lambda.
-            //         let maybe_lambda_type= &f.meta().1;
-            //         eprintln!("LAMBDA_TYPE: {:?}", maybe_lambda_type);
-            //         if let Some(lambda_type) = maybe_lambda_type {
-            //             eprintln!("checking lambda_type: {:?}", lambda_type);
-            //             match lambda_type {
-            //                 ExprType::Arrow(arrow) => {
-            //                     if let Some(app_type) = maybe_app_type {
-
-            //                         if !compatible_as_subtype(
-            //                             ir,
-            //                             &maybe_app_type,
-            //                             &Some(arrow.body_type.clone()),
-            //                         ) {
-            //                             eprintln!(
-            //                                 "C Type mismatch in app: {} vs {}",
-            //                                 app_type.dump_str(),
-            //                                 arrow.body_type.dump_str()
-            //                             );
-            //                             diagnostics.push_error(DatamodelError::new_validation_error(
-            //                                 &format!(
-            //                                     "D Type mismatch in app: {} vs {}",
-            //                                     app_type.dump_str(),
-            //                                     arrow.body_type.dump_str()
-            //                                 ),
-            //                                 span.clone(),
-            //                             ));
-            //                         }
-            //                     }
-            //                     for (param_type, arg) in arrow.param_types.iter().zip(args.iter()) {
-            //                         eprintln!("TYPECHECKING APP COMPARING PARAMTYPE: {:?} vs ARG: {:?}", param_type, arg);
-            //                         if !compatible_as_subtype(
-            //                             ir,
-            //                             &arg.meta().1,
-            //                             &Some(param_type.clone()),
-            //                         ) {
-            //                             eprintln!(
-            //                                 "E Type mismatch in app: {} vs {}",
-            //                                 arg.meta()
-            //                                     .1
-            //                                     .as_ref()
-            //                                     .map_or("?".to_string(), |t| t.dump_str()),
-            //                                 param_type.dump_str()
-            //                             );
-            //                             diagnostics.push_error(
-            //                                 DatamodelError::new_validation_error(
-            //                                     &format!(
-            //                                         "F Type mismatch in app: {} vs {}",
-            //                                         arg.meta()
-            //                                             .1
-            //                                             .as_ref()
-            //                                             .map_or("?".to_string(), |t| t.dump_str()),
-            //                                         param_type.dump_str()
-            //                                     ),
-            //                                     span.clone(),
-            //                                 ),
-            //                             );
-            //                         }
-            //                     }
-            //                 }
-            //                 ExprType::Atom(_) => {
-            //                     diagnostics.push_error(DatamodelError::new_validation_error(
-            //                         "Expected a function type",
-            //                         span.clone(),
-            //                     ));
-            //                 }
-            //             }
-            //         }
-
-            //         typecheck_in_context(ir, diagnostics, &inner_context, body)?;
-
-            //         Ok(())
-            //     }
-            //     _ => Ok(()),
-            // }
-            // Applications typecheck if the function arguments
         }
         Expr::Let(let_expr, _, _, _) => Ok(()),
         Expr::ArgsTuple(args, _) => Ok(()),
@@ -458,7 +381,66 @@ pub fn infer_types_in_context(
                 (span.clone(), maybe_type.clone()),
             ))
         }
-        _ => expr.clone(),
+        Expr::List(items, (span, maybe_type)) => {
+            let new_items = items
+                .iter()
+                .map(|item| {
+                    Arc::unwrap_or_clone(infer_types_in_context(
+                        typing_context,
+                        Arc::new(item.clone()),
+                    ))
+                })
+                .collect();
+            Arc::new(Expr::List(new_items, (span.clone(), maybe_type.clone())))
+        }
+        Expr::Map(items, (span, maybe_type)) => {
+            let new_items = items
+                .iter()
+                .map(|(key, value)| {
+                    (
+                        key.clone(),
+                        Arc::unwrap_or_clone(infer_types_in_context(
+                            typing_context,
+                            Arc::new(value.clone()),
+                        )),
+                    )
+                })
+                .collect();
+            Arc::new(Expr::Map(new_items, (span.clone(), maybe_type.clone())))
+        }
+        Expr::ClassConstructor {
+            name,
+            fields,
+            spread,
+            meta,
+        } => {
+            let new_fields = fields
+                .iter()
+                .map(|(name, value)| {
+                    (
+                        name.clone(),
+                        Arc::unwrap_or_clone(infer_types_in_context(
+                            typing_context,
+                            Arc::new(value.clone()),
+                        )),
+                    )
+                })
+                .collect();
+            let new_spread = spread.as_ref().map(|s| {
+                Box::new(Arc::unwrap_or_clone(infer_types_in_context(
+                    typing_context,
+                    Arc::new(s.as_ref().clone()),
+                )))
+            });
+            Arc::new(Expr::ClassConstructor {
+                name: name.clone(),
+                fields: new_fields,
+                spread: new_spread,
+                meta: meta.clone(),
+            })
+        }
+        Expr::LLMFunction(llm_function, args, (span, maybe_type)) => expr.clone(),
+        Expr::BoundVar(_, _) => expr.clone(),
     }
 }
 

--- a/engine/baml-runtime/src/eval_expr.rs
+++ b/engine/baml-runtime/src/eval_expr.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use crate::{BamlRuntime, FunctionResult};
 use baml_types::expr::{Expr, ExprMetadata, Name, VarIndex};
-use baml_types::Arrow;
+use baml_types::{Arrow, FieldType, TypeValue};
 use baml_types::{BamlMap, BamlValue, BamlValueWithMeta};
 use internal_baml_core::ir::repr::IntermediateRepr;
 
@@ -32,7 +32,7 @@ impl<'a> EvalEnv<'a> {
 }
 
 /// Substitute val for var_name in expr.
-fn subst2<'a>(
+fn subst<'a>(
     expr: &Expr<ExprMetadata>,
     var_name: &VarIndex,
     val: &Expr<ExprMetadata>,
@@ -49,26 +49,26 @@ fn subst2<'a>(
         Expr::FreeVar(name, _) => Ok(expr.clone()),
         Expr::Atom(_) => Ok(expr.clone()),
         Expr::App(f, x, meta) => {
-            let f2 = subst2(f, var_name, val, env)?;
-            let x2 = subst2(x, var_name, val, env)?;
+            let f2 = subst(f, var_name, val, env)?;
+            let x2 = subst(x, var_name, val, env)?;
             Ok(Expr::App(Arc::new(f2), Arc::new(x2), meta.clone()))
         }
         Expr::Lambda(params, body, meta) => Ok(Expr::Lambda(
             params.clone(),
-            Arc::new(subst2(body, var_name, val, env)?),
+            Arc::new(subst(body, var_name, val, env)?),
             meta.clone(),
         )),
         Expr::ArgsTuple(args, meta) => {
             let mut new_args = Vec::new();
             for arg in args {
-                new_args.push(subst2(arg, var_name, val, env)?);
+                new_args.push(subst(arg, var_name, val, env)?);
             }
             Ok(Expr::ArgsTuple(new_args, meta.clone()))
         }
         Expr::LLMFunction(_, _, _) => Ok(expr.clone()),
         Expr::Let(name, value, body, meta) => {
-            let new_value = subst2(value, var_name, val, env)?;
-            let new_body = subst2(body, var_name, val, env)?;
+            let new_value = subst(value, var_name, val, env)?;
+            let new_body = subst(body, var_name, val, env)?;
             Ok(Expr::Let(
                 name.clone(),
                 Arc::new(new_value),
@@ -79,7 +79,7 @@ fn subst2<'a>(
         Expr::List(items, meta) => {
             let new_items = items
                 .iter()
-                .map(|item| subst2(item, var_name, val, env))
+                .map(|item| subst(item, var_name, val, env))
                 .collect::<anyhow::Result<Vec<_>>>()?;
             Ok(Expr::List(new_items, meta.clone()))
         }
@@ -87,7 +87,7 @@ fn subst2<'a>(
             let new_items = items
                 .iter()
                 .map(|(key, value)| {
-                    let new_value = subst2(value, var_name, val, env)?;
+                    let new_value = subst(value, var_name, val, env)?;
                     Ok((key.clone(), new_value))
                 })
                 .collect::<anyhow::Result<BamlMap<_, _>>>()?;
@@ -102,14 +102,14 @@ fn subst2<'a>(
             let new_fields = fields
                 .iter()
                 .map(|(key, value)| {
-                    let new_value = subst2(value, var_name, val, env)?;
+                    let new_value = subst(value, var_name, val, env)?;
                     Ok((key.clone(), new_value))
                 })
                 .collect::<anyhow::Result<BamlMap<_, _>>>()?;
             let new_spread = spread
                 .as_ref()
                 .map(|spread| {
-                    subst2(spread, var_name, val, env).map(|spread| Box::new(spread.clone()))
+                    subst(spread, var_name, val, env).map(|spread| Box::new(spread.clone()))
                 })
                 .transpose()?;
             Ok(Expr::ClassConstructor {
@@ -129,12 +129,13 @@ fn subst2<'a>(
 async fn beta_reduce<'a>(
     env: &EvalEnv<'a>,
     expr: &Expr<ExprMetadata>,
+    eval_final_llm_fn: bool,
 ) -> anyhow::Result<Expr<ExprMetadata>> {
     match expr {
         Expr::Atom(_) => Ok(expr.clone()),
         Expr::Let(name, value, body, meta) => {
             // First evaluate the bound expression
-            let evaluated_value = Box::pin(beta_reduce(env, value)).await?;
+            let evaluated_value = Box::pin(beta_reduce(env, value, eval_final_llm_fn)).await?;
 
             // Then substitute the evaluated value into the body
             let target = VarIndex {
@@ -142,84 +143,80 @@ async fn beta_reduce<'a>(
                 tuple: 0,
             };
             let closed_body = body.close(&target, name);
-            let substituted_body = subst2(&closed_body, &target, &evaluated_value, env)?;
+            let substituted_body = subst(&closed_body, &target, &evaluated_value, env)?;
 
             // Finally evaluate the body with the substitution
-            Box::pin(beta_reduce(env, &substituted_body)).await
+            Box::pin(beta_reduce(env, &substituted_body, eval_final_llm_fn)).await
         }
-        Expr::App(f, x, meta) => {
-            match (f.as_ref(), x.as_ref()) {
-                (Expr::Lambda(arity, body, _), Expr::ArgsTuple(args, _)) => {
-                    let pairs: Vec<(VarIndex, Expr<ExprMetadata>)> = args
-                        .iter()
-                        .enumerate()
-                        .map(|(index, arg)| {
-                            (
-                                VarIndex {
-                                    de_bruijn: 0,
-                                    tuple: index as u32,
-                                },
-                                arg.clone(),
-                            )
-                        })
-                        .collect::<Vec<_>>();
-                    let new_body = pairs
-                        .iter()
-                        .fold(body.as_ref().clone(), |acc, (param, arg)| {
-                            subst2(&acc, &param, &arg, env).as_ref().unwrap().clone()
-                        });
-                    Box::pin(beta_reduce(env, &new_body)).await
+        Expr::App(f, x, meta) => match (f.as_ref(), x.as_ref()) {
+            (Expr::Lambda(arity, body, _), Expr::ArgsTuple(args, _)) => {
+                let pairs: Vec<(VarIndex, Expr<ExprMetadata>)> = args
+                    .iter()
+                    .enumerate()
+                    .map(|(index, arg)| {
+                        (
+                            VarIndex {
+                                de_bruijn: 0,
+                                tuple: index as u32,
+                            },
+                            arg.clone(),
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let new_body = pairs
+                    .iter()
+                    .fold(body.as_ref().clone(), |acc, (param, arg)| {
+                        subst(&acc, &param, &arg, env).as_ref().unwrap().clone()
+                    });
+                Box::pin(beta_reduce(env, &new_body, eval_final_llm_fn)).await
+            }
+            (Expr::Lambda(arity, body, _), arg) => {
+                let args = match arg {
+                    Expr::ArgsTuple(args, _) => args.clone(),
+                    x => vec![x.clone()],
+                };
+                let substitutions: Vec<(VarIndex, Expr<ExprMetadata>)> = args
+                    .iter()
+                    .enumerate()
+                    .map(|(index, arg)| {
+                        (
+                            VarIndex {
+                                de_bruijn: 0,
+                                tuple: index as u32,
+                            },
+                            arg.clone(),
+                        )
+                    })
+                    .collect();
+                let new_body = substitutions
+                    .iter()
+                    .fold(body.as_ref().clone(), |acc, (param, arg)| {
+                        subst(&acc, &param, &arg, env).as_ref().unwrap().clone()
+                    });
+                Box::pin(beta_reduce(env, &new_body, eval_final_llm_fn)).await
+            }
+            (Expr::LLMFunction(name, arg_names, _), Expr::ArgsTuple(args, _)) => {
+                let mut evaluated_args: Vec<BamlValue> = Vec::new();
+                for arg in args {
+                    let val = eval_to_value(env, arg).await;
+                    evaluated_args.push(val.unwrap().unwrap().clone().value());
                 }
-                (Expr::Lambda(arity, body, _), arg) => {
-                    let args = match arg {
-                        Expr::ArgsTuple(args, _) => args.clone(),
-                        x => vec![x.clone()],
-                    };
-                    let substitutions: Vec<(VarIndex, Expr<ExprMetadata>)> = args
-                        .iter()
-                        .enumerate()
-                        .map(|(index, arg)| {
-                            (
-                                VarIndex {
-                                    de_bruijn: 0,
-                                    tuple: index as u32,
-                                },
-                                arg.clone(),
-                            )
-                        })
-                        .collect();
-                    let new_body =
-                        substitutions
-                            .iter()
-                            .fold(body.as_ref().clone(), |acc, (param, arg)| {
-                                subst2(&acc, &param, &arg, env).as_ref().unwrap().clone()
-                            });
-                    Box::pin(beta_reduce(env, &new_body)).await
+
+                let params = evaluated_args
+                    .into_iter()
+                    .zip(arg_names.iter())
+                    .map(|(arg, name)| (name.clone(), arg))
+                    .collect::<HashMap<_, _>>();
+                let args_map = BamlMap::from_iter(params.into_iter());
+                let ctx = env
+                    .runtime
+                    .create_ctx_manager(BamlValue::String("none".to_string()), None);
+
+                let app_span = SerializedSpan::serialize(&expr.meta().0);
+                if let Some(tx) = &env.expr_tx {
+                    tx.unbounded_send(vec![app_span]).unwrap();
                 }
-                (Expr::LLMFunction(name, arg_names, _), Expr::ArgsTuple(args, _)) => {
-                    let mut evaluated_args: Vec<BamlValue> = Vec::new();
-                    for arg in args {
-                        let val = eval_to_value(env, arg).await;
-                        evaluated_args.push(val.unwrap().unwrap().clone().value());
-                    }
-
-                    let params = evaluated_args
-                        .into_iter()
-                        .zip(arg_names.iter())
-                        .map(|(arg, name)| (name.clone(), arg))
-                        .collect::<HashMap<_, _>>();
-                    let args_map = BamlMap::from_iter(params.into_iter());
-                    let ctx = env
-                        .runtime
-                        .create_ctx_manager(BamlValue::String("none".to_string()), None);
-
-                    let app_span = SerializedSpan::serialize(&expr.meta().0);
-                    if let Some(tx) = &env.expr_tx {
-                        tx.unbounded_send(vec![app_span]).unwrap();
-                    }
-                    // if let Some(tx) = &env.expr_tx {
-                    //     tx.unbounded_send(vec![]).unwrap();
-                    // }
+                if eval_final_llm_fn {
                     let res: anyhow::Result<FunctionResult> = env
                         .runtime
                         .call_function(name.clone(), &args_map, &ctx, None, None, None)
@@ -241,19 +238,21 @@ async fn beta_reduce<'a>(
                         .0
                         .map_meta(|_| ());
                     Ok(Expr::Atom(val.map_meta(|_| meta.clone())))
+                } else {
+                    Ok(expr.clone())
                 }
-                (Expr::FreeVar(name, _), _) => {
-                    let var_lookup = env
-                        .context
-                        .get(name)
-                        .context(format!("Variable not found: {:?}", name))?;
-                    let new_app = Expr::App(Arc::new(var_lookup.clone()), x.clone(), meta.clone());
-                    let res = Box::pin(beta_reduce(env, &new_app)).await?;
-                    Ok(res)
-                }
-                _ => Err(anyhow::anyhow!("Not a function: {:?}", f)),
             }
-        }
+            (Expr::FreeVar(name, _), _) => {
+                let var_lookup = env
+                    .context
+                    .get(name)
+                    .context(format!("Variable not found: {:?}", name))?;
+                let new_app = Expr::App(Arc::new(var_lookup.clone()), x.clone(), meta.clone());
+                let res = Box::pin(beta_reduce(env, &new_app, eval_final_llm_fn)).await?;
+                Ok(res)
+            }
+            _ => Err(anyhow::anyhow!("Not a function: {:?}", f)),
+        },
         Expr::FreeVar(name, _) => {
             if let Some(cached) = env.evaluated_cache.lock().unwrap().get(name) {
                 return Ok(cached.clone());
@@ -265,7 +264,7 @@ async fn beta_reduce<'a>(
                 .context(format!("Variable not found: {:?}", name))?;
 
             // Evaluate the expression
-            let evaluated = Box::pin(beta_reduce(env, var_lookup)).await?;
+            let evaluated = Box::pin(beta_reduce(env, var_lookup, eval_final_llm_fn)).await?;
 
             // Cache the result
             env.evaluated_cache
@@ -279,8 +278,159 @@ async fn beta_reduce<'a>(
         Expr::List(_, _) => Ok(expr.clone()),
         Expr::Map(_, _) => Ok(expr.clone()),
         Expr::ClassConstructor { .. } => Ok(expr.clone()),
-        _ => Err(anyhow::anyhow!("Not an application: {:?}", expr)),
+        Expr::ArgsTuple(_, _) => Ok(expr.clone()),
+        Expr::Lambda(_, _, _) => Ok(expr.clone()),
+        _ => panic!("Tried to beta reduce a {}", expr.dump_str()), // Err(anyhow::anyhow!("Not an application: {:?}", expr)),
     }
+}
+
+pub async fn eval_to_value_or_llm_call<'a>(
+    env: &EvalEnv<'a>,
+    expr: &Expr<ExprMetadata>,
+) -> anyhow::Result<ExprEvalResult> {
+    let mut current_expr = expr.clone();
+
+    eprintln!("start eval_to_value_or_llm_call:\n{:?}", expr.dump_str());
+    for steps in 0..MAX_STEPS {
+        eprintln!(
+            "loop eval_to_value_or_lm_call: n: {}, current_expr: {}",
+            steps,
+            current_expr.dump_str()
+        );
+        match current_expr {
+            Expr::App(ref f, ref args, ref meta) => match (f.as_ref(), args.as_ref()) {
+                (Expr::LLMFunction(name, arg_names, _), Expr::ArgsTuple(args, _)) => {
+                    let mut evaluated_args: Vec<(String, BamlValue)> = Vec::new();
+                    for (arg_name, arg) in arg_names.into_iter().zip(args) {
+                        let val = eval_to_value(env, arg).await;
+                        evaluated_args
+                            .push((arg_name.clone(), val.unwrap().unwrap().clone().value()));
+                    }
+                    let res = ExprEvalResult::LLMCall {
+                        name: name.clone(),
+                        args: BamlMap::from_iter(evaluated_args.into_iter()),
+                    };
+                    return Ok(res);
+                }
+                _ => {
+                    let res = Box::pin(beta_reduce(env, &current_expr, false)).await?;
+                    current_expr = res;
+                }
+            },
+            Expr::Atom(value) => {
+                return Ok(ExprEvalResult::Value {
+                    value: value.clone().map_meta(|_| ()),
+                    field_type: FieldType::Primitive(TypeValue::Null), // TODO: get the actual type
+                });
+            }
+            Expr::List(items, meta) => {
+                let mut new_items = Vec::new();
+                for item in items {
+                    let val = Box::pin(eval_to_value(env, &item))
+                        .await?
+                        .context("Evaluated value to None")?;
+                    new_items.push(val);
+                }
+                let val = BamlValueWithMeta::List(new_items, ());
+                return Ok(ExprEvalResult::Value {
+                    value: val,
+                    field_type: meta
+                        .1
+                        .clone()
+                        .unwrap_or(FieldType::Primitive(TypeValue::Null)), // TODO: get the actual type
+                });
+            }
+            Expr::Map(items, meta) => {
+                let mut new_items = BamlMap::new();
+                for (key, value) in items {
+                    let val = Box::pin(eval_to_value(env, &value))
+                        .await?
+                        .context("Evaluated value to None")?;
+                    new_items.insert(key.clone(), val);
+                }
+                let val = BamlValueWithMeta::Map(new_items, ());
+                return Ok(ExprEvalResult::Value {
+                    value: val,
+                    field_type: meta
+                        .1
+                        .clone()
+                        .unwrap_or(FieldType::Primitive(TypeValue::Null)), // TODO: get the actual type
+                });
+            }
+            Expr::ClassConstructor {
+                name,
+                fields,
+                spread,
+                meta,
+            } => {
+                let mut new_fields = BamlMap::new();
+                for (key, value) in fields {
+                    let val = Box::pin(eval_to_value(env, &value))
+                        .await?
+                        .context("Evaluated value to None")?;
+                    new_fields.insert(key.clone(), val);
+                }
+                let mut spread_fields = match spread {
+                    Some(spread) => {
+                        let res = Box::pin(eval_to_value(env, spread.as_ref())).await?;
+                        match res {
+                            Some(BamlValueWithMeta::Class(spread_class_name, spread_fields, _)) => {
+                                if name != spread_class_name {
+                                    return Err(anyhow::anyhow!("Class constructor name mismatch"));
+                                }
+                                spread_fields.clone()
+                            }
+                            _ => {
+                                return Err(anyhow::anyhow!("Spread is not a class"));
+                            }
+                        }
+                    }
+                    None => BamlMap::new(),
+                };
+                spread_fields.extend(new_fields);
+                let val = BamlValueWithMeta::Class(name.clone(), spread_fields, ());
+                return Ok(ExprEvalResult::Value {
+                    value: val,
+                    field_type: FieldType::Class(name),
+                });
+            }
+            Expr::LLMFunction(_, _, _) => {
+                return Err(anyhow::anyhow!("Bare LLM function found"));
+            }
+            Expr::Lambda(_, _, _) => {
+                return Err(anyhow::anyhow!("Bare lambda found: {}", expr.dump_str()));
+            }
+            Expr::Let(var_name, value, body, meta) => {
+                let res = beta_reduce(env, &expr, false).await?;
+                if res.temporary_same_state(expr) {
+                    return Err(anyhow::anyhow!("Failed to make progress"));
+                }
+                current_expr = res;
+            }
+            Expr::BoundVar(_, _) => {
+                return Err(anyhow::anyhow!("Bare bound variable found"));
+            }
+            Expr::FreeVar(_, _) => {
+                return Err(anyhow::anyhow!("Bare free variable found"));
+            }
+            Expr::ArgsTuple(_, _) => {
+                return Err(anyhow::anyhow!("Bare args tuple found"));
+            }
+        }
+    }
+    Err(anyhow::anyhow!("Max steps reached. {:?}", current_expr))
+}
+
+#[derive(Clone, Debug)]
+pub enum ExprEvalResult {
+    Value {
+        value: BamlValueWithMeta<()>,
+        field_type: FieldType,
+    },
+    LLMCall {
+        name: String,
+        args: BamlMap<String, BamlValue>,
+    },
 }
 
 /// Fully evaluate an expression to a value.
@@ -351,7 +501,7 @@ pub async fn eval_to_value<'a>(
             }
             other => {
                 // let new_expr = step(env, &other).await?;
-                let new_expr = Box::pin(beta_reduce(env, &other)).await?;
+                let new_expr = Box::pin(beta_reduce(env, &other, true)).await?;
 
                 if new_expr.temporary_same_state(expr) {
                     return Err(anyhow::anyhow!("Failed to make progress."));
@@ -363,7 +513,7 @@ pub async fn eval_to_value<'a>(
     Err(anyhow::anyhow!("Max steps reached."))
 }
 
-// #[cfg(test)]
+#[cfg(test)]
 mod tests {
     use crate::internal_baml_diagnostics::Span;
     use baml_types::{BamlMap, BamlValue};
@@ -407,17 +557,17 @@ function CombinePoems(poem1: string, poem2: string) -> string {
     "#
 }
 
-let poem = MakePoem(10);
+let poem = MakePoem(1);
 
 let another = {
-  let x = MakePoem(10);
-  let y = MakePoem(5);
+  let x = MakePoem(2);
+  let y = MakePoem(3);
   CombinePoems(x,y)
 };
 
 fn Pipeline() -> string {
-    let x = MakePoem(6);
-    let y = MakePoem(6);
+    let x = MakePoem(4);
+    let y = MakePoem(5);
     let a = MakePoem(6);
     let b = MakePoem(6);
     let xy = CombinePoems(x,y);
@@ -490,6 +640,20 @@ test TestMakePerson() {
   functions [MakePerson]
   args { }
 }
+
+function Echo(msg: string) -> string {
+    client GPT4o
+    prompt #"Please repeat the message back to me, with three words of elaboration and a twist: {{ msg }}"#
+  }
+  
+  fn Go() -> string {
+    Echo("Hello")
+  }
+  
+  test Go {
+    functions [Go]
+    args {}
+  }
         "##,
         );
         // dbg!(&rt.inner.ir.find_function("OuterPyramid").unwrap().item);
@@ -500,6 +664,131 @@ test TestMakePerson() {
         };
         let f = rt.inner.ir.find_expr_fn("OuterPyramid").unwrap();
         dbg!(&f.item);
+        let (res, _) = rt
+            // .run_test("Second", "TestSecond", &ctx, Some(on_event))
+            .run_test("Go", "Go", &ctx, Some(on_event), None)
+            // .run_test("MakePerson", "TestMakePerson", &ctx, Some(on_event), None)
+            // .run_test("CompareHaikus", "Test", &ctx, Some(on_event))
+            // .run_test("LlmParseInt", "TestParse", &ctx, Some(on_event))
+            .await;
+        dbg!(res);
+        assert!(false);
+    }
+
+    // #[tokio::test]
+    async fn test_fn_stream() {
+        let rt = runtime(
+            r##"
+function MakePoem(length: int) -> string {
+    client GPT4o
+    prompt #"Write a poem {{ length }} lines long."#
+}
+
+function CombinePoems(poem1: string, poem2: string) -> string {
+    client GPT4o
+    prompt #"Combine the following two poems into one poem.
+
+    Poem 1:
+    {{ poem1 }}
+
+    Poem 2:
+    {{ poem2 }}
+    "#
+}
+
+let poem = MakePoem(1);
+
+let another = {
+  let x = MakePoem(2);
+  let y = MakePoem(3);
+  CombinePoems(x,y)
+};
+
+fn Pipeline() -> string {
+    let x = MakePoem(4);
+    let y = MakePoem(5);
+    let a = MakePoem(6);
+    let b = MakePoem(7);
+    let xy = CombinePoems(x,y);
+    let ab = CombinePoems(a,b);
+    CombinePoems(xy, ab)
+}
+
+fn Pyramid() -> string {
+  CombinePoems( CombinePoems( MakePoem(8), MakePoem(9)), MakePoem(10))
+}
+
+let default_person = Person {
+  name: "John Doe",
+  age: 20,
+  poem: "Never was there a man more plain."
+};
+
+class Person {
+  name string
+  age int
+  poem string
+}
+
+fn MakePerson() -> Person {
+  Person { name: "Greg", poem: "Hello, world!", ..default_person }
+}
+
+fn OuterPyramid() -> string {
+  CombinePoems(poem, another)
+}
+
+fn ExprList() -> string[] {
+  [ MakePoem(11), MakePoem(12) ]
+}
+
+test TestPipeline() {
+  functions [Pipeline]
+  args { }
+}
+
+test TestPyramid() {
+  functions [Pyramid]
+  args { }
+}
+
+test OuterPyramid() {
+  functions [OuterPyramid]
+  args { }
+}
+
+client<llm> GPT4o {
+  provider openai
+  options {
+    model gpt-4o
+    api_key env.OPENAI_API_KEY
+  }
+}
+
+test TestMakePoem() {
+    functions [MakePoem]
+    args { length 4 }
+}
+
+test TestExprList() {
+  functions [ExprList]
+  args { }
+}
+
+test TestMakePerson() {
+  functions [MakePerson]
+  args { }
+}
+        "##,
+        );
+        // dbg!(&rt.inner.ir.find_function("OuterPyramid").unwrap().item);
+        let ctx = rt.create_ctx_manager(BamlValue::String("test".to_string()), None);
+
+        let on_event = |res: FunctionResult| {
+            eprintln!("on_event: {:?}", res);
+        };
+        let f = rt.inner.ir.find_expr_fn("OuterPyramid").unwrap();
+        // dbg!(&f.item);
         let (res, _) = rt
             // .run_test("Second", "TestSecond", &ctx, Some(on_event))
             .run_test("OuterPyramid", "OuterPyramid", &ctx, Some(on_event), None)

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -28,9 +28,11 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use anyhow::Result;
+use eval_expr::ExprEvalResult;
 use futures::channel::mpsc;
 use internal_baml_core::ast::Span;
 use internal_baml_core::ir::repr::initial_context;
+use internal_baml_core::ir::repr::IntermediateRepr;
 use jsonish::ResponseValueMeta;
 use tokio::sync::Mutex;
 
@@ -332,56 +334,95 @@ impl BamlRuntime {
         let expr_fn = self.inner.ir().find_expr_fn(function_name);
         let is_expr_fn = expr_fn.is_ok();
 
-        if is_expr_fn {
-            // let type_builder = self
-            //     .inner
-            //     .get_test_type_builder(function_name, test_name, ctx)
-            //     .ok_or(None);
-            let rctx = ctx
-                .create_ctx(None, None, span.clone().map(|s| s.span_id))
-                .unwrap();
-            let (params, _constraints) = self
-                .get_test_params_and_constraints(function_name, test_name, &rctx, true)
-                .unwrap();
-
-            // Call the runtime synchronously.
-            let (response_res, span_uuid) = self
-                .call_function_with_expr_events(
-                    function_name.into(),
-                    &params,
-                    &ctx,
-                    None, // TODO: Test with TypeBuilder.
-                    None, // TODO: Create callback.
-                    None, // TODO: Use Collectors?
-                    expr_tx,
-                )
-                .await;
-
-            log::info!("** response_res: {:#?}", response_res);
-            let test_response = TestResponse {
-                function_response: response_res.unwrap(),
-                function_span: span_uuid,
-                constraints_result: TestConstraintsResult::empty(),
-            };
-            return (Ok(test_response), None);
-        }
-
         if let Some(span) = span.clone() {
-            if let Some(collector) = collector {
+            if let Some(collector) = collector.clone() {
                 collector.track_function(FunctionId(span.clone().span_id.to_string()));
             }
         }
 
         let run_to_response = || async {
-            let type_builder = self
-                .inner
-                .get_test_type_builder(function_name, test_name, ctx)
-                .unwrap();
+            let rctx_no_tb = ctx.create_ctx(None, None, span.clone().map(|s| s.span_id))?;
+            let (params, constraints) =
+                self.get_test_params_and_constraints(function_name, test_name, &rctx_no_tb, true)?;
+
+            // Run the expression to either a value or a final LLM call.
+            // (If it's not an expr fn, it'll be a final LLM call.)
+            let expr_eval_result = expr_eval_result(
+                self,
+                ctx,
+                expr_tx.clone(),
+                collector.clone(),
+                self.tracer.clone(),
+                None,
+                None,
+                function_name,
+                &params,
+            )
+            .await?;
+
+            // If the expression evaluates to an LLM call, shadow the old function_name and params (of
+            // the test function) with the new function_name and params (of the LLM call).
+            let (function_name, params): (String, BamlMap<String, BamlValue>) =
+                match &expr_eval_result {
+                    ExprEvalResult::Value { value, field_type } => {
+                        (function_name.to_string(), params.clone())
+                    }
+                    ExprEvalResult::LLMCall { name, args } => (name.to_string(), args.clone()),
+                };
+
+            let type_builder = if is_expr_fn {
+                None
+            } else {
+                self.inner
+                    .get_test_type_builder(&function_name, test_name, ctx)
+                    .unwrap()
+            };
 
             let rctx =
                 ctx.create_ctx(type_builder.as_ref(), None, span.clone().map(|s| s.span_id))?;
-            let (params, constraints) =
-                self.get_test_params_and_constraints(function_name, test_name, &rctx, true)?;
+
+            let (function_name, params) = match expr_eval_result {
+                ExprEvalResult::Value { value, field_type } => {
+                    let fake_syntax_span = Span::fake();
+                    return Ok(TestResponse {
+                        // TODO: Factor out fake response data.
+                        function_response: FunctionResult::new(
+                            OrchestrationScope { scope: vec![] },
+                            LLMResponse::Success(LLMCompleteResponse {
+                                client: "openai".to_string(),
+                                model: "gpt-3.5-turbo".to_string(),
+                                prompt: RenderedPrompt::Completion(
+                                    "Sample raw response".to_string(),
+                                ),
+                                request_options: BamlMap::new(),
+                                content: "Sample raw response".to_string(),
+                                start_time: SystemTime::now(),
+                                latency: Duration::from_millis(2025),
+                                metadata: LLMCompleteResponseMetadata {
+                                    baml_is_complete: true,
+                                    finish_reason: Some("stop".to_string()),
+                                    prompt_tokens: Some(50),
+                                    output_tokens: Some(50),
+                                    total_tokens: Some(100),
+                                },
+                            }),
+                            // TODO: Run checks and asserts.
+                            Some(Ok(ResponseBamlValue(value.map_meta(|_| {
+                                ResponseValueMeta(
+                                    vec![],
+                                    vec![],
+                                    Completion::default(),
+                                    field_type.clone(),
+                                )
+                            })))),
+                        ),
+                        function_span: None,
+                        constraints_result: TestConstraintsResult::empty(),
+                    });
+                }
+                ExprEvalResult::LLMCall { name, args } => (name, args),
+            };
+
             let mut stream = self.inner.stream_function_impl(
                 function_name.into(),
                 &params,
@@ -400,6 +441,9 @@ impl BamlRuntime {
                 .iter()
                 .last()
                 .context("Expected non-empty event chain")?;
+            if let Some(expr_tx) = expr_tx {
+                expr_tx.unbounded_send(vec![]).unwrap();
+            }
             let complete_resp = match llm_resp {
                 LLMResponse::Success(complete_llm_response) => Ok(complete_llm_response),
                 LLMResponse::InternalFailure(e) => Err(anyhow::anyhow!("{}", e)),
@@ -501,9 +545,16 @@ impl BamlRuntime {
         cb: Option<&ClientRegistry>,
         collectors: Option<Vec<Arc<Collector>>>,
     ) -> (Result<FunctionResult>, Option<uuid::Uuid>) {
-        let res = self
-            .call_function_with_expr_events(function_name, params, ctx, tb, cb, collectors, None)
-            .await;
+        let res = Box::pin(self.call_function_with_expr_events(
+            function_name,
+            params,
+            ctx,
+            tb,
+            cb,
+            collectors,
+            None,
+        ))
+        .await;
         res
     }
 
@@ -657,7 +708,7 @@ impl BamlRuntime {
         (response, target_id)
     }
 
-    pub fn stream_function(
+    pub fn stream_function_with_expr_events(
         &self,
         function_name: String,
         params: &BamlMap<String, BamlValue>,
@@ -665,6 +716,7 @@ impl BamlRuntime {
         tb: Option<&TypeBuilder>,
         cb: Option<&ClientRegistry>,
         collectors: Option<Vec<Arc<Collector>>>,
+        expr_tx: Option<mpsc::UnboundedSender<Vec<SerializedSpan>>>,
     ) -> Result<FunctionResultStream> {
         self.inner.stream_function_impl(
             function_name,
@@ -675,6 +727,18 @@ impl BamlRuntime {
             self.async_runtime.clone(),
             collectors.unwrap_or_else(|| vec![]),
         )
+    }
+
+    pub fn stream_function(
+        &self,
+        function_name: String,
+        params: &BamlMap<String, BamlValue>,
+        ctx: &RuntimeContextManager,
+        tb: Option<&TypeBuilder>,
+        cb: Option<&ClientRegistry>,
+        collectors: Option<Vec<Arc<Collector>>>,
+    ) -> Result<FunctionResultStream> {
+        self.stream_function_with_expr_events(function_name, params, ctx, tb, cb, collectors, None)
     }
 
     pub async fn build_request(
@@ -1052,4 +1116,90 @@ pub fn baml_src_files(dir: &std::path::PathBuf) -> Result<Vec<PathBuf>> {
     }
 
     Ok(src_files)
+}
+
+/// The function name requested by the user may be an expression function or an LLM function.
+///
+/// If it's an LLM function, just return the function name and params.
+///
+/// If it's an expression function, determine whether it evaluates to an LLM function,
+/// and if so, return that function and its params. Not all expr functios evaluate to
+/// a (single) LLM function. So in those cases, just return the final value. (for example,
+/// some expression functions compute a list of values that are each the result of an LLM
+/// function - this can't be streamed, it can only be returned as a whole list).
+async fn expr_eval_result(
+    runtime: &BamlRuntime,
+    mgr: &RuntimeContextManager,
+    expr_tx: Option<mpsc::UnboundedSender<Vec<SerializedSpan>>>,
+    collector: Option<Arc<Collector>>,
+    tracer: Arc<BamlTracer>,
+    tb: Option<&TypeBuilder>,
+    cb: Option<&ClientRegistry>,
+    function_name: &str,
+    params: &BamlMap<String, BamlValue>,
+) -> Result<ExprEvalResult> {
+    let fake_syntax_span = Span::fake();
+    let ir = runtime.inner.ir();
+    let is_expr_fn = ir.find_expr_fn(function_name).is_ok();
+    let maybe_expr_f = ir.find_expr_fn(function_name);
+    match maybe_expr_f {
+        Ok(expr_fn) => {
+            log::trace!("Calling function: {}", function_name);
+            let span = tracer.start_span(&function_name, mgr, params);
+
+            if let Some(span) = span.clone() {
+                if let Some(collector) = collector {
+                    collector.track_function(FunctionId(span.clone().span_id.to_string()));
+                }
+            }
+            let ctx = mgr.create_ctx(tb, cb, span.clone().map(|s| s.span_id))?;
+            let env = EvalEnv {
+                context: initial_context(ir),
+                runtime,
+                expr_tx: expr_tx.clone(),
+                evaluated_cache: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            };
+
+            let param_baml_values = params
+                .iter()
+                .map(|(k, v)| {
+                    let arg_type = infer_type(v);
+                    let baml_value_with_meta: BamlValueWithMeta<ExprMetadata> = match arg_type {
+                        None => Ok::<_, anyhow::Error>(BamlValueWithMeta::with_const_meta(
+                            v,
+                            (Span::fake(), None),
+                        )),
+                        Some(arg_type) => {
+                            let value_unit_meta: BamlValueWithMeta<()> =
+                                BamlValueWithMeta::with_const_meta(v, ());
+                            let baml_value = runtime
+                                .inner
+                                .ir()
+                                .distribute_type_with_meta(value_unit_meta, arg_type)?;
+                            let baml_value_with_meta = baml_value
+                                .map_meta_owned(|(_, field_type)| (Span::fake(), Some(field_type)));
+
+                            Ok(baml_value_with_meta)
+                        }
+                    }?;
+                    Ok(Expr::Atom(baml_value_with_meta))
+                })
+                .collect::<Result<_>>()
+                .unwrap_or(vec![]); //TODO: Is it acceptable to swallow errors here?
+            let params_expr: Expr<ExprMetadata> =
+                Expr::ArgsTuple(param_baml_values, (fake_syntax_span.clone(), None));
+            let result_type = expr_fn.elem().output.clone();
+            let fn_call_expr = Expr::App(
+                Arc::new(expr_fn.elem().expr.clone()),
+                Arc::new(params_expr),
+                (fake_syntax_span.clone(), Some(result_type.clone())),
+            );
+            let res = eval_expr::eval_to_value_or_llm_call(&env, &fn_call_expr).await?;
+            Ok(res)
+        }
+        Err(e) => Ok(ExprEvalResult::LLMCall {
+            name: function_name.to_string(),
+            args: params.clone(),
+        }),
+    }
 }


### PR DESCRIPTION
When a workflow ends with an LLM call, the workflow will stream that LLM call.

In other words, when you call a function whose final expression is a single LLM call, the result can be streamed. But if the final expression is something other than an LLM call, like a list or a class constructor, the result will be delivered in one shot.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR enables streaming for workflows ending with an LLM call by evaluating if the final expression is a single LLM call, with updates to type inference, expression evaluation, and runtime execution.
> 
>   - **Behavior**:
>     - Workflows ending with an LLM call now support streaming if the final expression is a single LLM call.
>     - Non-LLM final expressions (e.g., lists, class constructors) are delivered in one shot.
>   - **Type Inference**:
>     - Updates to `infer_types_in_context()` in `expr_typecheck.rs` to handle new expression types.
>     - Introduces `initial_typing_context()` in `repr.rs` for better type inference.
>   - **Expression Evaluation**:
>     - Adds `eval_to_value_or_llm_call()` in `eval_expr.rs` to evaluate expressions to either a value or an LLM call.
>     - Modifies `beta_reduce()` in `eval_expr.rs` to support LLM function evaluation.
>   - **Runtime Execution**:
>     - Updates `BamlRuntime` in `lib.rs` to handle expression functions and determine if they result in an LLM call.
>     - Introduces `expr_eval_result()` in `lib.rs` to evaluate expression functions and determine streaming capability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 002d33fc2a3ca2b7c19a54ae01ef5a9f802530a7. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->