### PR TITLE
[bug] Correctly parse enums when other json elements may exist in the string

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use baml_types::{BamlMap, CompletionState, Constraint, ConstraintLevel};
+use baml_types::{BamlMap, CompletionState, Constraint, ConstraintLevel, LiteralValue};
 use internal_baml_core::{ir::FieldType, ir::TypeValue};
 
 use crate::deserializer::{
@@ -33,7 +33,7 @@ impl TypeCoercer for FieldType {
                     scope = ctx.display_scope(),
                     current = value.map(|v| v.r#type()).unwrap_or("<null>".into())
                 );
-                if matches!(target, FieldType::Primitive(TypeValue::String)) {
+                if matches!(target, FieldType::Primitive(TypeValue::String) | FieldType::Enum(_) | FieldType::Literal(LiteralValue::String(_))) {
                     self.coerce(
                         ctx,
                         target,

--- a/engine/baml-lib/jsonish/src/tests/test_enum.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_enum.rs
@@ -293,3 +293,21 @@ test_failing_deserializer!(
     "The answer is not car or car-2!",
     FieldType::Enum("Car".to_string())
 );
+
+test_deserializer!(
+    test_weird_characters,
+    r#"
+enum MessageType {
+  SPAM
+  NOT_SPAM
+}
+    "#,
+    r#"
+The text "Buy cheap watches now! Limited time offer!!!" is typically characterized by unsolicited 
+offers and urgency ($^{$_{Ω}$rel}$), which are common traits of spam messages. Therefore, it should be classified as:
+
+- **SPAM**
+    "#,
+    FieldType::Enum("MessageType".to_string()),
+    "SPAM"
+);


### PR DESCRIPTION
Fixes #1888

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes enum parsing in `field_type.rs` to handle JSON strings with additional elements, verified by new test in `test_enum.rs`.
> 
>   - **Behavior**:
>     - Fixes enum parsing in `coerce()` in `field_type.rs` to handle cases where other JSON elements exist in the string.
>     - Adds support for `FieldType::Enum(_)` and `FieldType::Literal(LiteralValue::String(_))` in `matches!` condition.
>   - **Tests**:
>     - Adds `test_weird_characters` in `test_enum.rs` to verify enum parsing with additional text and special characters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for bb03cfa075d76d744835d7af2290629dd9a61310. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->