### PR TITLE
Build win arm64

### DIFF
--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -53,7 +53,7 @@ jobs:
             runs_on: windows-latest
 
           - target: aarch64-pc-windows-msvc
-            runs_on: windows-latest
+            runs_on: windows-11-arm
             interpreter: 3.11 3.12 3.13
 
     name: ${{ matrix._.target }}

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -59,6 +59,62 @@ jobs:
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.runs_on }}
     steps:
+      - name: Setup build environment (ARM64 Windows)
+        if: matrix._.target == 'aarch64-pc-windows-msvc'
+        shell:
+          powershell
+          # Notes
+          # * We update `Expand-Archive` to avoid "" is not a supported archive file format when extracting
+          #   files that don't end in `.zip`
+        run: |
+          Write-Output "> Update Expand-Archive (Microsoft.PowerShell.Archive)"
+          Install-PackageProvider -Name NuGet -Force
+          Install-Module -Name Microsoft.PowerShell.Archive -Force
+
+          Write-Output "> Setup bash.exe (git-for-windows/PortableGit)"
+          Invoke-WebRequest "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/PortableGit-2.47.1-arm64.7z.exe" -OutFile /git.7z.exe
+          /git.7z.exe -o/git -y
+
+          Write-Output "> Setup Rust"
+          Invoke-WebRequest "https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe" -OutFile /rustup-init.exe
+          /rustup-init.exe --default-host aarch64-pc-windows-msvc -y
+
+          Write-Output "> Setup VS Build Tools"
+          Invoke-WebRequest "https://aka.ms/vs/17/release/vs_BuildTools.exe" -OutFile /vs_BuildTools.exe
+          Start-Process C:/vs_BuildTools.exe -ArgumentList " `
+              --add Microsoft.VisualStudio.Workload.NativeDesktop `
+              --add Microsoft.VisualStudio.Workload.VCTools `
+              --add Microsoft.VisualStudio.Component.VC.Tools.arm64 `
+              --add Microsoft.VisualStudio.Component.VC.Llvm.Clang `
+              --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset `
+              --includeRecommended --quiet --norestart --wait" -Wait
+
+          Write-Output "> Setup CMake"
+          Invoke-WebRequest "https://github.com/Kitware/CMake/releases/download/v3.31.2/cmake-3.31.2-windows-arm64.zip" -OutFile /cmake.zip
+          Expand-Archive /cmake.zip -DestinationPath /
+
+          Write-Output "> Download jq.exe (github.com/jqlang) (needed for tomlq / yq)"
+          Invoke-WebRequest https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-windows-i386.exe -OutFile /jq.exe
+
+          Write-Output "> Update GITHUB_PATH"
+          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + "C:/git/bin/")
+          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + $Env:USERPROFILE + "/.cargo/bin/")
+          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/bin/")
+          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + "C:/cmake-3.31.2-windows-arm64/bin")
+          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + "C:/")
+          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n")
+
+          Get-Content $Env:GITHUB_PATH | Out-Host
+
+      - name: Check build environment (ARM64 Windows)
+        if: matrix._.target == 'aarch64-pc-windows-msvc'
+        run: |
+          set -x
+          bash --version
+          rustup show
+          clang -v
+          cmake --version
+
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -54,6 +54,7 @@ jobs:
 
           - target: aarch64-pc-windows-msvc
             runs_on: windows-latest
+            interpreter: 3.11 3.12 3.13
 
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.runs_on }}
@@ -61,7 +62,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix._.target == 'aarch64-pc-windows-msvc' && '3.11' || '3.8' }}
           architecture: ${{ matrix._.runs_on == 'windows-latest' && 'x64' || null }}
 
       - name: Build wheels
@@ -72,7 +73,7 @@ jobs:
           command: build
           # building in engine/ ensures that we pick up .cargo/config.toml
           working-directory: engine
-          args: --release --out language_client_python/dist --manifest-path language_client_python/Cargo.toml
+          args: --release --out language_client_python/dist --manifest-path language_client_python/Cargo.toml ${{ matrix._.interpreter && format('--interpreter {0}', matrix._.interpreter) || '' }}
           manylinux: ${{ matrix._.manylinux }}
           before-script-linux: |
             if command -v yum &> /dev/null; then

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -21,40 +21,40 @@ jobs:
       fail-fast: false
       matrix:
         _:
-          # - target: x86_64-unknown-linux-gnu
-          #   runs_on: ubuntu-latest
-          #   manylinux: 2_17
+          - target: x86_64-unknown-linux-gnu
+            runs_on: ubuntu-latest
+            manylinux: 2_17
 
-          # - target: aarch64-unknown-linux-gnu
-          #   runs_on: ubuntu-latest
-          #   manylinux: 2_24
-          #   # I'm not sure if this actually works; I can't 'pip install ./local-path.whl'
-          #   # from inside a container based off quay.io/pypa/manylinux2014_aarch64
-          #   # see https://github.com/astral-sh/uv/issues/3439#issuecomment-2110448346
-          #   # manylinux: 2_28
-          #   # env:
-          #   #   # Workaround ring 0.17 build issue
-          #   #   # see https://github.com/briansmith/ring/issues/1728
-          #   #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
+          - target: aarch64-unknown-linux-gnu
+            runs_on: ubuntu-latest
+            manylinux: 2_24
+            # I'm not sure if this actually works; I can't 'pip install ./local-path.whl'
+            # from inside a container based off quay.io/pypa/manylinux2014_aarch64
+            # see https://github.com/astral-sh/uv/issues/3439#issuecomment-2110448346
+            # manylinux: 2_28
+            # env:
+            #   # Workaround ring 0.17 build issue
+            #   # see https://github.com/briansmith/ring/issues/1728
+            #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
 
-          # - target: x86_64-unknown-linux-musl
-          #   runs_on: ubuntu-latest
-          #   # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
-          #   manylinux: musllinux_1_1
+          - target: x86_64-unknown-linux-musl
+            runs_on: ubuntu-latest
+            # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
+            manylinux: musllinux_1_1
 
-          # - target: aarch64-unknown-linux-musl
-          #   runs_on: ubuntu-latest
-          #   # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
-          #   manylinux: musllinux_1_1
+          - target: aarch64-unknown-linux-musl
+            runs_on: ubuntu-latest
+            # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
+            manylinux: musllinux_1_1
 
-          # - target: x86_64-apple-darwin
-          #   runs_on: macos-latest
+          - target: x86_64-apple-darwin
+            runs_on: macos-latest
 
-          # - target: aarch64-apple-darwin
-          #   runs_on: macos-latest
+          - target: aarch64-apple-darwin
+            runs_on: macos-latest
 
-          # - target: x86_64-pc-windows-msvc
-          #   runs_on: windows-latest
+          - target: x86_64-pc-windows-msvc
+            runs_on: windows-latest
 
           - target: aarch64-pc-windows-msvc
             runs_on: windows-11-arm
@@ -95,7 +95,7 @@ jobs:
         with:
           python-version: ${{ matrix._.target == 'aarch64-pc-windows-msvc' && '3.11' || '3.8' }}
           architecture: ${{ matrix._.architecture }}
-        id: python311
+        id: python-setup
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -107,7 +107,7 @@ jobs:
           command: build
           # building in engine/ ensures that we pick up .cargo/config.toml
           working-directory: engine
-          args: --release --out language_client_python/dist --manifest-path language_client_python/Cargo.toml --interpreter ${{ steps.python311.outputs.python-path }}
+          args: --release --out language_client_python/dist --manifest-path language_client_python/Cargo.toml ${{ matrix._.target == 'aarch64-pc-windows-msvc' && format('--interpreter {0}', steps.python-setup.outputs.python-path) || '' }}
           manylinux: ${{ matrix._.manylinux }}
           before-script-linux: |
             if command -v yum &> /dev/null; then

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -87,6 +87,6 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix._.target }}
+          name: wheels-${{ matrix._.target }}-${{ matrix._.interpreter || 'all' }}
           path: engine/language_client_python/dist
           if-no-files-found: error

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -58,6 +58,7 @@ jobs:
 
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.runs_on }}
+    # See also https://github.com/mcrumiller/polars/.github/workflows/release-python.yml#L282
     steps:
       - name: Setup build environment (ARM64 Windows)
         if: matrix._.target == 'aarch64-pc-windows-msvc'
@@ -106,14 +107,14 @@ jobs:
 
           Get-Content $Env:GITHUB_PATH | Out-Host
 
-      - name: Check build environment (ARM64 Windows)
-        if: matrix._.target == 'aarch64-pc-windows-msvc'
-        run: |
-          set -x
-          bash --version
-          rustup show
-          clang -v
-          cmake --version
+      # - name: Check build environment (ARM64 Windows)
+      #   if: matrix._.target == 'aarch64-pc-windows-msvc'
+      #   run: |
+      #     set -x
+      #     bash --version
+      #     rustup show
+      #     clang -v
+      #     cmake --version
 
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -2,6 +2,9 @@ name: BAML Release - Build Python
 
 on:
   workflow_call: {}
+  push:
+    branches:
+      - baml-py-win
 
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow
@@ -47,6 +50,9 @@ jobs:
             runs_on: macos-latest
 
           - target: x86_64-pc-windows-msvc
+            runs_on: windows-latest
+
+          - target: aarch64-pc-windows-msvc
             runs_on: windows-latest
 
     name: ${{ matrix._.target }}

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-build-python
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     strategy:
@@ -55,6 +59,7 @@ jobs:
           - target: aarch64-pc-windows-msvc
             runs_on: windows-11-arm
             interpreter: 3.11 3.12 3.13
+            architecture: arm64
 
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.runs_on }}
@@ -68,59 +73,28 @@ jobs:
           # * We update `Expand-Archive` to avoid "" is not a supported archive file format when extracting
           #   files that don't end in `.zip`
         run: |
-          Write-Output "> Update Expand-Archive (Microsoft.PowerShell.Archive)"
-          Install-PackageProvider -Name NuGet -Force
-          Install-Module -Name Microsoft.PowerShell.Archive -Force
+          # rustup is not installed in aarch64
+          if (-not (Get-Command rustup -ErrorAction SilentlyContinue)) {
+              Invoke-WebRequest -Uri "https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe" -OutFile "rustup-init.exe"
+              .\rustup-init.exe --default-toolchain stable -y
+              Remove-Item "rustup-init.exe"
+              "$env:USERPROFILE/.cargo/bin" | Out-File -FilePath "$env:GITHUB_PATH" -Append
+          }
 
-          Write-Output "> Setup bash.exe (git-for-windows/PortableGit)"
-          Invoke-WebRequest "https://github.com/git-for-windows/git/releases/download/v2.47.1.windows.1/PortableGit-2.47.1-arm64.7z.exe" -OutFile /git.7z.exe
-          /git.7z.exe -o/git -y
-
-          Write-Output "> Setup Rust"
-          Invoke-WebRequest "https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe" -OutFile /rustup-init.exe
-          /rustup-init.exe --default-host aarch64-pc-windows-msvc -y
-
-          Write-Output "> Setup VS Build Tools"
-          Invoke-WebRequest "https://aka.ms/vs/17/release/vs_BuildTools.exe" -OutFile /vs_BuildTools.exe
-          Start-Process C:/vs_BuildTools.exe -ArgumentList " `
-              --add Microsoft.VisualStudio.Workload.NativeDesktop `
-              --add Microsoft.VisualStudio.Workload.VCTools `
-              --add Microsoft.VisualStudio.Component.VC.Tools.arm64 `
-              --add Microsoft.VisualStudio.Component.VC.Llvm.Clang `
-              --add Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset `
-              --includeRecommended --quiet --norestart --wait" -Wait
-
-          Write-Output "> Setup CMake"
-          Invoke-WebRequest "https://github.com/Kitware/CMake/releases/download/v3.31.2/cmake-3.31.2-windows-arm64.zip" -OutFile /cmake.zip
-          Expand-Archive /cmake.zip -DestinationPath /
-
-          Write-Output "> Download jq.exe (github.com/jqlang) (needed for tomlq / yq)"
-          Invoke-WebRequest https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-windows-i386.exe -OutFile /jq.exe
-
-          Write-Output "> Update GITHUB_PATH"
-          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + "C:/git/bin/")
-          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + $Env:USERPROFILE + "/.cargo/bin/")
-          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + "C:/Program Files (x86)/Microsoft Visual Studio/2022/BuildTools/VC/Tools/Llvm/bin/")
-          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + "C:/cmake-3.31.2-windows-arm64/bin")
-          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n" + "C:/")
-          [System.IO.File]::AppendAllText($Env:GITHUB_PATH, "`n")
-
-          Get-Content $Env:GITHUB_PATH | Out-Host
-
-      # - name: Check build environment (ARM64 Windows)
-      #   if: matrix._.target == 'aarch64-pc-windows-msvc'
-      #   run: |
-      #     set -x
-      #     bash --version
-      #     rustup show
-      #     clang -v
-      #     cmake --version
+      - name: Check build environment (ARM64 Windows)
+        if: matrix._.target == 'aarch64-pc-windows-msvc'
+        run: |
+          set -x
+          bash --version
+          rustup show
+          clang -v
+          cmake --version
 
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix._.target == 'aarch64-pc-windows-msvc' && '3.11' || '3.8' }}
-          architecture: ${{ matrix._.runs_on == 'windows-latest' && 'x64' || null }}
+          architecture: ${{ matrix._.architecture }}
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -58,7 +58,6 @@ jobs:
 
           - target: aarch64-pc-windows-msvc
             runs_on: windows-11-arm
