### PR TITLE
Remove fancy bool

### DIFF
--- a/engine/language_client_cffi/src/lib.rs
+++ b/engine/language_client_cffi/src/lib.rs
@@ -87,7 +87,7 @@ use std::os::raw::c_char;
 
 use baml_types::BamlValue;
 
-pub type CallbackFn = extern "C" fn(call_id: u32, is_done: bool, content: *const i8, length: usize);
+pub type CallbackFn = extern "C" fn(call_id: u32, is_done: i32, content: *const i8, length: usize);
 
 /// cbindgen:ignore
 static RESULT_CALLBACK_FN: OnceCell<CallbackFn> = OnceCell::new();
@@ -122,21 +122,27 @@ fn safe_trigger_callback(id: u32, is_done: bool, result: Result<FunctionResult>)
             Some(Ok(content)) => {
                 let mut builder = flatbuffers::FlatBufferBuilder::new();
                 let content = ctypes::serialize_baml_value_with_meta(&content.0, &mut builder);
-                callback_fn(id, is_done, content.as_ptr() as *const i8, content.len());
+                let is_done_int = if is_done { 1 } else { 0 };
+                callback_fn(
+                    id,
+                    is_done_int,
+                    content.as_ptr() as *const i8,
+                    content.len(),
+                );
             }
             Some(Err(e)) => {
                 // let c_message = CString::new(e.to_string()).unwrap();
                 let message = e.to_string();
-                error_callback_fn(id, true, message.as_ptr() as *const i8, message.len());
+                error_callback_fn(id, 1, message.as_ptr() as *const i8, message.len());
             }
             None => {
                 let message = "No result from baml".to_string();
-                error_callback_fn(id, true, message.as_ptr() as *const i8, message.len());
+                error_callback_fn(id, 1, message.as_ptr() as *const i8, message.len());
             }
         },
         Err(e) => {
             let message = format!("Error: {}", e);
-            error_callback_fn(id, true, message.as_ptr() as *const i8, message.len());
+            error_callback_fn(id, 1, message.as_ptr() as *const i8, message.len());
         }
     }
 }

--- a/engine/language_client_go/baml_go/exports.go
+++ b/engine/language_client_go/baml_go/exports.go
@@ -10,7 +10,6 @@ import (
 #cgo CFLAGS: -O3 -g
 #include <baml_cffi_wrapper.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
 */

--- a/engine/language_client_go/baml_go/lib.go
+++ b/engine/language_client_go/baml_go/lib.go
@@ -26,7 +26,6 @@ import (
 #include <dlfcn.h>
 #include <baml_cffi_wrapper.h>
 #include <stdlib.h>
-#include <stdbool.h>
 #include <string.h>
 #include <stdint.h>
 #include <string.h>

--- a/engine/language_client_go/include/baml_cffi_generated.h
+++ b/engine/language_client_go/include/baml_cffi_generated.h
@@ -11,7 +11,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-typedef void (*CallbackFn)(uint32_t call_id, bool is_done, const int8_t *content, uintptr_t length);
+typedef void (*CallbackFn)(uint32_t call_id,
+                           int32_t is_done,
+                           const int8_t *content,
+                           uintptr_t length);
 
 const char *version(void);
 

--- a/engine/language_client_go/pkg/callbacks.go
+++ b/engine/language_client_go/pkg/callbacks.go
@@ -2,7 +2,6 @@ package baml
 
 /*
 #include <stdlib.h>
-#include <stdbool.h>
 #include <stdint.h>
 */
 import "C"
@@ -59,7 +58,7 @@ func SetTypeMap(t TypeMap) {
 }
 
 //export error_callback
-func error_callback(id C.uint32_t, isDone C.bool, content *C.int8_t, length C.int) {
+func error_callback(id C.uint32_t, isDone C.int, content *C.int8_t, length C.int) {
 	fmt.Println("Error callback")
 	callbackMutex.RLock()
 	id_uint := uint32(id)
@@ -86,7 +85,7 @@ func error_callback(id C.uint32_t, isDone C.bool, content *C.int8_t, length C.in
 }
 
 //export trigger_callback
-func trigger_callback(id C.uint32_t, isDone C.bool, content *C.int8_t, length C.int) {
+func trigger_callback(id C.uint32_t, isDone C.int, content *C.int8_t, length C.int) {
 	callbackMutex.RLock()
 	id_uint := uint32(id)
 	callback, exists := dynamicCallbacks[id_uint]
@@ -100,7 +99,7 @@ func trigger_callback(id C.uint32_t, isDone C.bool, content *C.int8_t, length C.
 		decoded_data := Decode(&parsed_data)
 
 		var res ResultCallback
-		if isDone {
+		if isDone == 1 {
 			res = ResultCallback{HasData: true, Data: &decoded_data}
 		} else {
 			res = ResultCallback{HasStreamData: true, StreamData: &decoded_data}
@@ -117,7 +116,7 @@ func trigger_callback(id C.uint32_t, isDone C.bool, content *C.int8_t, length C.
 			break
 		}
 
-		if bool(isDone) || force_close {
+		if isDone == 1 || force_close {
 			close(callback.channel)
 			callbackMutex.Lock()
 			defer callbackMutex.Unlock()

--- a/engine/language_client_go/pkg/runtime.go
+++ b/engine/language_client_go/pkg/runtime.go
@@ -2,10 +2,9 @@ package baml
 
 /*
 #include <stdlib.h>
-#include <stdbool.h>
 
-extern void trigger_callback(uint32_t, bool, const int8_t *, int);
-extern void error_callback(uint32_t, bool, const int8_t *, int);
+extern void trigger_callback(uint32_t, int, const int8_t *, int);
+extern void error_callback(uint32_t, int, const int8_t *, int);
 */
 import "C"
 


### PR DESCRIPTION
Someone who knows rust and cgo better than me may also wanna look at this, cause I know neither, but my local tests appear to be running?
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `is_done` type from `bool` to `int` in callback functions across Rust and Go code for compatibility.
> 
>   - **Behavior**:
>     - Change `is_done` type from `bool` to `int` in `CallbackFn` in `lib.rs` and `baml_cffi_generated.h`.
>     - Update `safe_trigger_callback()` in `lib.rs` to convert `bool` to `int` for `is_done`.
>     - Modify `trigger_callback()` and `error_callback()` in `callbacks.go` to use `int` for `is_done`.
>   - **Code Cleanup**:
>     - Remove `#include <stdbool.h>` from `exports.go`, `lib.go`, and `callbacks.go` as `bool` is no longer used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 49cd8202b17ebf022a95d8e78b80712914021bd3. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->