### PR TITLE
[Rust LSP] Support generateCodeOnSave setting, clean up error messages

### DIFF
--- a/engine/language_server/src/baml_project/mod.rs
+++ b/engine/language_server/src/baml_project/mod.rs
@@ -159,6 +159,7 @@ impl BamlProject {
         let runtime = self.runtime(env);
         if let Err(e) = runtime {
             if (e.has_errors()) {
+                tracing::error!("Failed to run codegen: {:?}", e);
                 return Err(anyhow::anyhow!("Project has errors."));
             } else {
                 tracing::error!("Failed to run codegen: {:?}", e);

--- a/engine/language_server/src/baml_project/mod.rs
+++ b/engine/language_server/src/baml_project/mod.rs
@@ -156,7 +156,16 @@ impl BamlProject {
             .collect();
         let start_time = Instant::now();
 
-        let runtime = self.runtime(env)?;
+        let runtime = self.runtime(env);
+        if let Err(e) = runtime {
+            if (e.has_errors()) {
+                return Err(anyhow::anyhow!("Project has errors."));
+            } else {
+                tracing::error!("Failed to run codegen: {:?}", e);
+                return Err(e.into());
+            }
+        }
+        let runtime = runtime.unwrap();
 
         let generated = match runtime.run_codegen(&all_files, no_version_check.unwrap_or(false)) {
             Ok(gen) => {

--- a/engine/language_server/src/server.rs
+++ b/engine/language_server/src/server.rs
@@ -77,6 +77,7 @@ impl Server {
             mut workspace_settings,
         } = AllSettings::from_value(
             init_params
+                .clone()
                 .initialization_options
                 .unwrap_or_else(|| serde_json::Value::Object(serde_json::Map::default())),
         );
@@ -107,7 +108,7 @@ impl Server {
         );
 
         let workspaces = init_params
-            .workspace_folders
+            .workspace_folders.clone()
             .filter(|folders| !folders.is_empty())
             .map(|folders| folders.into_iter().filter_map(|folder| {
                 let baml_src_dir = find_baml_src(&PathBuf::from(folder.uri.path()))?;
@@ -129,6 +130,8 @@ impl Server {
             .ok_or_else(|| {
                 anyhow::anyhow!("Failed to get the current working directory while creating a default workspace.")
             })?;
+
+        // tracing::info!("init params: {:?}", init_params);
 
         // for some reason tracing logs are not available before this point
         tracing::info!("Starting server with {} worker threads", worker_threads);
@@ -229,6 +232,7 @@ impl Server {
         let mut scheduler =
             schedule::Scheduler::new(&mut session, worker_threads, connection.make_sender());
         Self::try_register_capabilities(&_client_capabilities, &mut scheduler);
+
         for msg in connection.incoming() {
             if connection.handle_shutdown(&msg)? {
                 break;

--- a/engine/language_server/src/server/api/notifications/did_change_configuration.rs
+++ b/engine/language_server/src/server/api/notifications/did_change_configuration.rs
@@ -15,7 +15,7 @@ impl super::SyncNotificationHandler for DidChangeConfiguration {
     fn run(
         _session: &mut Session,
         notifier: Notifier,
-        _requester: &mut Requester,
+        requester: &mut Requester,
         params: types::DidChangeConfigurationParams,
     ) -> Result<()> {
         tracing::info!("*** DID CHANGE CONFIGURATION: {:?}", params);
@@ -41,7 +41,7 @@ impl super::SyncNotificationHandler for DidChangeConfiguration {
 
         // Also manually schedule a request for latest settings since sometimes the above params just have Null (not sure why)
         // note that the task will run after this current task is done.
-        _requester.request::<types::request::WorkspaceConfiguration>(
+        requester.request::<types::request::WorkspaceConfiguration>(
             ConfigurationParams {
                 items: vec![types::ConfigurationItem {
                     scope_uri: None,

--- a/engine/language_server/src/server/api/notifications/did_change_configuration.rs
+++ b/engine/language_server/src/server/api/notifications/did_change_configuration.rs
@@ -1,9 +1,9 @@
 use crate::server::api::ResultExt;
 use crate::server::client::{Notifier, Requester};
-use crate::server::Result;
+use crate::server::{Result, Task};
 use crate::session::Session;
-use lsp_types as types;
 use lsp_types::notification as notif;
+use lsp_types::{self as types, ConfigurationItem, ConfigurationParams};
 
 pub(crate) struct DidChangeConfiguration;
 
@@ -18,11 +18,12 @@ impl super::SyncNotificationHandler for DidChangeConfiguration {
         _requester: &mut Requester,
         params: types::DidChangeConfigurationParams,
     ) -> Result<()> {
-        tracing::info!("*** DID CHANGE CONFIGURATION");
+        tracing::info!("*** DID CHANGE CONFIGURATION: {:?}", params);
 
         // Extract the BAML configuration from the params
         if let Some(settings) = params.settings.as_object() {
             if let Some(baml_settings) = settings.get("baml") {
+                tracing::info!("BAML settings: {:?}", baml_settings);
                 // Send the BAML settings as a notification
                 notifier
                     .0
@@ -34,8 +35,28 @@ impl super::SyncNotificationHandler for DidChangeConfiguration {
                     ))
                     .internal_error()?;
                 tracing::info!("Sent baml_settings_updated notification");
+                _session.update_baml_settings(baml_settings.clone());
             }
         }
+
+        // Also manually schedule a request for latest settings since sometimes the above params just have Null (not sure why)
+        // note that the task will run after this current task is done.
+        _requester.request::<types::request::WorkspaceConfiguration>(
+            ConfigurationParams {
+                items: vec![types::ConfigurationItem {
+                    scope_uri: None,
+                    section: Some("baml".to_string()),
+                }],
+            },
+            |response| {
+                Task::local(move |session, _, _, _| {
+                    tracing::info!("Workspace configuration request received: {:?}", response);
+                    if let Some(first_response) = response.first() {
+                        session.update_baml_settings(first_response.clone());
+                    }
+                })
+            },
+        );
 
         Ok(())
     }

--- a/engine/language_server/src/server/api/notifications/did_open.rs
+++ b/engine/language_server/src/server/api/notifications/did_open.rs
@@ -1,15 +1,16 @@
-use lsp_types::notification::DidOpenTextDocument;
-use lsp_types::{DidOpenTextDocumentParams, PublishDiagnosticsParams, TextDocumentItem};
-
 use crate::server::api::diagnostics::publish_session_lsp_diagnostics;
 use crate::server::api::notifications::baml_src_version::BamlSrcVersionPayload;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
 use crate::server::api::ResultExt;
 use crate::server::client::{Notifier, Requester};
-use crate::server::Result;
+use crate::server::{Result, Task};
 use crate::session::Session;
 use crate::{DocumentKey, TextDocument};
-
+use lsp_types::notification::DidOpenTextDocument;
+use lsp_types::{
+    self as types, ConfigurationItem, ConfigurationParams, DidOpenTextDocumentParams,
+    PublishDiagnosticsParams, TextDocumentItem,
+};
 pub(crate) struct DidOpenTextDocumentHandler;
 
 impl NotificationHandler for DidOpenTextDocumentHandler {
@@ -26,6 +27,25 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
         tracing::info!("DidOpenTextDocumentHandler");
 
         let url = params.text_document.uri;
+
+        // TODO: do this when server initializes instead of every time a file is opened
+        // note this just schedules the task. It will run after the current task is done.
+        _requester.request::<types::request::WorkspaceConfiguration>(
+            ConfigurationParams {
+                items: vec![types::ConfigurationItem {
+                    scope_uri: None,
+                    section: Some("baml".to_string()),
+                }],
+            },
+            |response| {
+                Task::local(move |session, _, _, _| {
+                    tracing::info!("Workspace configuration request received: {:?}", response);
+                    if let Some(first_response) = response.first() {
+                        session.update_baml_settings(first_response.clone());
+                    }
+                })
+            },
+        );
 
         let file_path = url
             .to_file_path()

--- a/engine/language_server/src/server/api/notifications/did_open.rs
+++ b/engine/language_server/src/server/api/notifications/did_open.rs
@@ -21,7 +21,7 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
     fn run(
         session: &mut Session,
         notifier: Notifier,
-        _requester: &mut Requester,
+        requester: &mut Requester,
         params: DidOpenTextDocumentParams,
     ) -> Result<()> {
         tracing::info!("DidOpenTextDocumentHandler");
@@ -30,7 +30,7 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
 
         // TODO: do this when server initializes instead of every time a file is opened
         // note this just schedules the task. It will run after the current task is done.
-        _requester.request::<types::request::WorkspaceConfiguration>(
+        requester.request::<types::request::WorkspaceConfiguration>(
             ConfigurationParams {
                 items: vec![types::ConfigurationItem {
                     scope_uri: None,

--- a/engine/language_server/src/server/api/notifications/did_save_text_document.rs
+++ b/engine/language_server/src/server/api/notifications/did_save_text_document.rs
@@ -68,9 +68,7 @@ impl super::SyncNotificationHandler for DidSaveTextDocument {
             },
             |e| {
                 tracing::error!("Error generating: {e}");
-                notifier
-                    .notify_baml_error(&format!("Error generating: {e}"))
-                    .unwrap_or(())
+                notifier.notify_baml_error(&format!("{e}")).unwrap_or(())
             },
         );
 
@@ -111,9 +109,7 @@ impl super::BackgroundDocumentNotificationHandler for DidSaveTextDocument {
                 },
                 |e| {
                     tracing::error!("Error generating: {e}");
-                    notifier
-                        .notify_baml_error(&format!("Error generating: {e}"))
-                        .unwrap_or(())
+                    notifier.notify_baml_error(&format!("{e}")).unwrap_or(())
                 },
             );
         } else {

--- a/engine/language_server/src/server/api/notifications/did_save_text_document.rs
+++ b/engine/language_server/src/server/api/notifications/did_save_text_document.rs
@@ -1,10 +1,11 @@
 use crate::server::api::notifications::baml_src_version::BamlSrcVersionPayload;
 use crate::server::api::ResultExt;
 use crate::server::client::{Notifier, Requester};
-use crate::server::Result;
+use crate::server::{Result, Task};
 use crate::session::{DocumentSnapshot, Session};
-use lsp_types as types;
 use lsp_types::notification as notif;
+use lsp_types::request::Request;
+use lsp_types::{self as types, ConfigurationParams};
 use std::borrow::Cow;
 
 pub struct DidSaveTextDocument;
@@ -27,6 +28,14 @@ impl super::SyncNotificationHandler for DidSaveTextDocument {
             .internal_error_msg("Could not convert URL to path")?;
         session.clear_unsaved_files();
         session.reload(Some(notifier.clone())).internal_error()?;
+
+        if let Some(generate_code_on_save) = session.baml_settings.clone().generate_code_on_save {
+            if generate_code_on_save == "never" {
+                tracing::info!("Skipping generator because generate_code_on_save is false");
+                return Ok(());
+            }
+        }
+
         tracing::info!("About to run generator. URL path: {:?}", path);
         let project = session
             .get_or_create_project(&path)

--- a/engine/language_server/src/server/api/requests/hover.rs
+++ b/engine/language_server/src/server/api/requests/hover.rs
@@ -52,11 +52,18 @@ impl SyncRequestHandler for Hover {
         }
         .internal_error()?;
         let position = params.text_document_position_params.position;
-        let hover = project
-            .lock()
-            .unwrap()
-            .handle_hover_request(&text_document_item, &position, notifier)
-            .internal_error()?;
+        // Just swallow the error here, we dont want hover failures to show error notifs for a user.
+        let hover = match project.lock().unwrap().handle_hover_request(
+            &text_document_item,
+            &position,
+            notifier,
+        ) {
+            Ok(hover) => hover,
+            Err(e) => {
+                tracing::error!("Error handling hover request: {}", e);
+                None
+            }
+        };
         Ok(hover)
     }
 }

--- a/engine/language_server/src/session.rs
+++ b/engine/language_server/src/session.rs
@@ -3,6 +3,7 @@
 use anyhow::Context;
 use index::DocumentController;
 use itertools::any;
+use serde_json::Value;
 use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
@@ -21,6 +22,7 @@ use crate::{PositionEncoding, TextDocument};
 pub(crate) use self::capabilities::ResolvedClientCapabilities;
 pub use self::index::DocumentQuery;
 pub(crate) use self::settings::AllSettings;
+pub use self::settings::BamlSettings;
 pub use self::settings::ClientSettings;
 use crate::server::client::Notifier;
 
@@ -44,6 +46,8 @@ pub struct Session {
     pub position_encoding: PositionEncoding,
     /// Tracks what LSP features the client supports and doesn't support.
     pub resolved_client_capabilities: Arc<ResolvedClientCapabilities>,
+
+    pub baml_settings: BamlSettings,
 }
 
 impl Clone for Session {
@@ -53,6 +57,7 @@ impl Clone for Session {
             baml_src_projects: self.baml_src_projects.clone(),
             position_encoding: self.position_encoding.clone(),
             resolved_client_capabilities: self.resolved_client_capabilities.clone(),
+            baml_settings: self.baml_settings.clone(),
         }
     }
 }
@@ -65,7 +70,7 @@ impl Session {
         workspace_folders: &[(Url, ClientSettings)],
     ) -> anyhow::Result<Self> {
         let mut projects = HashMap::new();
-        let index = index::Index::new(global_settings);
+        let index = index::Index::new(global_settings.clone());
 
         for (url, _) in workspace_folders {
             let workspace_path = url
@@ -99,7 +104,19 @@ impl Session {
             resolved_client_capabilities: Arc::new(ResolvedClientCapabilities::new(
                 client_capabilities,
             )),
+            baml_settings: BamlSettings::default(),
         })
+    }
+
+    pub fn update_baml_settings(&mut self, settings: Value) {
+        match serde_json::from_value(settings) {
+            Ok(parsed_settings) => {
+                self.baml_settings = parsed_settings;
+            }
+            Err(err) => {
+                tracing::error!("Failed to parse BAML settings: {}", err);
+            }
+        }
     }
 
     /// Gets or creates a project for the given path.

--- a/engine/language_server/src/session/settings.rs
+++ b/engine/language_server/src/session/settings.rs
@@ -7,8 +7,16 @@ use serde::Deserialize;
 /// Maps a workspace URI to its associated client settings. Used during server initialization.
 pub(crate) type WorkspaceSettingsMap = FxHashMap<Url, ClientSettings>;
 
+#[derive(Debug, Deserialize, Default, Clone)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+#[serde(rename_all = "camelCase")]
+pub struct BamlSettings {
+    pub(crate) cli_path: Option<String>,
+    pub(crate) generate_code_on_save: Option<String>,
+}
+
 /// This is a direct representation of the settings schema sent by the client.
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub struct ClientSettings {
@@ -20,7 +28,7 @@ pub struct ClientSettings {
 
 /// Settings needed to initialize tracing. These will only be
 /// read from the global configuration.
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Clone)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TracingSettings {


### PR DESCRIPTION
- **Respect on-save notifications**
- **clean up error panel when theres diangostic errors and you try to generate**
- **obey the generateCodeOnSave vscode setting**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves configuration handling, error management, and respects on-save notifications in the language server.
> 
>   - **Behavior**:
>     - `BamlProject::run_generators_native` in `baml_project/mod.rs` now handles errors more gracefully, logging specific error messages and returning appropriate errors.
>     - `DidSaveTextDocument` in `did_save_text_document.rs` respects `generate_code_on_save` setting, skipping code generation if set to "never".
>   - **Configuration Handling**:
>     - `DidChangeConfiguration` in `did_change_configuration.rs` updates session BAML settings and requests latest settings if params are null.
>     - `DidOpenTextDocument` in `did_open.rs` requests workspace configuration on file open.
>   - **Error Handling**:
>     - `Hover` in `hover.rs` swallows errors to prevent user-facing notifications on hover failures.
>   - **Session Management**:
>     - `Session` in `session.rs` now includes `baml_settings` and updates them via `update_baml_settings()`.
>     - `Session::reload` reloads projects and updates runtime, logging errors if they occur.
>   - **Misc**:
>     - Minor logging improvements in `server.rs` and `session.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for d0ce84c970eba60f3b671192788ffaa9c47f6307. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->