### PR TITLE
Maps are being returned not as pointers as they are already pointers

### DIFF
--- a/engine/language_client_codegen/src/go/generate_types.rs
+++ b/engine/language_client_codegen/src/go/generate_types.rs
@@ -65,6 +65,11 @@ fn render_value_coercion(container_variable_name: &str, field_type: &GoType) -> 
             inner_type.name,
             render_value_coercion("__holder", inner_type),
         );
+    } else if field_type.is_slice || field_type.is_map {
+        return format!(
+            "baml.Decode({container_variable_name}).({})",
+            filters::type_name_without_pointer(&field_type.name).unwrap()
+        );
     } else {
         return format!(
             "*baml.Decode({container_variable_name}).(*{})",
@@ -229,6 +234,7 @@ pub struct GoType {
     name: String,
     is_pointer: bool,
     is_slice: bool,
+    is_map: bool,
     is_primitive: bool,
     is_class: bool,
     is_integer: bool,
@@ -530,6 +536,7 @@ impl ToTypeReferenceInTypeDefinition for FieldType {
             is_pointer: self.is_optional(),
             is_union: matches!(simplified, FieldType::Union(_)),
             is_slice: matches!(simplified, FieldType::List(_)),
+            is_map: matches!(simplified, FieldType::Map(_, _)),
             is_primitive: self.is_primitive(),
             is_class: matches!(simplified, FieldType::Class(_)),
             is_integer: matches!(simplified, FieldType::Primitive(TypeValue::Int)),

--- a/integ-tests/go/baml_client/types/types.go
+++ b/integ-tests/go/baml_client/types/types.go
@@ -3849,7 +3849,7 @@ func (c *Recipe) Decode(holder cffi.CFFIValueClass) {
 			switch key {
 
 			case "ingredients":
-				c.Ingredients = *baml.Decode(valueHolder).(*map[string]Quantity)
+				c.Ingredients = baml.Decode(valueHolder).(map[string]Quantity)
 
 			case "recipe_type":
 				c.Recipe_type = *baml.Decode(valueHolder).(*Union__string_breakfast__string_dinner)

--- a/integ-tests/go/baml_client/types/unions.go
+++ b/integ-tests/go/baml_client/types/unions.go
@@ -2460,7 +2460,7 @@ func (u *Union__int__string__bool__float__List__string__Map__string_List__string
 
 	case "Map__string_List__string":
 		u.variant = "Map__string_List__string"
-		value := *baml.Decode(valueHolder).(*map[string][]string)
+		value := baml.Decode(valueHolder).(map[string][]string)
 		u.variant_Map__string_List__string = &value
 
 	}
@@ -2868,7 +2868,7 @@ func (u *Union__string__Map__string_RecursiveUnion) Decode(holder *cffi.CFFIValu
 
 	case "Map__string_RecursiveUnion":
 		u.variant = "Map__string_RecursiveUnion"
-		value := *baml.Decode(valueHolder).(*map[string]RecursiveUnion)
+		value := baml.Decode(valueHolder).(map[string]RecursiveUnion)
 		u.variant_Map__string_RecursiveUnion = &value
 
 	}

--- a/integ-tests/go/cffi_test.go
+++ b/integ-tests/go/cffi_test.go
@@ -65,6 +65,14 @@ func TestEncodeDecode(t *testing.T) {
 			Name:       &[]string{"John Doe"}[0],
 			Hair_color: &[]b.Color{b.ColorRED}[0],
 		}},
+		{&b.Recipe{
+			Recipe_type: *b.Union__string_breakfast__string_dinnerNewWithString_breakfast(&[]string{"breakfast"}[0]),
+			Ingredients: map[string]b.Quantity{
+				"a": {
+					Amount: *b.Union__int__floatNewWithInt(&[]int64{1}[0]),
+				},
+			},
+		}},
 		// {b.RecursiveUnion(*b.Union__string__Map__string_RecursiveUnionNewWithMap__string_RecursiveUnion(&map[string]b.RecursiveUnion{
 		// 	"key": b.RecursiveUnion(*b.Union__string__Map__string_RecursiveUnionNewWithString(&[]string{"value"}[0])),
 		// 	"key2": b.RecursiveUnion(*b.Union__string__Map__string_RecursiveUnionNewWithMap__string_RecursiveUnion(&map[string]b.RecursiveUnion{


### PR DESCRIPTION
This was incorrectly attempting to coerce maps/lists as pointers when Decode does not return them that way.

Added a test that failed before and now passes.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes incorrect pointer coercion for maps and lists in `render_value_coercion()` and adds a test to verify the fix.
> 
>   - **Behavior**:
>     - Fixes incorrect pointer coercion for maps and lists in `render_value_coercion()` in `generate_types.rs`.
>     - Adds a test case in `cffi_test.go` to verify correct handling of maps and lists.
>   - **Models**:
>     - Adds `is_map` field to `GoType` struct in `generate_types.rs`.
>     - Updates `ToTypeReferenceInTypeDefinition` implementation to set `is_map` for `FieldType::Map`.
>   - **Misc**:
>     - Updates `Decode` calls in `types.go` and `unions.go` to remove unnecessary pointer dereferencing for maps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for e1fc8a0f6cfc10e2d332f336dd0acbc87a19fbe6. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->