### PR TITLE
add support for plumbing through some errors for go

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1289,6 +1289,7 @@ dependencies = [
  "baml-runtime",
  "baml-types",
  "cbindgen",
+ "env_logger",
  "flatbuffers",
  "flatc",
  "flatc-rust",

--- a/engine/language_client_cffi/Cargo.toml
+++ b/engine/language_client_cffi/Cargo.toml
@@ -29,6 +29,7 @@ tokio-util = { version = "0.7", features = ["full"] }
 once_cell.workspace = true
 anyhow.workspace = true
 flatbuffers = "25.2.10"
+env_logger.workspace = true
 
 [build-dependencies]
 cbindgen = "0.28.0"

--- a/engine/language_client_cffi/Makefile.toml
+++ b/engine/language_client_cffi/Makefile.toml
@@ -39,7 +39,7 @@ dependencies = ["build-local"]
 # Integration test tasks
 #-----------------------------------------------------------------------------
 [tasks.integ-tests-generate]
-script = "cd ../../integ-tests && ../baml-cli/baml-cli generate"
+script = "cd ../../integ-tests && BAML_LIBRARY_PATH=$(pwd)/../engine/target/debug/libbaml_cffi.dylib ../baml-cli/baml-cli generate"
 dependencies = ["build-go-cli"]
 
 [tasks.integ-tests-build]

--- a/engine/language_client_cffi/src/lib.rs
+++ b/engine/language_client_cffi/src/lib.rs
@@ -107,12 +107,14 @@ static ERROR_CALLBACK_FN: OnceCell<CallbackFn> = OnceCell::new();
 
 #[no_mangle]
 extern "C" fn register_callbacks(callback_fn: CallbackFn, error_callback_fn: CallbackFn) {
-    baml_log::init();
+    println!("Registering callbacks");
+    let _ = baml_log::init();
+    let _ = env_logger::try_init_from_env(env_logger::Env::new().filter("BAML_INTERNAL_LOG"));
 
     // Create a global runtime or pass it along as needed.
     unsafe {
-        RESULT_CALLBACK_FN.set(std::mem::transmute(callback_fn));
-        ERROR_CALLBACK_FN.set(std::mem::transmute(error_callback_fn));
+        let _ = RESULT_CALLBACK_FN.set(std::mem::transmute(callback_fn));
+        let _ = ERROR_CALLBACK_FN.set(std::mem::transmute(error_callback_fn));
     }
 }
 
@@ -120,6 +122,10 @@ fn safe_trigger_callback(id: u32, is_done: bool, result: Result<FunctionResult>)
     let callback_fn = RESULT_CALLBACK_FN
         .get()
         .expect("expected callback function to be set. Did you call register_callbacks?");
+
+    let error_callback_fn = ERROR_CALLBACK_FN
+        .get()
+        .expect("expected error callback function to be set. Did you call register_callbacks?");
 
     match result {
         Ok(result) => match result.parsed() {
@@ -129,19 +135,33 @@ fn safe_trigger_callback(id: u32, is_done: bool, result: Result<FunctionResult>)
                 callback_fn(id, is_done, content.as_ptr() as *const i8, content.len());
             }
             Some(Err(e)) => {
-                println!("Error: {}", e);
                 // let c_message = CString::new(e.to_string()).unwrap();
-                // error_callback_fn(id, c_message.as_ptr() as *const libc::c_char);
+                let message = e.to_string();
+                error_callback_fn(
+                    id,
+                    true,
+                    message.as_ptr() as *const libc::c_char,
+                    message.len(),
+                );
             }
             None => {
-                println!("No result");
-                // error_callback_fn(id, c_message.as_ptr() as *const libc::c_char);
+                let message = "No result from baml".to_string();
+                error_callback_fn(
+                    id,
+                    true,
+                    message.as_ptr() as *const libc::c_char,
+                    message.len(),
+                );
             }
         },
         Err(e) => {
-            println!("Error: {}", e);
-            // let c_message = CString::new(e.to_string()).unwrap();
-            // error_callback_fn(id, c_message.as_ptr() as *const libc::c_char);
+            let message = format!("Error: {}", e);
+            error_callback_fn(
+                id,
+                true,
+                message.as_ptr() as *const libc::c_char,
+                message.len(),
+            );
         }
     }
 }