-            interpreter: 3.11 3.12 3.13
             architecture: arm64
 
     name: ${{ matrix._.target }}
@@ -91,11 +90,40 @@ jobs:
           cmake --version
 
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+
+      # Setup Python for non-ARM64 Windows targets and other OS
+      - name: Setup Python (default)
+        if: matrix._.target != 'aarch64-pc-windows-msvc'
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix._.target == 'aarch64-pc-windows-msvc' && '3.11' || '3.8' }}
+          python-version: "3.8"
           architecture: ${{ matrix._.architecture }}
-        id: python-setup
+
+      # Setup Python versions for ARM64 Windows
+      - name: Setup Python 3.11 (ARM64 Windows)
+        if: matrix._.target == 'aarch64-pc-windows-msvc'
+        uses: actions/setup-python@v5
+        id: py311
+        with:
+          python-version: "3.11"
+          architecture: "arm64"
+          allow-prereleases: true
+      - name: Setup Python 3.12 (ARM64 Windows)
+        if: matrix._.target == 'aarch64-pc-windows-msvc'
+        uses: actions/setup-python@v5
+        id: py312
+        with:
+          python-version: "3.12"
+          architecture: "arm64"
+          allow-prereleases: true
+      - name: Setup Python 3.13 (ARM64 Windows)
+        if: matrix._.target == 'aarch64-pc-windows-msvc'
+        uses: actions/setup-python@v5
+        id: py313
+        with:
+          python-version: "3.13"
+          architecture: "arm64"
+          allow-prereleases: true
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -107,7 +135,7 @@ jobs:
           command: build
           # building in engine/ ensures that we pick up .cargo/config.toml
           working-directory: engine
