### PR TITLE
Be more resilient to gemini outputting thoughts in api response

### DIFF
--- a/.github/workflows/build-ruby-release.reusable.yaml
+++ b/.github/workflows/build-ruby-release.reusable.yaml
@@ -3,7 +3,7 @@ name: BAML Release - Build Ruby
 on:
   workflow_call: {}
   push:
-    branches: [bump-ruby]
+    branches: [gemini-fix]
 
 permissions:
   contents: read

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -417,29 +417,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b756939cb2f8dc900aa6dcd505e6e2428e9cae7ff7b028c49e3946efa70878"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.28.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "aws-runtime"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,7 +1177,6 @@ dependencies = [
  "reqwest-eventsource",
  "ring",
  "rstest",
- "rustls 0.23.26",
  "scopeguard",
  "secrecy",
  "send_wrapper 0.6.0",
@@ -1235,7 +1211,7 @@ dependencies = [
  "wasmtimer",
  "web-sys",
  "web-time",
- "which 6.0.3",
+ "which",
 ]
 
 [[package]]
@@ -1401,15 +1377,12 @@ dependencies = [
  "itertools 0.10.5",
  "lazy_static",
  "lazycell",
- "log",
- "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.87",
- "which 4.4.2",
 ]
 
 [[package]]
@@ -1555,11 +1528,6 @@ name = "cc"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47de7e88bbbd467951ae7f5a6f34f70d1b4d9cfce53d5fd70f74ebe118b3db56"
-dependencies = [
- "jobserver",
- "libc",
- "once_cell",
-]
 
 [[package]]
 name = "cexpr"
@@ -2424,12 +2392,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -3614,16 +3576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "jobserver"
-version = "0.1.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
-dependencies = [
- "getrandom 0.3.2",
- "libc",
-]
-
-[[package]]
 name = "jod-thread"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4681,16 +4633,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
-dependencies = [
- "proc-macro2",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5270,8 +5212,6 @@ version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
- "aws-lc-rs",
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5346,7 +5286,6 @@ version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aa4eeac2588ffff23e9d7a7e9b3f971c5fb5b7ebc9452745e0c232c64f83b2f"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -6850,18 +6789,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.34",
 ]
 
 [[package]]

--- a/engine/baml-runtime/Cargo.toml
+++ b/engine/baml-runtime/Cargo.toml
@@ -172,7 +172,6 @@ notify-debouncer-full = "0.3.1"
 ring = { version = "0.17.4", features = ["std"] }
 tokio = { version = "1", features = ["full"] }
 reqwest.workspace = true
-rustls = "0.23.26"
 walkdir = "2.5.0"
 which = "6.0.3"
 indicatif = "0.17"

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/googleai_client.rs
@@ -359,26 +359,6 @@ impl ToProviderMessage for GoogleAIClient {
     }
 }
 