--- a/engine/language_client_go/pkg/callbacks.go
+++ b/engine/language_client_go/pkg/callbacks.go
@@ -9,6 +9,7 @@ import "C"
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 	"unsafe"
@@ -19,6 +20,10 @@ import (
 
 type BamlError struct {
 	Message string
+}
+
+func (e BamlError) Error() string {
+	return e.Message
 }
 
 type BamlClientError struct {
@@ -51,6 +56,33 @@ var (
 
 func SetTypeMap(t TypeMap) {
 	typeMap = t
+}
+
+//export error_callback
+func error_callback(id C.uint32_t, isDone C.bool, content *C.int8_t, length C.int) {
+	fmt.Println("Error callback")
+	callbackMutex.RLock()
+	id_uint := uint32(id)
+	callback, exists := dynamicCallbacks[id_uint]
+	callbackMutex.RUnlock()
+
+	if exists {
+		content_bytes := C.GoBytes(unsafe.Pointer(content), length)
+
+		// Parse the content as a string
+		content_str := string(content_bytes)
+
+		// TODO: cast to the right error type
+		err := BamlError{Message: content_str}
+
+		// Send the error to the callback
+		callback.channel <- ResultCallback{Error: err}
+
+		close(callback.channel)
+		callbackMutex.Lock()
+		defer callbackMutex.Unlock()
+		delete(dynamicCallbacks, id_uint)
+	}
 }
 
 //export trigger_callback

--- a/engine/language_client_go/pkg/runtime.go
+++ b/engine/language_client_go/pkg/runtime.go
@@ -5,6 +5,7 @@ package baml
 #include <stdbool.h>
 
 extern void trigger_callback(uint32_t, bool, const int8_t *, int);
+extern void error_callback(uint32_t, bool, const int8_t *, int);
 */
 import "C"
 
@@ -36,7 +37,7 @@ func InvokeRuntimeCli(args []string) int {
 }
 
 func init() {
-	if err := baml_go.RegisterCallbacks(C.trigger_callback, C.trigger_callback); err != nil {
+	if err := baml_go.RegisterCallbacks(C.trigger_callback, C.error_callback); err != nil {
 		panic(err)
 	}
 }

--- a/integ-tests/go/go.mod
+++ b/integ-tests/go/go.mod
@@ -2,11 +2,13 @@ module example.com/integ-tests
 
 go 1.24.0
 
-require github.com/boundaryml/baml v0.2.0
+require (
+	github.com/boundaryml/baml v0.2.0
+	github.com/google/flatbuffers v25.2.10+incompatible
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/flatbuffers v25.2.10+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/integ-tests/go/test.go
+++ b/integ-tests/go/test.go
@@ -5,27 +5,24 @@ import (
 	"fmt"
 
 	b "example.com/integ-tests/baml_client"
-	"example.com/integ-tests/baml_client/types"
 )
 
 func main() {
 	ctx := context.Background()
 
-	param := types.Union__List__string__string{}
-	param.SetString("oranges")
-	v2, err := b.AaaSamOutputFormat(ctx, &param)
+	v2, err := b.AaaSamOutputFormat(ctx, "oranges")
 	if err != nil {
 		panic(err)
 	}
 	fmt.Println(*v2)
 
-	v2, err = b.AaaSamOutputFormat(ctx, nil)
+	v2, err = b.AaaSamOutputFormat(ctx, "pineapple")
 	if err != nil {
 		panic(err)
 	}
 	fmt.Println(*v2)
 
-	stream := b.Stream.AaaSamOutputFormat(ctx, &param)
+	stream := b.Stream.AaaSamOutputFormat(ctx, "pineapple")
 	for chunk := range stream {
 		fmt.Println(chunk)
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add error handling support to the Go client for BAML runtime by implementing error callbacks and updating integration tests.
> 
>   - **Error Handling**:
>     - Added `env_logger` dependency in `Cargo.lock` and `Cargo.toml` for logging support.
>     - Implemented `error_callback` in `callbacks.go` to handle errors from Rust and send them to Go callbacks.
>     - Updated `register_callbacks()` in `lib.rs` to initialize `env_logger` and set error callback.
>     - Modified `safe_trigger_callback()` in `lib.rs` to use `ERROR_CALLBACK_FN` for error handling.
>   - **Integration Tests**:
>     - Updated `Makefile.toml` to set `BAML_LIBRARY_PATH` for integration tests.
>     - Modified `test.go` to use string parameters directly instead of `types.Union__List__string__string{}`.
>   - **Misc**:
>     - Updated `runtime.go` to register `error_callback` during initialization.
>     - Added `github.com/google/flatbuffers` to `go.mod` in `integ-tests/go`.
>     - Minor logging and error handling improvements in `callbacks.go` and `runtime.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 070c4cd7f46a39919f9ef0e79398c3922a6bf9cd. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->