-          args: --release --out language_client_python/dist --manifest-path language_client_python/Cargo.toml ${{ matrix._.target == 'aarch64-pc-windows-msvc' && format('--interpreter {0}', steps.python-setup.outputs.python-path) || '' }}
+          args: --release --out language_client_python/dist --manifest-path language_client_python/Cargo.toml ${{ (matrix._.target == 'aarch64-pc-windows-msvc' && format('--interpreter {0} {1} {2}', steps.py311.outputs.python-path, steps.py312.outputs.python-path, steps.py313.outputs.python-path)) || '' }}
           manylinux: ${{ matrix._.manylinux }}
           before-script-linux: |
             if command -v yum &> /dev/null; then
@@ -121,6 +149,6 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix._.target }}-${{ matrix._.interpreter || 'all' }}
+          name: wheels-${{ matrix._.target }}
           path: engine/language_client_python/dist
           if-no-files-found: error

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -67,7 +67,9 @@ jobs:
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
-        env: ${{ matrix._.env || fromJSON('{}') }}
+        env:
+          # see https://github.com/PyO3/maturin/issues/2110
+          XWIN_VERSION: "16"
         with:
           target: ${{ matrix._.target }}
           command: build

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -21,40 +21,40 @@ jobs:
       fail-fast: false
       matrix:
         _:
