### PR TITLE
add docs about esm support

### DIFF
--- a/fern/01-guide/02-languages/typescript.mdx
+++ b/fern/01-guide/02-languages/typescript.mdx
@@ -80,17 +80,23 @@ To set up BAML with Typescript do the following:
       ```
 
       ```bash deno
-      deno run --unstable-sloppy-imports -A npm:@boundaryml/baml/baml-cli generate
-      # Note: ESM is especially important for Deno, so you must explicitly
-      # allow our Node import style, with the `--unstable-sloppy-imports` flag
-      # and in your Deno VSCode configuration:
-      #
-      # {
-      #   "deno.unstable": ["sloppy-imports"]
-      # }
+      deno run -A npm:@boundaryml/baml/baml-cli generate
+      # You may need to use the --unstable-sloppy-imports flag if you get an error about ESM
+      # https://github.com/BoundaryML/baml/issues/1213#issuecomment-2526200783
 
       ```
     </CodeBlocks>
+
+    <Note>
+      If you need baml_client to be 'ESM' compatible, you can add the following `generator` configuration to your `.baml` file:
+
+      ```baml
+      generator typescript {
+        ...
+        module_format "esm" // the default is "cjs" for CommonJS
+      }
+      ```
+    </Note>
 
     You can modify your `package.json` so you have a helper prefix in front of your build command.
 

--- a/fern/01-guide/08-frameworks/01-react-nextjs/01-quick-start.mdx
+++ b/fern/01-guide/08-frameworks/01-react-nextjs/01-quick-start.mdx
@@ -219,6 +219,18 @@ generator typescript {
 
 <Markdown src="../../../snippets/baml/cli/generate.mdx" />
 
+
+ <Note>
+      If you need baml_client to be 'ESM' compatible, you can add the following `generator` configuration to your `.baml` file:
+
+      ```baml
+      generator typescript {
+        ...
+        module_format "esm" // the default is "cjs" for CommonJS
+      }
+      ```
+    </Note>
+
 ### Generated React Hooks
 
 BAML automatically generates type-safe Next.js server actions and React hooks for your BAML functions.

--- a/fern/03-reference/generator.mdx
+++ b/fern/03-reference/generator.mdx
@@ -41,6 +41,11 @@ generator target {
 
     // Version of runtime to generate code for (should match the package @boundaryml/baml version)
     version "0.76.2"
+
+    // The format of the generated module.
+    // "esm" - Use ES modules
+    // "cjs" - Use CommonJS modules (default)
+    module_format "cjs"
 }
 ```
 
@@ -58,6 +63,11 @@ generator target {
 
     // Version of runtime to generate code for (should match the package @boundaryml/baml version)
     version "0.76.2"
+
+    // The format of the generated module.
+    // "esm" - Use ES modules 
+    // "cjs" - Use CommonJS modules (default)
+    module_format "cjs"
 }
 ```
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add documentation for ESM support in BAML, including configuration instructions for TypeScript and React/Next.js setups.
> 
>   - **Documentation**:
>     - Added instructions for ESM compatibility in `typescript.mdx` and `01-quick-start.mdx`.
>     - Updated `generator.mdx` to include `module_format` option for TypeScript and React/Next.js.
>   - **Configuration**:
>     - Introduced `module_format "esm"` option in `.baml` file for ESM support, default is `"cjs"`.
>     - Provided guidance on using `--unstable-sloppy-imports` flag for Deno in `typescript.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 24b37b7b865f50dbee13d8470a6ef5a41307cea8. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->