### PR TITLE
fix union streaming bug

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
@@ -4,6 +4,7 @@
 use crate::deserializer::coercer::ParsingError;
 use crate::{BamlValueWithFlags, Flag};
 use indexmap::{IndexMap, IndexSet};
+use internal_baml_core::ir::ir_helpers::infer_type_with_meta;
 use internal_baml_core::ir::repr::{IntermediateRepr, Walker};
 use internal_baml_core::ir::{Field, IRHelper, IRHelperExtended, IRSemanticStreamingHelper};
 
@@ -70,7 +71,7 @@ fn process_node(
     let (completion_state, field_type) = value.meta().clone();
     let (base_type, (_, streaming_behavior)) = ir.distribute_metadata(field_type);
 
-    let must_be_done = required_done(ir, field_type);
+    let must_be_done = required_done(ir, field_type, &value);
     let allow_partials_in_sub_nodes = allow_partials && !must_be_done;
 
     let new_meta = Completion {
@@ -276,7 +277,11 @@ fn needed_fields(
 
 /// Whether a type must be complete before being included as a node
 /// in a streamed value.
-fn required_done(ir: &impl IRHelperExtended, field_type: &FieldType) -> bool {
+fn required_done<T>(
+    ir: &impl IRHelperExtended,
+    field_type: &FieldType,
+    value: &BamlValueWithMeta<T>,
+) -> bool {
     let (base_type, (_, streaming_behavior)) = ir.distribute_metadata(field_type);
     let type_implies_done = match base_type {
         FieldType::Primitive(tv) => match tv {
@@ -295,9 +300,12 @@ fn required_done(ir: &impl IRHelperExtended, field_type: &FieldType) -> bool {
         FieldType::Tuple(_) => false,
         FieldType::RecursiveTypeAlias(_) => false,
         FieldType::Class(_) => false,
-        // TODO: This rule is pretty aggressive. For example in the case of
-        // Class | Enum it would not allow classes to be streamed.
-        FieldType::Union(options) => options.iter().all(|option| required_done(ir, option)),
+        FieldType::Union(options) => options.iter().any(|option| {
+            let variant_required_done = required_done(ir, option, value);
+            let value_unifies_with_variant =
+                infer_type_with_meta(value).map_or(false, |v| &v == option);
+            variant_required_done && value_unifies_with_variant
+        }),
         FieldType::Arrow(_) => false, // TODO: Error? Arrow shouldn't appear here.
         FieldType::WithMetadata { .. } => {
             unreachable!("distribute_metadata always consumes `WithMetadata`.")

--- a/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
@@ -297,7 +297,7 @@ fn required_done(ir: &impl IRHelperExtended, field_type: &FieldType) -> bool {
         FieldType::Class(_) => false,
         // TODO: This rule is pretty aggressive. For example in the case of
         // Class | Enum it would not allow classes to be streamed.
-        FieldType::Union(options) => options.iter().any(|option| required_done(ir, option)),
+        FieldType::Union(options) => options.iter().all(|option| required_done(ir, option)),
         FieldType::Arrow(_) => false, // TODO: Error? Arrow shouldn't appear here.
         FieldType::WithMetadata { .. } => {
             unreachable!("distribute_metadata always consumes `WithMetadata`.")

--- a/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/semantic_streaming.rs
@@ -300,12 +300,28 @@ fn required_done<T>(
         FieldType::Tuple(_) => false,
         FieldType::RecursiveTypeAlias(_) => false,
         FieldType::Class(_) => false,
-        FieldType::Union(options) => options.iter().any(|option| {
-            let variant_required_done = required_done(ir, option, value);
-            let value_unifies_with_variant =
-                infer_type_with_meta(value).map_or(false, |v| &v == option);
-            variant_required_done && value_unifies_with_variant
-        }),
+        FieldType::Union(options) => {
+            // Determining whether a union requires done is complicated.
+            // If all the variants are required to be done, then the union
+            // requires done.
+            let all_require_done = options.iter().all(|option| required_done(ir, option, value));
+            if all_require_done { return true; }
+
+            // If none of the variants are required to be done, then the union
+            // does not require done.
+            let none_require_done = options.iter().all(|option| !required_done(ir, option, value));
+            if none_require_done { return false; }
+
+            // Otherwise, the answer depends on the value we are streaming.
+            // Search for the variant that matches the value, and use the
+            // required_done property of that variant.
+            options.iter().any(|option| {
+                let variant_required_done = required_done(ir, option, value);
+                let value_unifies_with_variant =
+                    infer_type_with_meta(value).map_or(false, |v| &v == option);
+                variant_required_done && value_unifies_with_variant
+            })
+        },
         FieldType::Arrow(_) => false, // TODO: Error? Arrow shouldn't appear here.
         FieldType::WithMetadata { .. } => {
             unreachable!("distribute_metadata always consumes `WithMetadata`.")

--- a/engine/baml-lib/jsonish/src/tests/test_streaming.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_streaming.rs
@@ -351,3 +351,46 @@ test_partial_deserializer_streaming!(
       ]
     }
 );
+
+const TODO_TOOLS_EXAMPLE: &str = r#"
+type Tool = MessageToUser | AddItem | AdjustItem | GetLastItemId
+
+class MessageToUser {
+    type "message_to_user" @stream.not_null
+    message string @stream.not_null
+}
+
+class AdjustItem {
+    type "adjust_item" @stream.not_null
+    item_id int
+    title string?
+    @@stream.done
+}
+
+class AddItem {
+    type "add_item" @stream.not_null
+    title string @stream.not_null
+    @@stream.done
+}
+
+class GetLastItemId {
+    type "get_last_item_id" @stream.not_null
+    @@stream.done
+}
+"#;
+
+test_partial_deserializer_streaming!(
+    test_todo_tools,
+    TODO_TOOLS_EXAMPLE,
+    r#"{"type": "message_to_user", "message": "Hello us"#,
+    FieldType::Union(vec![
+        FieldType::class("MessageToUser"),
+        FieldType::class("AdjustItem"),
+        FieldType::class("AddItem"),
+        FieldType::class("GetLastItemId"),
+    ]),
+    {
+        "type": "message_to_user",
+        "message": "Hello user"
+    }
+);

--- a/engine/baml-lib/jsonish/src/tests/test_streaming.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_streaming.rs
@@ -380,7 +380,7 @@ class GetLastItemId {
 "#;
 
 test_partial_deserializer_streaming!(
-    test_todo_tools,
+    test_todo_tools_message,
     TODO_TOOLS_EXAMPLE,
     r#"{"type": "message_to_user", "message": "Hello us"#,
     FieldType::Union(vec![
@@ -391,6 +391,18 @@ test_partial_deserializer_streaming!(
     ]),
     {
         "type": "message_to_user",
-        "message": "Hello user"
+        "message": "Hello us"
     }
+);
+
+test_partial_deserializer_streaming_failure!(
+    test_todo_tools_adjust_item,
+    TODO_TOOLS_EXAMPLE,
+    r#"{"type": "adjust_item", "item_id": 1, "title": "New Title"#,
+    FieldType::Union(vec![
+        FieldType::class("MessageToUser"),
+        FieldType::class("AdjustItem"),
+        FieldType::class("AddItem"),
+        FieldType::class("GetLastItemId"),
+    ])
 );

--- a/flake.lock
+++ b/flake.lock
@@ -71,12 +71,29 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1745391562,
+        "narHash": "sha256-sPwcCYuiEopaafePqlG826tBhctuJsLx/mhKKM5Fmjo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8a2f738d9d1f1d986b5a4cd2fd2061a7127237d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "rust-analyzer-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     fenix = {
       url = "github:nix-community/fenix";
@@ -12,13 +13,14 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, fenix, ... }:
+  outputs = { self, nixpkgs, nixpkgs-unstable, flake-utils, fenix, ... }:
 
 
     flake-utils.lib.eachDefaultSystem (system:
 
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
         clang = pkgs.llvmPackages_17.clang;
         pythonEnv = pkgs.python3.withPackages (ps: []);
 
@@ -35,6 +37,7 @@
 
         appleDeps = with pkgs.darwin.apple_sdk.frameworks; [
           CoreServices
+          System
           SystemConfiguration
           pkgs.libiconv-darwin
         ];
@@ -72,7 +75,7 @@
           vsce # VSCode extension packaging tool
           toolchain
           nodejs
-          uv
+          pkgs-unstable.uv
           wasm-pack
           pkgs.gcc
           napi-rs-cli

--- a/integ-tests/python/uv.lock
+++ b/integ-tests/python/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.9, <4"
 resolution-markers = [
     "python_full_version < '3.10'",
@@ -199,7 +198,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -576,6 +575,8 @@ version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz", hash = "sha256:cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5", size = 508502 }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/d4/8095b53c4950f44dc99b8d983b796f405ae1f58d80978fcc0421491b4201/psutil-6.1.1-cp27-none-win32.whl", hash = "sha256:6d4281f5bbca041e2292be3380ec56a9413b790579b8e593b1784499d0005dac", size = 246855 },
+    { url = "https://files.pythonhosted.org/packages/b1/63/0b6425ea4f2375988209a9934c90d6079cc7537847ed58a28fbe30f4277e/psutil-6.1.1-cp27-none-win_amd64.whl", hash = "sha256:c777eb75bb33c47377c9af68f30e9f11bc78e0f07fbf907be4a5d70b2fe5f030", size = 250110 },
     { url = "https://files.pythonhosted.org/packages/61/99/ca79d302be46f7bdd8321089762dd4476ee725fce16fc2b2e1dbba8cac17/psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8", size = 247511 },
     { url = "https://files.pythonhosted.org/packages/0b/6b/73dbde0dd38f3782905d4587049b9be64d76671042fdcaf60e2430c6796d/psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377", size = 248985 },
     { url = "https://files.pythonhosted.org/packages/17/38/c319d31a1d3f88c5b79c68b3116c129e5133f1822157dd6da34043e32ed6/psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003", size = 284488 },
@@ -792,7 +793,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ruff" },
-    { name = "types-assertpy" },
 ]
 
 [package.metadata]
@@ -815,10 +815,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "ruff", specifier = ">=0.9.10" },
-    { name = "types-assertpy" },
-]
+dev = [{ name = "ruff", specifier = ">=0.9.10" }]
 
 [[package]]
 name = "requests"
@@ -917,20 +914,11 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
-]
-
-[[package]]
-name = "types-assertpy"
-version = "1.1.0.20250407"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d2/2d/989461761b4c8841dafc336481f7818d73bdcf1c6413c5fc817139130f04/types_assertpy-1.1.0.20250407.tar.gz", hash = "sha256:b20569e9b750163663eefcf313f01a49a5933789dc3fab03831698326c8fc870", size = 10228 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/27/299035752bb2d234f7f7b1f551f5bab5e4eca4e6b17c2f3bb2bb16469c82/types_assertpy-1.1.0.20250407-py3-none-any.whl", hash = "sha256:4c5c133e73d537391a50f65c4001ef1cab64db2eaf0c0837b70ab135c0b9f8f1", size = 12818 },
 ]
 
 [[package]]

--- a/integ-tests/python/uv.lock
+++ b/integ-tests/python/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.9, <4"
 resolution-markers = [
     "python_full_version < '3.10'",
@@ -198,7 +199,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -575,8 +576,6 @@ version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz", hash = "sha256:cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5", size = 508502 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/d4/8095b53c4950f44dc99b8d983b796f405ae1f58d80978fcc0421491b4201/psutil-6.1.1-cp27-none-win32.whl", hash = "sha256:6d4281f5bbca041e2292be3380ec56a9413b790579b8e593b1784499d0005dac", size = 246855 },
-    { url = "https://files.pythonhosted.org/packages/b1/63/0b6425ea4f2375988209a9934c90d6079cc7537847ed58a28fbe30f4277e/psutil-6.1.1-cp27-none-win_amd64.whl", hash = "sha256:c777eb75bb33c47377c9af68f30e9f11bc78e0f07fbf907be4a5d70b2fe5f030", size = 250110 },
     { url = "https://files.pythonhosted.org/packages/61/99/ca79d302be46f7bdd8321089762dd4476ee725fce16fc2b2e1dbba8cac17/psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8", size = 247511 },
     { url = "https://files.pythonhosted.org/packages/0b/6b/73dbde0dd38f3782905d4587049b9be64d76671042fdcaf60e2430c6796d/psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377", size = 248985 },
     { url = "https://files.pythonhosted.org/packages/17/38/c319d31a1d3f88c5b79c68b3116c129e5133f1822157dd6da34043e32ed6/psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003", size = 284488 },
@@ -793,6 +792,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ruff" },
+    { name = "types-assertpy" },
 ]
 
 [package.metadata]
@@ -815,7 +815,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.9.10" }]
+dev = [
+    { name = "ruff", specifier = ">=0.9.10" },
+    { name = "types-assertpy" },
+]
 
 [[package]]
 name = "requests"
@@ -914,11 +917,20 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
+]
+
+[[package]]
+name = "types-assertpy"
+version = "1.1.0.20250407"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d2/2d/989461761b4c8841dafc336481f7818d73bdcf1c6413c5fc817139130f04/types_assertpy-1.1.0.20250407.tar.gz", hash = "sha256:b20569e9b750163663eefcf313f01a49a5933789dc3fab03831698326c8fc870", size = 10228 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/27/299035752bb2d234f7f7b1f551f5bab5e4eca4e6b17c2f3bb2bb16469c82/types_assertpy-1.1.0.20250407-py3-none-any.whl", hash = "sha256:4c5c133e73d537391a50f65c4001ef1cab64db2eaf0c0837b70ab135c0b9f8f1", size = 12818 },
 ]
 
 [[package]]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes union streaming bug by modifying `required_done()` to consider the value being streamed and updates tests and Nix flake configuration.
> 
>   - **Behavior**:
>     - Fixes union streaming bug by modifying `required_done()` in `semantic_streaming.rs` to consider the value being streamed.
>     - Adds logic to handle cases where some union variants require completion and others do not.
>   - **Tests**:
>     - Adds `test_todo_tools_message` and `test_todo_tools_adjust_item` in `test_streaming.rs` to verify union streaming behavior.
>   - **Nix Flake**:
>     - Updates `flake.nix` and `flake.lock` to include `nixpkgs-unstable`.
>     - Modifies build inputs to use `pkgs-unstable.uv`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 95747801eb4fb122f97af24bf78e0beea5eacac9. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->