-          - target: x86_64-unknown-linux-gnu
-            runs_on: ubuntu-latest
-            manylinux: 2_17
+          # - target: x86_64-unknown-linux-gnu
+          #   runs_on: ubuntu-latest
+          #   manylinux: 2_17
 
-          - target: aarch64-unknown-linux-gnu
-            runs_on: ubuntu-latest
-            manylinux: 2_24
-            # I'm not sure if this actually works; I can't 'pip install ./local-path.whl'
-            # from inside a container based off quay.io/pypa/manylinux2014_aarch64
-            # see https://github.com/astral-sh/uv/issues/3439#issuecomment-2110448346
-            # manylinux: 2_28
-            # env:
-            #   # Workaround ring 0.17 build issue
-            #   # see https://github.com/briansmith/ring/issues/1728
-            #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
+          # - target: aarch64-unknown-linux-gnu
+          #   runs_on: ubuntu-latest
+          #   manylinux: 2_24
+          #   # I'm not sure if this actually works; I can't 'pip install ./local-path.whl'
+          #   # from inside a container based off quay.io/pypa/manylinux2014_aarch64
+          #   # see https://github.com/astral-sh/uv/issues/3439#issuecomment-2110448346
+          #   # manylinux: 2_28
+          #   # env:
+          #   #   # Workaround ring 0.17 build issue
+          #   #   # see https://github.com/briansmith/ring/issues/1728
+          #   #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
 
