### PR TITLE
chore: fix concurrency groups

### DIFF
--- a/.github/workflows/build-vscode-release.reusable.yaml
+++ b/.github/workflows/build-vscode-release.reusable.yaml
@@ -1,5 +1,10 @@
 name: BAML Release - Build VSCode Extension (Matrix Packaging)
 
+concurrency:
+  # suffix is important to prevent a concurrency deadlock with the calling workflow
+  group: ${{ github.workflow }}-${{ github.ref }}-build-vscode
+  cancel-in-progress: true
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -8,7 +8,8 @@ on:
     branches: [ sam/integ-tests-ci ]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # suffix is important to prevent a concurrency deadlock with the calling workflow
+  group: ${{ github.workflow }}-${{ github.ref }}-integ-tests
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ on:
       - "test-release/*.*"
       - "*.*"
 concurrency:
+  # No suffix specified - in reusable workflows we need a statically-defined suffix
+  # to prevent workflow_call workflows from triggering a concurrency deadlock
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix concurrency group naming in GitHub workflows to prevent deadlocks by adding specific suffixes.
> 
>   - **Concurrency Group Fixes**:
>     - In `build-vscode-release.reusable.yaml`, added suffix `-build-vscode` to concurrency group to prevent deadlocks.
>     - In `integ-tests.yml`, added suffix `-integ-tests` to concurrency group to prevent deadlocks.
>     - In `release.yml`, added comment explaining the need for a statically-defined suffix in reusable workflows to prevent deadlocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 66b0e3b3a986c2873c06b151e9c1557f26f0c5f7. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->