### PR TITLE
This appears to fix the linux cgo build of baml-cli for me inside a docker container

### DIFF
--- a/engine/language_client_go/pkg/runtime.go
+++ b/engine/language_client_go/pkg/runtime.go
@@ -2,9 +2,10 @@ package baml
 
 /*
 #include <stdlib.h>
+#include <stdint.h>
 
-extern void trigger_callback(uint32_t, int, const int8_t *, int);
-extern void error_callback(uint32_t, int, const int8_t *, int);
+extern void trigger_callback(uint32_t id, int is_done, const int8_t *content, int length);
+extern void error_callback(uint32_t id, int is_done, const int8_t *content, int length);
 */
 import "C"
 


### PR DESCRIPTION
I was able to mount the docker image and fuck with the file until it built.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Linux cgo build issue for `baml-cli` by updating C function declarations in `runtime.go`.
> 
>   - **Build Fix**:
>     - Add `#include <stdint.h>` in `runtime.go` to ensure proper type definitions for `uint32_t` and `int8_t`.
>     - Modify `trigger_callback` and `error_callback` function declarations to include parameter names for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 32d0860c19b400dadaa4a29bdef2cc7b0dd36c19. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->