### PR TITLE
Remove cast slice

### DIFF
--- a/engine/language_client_codegen/src/go/generate_types.rs
+++ b/engine/language_client_codegen/src/go/generate_types.rs
@@ -28,15 +28,6 @@ pub(crate) fn cast_value(container_variable_name: &str, field_type: &GoType) -> 
                 .ok()
                 .unwrap()
         );
-    } else if field_type.is_slice {
-        let inner_type = field_type.underlying_type.as_ref().unwrap();
-        return format!(
-            r#"castSlice({container_variable_name}, func(item any) {} {{
-    return {}
-}})"#,
-            inner_type.name,
-            cast_value("item", inner_type),
-        );
     } else if field_type.is_union {
         return format!("*({container_variable_name}).(*{})", field_type.name);
     } else if field_type.is_pointer {

--- a/engine/language_client_codegen/src/go/templates/client.go.j2
+++ b/engine/language_client_codegen/src/go/templates/client.go.j2
@@ -29,15 +29,6 @@ type stream struct {}
 
 var Stream = &stream{}
 
-func castSlice[T any](result any, castResult func(any) T) []T {
-	items := result.([]any)
-	casted := make([]T, len(items))
-	for i, item := range items {
-		casted[i] = castResult(item)
-	}
-	return casted
-}
-
 func castOptional[T any](result any, castResult func(any) T) *T {
 	if result == nil {
 		return nil

--- a/integ-tests/go/baml_client/client.go
+++ b/integ-tests/go/baml_client/client.go
@@ -39,15 +39,6 @@ type stream struct{}
 
 var Stream = &stream{}
 
-func castSlice[T any](result any, castResult func(any) T) []T {
-	items := result.([]any)
-	casted := make([]T, len(items))
-	for i, item := range items {
-		casted[i] = castResult(item)
-	}
-	return casted
-}
-
 func castOptional[T any](result any, castResult func(any) T) *T {
 	if result == nil {
 		return nil
@@ -1872,9 +1863,7 @@ func DynamicListInputOutput(ctx context.Context, input []types.DynInputOutput) (
 	}
 
 	castResult := func(result any) []types.DynInputOutput {
-		return castSlice(result, func(item any) types.DynInputOutput {
-			return *(item).(*types.DynInputOutput)
-		})
+		return (result).([]types.DynInputOutput)
 	}
 
 	casted := castResult(*result.Data)
@@ -2122,9 +2111,7 @@ func ExtractHobby(ctx context.Context, text string) (*[]types.Hobby, error) {
 	}
 
 	castResult := func(result any) []types.Hobby {
-		return castSlice(result, func(item any) types.Hobby {
-			return (item).(types.Hobby)
-		})
+		return (result).([]types.Hobby)
 	}
 
 	casted := castResult(*result.Data)
@@ -2186,9 +2173,7 @@ func ExtractNames(ctx context.Context, input string) (*[]string, error) {
 	}
 
 	castResult := func(result any) []string {
-		return castSlice(result, func(item any) string {
-			return (item).(string)
-		})
+		return (result).([]string)
 	}
 
 	casted := castResult(*result.Data)
@@ -2250,9 +2235,7 @@ func ExtractPeople(ctx context.Context, text string) (*[]types.Person, error) {
 	}
 
 	castResult := func(result any) []types.Person {
-		return castSlice(result, func(item any) types.Person {
-			return *(item).(*types.Person)
-		})
+		return (result).([]types.Person)
 	}
 
 	casted := castResult(*result.Data)
@@ -2628,9 +2611,7 @@ func FnEnumListOutput(ctx context.Context, input string) (*[]types.EnumOutput, e
 	}
 
 	castResult := func(result any) []types.EnumOutput {
-		return castSlice(result, func(item any) types.EnumOutput {
-			return (item).(types.EnumOutput)
-		})
+		return (result).([]types.EnumOutput)
 	}
 
 	casted := castResult(*result.Data)
@@ -3064,9 +3045,7 @@ func FnOutputClassList(ctx context.Context, input string) (*[]types.TestOutputCl
 	}
 
 	castResult := func(result any) []types.TestOutputClass {
-		return castSlice(result, func(item any) types.TestOutputClass {
-			return *(item).(*types.TestOutputClass)
-		})
+		return (result).([]types.TestOutputClass)
 	}
 
 	casted := castResult(*result.Data)
@@ -3500,9 +3479,7 @@ func FnOutputStringList(ctx context.Context, input string) (*[]string, error) {
 	}
 
 	castResult := func(result any) []string {
-		return castSlice(result, func(item any) string {
-			return (item).(string)
-		})
+		return (result).([]string)
 	}
 
 	casted := castResult(*result.Data)
@@ -4928,11 +4905,7 @@ func OptionalTest_Function(ctx context.Context, input string) (*[]*types.Optiona
 	}
 
 	castResult := func(result any) []*types.OptionalTest_ReturnType {
-		return castSlice(result, func(item any) *types.OptionalTest_ReturnType {
-			return castOptional(item, func(item any) types.OptionalTest_ReturnType {
-				return *(item).(*types.OptionalTest_ReturnType)
-			})
-		})
+		return (result).([]*types.OptionalTest_ReturnType)
 	}
 
 	casted := castResult(*result.Data)
@@ -6482,9 +6455,7 @@ func StreamUnionIntegers(ctx context.Context, digits int64) (*[]types.Union__int
 	}
 
 	castResult := func(result any) []types.Union__int__string {
-		return castSlice(result, func(item any) types.Union__int__string {
-			return *(item).(*types.Union__int__string)
-		})
+		return (result).([]types.Union__int__string)
 	}
 
 	casted := castResult(*result.Data)
@@ -8716,9 +8687,7 @@ func TestFnNamedArgsSingleStringList(ctx context.Context, myArg []string) (*[]st
 	}
 
 	castResult := func(result any) []string {
-		return castSlice(result, func(item any) string {
-			return (item).(string)
-		})
+		return (result).([]string)
 	}
 
 	casted := castResult(*result.Data)


### PR DESCRIPTION
This casting is no longer needed, and actually blows up.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `castSlice` and update `CFFIValueUnionVariant` to use `variant_name` instead of `value_type_index`.
> 
>   - **Behavior**:
>     - Remove `castSlice` function from `client.go.j2` and `generate_types.rs`.
>     - Add `variant_name` field to `CFFIValueUnionVariant` in `cffi_generated.rs` and `cffi.fbs`.
>     - Update `EncodeUnion` and `Decode` methods to use `variant_name` instead of `value_type_index`.
>   - **Code Generation**:
>     - Update Go and Python client code to handle `variant_name`.
>     - Add `RecursiveUnionTest` function and related types in integration tests.
>   - **Misc**:
>     - Adjust offsets in `CFFIValueUnionVariant` methods in `CFFIValueUnionVariant.go`.
>     - Remove unused code and adjust comments in `encode.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 299d9a3eb71cb72e94495475623d9081eb9f7978. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->