-          - target: x86_64-unknown-linux-musl
-            runs_on: ubuntu-latest
-            # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
-            manylinux: musllinux_1_1
+          # - target: x86_64-unknown-linux-musl
+          #   runs_on: ubuntu-latest
+          #   # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
+          #   manylinux: musllinux_1_1
 
-          - target: aarch64-unknown-linux-musl
-            runs_on: ubuntu-latest
-            # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
-            manylinux: musllinux_1_1
+          # - target: aarch64-unknown-linux-musl
+          #   runs_on: ubuntu-latest
+          #   # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
+          #   manylinux: musllinux_1_1
 
-          - target: x86_64-apple-darwin
-            runs_on: macos-latest
+          # - target: x86_64-apple-darwin
+          #   runs_on: macos-latest
 
-          - target: aarch64-apple-darwin
-            runs_on: macos-latest
+          # - target: aarch64-apple-darwin
+          #   runs_on: macos-latest
 
-          - target: x86_64-pc-windows-msvc
-            runs_on: windows-latest
+          # - target: x86_64-pc-windows-msvc
+          #   runs_on: windows-latest
 
           - target: aarch64-pc-windows-msvc
             runs_on: windows-11-arm
@@ -95,6 +95,7 @@ jobs:
         with:
           python-version: ${{ matrix._.target == 'aarch64-pc-windows-msvc' && '3.11' || '3.8' }}
           architecture: ${{ matrix._.architecture }}
+        id: python311
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
@@ -106,7 +107,7 @@ jobs:
           command: build
           # building in engine/ ensures that we pick up .cargo/config.toml
           working-directory: engine
-          args: --release --out language_client_python/dist --manifest-path language_client_python/Cargo.toml ${{ matrix._.interpreter && format('--interpreter {0}', matrix._.interpreter) || '' }}
+          args: --release --out language_client_python/dist --manifest-path language_client_python/Cargo.toml --interpreter ${{ steps.python311.outputs.python-path }}
           manylinux: ${{ matrix._.manylinux }}
           before-script-linux: |
             if command -v yum &> /dev/null; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 
   build-typescript-release:
     uses: ./.github/workflows/build-typescript-release.reusable.yaml
