### PR TITLE
Fix height rendering issue on playground

### DIFF
--- a/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-text.tsx
+++ b/typescript/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-text.tsx
@@ -88,8 +88,9 @@ export const RenderPromptPart: React.FC<{
         </div>
       )}
       <ScrollArea className='relative flex-1 p-2 pb-6 bg-muted/50 dark:bg-slate-900' type='always'>
+        {/* This should match the ParsedResponseRenderer max-h- as well */}
         <pre
-          className={`whitespace-pre-wrap text-xs  ${isFullTextVisible ? 'max-h-fit' : 'max-h-64'}`}
+          className={`whitespace-pre-wrap text-xs  ${isFullTextVisible ? 'max-h-[500px]' : 'max-h-64'}`}
           dangerouslySetInnerHTML={{ __html: renderContent }}
         />
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adjust `max-h-fit` to `max-h-[500px]` in `render-text.tsx` for consistent text rendering height.
> 
>   - **UI Fix**:
>     - In `render-text.tsx`, adjust `max-h-fit` to `max-h-[500px]` for `pre` element when `isFullTextVisible` is true, ensuring consistent height rendering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 9e90afbe1a7124a4af16b81b1c244071868fc3b2. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->