### PR TITLE
fix libc char for unix

### DIFF
--- a/engine/language_client_cffi/src/lib.rs
+++ b/engine/language_client_cffi/src/lib.rs
@@ -137,31 +137,16 @@ fn safe_trigger_callback(id: u32, is_done: bool, result: Result<FunctionResult>)
             Some(Err(e)) => {
                 // let c_message = CString::new(e.to_string()).unwrap();
                 let message = e.to_string();
-                error_callback_fn(
-                    id,
-                    true,
-                    message.as_ptr() as *const libc::c_char,
-                    message.len(),
-                );
+                error_callback_fn(id, true, message.as_ptr() as *const i8, message.len());
             }
             None => {
                 let message = "No result from baml".to_string();
-                error_callback_fn(
-                    id,
-                    true,
-                    message.as_ptr() as *const libc::c_char,
-                    message.len(),
-                );
+                error_callback_fn(id, true, message.as_ptr() as *const i8, message.len());
             }
         },
         Err(e) => {
             let message = format!("Error: {}", e);
-            error_callback_fn(
-                id,
-                true,
-                message.as_ptr() as *const libc::c_char,
-                message.len(),
-            );
+            error_callback_fn(id, true, message.as_ptr() as *const i8, message.len());
         }
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change `error_callback_fn` calls in `safe_trigger_callback` to use `i8` instead of `libc::c_char` for error message pointers.
> 
>   - **Behavior**:
>     - Change `error_callback_fn` calls in `safe_trigger_callback` to use `i8` instead of `libc::c_char` for error message pointers.
>   - **Functions**:
>     - Affects `safe_trigger_callback` in `lib.rs` by changing the type of error message pointers.
>   - **Misc**:
>     - Simplifies error callback function calls by removing redundant type casting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 88497d751857db555d0d84c9f140a73ead1069ba. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->