### PR TITLE
make vertex types optional since they sometimes go missing

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
@@ -300,33 +300,33 @@ pub struct CitationMetadata {
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct Citation {
-    pub start_index: i32,
-    pub end_index: i32,
-    pub uri: String,
-    pub title: String,
-    pub license: String,
-    pub publication_date: Date,
+    pub start_index: Option<i32>,
+    pub end_index: Option<i32>,
+    pub uri: Option<String>,
+    pub title: Option<String>,
+    pub license: Option<String>,
+    pub publication_date: Option<Date>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Date {
-    pub year: i32,
-    pub month: i32,
-    pub day: i32,
+    pub year: Option<i32>,
+    pub month: Option<i32>,
+    pub day: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GroundingMetadata {
-    pub web_search_queries: Vec<String>,
-    pub search_entry_point: SearchEntryPoint,
+    pub web_search_queries: Option<Vec<String>>,
+    pub search_entry_point: Option<SearchEntryPoint>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchEntryPoint {
-    pub rendered_content: String,
-    pub sdk_blob: Vec<u8>,
+    pub rendered_content: Option<String>,
+    pub sdk_blob: Option<Vec<u8>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/types.rs
@@ -321,23 +321,23 @@ pub struct Citation {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Date {
-    pub year: i32,
-    pub month: i32,
-    pub day: i32,
+    pub year: Option<i32>,
+    pub month: Option<i32>,
+    pub day: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GroundingMetadata {
-    pub web_search_queries: Vec<String>,
-    pub search_entry_point: SearchEntryPoint,
+    pub web_search_queries: Option<Vec<String>>,
+    pub search_entry_point: Option<SearchEntryPoint>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct SearchEntryPoint {
-    pub rendered_content: String,
-    pub sdk_blob: Vec<u8>,
+    pub rendered_content: Option<String>,
+    pub sdk_blob: Option<Vec<u8>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/integ-tests/python/uv.lock
+++ b/integ-tests/python/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.9, <4"
 resolution-markers = [
     "python_full_version < '3.10'",
@@ -199,7 +198,7 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
@@ -576,6 +575,8 @@ version = "6.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/5a/07871137bb752428aa4b659f910b399ba6f291156bdea939be3e96cae7cb/psutil-6.1.1.tar.gz", hash = "sha256:cf8496728c18f2d0b45198f06895be52f36611711746b7f30c464b422b50e2f5", size = 508502 }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/d4/8095b53c4950f44dc99b8d983b796f405ae1f58d80978fcc0421491b4201/psutil-6.1.1-cp27-none-win32.whl", hash = "sha256:6d4281f5bbca041e2292be3380ec56a9413b790579b8e593b1784499d0005dac", size = 246855 },
+    { url = "https://files.pythonhosted.org/packages/b1/63/0b6425ea4f2375988209a9934c90d6079cc7537847ed58a28fbe30f4277e/psutil-6.1.1-cp27-none-win_amd64.whl", hash = "sha256:c777eb75bb33c47377c9af68f30e9f11bc78e0f07fbf907be4a5d70b2fe5f030", size = 250110 },
     { url = "https://files.pythonhosted.org/packages/61/99/ca79d302be46f7bdd8321089762dd4476ee725fce16fc2b2e1dbba8cac17/psutil-6.1.1-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:fc0ed7fe2231a444fc219b9c42d0376e0a9a1a72f16c5cfa0f68d19f1a0663e8", size = 247511 },
     { url = "https://files.pythonhosted.org/packages/0b/6b/73dbde0dd38f3782905d4587049b9be64d76671042fdcaf60e2430c6796d/psutil-6.1.1-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:0bdd4eab935276290ad3cb718e9809412895ca6b5b334f5a9111ee6d9aff9377", size = 248985 },
     { url = "https://files.pythonhosted.org/packages/17/38/c319d31a1d3f88c5b79c68b3116c129e5133f1822157dd6da34043e32ed6/psutil-6.1.1-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b6e06c20c05fe95a3d7302d74e7097756d4ba1247975ad6905441ae1b5b66003", size = 284488 },
@@ -792,7 +793,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "ruff" },
-    { name = "types-assertpy" },
 ]
 
 [package.metadata]
@@ -815,10 +815,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
-    { name = "ruff", specifier = ">=0.9.10" },
-    { name = "types-assertpy" },
-]
+dev = [{ name = "ruff", specifier = ">=0.9.10" }]
 
 [[package]]
 name = "requests"
@@ -917,20 +914,11 @@ name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "platform_system == 'Windows'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540 },
-]
-
-[[package]]
-name = "types-assertpy"
-version = "1.1.0.20250502"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2d/51/98d2bf5a9f3a98a933f0bb598b0905531a3fec81ae7ba97625a46f8d57d4/types_assertpy-1.1.0.20250502.tar.gz", hash = "sha256:7735027f3e63f91a1f3a24819024991358f083a40aceb5dd117e5691e9d4a0de", size = 10387 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/15/04ac9cde31889ac1954d5d56fe10d695f6c8fe54ce4a833c5690d327e969/types_assertpy-1.1.0.20250502-py3-none-any.whl", hash = "sha256:dc025f53b74b7bd75ecb830755af10261908c57fb20df38fd42caaca427c5aac", size = 12848 },
 ]
 
 [[package]]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Made several fields optional in `google/types.rs` and `vertex/types.rs` structs and updated dependencies in `uv.lock`.
> 
>   - **Struct Changes**:
>     - In `google/types.rs` and `vertex/types.rs`, made fields in `Citation`, `Date`, `GroundingMetadata`, and `SearchEntryPoint` structs optional.
>   - **Dependency Changes**:
>     - In `uv.lock`, changed platform marker for `colorama` dependency from `sys_platform == 'win32'` to `platform_system == 'Windows'`.
>     - Removed `types-assertpy` from dev-dependencies in `uv.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 8587647b5b6a08355bf8ae8930d02c22cee569cc. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->