### PR TITLE
Remove run command from CLI

### DIFF
--- a/engine/baml-runtime/src/test_executor/mod.rs
+++ b/engine/baml-runtime/src/test_executor/mod.rs
@@ -166,9 +166,9 @@ impl TestExecutor for BamlRuntime {
 
             println!(
                 "{}",
-                "To run these tests, rerun using the \"run\" command:".blue()
+                "To run these tests, rerun without the --list arg:".blue()
             );
-            println!("{}", "baml-cli test run [args]".blue());
+            println!("{}", "baml-cli test [args]".blue());
         }
 
         Ok(())


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `run` command from CLI instructions in `TestExecutor` implementation in `mod.rs`.
> 
>   - **Behavior**:
>     - Update CLI instructions in `TestExecutor` implementation in `mod.rs` to remove `run` command.
>     - Users are now instructed to rerun tests without `--list` argument instead of using `run` command.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for b1ebd7fd852d82d6f720564833f20d3876548c1d. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->