-  
+
   build-cli:
     needs: determine-version
     uses: ./.github/workflows/build-cli-release.reusable.yaml
@@ -79,14 +79,14 @@ jobs:
 
   # This job now calls the reusable workflow which contains the matrix strategy
   build-vscode-reusable: # Renamed job for clarity
-    needs: [ determine-version, build-cli ]
+    needs: [determine-version, build-cli]
     uses: ./.github/workflows/build-vscode-release.reusable.yaml
     with:
       # No artifact_name needed here anymore
       version: ${{ needs.determine-version.outputs.version_string }}
       # Pass the boolean output directly
       is_release_build: ${{ needs.determine-version.outputs.is_release_tag == 'true' }}
-  
+
   # Kick off integration tests when we build everything.
   # This does not yet succeed/pass consistently, or even run everything, but it's a good start.
   integ-tests:
@@ -105,7 +105,6 @@ jobs:
       - build-vscode-reusable # Depends on the job calling the reusable workflow
     steps:
       - run: echo "::do-nothing::" >/dev/null
-      
 
   publish-to-pypi:
     environment: release
@@ -129,8 +128,8 @@ jobs:
           set -euo pipefail
           ls dist/
           wheel_count=$(ls dist/*.whl 2>/dev/null | wc -l)
-          if [ "$wheel_count" -lt 7 ]; then
-            echo "Error: Expected at least 7 wheels, but found $wheel_count"
+          if [ "$wheel_count" -lt 8 ]; then
+            echo "Error: Expected at least 8 wheels, but found $wheel_count"
             exit 1
           fi
           echo "Found $wheel_count wheels"
@@ -223,8 +222,6 @@ jobs:
             gem push $i
           done
 
-
-
   publish-to-open-vsx:
     environment: release
     needs: [determine-version, all-builds] # Also need determine-version for the condition
@@ -308,9 +305,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           # Match artifacts starting with 'baml-cli-'
-          pattern: baml-cli-* 
+          pattern: baml-cli-*
           # Download into this directory
-          path: cli-artifacts 
+          path: cli-artifacts
           merge-multiple: true # Merge artifacts from different OS/arch into the path
 
       # Download all CFFI library artifacts produced by the build-cli job
@@ -318,9 +315,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           # Match artifacts starting with 'libbaml-cffi-'
-          pattern: libbaml-cffi-* 
+          pattern: libbaml-cffi-*
           # Download into a separate directory
-          path: cffi-artifacts 
+          path: cffi-artifacts
           merge-multiple: true # Merge artifacts from different OS into the path
 
       - name: List downloaded CLI artifacts

--- a/engine/language_client_python/pyproject.toml
+++ b/engine/language_client_python/pyproject.toml
@@ -15,7 +15,8 @@ build-backend = "maturin"
 [tool.maturin]
 python-source = "python_src"
 # "extension-module" tells pyo3 we want to build an extension module (skips linking against libpython.so).
-features = ["pyo3/extension-module"]
+# The second feature is to fix windows aarch64 https://github.com/samuelcolvin/rtoml/pull/73/files
+features = ["pyo3/extension-module", "pyo3/generate-import-lib"]
 
 [project.scripts]
 baml-cli = "baml_py:invoke_runtime_cli"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for building Python wheels for Windows ARM64 in GitHub Actions workflows and update `pyproject.toml` for compatibility.
> 
>   - **Build System**:
>     - Add ARM64 Windows target to `build-python-release.reusable.yaml`.
>     - Setup build environment for ARM64 Windows, including Rust and Python 3.11, 3.12, 3.13.
>     - Update `pyproject.toml` to include `pyo3/generate-import-lib` feature for Windows ARM64.
>   - **Workflows**:
>     - Modify `release.yml` to expect at least 8 wheels, reflecting the new ARM64 build.
>     - Minor formatting changes in `release.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 63d12a4ed56b25e11214805fbd418eaa8c557892. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->