-/// The Google Gemini 2 model has an experimental feature
-/// called Flash Thinking Mode, which is turned on in a particular
-/// named model: gemini-2.0-flash-thinking-exp-1219
-///
-/// When run in this mode, Gemini returns `candidates` with 2 parts each.
-/// Part 0 is the chain of thought, part 1 is the actual output.
-/// Other Gemini models put the output data in part 0.
-///
-/// TODO: Explicitly represent Flash Thinking Mode response and
-/// do more thorough checking for the content part.
-/// For examples of how to introspect the response more safely, see:
-/// https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/getting-started/intro_gemini_2_0_flash_thinking_mode.ipynb
-fn content_part(model_name: &str) -> usize {
-    if model_name.contains("gemini-2.0-flash-thinking-exp-1219") {
-        1
-    } else {
-        0
-    }
-}
-
 impl CompletionToProviderBody for GoogleAIClient {
     fn completion_to_provider_body(
         &self,

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/response_handler.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use super::types::GoogleResponse;
+use super::types::{GoogleResponse, Part};
 use crate::internal::llm_client::{
     primitive::request::RequestBuilder, traits::WithClient, ErrorCode, LLMCompleteResponse,
     LLMCompleteResponseMetadata, LLMErrorResponse, LLMResponse,
@@ -26,6 +26,7 @@ pub fn parse_google_response<C: WithClient + RequestBuilder>(
     instant_now: web_time::Instant,
     model_name: Option<String>,
 ) -> LLMResponse {
+    // baml_log::info!("Parsing Google response: {:#?}", response_body);
     let response = match GoogleResponse::deserialize(&response_body)
         .context(format!(
             "Failed to parse into a response accepted by {}: {}",
@@ -78,11 +79,11 @@ pub fn parse_google_response<C: WithClient + RequestBuilder>(
     };
 
     let model_name = model_name.unwrap_or("<unknown>".to_string());
-    let part_index = content_part(&model_name);
+    let text_content = text_content_part(&content.parts);
     LLMResponse::Success(LLMCompleteResponse {
         client: client.context().name.to_string(),
         prompt: to_prompt(prompt),
-        content: content.parts[part_index].text.clone(),
+        content: text_content.unwrap_or_default(),
         start_time: system_now,
         latency: instant_now.elapsed(),
         request_options: client.request_options().clone(),
@@ -101,12 +102,11 @@ pub fn parse_google_response<C: WithClient + RequestBuilder>(
     })
 }
 
-fn content_part(model_name: &str) -> usize {
-    if model_name.contains("gemini-2.0-flash-thinking-exp-1219") {
-        1
-    } else {
-        0
-    }
+fn text_content_part(parts: &Vec<Part>) -> Option<String> {
+    parts
+        .iter()
+        .position(|part| !part.text.is_empty() && part.thought.unwrap_or(false) == false)
+        .map(|index| parts[index].text.clone())
 }
 
 pub fn scan_google_response_stream(
@@ -145,18 +145,13 @@ pub fn scan_google_response_stream(
         Err(e) => return Err(e),
     };
     if let Some(choice) = event.candidates.get(0) {
-        let part_index = content_part(
-            model_name
-                .as_ref()
-                .map(|s| s.as_str())
-                .unwrap_or("<unknown>"),
-        );
-        if let Some(content) = choice
+        let text_content = &choice
             .content
             .as_ref()
-            .and_then(|c| c.parts.get(part_index))
-        {
-            inner.content += &content.text;
+            .and_then(|c| text_content_part(&c.parts));
+
+        if let Some(text_content) = text_content {
+            inner.content += &text_content;
         }
         inner.metadata.finish_reason = choice.finish_reason.as_ref().map(|r| r.to_string());
         if choice
@@ -235,6 +230,7 @@ mod tests {
                         function_call: None,
                         function_response: None,
                         video_metadata: None,
+                        thought: None,
                     }],
                     role: Some("model".to_string()),
                 }),

--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
@@ -245,6 +245,7 @@ pub struct Part {
     pub function_call: Option<FunctionCall>,
     pub function_response: Option<FunctionResponse>,
     pub video_metadata: Option<VideoMetadata>,
+    pub thought: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -115,16 +115,16 @@ static TOKIO_SINGLETON: OnceLock<std::io::Result<Arc<tokio::runtime::Runtime>>> 
 
 static INIT: std::sync::Once = std::sync::Once::new();
 
-fn setup_crypto_provider() {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        use rustls::crypto::CryptoProvider;
-        INIT.call_once(|| {
-            let provider = rustls::crypto::ring::default_provider();
-            CryptoProvider::install_default(provider).expect("failed to install CryptoProvider");
-        });
-    }
-}
+// fn setup_crypto_provider() {
+//     #[cfg(not(target_arch = "wasm32"))]
+//     {
+//         use rustls::crypto::CryptoProvider;
+//         INIT.call_once(|| {
+//             let provider = rustls::crypto::ring::default_provider();
+//             CryptoProvider::install_default(provider).expect("failed to install CryptoProvider");
+//         });
+//     }
+// }
 
 #[derive(Clone)]
 pub struct BamlRuntime {
@@ -187,7 +187,7 @@ impl BamlRuntime {
         path: &std::path::Path,
         env_vars: HashMap<T, T>,
     ) -> Result<Self> {
-        setup_crypto_provider();
+        // setup_crypto_provider();
         let path = Self::parse_baml_src_path(path)?;
 
         let copy = env_vars
@@ -210,7 +210,7 @@ impl BamlRuntime {
         files: &HashMap<T, T>,
         env_vars: HashMap<U, U>,
     ) -> Result<Self> {
-        setup_crypto_provider();
+        // setup_crypto_provider();
         let copy = env_vars
             .iter()
             .map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string()))

--- a/integ-tests/python/tests/test_functions.py
+++ b/integ-tests/python/tests/test_functions.py
@@ -793,6 +793,56 @@ async def test_streaming_gemini():
 
 
 @pytest.mark.asyncio
+async def test_gemini_models():
+    client_registry = baml_py.ClientRegistry()
+    # # Test with gemini-1.5-flash-thinking-exp-1219
+    # client_registry.add_llm_client(
+    #     "MyCustomGeminiClient",
+    #     "google-ai",
+    #     {"model": "gemini-1.5-flash-thinking-exp-1219"},
+    # )
+    # client_registry.set_primary("MyCustomGeminiClient")
+    # res = await b.TestGemini(
+    #     input="Dr.Pepper", baml_options={"client_registry": client_registry}
+    # )
+    # assert len(res) > 0, "Expected non-empty result but got empty."
+
+    # Test with gemini-2.5-pro-preview-05-06
+    # client_registry.add_llm_client(
+    #     "Gemini25ProMay", "google-ai", {"model": "gemini-2.5-pro-preview-05-06"}
+    # )
+    # client_registry.set_primary("Gemini25ProMay")
+    # res = await b.TestGemini(
+    #     input="sea. Actually output the multiplication of 23*12/12+3 and take square root of 10.",
+    #     baml_options={"client_registry": client_registry},
+    # )
+    # assert len(res) > 0, "Expected non-empty result but got empty."
+
+    # Test with gemini-2.5-pro-preview-03-25
+    # client_registry.add_llm_client(
+    #     "Gemini25ProMarch", "google-ai", {"model": "gemini-2.5-pro-preview-03-25"}
+    # )
+    # client_registry.set_primary("Gemini25ProMarch")
+    # res = await b.TestGemini(
+    #     input="sea. Actually just output a json object with the keys 'name' and 'age'.",
+    #     baml_options={"client_registry": client_registry},
+    # )
+    # assert len(res) > 0, "Expected non-empty result but got empty."
+
+    # Test with gemini-2.0-flash-thinking-exp-1219
+    client_registry.add_llm_client(
+        "GeminiFlashThinking",
+        "google-ai",
+        {"model": "gemini-2.0-flash-thinking-exp-1219"},
+    )
+    client_registry.set_primary("GeminiFlashThinking")
+    res = await b.TestGemini(
+        input="sea", baml_options={"client_registry": client_registry}
+    )
+    assert len(res) > 0, "Expected non-empty result but got empty."
+
+
+@pytest.mark.asyncio
 async def test_tracing_async_only():
     @trace
     async def top_level_async_tracing():


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improve resilience to Gemini API responses with 'thoughts' by updating response parsing logic and adding tests.
> 
>   - **Behavior**:
>     - Update `parse_google_response` and `scan_google_response_stream` in `response_handler.rs` to handle Gemini responses with 'thoughts' by checking for non-empty text parts not marked as 'thoughts'.
>     - Remove `content_part()` function from `googleai_client.rs` and `response_handler.rs`.
>   - **Testing**:
>     - Add `test_gemini_models()` in `test_functions.py` to verify handling of different Gemini models.
>   - **Misc**:
>     - Change branch trigger in `build-ruby-release.reusable.yaml` from `bump-ruby` to `gemini-fix`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 23314b9e458c15d323055ee564f775d886754d43. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->