### PR TITLE
Makes the calls for client return pointers except for maps and slices which are already pointers

### DIFF
--- a/engine/language_client_codegen/src/go/generate_types.rs
+++ b/engine/language_client_codegen/src/go/generate_types.rs
@@ -20,27 +20,19 @@ pub(crate) struct GoTypes<'ir> {
 }
 
 pub(crate) fn cast_value(container_variable_name: &str, field_type: &GoType) -> String {
-    if field_type.is_class {
-        return format!(
-            "*({}).(*{})",
-            container_variable_name,
-            filters::type_name_without_pointer(&field_type.name)
-                .ok()
-                .unwrap()
-        );
-    } else if field_type.is_union {
-        return format!("*({container_variable_name}).(*{})", field_type.name);
+    if field_type.is_slice || field_type.is_map {
+        return format!("({}).({})", container_variable_name, field_type.name);
     } else if field_type.is_pointer {
         let inner_type = field_type.underlying_type.as_ref().unwrap();
         return format!(
-            "castOptional({container_variable_name}, func (item any) {} {{
+            "castOptional({container_variable_name}, func (item any) *{} {{
     return {}
 }})",
             inner_type.name,
             cast_value("item", inner_type),
         );
     } else {
-        return format!("({}).({})", container_variable_name, field_type.name);
+        return format!("({}).(*{})", container_variable_name, field_type.name);
     }
 }
 
@@ -231,16 +223,16 @@ struct GoField<'ir> {
 }
 
 pub struct GoType {
-    name: String,
-    is_pointer: bool,
-    is_slice: bool,
-    is_map: bool,
-    is_primitive: bool,
-    is_class: bool,
-    is_integer: bool,
-    is_enum: bool,
-    is_union: bool,
-    underlying_type: Option<Box<GoType>>,
+    pub name: String,
+    pub is_pointer: bool,
+    pub is_slice: bool,
+    pub is_map: bool,
+    pub is_primitive: bool,
+    pub is_class: bool,
+    pub is_integer: bool,
+    pub is_enum: bool,
+    pub is_union: bool,
+    pub underlying_type: Option<Box<GoType>>,
 }
 
 struct GoTypeAlias<'ir> {

--- a/engine/language_client_codegen/src/go/mod.rs
+++ b/engine/language_client_codegen/src/go/mod.rs
@@ -26,8 +26,7 @@ struct GoFunction {
     name: String,
     go_name: String,
     partial_return_type: String,
-    return_type: String,
-    return_type_type: GoType,
+    return_type: GoType,
     args: Vec<(String, String)>,
 }
 
@@ -90,8 +89,7 @@ impl TryFrom<(&'_ IntermediateRepr, &'_ crate::GeneratorArgs)> for GoClient {
                                 name
                             },
                             partial_return_type: f.elem().output().to_partial_type_ref(ir, true),
-                            return_type: f.elem().output().to_type_ref(ir, true),
-                            return_type_type: f.elem().output().to_type_ref_2(ir, true),
+                            return_type: f.elem().output().to_type_ref_2(ir, true),
                             args: f
                                 .inputs()
                                 .iter()

--- a/engine/language_client_codegen/src/go/templates/client.go.j2
+++ b/engine/language_client_codegen/src/go/templates/client.go.j2
@@ -37,11 +37,19 @@ func castOptional[T any](result any, castResult func(any) T) *T {
 	return &val
 }
 
+{% macro return_type_name(fn) -%}
+{% if fn.return_type.is_slice || fn.return_type.is_map -%}
+{{ fn.return_type.name }}
+{%- else -%}
+*{{ fn.return_type.name }}
+{%- endif %}
+{%- endmacro %}
+
 {% for fn in funcs %}
 
 func {{ fn.name }}(ctx context.Context{% for (name, type) in fn.args -%}
         , {{name}} {{type}}
-        {%- endfor %}) (*{{ fn.return_type }}, error) {
+        {%- endfor %}) ({% call return_type_name(fn) %}, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{ {% for (name, type) in fn.args -%}"{{name}}": {{name}},{% endfor %} },
 	}
@@ -58,18 +66,18 @@ func {{ fn.name }}(ctx context.Context{% for (name, type) in fn.args -%}
 		return nil, result.Error
 	}
 
-	castResult := func (result any) {{ fn.return_type }} {
-		return {{ crate::go::cast_value("result", fn.return_type_type) }}
+	castResult := func (result any) {% call return_type_name(fn) %} {
+		return {{ crate::go::cast_value("result", fn.return_type) }}
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) {{ fn.name }}(ctx context.Context{% for (name, type) in fn.args -%}
 		, {{name}} {{type}}
-		{%- endfor %}) <-chan {{ fn.return_type }} {
+		{%- endfor %}) <-chan {% call return_type_name(fn) %} {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{ {% for (name, type) in fn.args -%}"{{name}}": {{name}},{% endfor %} },
 	}
@@ -77,7 +85,7 @@ func (*stream) {{ fn.name }}(ctx context.Context{% for (name, type) in fn.args -
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan {{ fn.return_type }})
+	channel := make(chan {% call return_type_name(fn) %})
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "{{ fn.name }}", encoded)
 	if err != nil {
 		close(channel)
@@ -98,7 +106,7 @@ func (*stream) {{ fn.name }}(ctx context.Context{% for (name, type) in fn.args -
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).({{ fn.return_type }})
+				channel <- (*result.Data).({% call return_type_name(fn) %})
 			}
 		}
 	}()

--- a/integ-tests/go/baml_client/client.go
+++ b/integ-tests/go/baml_client/client.go
@@ -64,16 +64,16 @@ func AaaSamOutputFormat(ctx context.Context, recipe string) (*types.Recipe, erro
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Recipe {
-		return *(result).(*types.Recipe)
+	castResult := func(result any) *types.Recipe {
+		return (result).(*types.Recipe)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AaaSamOutputFormat(ctx context.Context, recipe string) <-chan types.Recipe {
+func (*stream) AaaSamOutputFormat(ctx context.Context, recipe string) <-chan *types.Recipe {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"recipe": recipe},
 	}
@@ -81,7 +81,7 @@ func (*stream) AaaSamOutputFormat(ctx context.Context, recipe string) <-chan typ
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Recipe)
+	channel := make(chan *types.Recipe)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AaaSamOutputFormat", encoded)
 	if err != nil {
 		close(channel)
@@ -102,7 +102,7 @@ func (*stream) AaaSamOutputFormat(ctx context.Context, recipe string) <-chan typ
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Recipe)
+				channel <- (*result.Data).(*types.Recipe)
 			}
 		}
 	}()
@@ -126,16 +126,16 @@ func AliasThatPointsToRecursiveType(ctx context.Context, data types.LinkedListAl
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.LinkedListAliasNode {
-		return *(result).(*types.LinkedListAliasNode)
+	castResult := func(result any) *types.LinkedListAliasNode {
+		return (result).(*types.LinkedListAliasNode)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AliasThatPointsToRecursiveType(ctx context.Context, data types.LinkedListAliasNode) <-chan types.LinkedListAliasNode {
+func (*stream) AliasThatPointsToRecursiveType(ctx context.Context, data types.LinkedListAliasNode) <-chan *types.LinkedListAliasNode {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"data": data},
 	}
@@ -143,7 +143,7 @@ func (*stream) AliasThatPointsToRecursiveType(ctx context.Context, data types.Li
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.LinkedListAliasNode)
+	channel := make(chan *types.LinkedListAliasNode)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AliasThatPointsToRecursiveType", encoded)
 	if err != nil {
 		close(channel)
@@ -164,7 +164,7 @@ func (*stream) AliasThatPointsToRecursiveType(ctx context.Context, data types.Li
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.LinkedListAliasNode)
+				channel <- (*result.Data).(*types.LinkedListAliasNode)
 			}
 		}
 	}()
@@ -188,16 +188,16 @@ func AliasWithMultipleAttrs(ctx context.Context, money int64) (*types.Checked[in
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Checked[int64] {
-		return (result).(types.Checked[int64])
+	castResult := func(result any) *types.Checked[int64] {
+		return (result).(*types.Checked[int64])
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AliasWithMultipleAttrs(ctx context.Context, money int64) <-chan types.Checked[int64] {
+func (*stream) AliasWithMultipleAttrs(ctx context.Context, money int64) <-chan *types.Checked[int64] {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"money": money},
 	}
@@ -205,7 +205,7 @@ func (*stream) AliasWithMultipleAttrs(ctx context.Context, money int64) <-chan t
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Checked[int64])
+	channel := make(chan *types.Checked[int64])
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AliasWithMultipleAttrs", encoded)
 	if err != nil {
 		close(channel)
@@ -226,7 +226,7 @@ func (*stream) AliasWithMultipleAttrs(ctx context.Context, money int64) <-chan t
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Checked[int64])
+				channel <- (*result.Data).(*types.Checked[int64])
 			}
 		}
 	}()
@@ -250,16 +250,16 @@ func AliasedInputClass(ctx context.Context, input types.InputClass) (*string, er
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AliasedInputClass(ctx context.Context, input types.InputClass) <-chan string {
+func (*stream) AliasedInputClass(ctx context.Context, input types.InputClass) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -267,7 +267,7 @@ func (*stream) AliasedInputClass(ctx context.Context, input types.InputClass) <-
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AliasedInputClass", encoded)
 	if err != nil {
 		close(channel)
@@ -288,7 +288,7 @@ func (*stream) AliasedInputClass(ctx context.Context, input types.InputClass) <-
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -312,16 +312,16 @@ func AliasedInputClass2(ctx context.Context, input types.InputClass) (*string, e
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AliasedInputClass2(ctx context.Context, input types.InputClass) <-chan string {
+func (*stream) AliasedInputClass2(ctx context.Context, input types.InputClass) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -329,7 +329,7 @@ func (*stream) AliasedInputClass2(ctx context.Context, input types.InputClass) <
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AliasedInputClass2", encoded)
 	if err != nil {
 		close(channel)
@@ -350,7 +350,7 @@ func (*stream) AliasedInputClass2(ctx context.Context, input types.InputClass) <
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -374,16 +374,16 @@ func AliasedInputClassNested(ctx context.Context, input types.InputClassNested) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AliasedInputClassNested(ctx context.Context, input types.InputClassNested) <-chan string {
+func (*stream) AliasedInputClassNested(ctx context.Context, input types.InputClassNested) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -391,7 +391,7 @@ func (*stream) AliasedInputClassNested(ctx context.Context, input types.InputCla
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AliasedInputClassNested", encoded)
 	if err != nil {
 		close(channel)
@@ -412,7 +412,7 @@ func (*stream) AliasedInputClassNested(ctx context.Context, input types.InputCla
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -436,16 +436,16 @@ func AliasedInputEnum(ctx context.Context, input types.AliasedEnum) (*string, er
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AliasedInputEnum(ctx context.Context, input types.AliasedEnum) <-chan string {
+func (*stream) AliasedInputEnum(ctx context.Context, input types.AliasedEnum) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -453,7 +453,7 @@ func (*stream) AliasedInputEnum(ctx context.Context, input types.AliasedEnum) <-
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AliasedInputEnum", encoded)
 	if err != nil {
 		close(channel)
@@ -474,7 +474,7 @@ func (*stream) AliasedInputEnum(ctx context.Context, input types.AliasedEnum) <-
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -498,16 +498,16 @@ func AliasedInputList(ctx context.Context, input []types.AliasedEnum) (*string, 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AliasedInputList(ctx context.Context, input []types.AliasedEnum) <-chan string {
+func (*stream) AliasedInputList(ctx context.Context, input []types.AliasedEnum) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -515,7 +515,7 @@ func (*stream) AliasedInputList(ctx context.Context, input []types.AliasedEnum) 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AliasedInputList", encoded)
 	if err != nil {
 		close(channel)
@@ -536,7 +536,7 @@ func (*stream) AliasedInputList(ctx context.Context, input []types.AliasedEnum) 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -560,16 +560,16 @@ func AllowedOptionals(ctx context.Context, optionals types.OptionalListAndMap) (
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.OptionalListAndMap {
-		return *(result).(*types.OptionalListAndMap)
+	castResult := func(result any) *types.OptionalListAndMap {
+		return (result).(*types.OptionalListAndMap)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AllowedOptionals(ctx context.Context, optionals types.OptionalListAndMap) <-chan types.OptionalListAndMap {
+func (*stream) AllowedOptionals(ctx context.Context, optionals types.OptionalListAndMap) <-chan *types.OptionalListAndMap {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"optionals": optionals},
 	}
@@ -577,7 +577,7 @@ func (*stream) AllowedOptionals(ctx context.Context, optionals types.OptionalLis
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.OptionalListAndMap)
+	channel := make(chan *types.OptionalListAndMap)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AllowedOptionals", encoded)
 	if err != nil {
 		close(channel)
@@ -598,7 +598,7 @@ func (*stream) AllowedOptionals(ctx context.Context, optionals types.OptionalLis
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.OptionalListAndMap)
+				channel <- (*result.Data).(*types.OptionalListAndMap)
 			}
 		}
 	}()
@@ -622,16 +622,16 @@ func AssertFn(ctx context.Context, a int64) (*int64, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) int64 {
-		return (result).(int64)
+	castResult := func(result any) *int64 {
+		return (result).(*int64)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AssertFn(ctx context.Context, a int64) <-chan int64 {
+func (*stream) AssertFn(ctx context.Context, a int64) <-chan *int64 {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"a": a},
 	}
@@ -639,7 +639,7 @@ func (*stream) AssertFn(ctx context.Context, a int64) <-chan int64 {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan int64)
+	channel := make(chan *int64)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AssertFn", encoded)
 	if err != nil {
 		close(channel)
@@ -660,7 +660,7 @@ func (*stream) AssertFn(ctx context.Context, a int64) <-chan int64 {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(int64)
+				channel <- (*result.Data).(*int64)
 			}
 		}
 	}()
@@ -684,16 +684,16 @@ func AudioInput(ctx context.Context, aud any) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AudioInput(ctx context.Context, aud any) <-chan string {
+func (*stream) AudioInput(ctx context.Context, aud any) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"aud": aud},
 	}
@@ -701,7 +701,7 @@ func (*stream) AudioInput(ctx context.Context, aud any) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AudioInput", encoded)
 	if err != nil {
 		close(channel)
@@ -722,7 +722,7 @@ func (*stream) AudioInput(ctx context.Context, aud any) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -746,16 +746,16 @@ func AudioInputOpenai(ctx context.Context, aud any, prompt string) (*string, err
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) AudioInputOpenai(ctx context.Context, aud any, prompt string) <-chan string {
+func (*stream) AudioInputOpenai(ctx context.Context, aud any, prompt string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"aud": aud, "prompt": prompt},
 	}
@@ -763,7 +763,7 @@ func (*stream) AudioInputOpenai(ctx context.Context, aud any, prompt string) <-c
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "AudioInputOpenai", encoded)
 	if err != nil {
 		close(channel)
@@ -784,7 +784,7 @@ func (*stream) AudioInputOpenai(ctx context.Context, aud any, prompt string) <-c
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -808,16 +808,16 @@ func BuildLinkedList(ctx context.Context, input []int64) (*types.LinkedList, err
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.LinkedList {
-		return *(result).(*types.LinkedList)
+	castResult := func(result any) *types.LinkedList {
+		return (result).(*types.LinkedList)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) BuildLinkedList(ctx context.Context, input []int64) <-chan types.LinkedList {
+func (*stream) BuildLinkedList(ctx context.Context, input []int64) <-chan *types.LinkedList {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -825,7 +825,7 @@ func (*stream) BuildLinkedList(ctx context.Context, input []int64) <-chan types.
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.LinkedList)
+	channel := make(chan *types.LinkedList)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "BuildLinkedList", encoded)
 	if err != nil {
 		close(channel)
@@ -846,7 +846,7 @@ func (*stream) BuildLinkedList(ctx context.Context, input []int64) <-chan types.
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.LinkedList)
+				channel <- (*result.Data).(*types.LinkedList)
 			}
 		}
 	}()
@@ -870,16 +870,16 @@ func BuildTree(ctx context.Context, input types.BinaryNode) (*types.Tree, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Tree {
-		return *(result).(*types.Tree)
+	castResult := func(result any) *types.Tree {
+		return (result).(*types.Tree)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) BuildTree(ctx context.Context, input types.BinaryNode) <-chan types.Tree {
+func (*stream) BuildTree(ctx context.Context, input types.BinaryNode) <-chan *types.Tree {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -887,7 +887,7 @@ func (*stream) BuildTree(ctx context.Context, input types.BinaryNode) <-chan typ
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Tree)
+	channel := make(chan *types.Tree)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "BuildTree", encoded)
 	if err != nil {
 		close(channel)
@@ -908,7 +908,7 @@ func (*stream) BuildTree(ctx context.Context, input types.BinaryNode) <-chan typ
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Tree)
+				channel <- (*result.Data).(*types.Tree)
 			}
 		}
 	}()
@@ -932,16 +932,16 @@ func ClassThatPointsToRecursiveClassThroughAlias(ctx context.Context, cls types.
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.ClassToRecAlias {
-		return *(result).(*types.ClassToRecAlias)
+	castResult := func(result any) *types.ClassToRecAlias {
+		return (result).(*types.ClassToRecAlias)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ClassThatPointsToRecursiveClassThroughAlias(ctx context.Context, cls types.ClassToRecAlias) <-chan types.ClassToRecAlias {
+func (*stream) ClassThatPointsToRecursiveClassThroughAlias(ctx context.Context, cls types.ClassToRecAlias) <-chan *types.ClassToRecAlias {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"cls": cls},
 	}
@@ -949,7 +949,7 @@ func (*stream) ClassThatPointsToRecursiveClassThroughAlias(ctx context.Context, 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.ClassToRecAlias)
+	channel := make(chan *types.ClassToRecAlias)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ClassThatPointsToRecursiveClassThroughAlias", encoded)
 	if err != nil {
 		close(channel)
@@ -970,7 +970,7 @@ func (*stream) ClassThatPointsToRecursiveClassThroughAlias(ctx context.Context, 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.ClassToRecAlias)
+				channel <- (*result.Data).(*types.ClassToRecAlias)
 			}
 		}
 	}()
@@ -994,16 +994,16 @@ func ClassifyDynEnumTwo(ctx context.Context, input string) (*types.DynEnumTwo, e
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.DynEnumTwo {
-		return (result).(types.DynEnumTwo)
+	castResult := func(result any) *types.DynEnumTwo {
+		return (result).(*types.DynEnumTwo)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ClassifyDynEnumTwo(ctx context.Context, input string) <-chan types.DynEnumTwo {
+func (*stream) ClassifyDynEnumTwo(ctx context.Context, input string) <-chan *types.DynEnumTwo {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -1011,7 +1011,7 @@ func (*stream) ClassifyDynEnumTwo(ctx context.Context, input string) <-chan type
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.DynEnumTwo)
+	channel := make(chan *types.DynEnumTwo)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ClassifyDynEnumTwo", encoded)
 	if err != nil {
 		close(channel)
@@ -1032,7 +1032,7 @@ func (*stream) ClassifyDynEnumTwo(ctx context.Context, input string) <-chan type
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.DynEnumTwo)
+				channel <- (*result.Data).(*types.DynEnumTwo)
 			}
 		}
 	}()
@@ -1056,16 +1056,16 @@ func ClassifyMessage(ctx context.Context, input string) (*types.Category, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Category {
-		return (result).(types.Category)
+	castResult := func(result any) *types.Category {
+		return (result).(*types.Category)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ClassifyMessage(ctx context.Context, input string) <-chan types.Category {
+func (*stream) ClassifyMessage(ctx context.Context, input string) <-chan *types.Category {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -1073,7 +1073,7 @@ func (*stream) ClassifyMessage(ctx context.Context, input string) <-chan types.C
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Category)
+	channel := make(chan *types.Category)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ClassifyMessage", encoded)
 	if err != nil {
 		close(channel)
@@ -1094,7 +1094,7 @@ func (*stream) ClassifyMessage(ctx context.Context, input string) <-chan types.C
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Category)
+				channel <- (*result.Data).(*types.Category)
 			}
 		}
 	}()
@@ -1118,16 +1118,16 @@ func ClassifyMessage2(ctx context.Context, input string) (*types.Category, error
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Category {
-		return (result).(types.Category)
+	castResult := func(result any) *types.Category {
+		return (result).(*types.Category)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ClassifyMessage2(ctx context.Context, input string) <-chan types.Category {
+func (*stream) ClassifyMessage2(ctx context.Context, input string) <-chan *types.Category {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -1135,7 +1135,7 @@ func (*stream) ClassifyMessage2(ctx context.Context, input string) <-chan types.
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Category)
+	channel := make(chan *types.Category)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ClassifyMessage2", encoded)
 	if err != nil {
 		close(channel)
@@ -1156,7 +1156,7 @@ func (*stream) ClassifyMessage2(ctx context.Context, input string) <-chan types.
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Category)
+				channel <- (*result.Data).(*types.Category)
 			}
 		}
 	}()
@@ -1180,16 +1180,16 @@ func ClassifyMessage3(ctx context.Context, input string) (*types.Category, error
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Category {
-		return (result).(types.Category)
+	castResult := func(result any) *types.Category {
+		return (result).(*types.Category)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ClassifyMessage3(ctx context.Context, input string) <-chan types.Category {
+func (*stream) ClassifyMessage3(ctx context.Context, input string) <-chan *types.Category {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -1197,7 +1197,7 @@ func (*stream) ClassifyMessage3(ctx context.Context, input string) <-chan types.
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Category)
+	channel := make(chan *types.Category)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ClassifyMessage3", encoded)
 	if err != nil {
 		close(channel)
@@ -1218,7 +1218,7 @@ func (*stream) ClassifyMessage3(ctx context.Context, input string) <-chan types.
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Category)
+				channel <- (*result.Data).(*types.Category)
 			}
 		}
 	}()
@@ -1242,16 +1242,16 @@ func Completion(ctx context.Context, prefix string, suffix string, language stri
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) Completion(ctx context.Context, prefix string, suffix string, language string) <-chan string {
+func (*stream) Completion(ctx context.Context, prefix string, suffix string, language string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"prefix": prefix, "suffix": suffix, "language": language},
 	}
@@ -1259,7 +1259,7 @@ func (*stream) Completion(ctx context.Context, prefix string, suffix string, lan
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "Completion", encoded)
 	if err != nil {
 		close(channel)
@@ -1280,7 +1280,7 @@ func (*stream) Completion(ctx context.Context, prefix string, suffix string, lan
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -1304,16 +1304,16 @@ func CustomTask(ctx context.Context, input string) (*types.Union__BookOrder__Fli
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Union__BookOrder__FlightConfirmation__GroceryReceipt {
-		return *(result).(*types.Union__BookOrder__FlightConfirmation__GroceryReceipt)
+	castResult := func(result any) *types.Union__BookOrder__FlightConfirmation__GroceryReceipt {
+		return (result).(*types.Union__BookOrder__FlightConfirmation__GroceryReceipt)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) CustomTask(ctx context.Context, input string) <-chan types.Union__BookOrder__FlightConfirmation__GroceryReceipt {
+func (*stream) CustomTask(ctx context.Context, input string) <-chan *types.Union__BookOrder__FlightConfirmation__GroceryReceipt {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -1321,7 +1321,7 @@ func (*stream) CustomTask(ctx context.Context, input string) <-chan types.Union_
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Union__BookOrder__FlightConfirmation__GroceryReceipt)
+	channel := make(chan *types.Union__BookOrder__FlightConfirmation__GroceryReceipt)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "CustomTask", encoded)
 	if err != nil {
 		close(channel)
@@ -1342,7 +1342,7 @@ func (*stream) CustomTask(ctx context.Context, input string) <-chan types.Union_
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Union__BookOrder__FlightConfirmation__GroceryReceipt)
+				channel <- (*result.Data).(*types.Union__BookOrder__FlightConfirmation__GroceryReceipt)
 			}
 		}
 	}()
@@ -1366,16 +1366,16 @@ func DescribeImage(ctx context.Context, img any) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) DescribeImage(ctx context.Context, img any) <-chan string {
+func (*stream) DescribeImage(ctx context.Context, img any) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"img": img},
 	}
@@ -1383,7 +1383,7 @@ func (*stream) DescribeImage(ctx context.Context, img any) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "DescribeImage", encoded)
 	if err != nil {
 		close(channel)
@@ -1404,7 +1404,7 @@ func (*stream) DescribeImage(ctx context.Context, img any) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -1428,16 +1428,16 @@ func DescribeImage2(ctx context.Context, classWithImage types.ClassWithImage, im
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) DescribeImage2(ctx context.Context, classWithImage types.ClassWithImage, img2 any) <-chan string {
+func (*stream) DescribeImage2(ctx context.Context, classWithImage types.ClassWithImage, img2 any) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"classWithImage": classWithImage, "img2": img2},
 	}
@@ -1445,7 +1445,7 @@ func (*stream) DescribeImage2(ctx context.Context, classWithImage types.ClassWit
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "DescribeImage2", encoded)
 	if err != nil {
 		close(channel)
@@ -1466,7 +1466,7 @@ func (*stream) DescribeImage2(ctx context.Context, classWithImage types.ClassWit
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -1490,16 +1490,16 @@ func DescribeImage3(ctx context.Context, classWithImage types.ClassWithImage, im
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) DescribeImage3(ctx context.Context, classWithImage types.ClassWithImage, img2 any) <-chan string {
+func (*stream) DescribeImage3(ctx context.Context, classWithImage types.ClassWithImage, img2 any) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"classWithImage": classWithImage, "img2": img2},
 	}
@@ -1507,7 +1507,7 @@ func (*stream) DescribeImage3(ctx context.Context, classWithImage types.ClassWit
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "DescribeImage3", encoded)
 	if err != nil {
 		close(channel)
@@ -1528,7 +1528,7 @@ func (*stream) DescribeImage3(ctx context.Context, classWithImage types.ClassWit
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -1552,16 +1552,16 @@ func DescribeImage4(ctx context.Context, classWithImage types.ClassWithImage, im
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) DescribeImage4(ctx context.Context, classWithImage types.ClassWithImage, img2 any) <-chan string {
+func (*stream) DescribeImage4(ctx context.Context, classWithImage types.ClassWithImage, img2 any) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"classWithImage": classWithImage, "img2": img2},
 	}
@@ -1569,7 +1569,7 @@ func (*stream) DescribeImage4(ctx context.Context, classWithImage types.ClassWit
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "DescribeImage4", encoded)
 	if err != nil {
 		close(channel)
@@ -1590,7 +1590,7 @@ func (*stream) DescribeImage4(ctx context.Context, classWithImage types.ClassWit
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -1614,16 +1614,16 @@ func DescribeMedia1599(ctx context.Context, img any, client_sector string, clien
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) DescribeMedia1599(ctx context.Context, img any, client_sector string, client_name string) <-chan string {
+func (*stream) DescribeMedia1599(ctx context.Context, img any, client_sector string, client_name string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"img": img, "client_sector": client_sector, "client_name": client_name},
 	}
@@ -1631,7 +1631,7 @@ func (*stream) DescribeMedia1599(ctx context.Context, img any, client_sector str
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "DescribeMedia1599", encoded)
 	if err != nil {
 		close(channel)
@@ -1652,7 +1652,7 @@ func (*stream) DescribeMedia1599(ctx context.Context, img any, client_sector str
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -1676,16 +1676,16 @@ func DifferentiateUnions(ctx context.Context) (*types.Union__OriginalA__Original
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Union__OriginalA__OriginalB {
-		return *(result).(*types.Union__OriginalA__OriginalB)
+	castResult := func(result any) *types.Union__OriginalA__OriginalB {
+		return (result).(*types.Union__OriginalA__OriginalB)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) DifferentiateUnions(ctx context.Context) <-chan types.Union__OriginalA__OriginalB {
+func (*stream) DifferentiateUnions(ctx context.Context) <-chan *types.Union__OriginalA__OriginalB {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -1693,7 +1693,7 @@ func (*stream) DifferentiateUnions(ctx context.Context) <-chan types.Union__Orig
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Union__OriginalA__OriginalB)
+	channel := make(chan *types.Union__OriginalA__OriginalB)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "DifferentiateUnions", encoded)
 	if err != nil {
 		close(channel)
@@ -1714,7 +1714,7 @@ func (*stream) DifferentiateUnions(ctx context.Context) <-chan types.Union__Orig
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Union__OriginalA__OriginalB)
+				channel <- (*result.Data).(*types.Union__OriginalA__OriginalB)
 			}
 		}
 	}()
@@ -1738,16 +1738,16 @@ func DummyOutputFunction(ctx context.Context, input string) (*types.DummyOutput,
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.DummyOutput {
-		return *(result).(*types.DummyOutput)
+	castResult := func(result any) *types.DummyOutput {
+		return (result).(*types.DummyOutput)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) DummyOutputFunction(ctx context.Context, input string) <-chan types.DummyOutput {
+func (*stream) DummyOutputFunction(ctx context.Context, input string) <-chan *types.DummyOutput {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -1755,7 +1755,7 @@ func (*stream) DummyOutputFunction(ctx context.Context, input string) <-chan typ
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.DummyOutput)
+	channel := make(chan *types.DummyOutput)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "DummyOutputFunction", encoded)
 	if err != nil {
 		close(channel)
@@ -1776,7 +1776,7 @@ func (*stream) DummyOutputFunction(ctx context.Context, input string) <-chan typ
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.DummyOutput)
+				channel <- (*result.Data).(*types.DummyOutput)
 			}
 		}
 	}()
@@ -1800,16 +1800,16 @@ func DynamicFunc(ctx context.Context, input types.DynamicClassOne) (*types.Dynam
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.DynamicClassTwo {
-		return *(result).(*types.DynamicClassTwo)
+	castResult := func(result any) *types.DynamicClassTwo {
+		return (result).(*types.DynamicClassTwo)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) DynamicFunc(ctx context.Context, input types.DynamicClassOne) <-chan types.DynamicClassTwo {
+func (*stream) DynamicFunc(ctx context.Context, input types.DynamicClassOne) <-chan *types.DynamicClassTwo {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -1817,7 +1817,7 @@ func (*stream) DynamicFunc(ctx context.Context, input types.DynamicClassOne) <-c
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.DynamicClassTwo)
+	channel := make(chan *types.DynamicClassTwo)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "DynamicFunc", encoded)
 	if err != nil {
 		close(channel)
@@ -1838,7 +1838,7 @@ func (*stream) DynamicFunc(ctx context.Context, input types.DynamicClassOne) <-c
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.DynamicClassTwo)
+				channel <- (*result.Data).(*types.DynamicClassTwo)
 			}
 		}
 	}()
@@ -1862,16 +1862,16 @@ func DynamicInputOutput(ctx context.Context, input types.DynInputOutput) (*types
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.DynInputOutput {
-		return *(result).(*types.DynInputOutput)
+	castResult := func(result any) *types.DynInputOutput {
+		return (result).(*types.DynInputOutput)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) DynamicInputOutput(ctx context.Context, input types.DynInputOutput) <-chan types.DynInputOutput {
+func (*stream) DynamicInputOutput(ctx context.Context, input types.DynInputOutput) <-chan *types.DynInputOutput {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -1879,7 +1879,7 @@ func (*stream) DynamicInputOutput(ctx context.Context, input types.DynInputOutpu
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.DynInputOutput)
+	channel := make(chan *types.DynInputOutput)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "DynamicInputOutput", encoded)
 	if err != nil {
 		close(channel)
@@ -1900,14 +1900,14 @@ func (*stream) DynamicInputOutput(ctx context.Context, input types.DynInputOutpu
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.DynInputOutput)
+				channel <- (*result.Data).(*types.DynInputOutput)
 			}
 		}
 	}()
 	return channel
 }
 
-func DynamicListInputOutput(ctx context.Context, input []types.DynInputOutput) (*[]types.DynInputOutput, error) {
+func DynamicListInputOutput(ctx context.Context, input []types.DynInputOutput) ([]types.DynInputOutput, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -1930,7 +1930,7 @@ func DynamicListInputOutput(ctx context.Context, input []types.DynInputOutput) (
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) DynamicListInputOutput(ctx context.Context, input []types.DynInputOutput) <-chan []types.DynInputOutput {
@@ -1986,16 +1986,16 @@ func ExpectFailure(ctx context.Context) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ExpectFailure(ctx context.Context) <-chan string {
+func (*stream) ExpectFailure(ctx context.Context) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -2003,7 +2003,7 @@ func (*stream) ExpectFailure(ctx context.Context) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ExpectFailure", encoded)
 	if err != nil {
 		close(channel)
@@ -2024,7 +2024,7 @@ func (*stream) ExpectFailure(ctx context.Context) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -2048,16 +2048,16 @@ func ExtractContactInfo(ctx context.Context, document string) (*types.ContactInf
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.ContactInfo {
-		return *(result).(*types.ContactInfo)
+	castResult := func(result any) *types.ContactInfo {
+		return (result).(*types.ContactInfo)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ExtractContactInfo(ctx context.Context, document string) <-chan types.ContactInfo {
+func (*stream) ExtractContactInfo(ctx context.Context, document string) <-chan *types.ContactInfo {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"document": document},
 	}
@@ -2065,7 +2065,7 @@ func (*stream) ExtractContactInfo(ctx context.Context, document string) <-chan t
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.ContactInfo)
+	channel := make(chan *types.ContactInfo)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ExtractContactInfo", encoded)
 	if err != nil {
 		close(channel)
@@ -2086,7 +2086,7 @@ func (*stream) ExtractContactInfo(ctx context.Context, document string) <-chan t
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.ContactInfo)
+				channel <- (*result.Data).(*types.ContactInfo)
 			}
 		}
 	}()
@@ -2110,16 +2110,16 @@ func ExtractEntities(ctx context.Context, text string) (*types.DynamicSchema, er
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.DynamicSchema {
-		return *(result).(*types.DynamicSchema)
+	castResult := func(result any) *types.DynamicSchema {
+		return (result).(*types.DynamicSchema)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ExtractEntities(ctx context.Context, text string) <-chan types.DynamicSchema {
+func (*stream) ExtractEntities(ctx context.Context, text string) <-chan *types.DynamicSchema {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"text": text},
 	}
@@ -2127,7 +2127,7 @@ func (*stream) ExtractEntities(ctx context.Context, text string) <-chan types.Dy
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.DynamicSchema)
+	channel := make(chan *types.DynamicSchema)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ExtractEntities", encoded)
 	if err != nil {
 		close(channel)
@@ -2148,14 +2148,14 @@ func (*stream) ExtractEntities(ctx context.Context, text string) <-chan types.Dy
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.DynamicSchema)
+				channel <- (*result.Data).(*types.DynamicSchema)
 			}
 		}
 	}()
 	return channel
 }
 
-func ExtractHobby(ctx context.Context, text string) (*[]types.Hobby, error) {
+func ExtractHobby(ctx context.Context, text string) ([]types.Hobby, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"text": text},
 	}
@@ -2178,7 +2178,7 @@ func ExtractHobby(ctx context.Context, text string) (*[]types.Hobby, error) {
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) ExtractHobby(ctx context.Context, text string) <-chan []types.Hobby {
@@ -2217,7 +2217,7 @@ func (*stream) ExtractHobby(ctx context.Context, text string) <-chan []types.Hob
 	return channel
 }
 
-func ExtractNames(ctx context.Context, input string) (*[]string, error) {
+func ExtractNames(ctx context.Context, input string) ([]string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -2240,7 +2240,7 @@ func ExtractNames(ctx context.Context, input string) (*[]string, error) {
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) ExtractNames(ctx context.Context, input string) <-chan []string {
@@ -2279,7 +2279,7 @@ func (*stream) ExtractNames(ctx context.Context, input string) <-chan []string {
 	return channel
 }
 
-func ExtractPeople(ctx context.Context, text string) (*[]types.Person, error) {
+func ExtractPeople(ctx context.Context, text string) ([]types.Person, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"text": text},
 	}
@@ -2302,7 +2302,7 @@ func ExtractPeople(ctx context.Context, text string) (*[]types.Person, error) {
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) ExtractPeople(ctx context.Context, text string) <-chan []types.Person {
@@ -2358,16 +2358,16 @@ func ExtractReceiptInfo(ctx context.Context, email string, reason types.Union__s
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.ReceiptInfo {
-		return *(result).(*types.ReceiptInfo)
+	castResult := func(result any) *types.ReceiptInfo {
+		return (result).(*types.ReceiptInfo)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ExtractReceiptInfo(ctx context.Context, email string, reason types.Union__string_curiosity__string_personal_finance) <-chan types.ReceiptInfo {
+func (*stream) ExtractReceiptInfo(ctx context.Context, email string, reason types.Union__string_curiosity__string_personal_finance) <-chan *types.ReceiptInfo {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"email": email, "reason": reason},
 	}
@@ -2375,7 +2375,7 @@ func (*stream) ExtractReceiptInfo(ctx context.Context, email string, reason type
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.ReceiptInfo)
+	channel := make(chan *types.ReceiptInfo)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ExtractReceiptInfo", encoded)
 	if err != nil {
 		close(channel)
@@ -2396,7 +2396,7 @@ func (*stream) ExtractReceiptInfo(ctx context.Context, email string, reason type
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.ReceiptInfo)
+				channel <- (*result.Data).(*types.ReceiptInfo)
 			}
 		}
 	}()
@@ -2420,16 +2420,16 @@ func ExtractResume(ctx context.Context, resume string, img *any) (*types.Resume,
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Resume {
-		return *(result).(*types.Resume)
+	castResult := func(result any) *types.Resume {
+		return (result).(*types.Resume)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ExtractResume(ctx context.Context, resume string, img *any) <-chan types.Resume {
+func (*stream) ExtractResume(ctx context.Context, resume string, img *any) <-chan *types.Resume {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"resume": resume, "img": img},
 	}
@@ -2437,7 +2437,7 @@ func (*stream) ExtractResume(ctx context.Context, resume string, img *any) <-cha
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Resume)
+	channel := make(chan *types.Resume)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ExtractResume", encoded)
 	if err != nil {
 		close(channel)
@@ -2458,7 +2458,7 @@ func (*stream) ExtractResume(ctx context.Context, resume string, img *any) <-cha
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Resume)
+				channel <- (*result.Data).(*types.Resume)
 			}
 		}
 	}()
@@ -2482,16 +2482,16 @@ func ExtractResume2(ctx context.Context, resume string) (*types.Resume, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Resume {
-		return *(result).(*types.Resume)
+	castResult := func(result any) *types.Resume {
+		return (result).(*types.Resume)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ExtractResume2(ctx context.Context, resume string) <-chan types.Resume {
+func (*stream) ExtractResume2(ctx context.Context, resume string) <-chan *types.Resume {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"resume": resume},
 	}
@@ -2499,7 +2499,7 @@ func (*stream) ExtractResume2(ctx context.Context, resume string) <-chan types.R
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Resume)
+	channel := make(chan *types.Resume)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ExtractResume2", encoded)
 	if err != nil {
 		close(channel)
@@ -2520,7 +2520,7 @@ func (*stream) ExtractResume2(ctx context.Context, resume string) <-chan types.R
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Resume)
+				channel <- (*result.Data).(*types.Resume)
 			}
 		}
 	}()
@@ -2544,18 +2544,18 @@ func FnClassOptionalOutput(ctx context.Context, input string) (**types.ClassOpti
 		return nil, result.Error
 	}
 
-	castResult := func(result any) *types.ClassOptionalOutput {
-		return castOptional(result, func(item any) types.ClassOptionalOutput {
-			return *(item).(*types.ClassOptionalOutput)
+	castResult := func(result any) **types.ClassOptionalOutput {
+		return castOptional(result, func(item any) *types.ClassOptionalOutput {
+			return (item).(*types.ClassOptionalOutput)
 		})
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnClassOptionalOutput(ctx context.Context, input string) <-chan *types.ClassOptionalOutput {
+func (*stream) FnClassOptionalOutput(ctx context.Context, input string) <-chan **types.ClassOptionalOutput {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -2563,7 +2563,7 @@ func (*stream) FnClassOptionalOutput(ctx context.Context, input string) <-chan *
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan *types.ClassOptionalOutput)
+	channel := make(chan **types.ClassOptionalOutput)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnClassOptionalOutput", encoded)
 	if err != nil {
 		close(channel)
@@ -2584,7 +2584,7 @@ func (*stream) FnClassOptionalOutput(ctx context.Context, input string) <-chan *
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(*types.ClassOptionalOutput)
+				channel <- (*result.Data).(**types.ClassOptionalOutput)
 			}
 		}
 	}()
@@ -2608,18 +2608,18 @@ func FnClassOptionalOutput2(ctx context.Context, input string) (**types.ClassOpt
 		return nil, result.Error
 	}
 
-	castResult := func(result any) *types.ClassOptionalOutput2 {
-		return castOptional(result, func(item any) types.ClassOptionalOutput2 {
-			return *(item).(*types.ClassOptionalOutput2)
+	castResult := func(result any) **types.ClassOptionalOutput2 {
+		return castOptional(result, func(item any) *types.ClassOptionalOutput2 {
+			return (item).(*types.ClassOptionalOutput2)
 		})
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnClassOptionalOutput2(ctx context.Context, input string) <-chan *types.ClassOptionalOutput2 {
+func (*stream) FnClassOptionalOutput2(ctx context.Context, input string) <-chan **types.ClassOptionalOutput2 {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -2627,7 +2627,7 @@ func (*stream) FnClassOptionalOutput2(ctx context.Context, input string) <-chan 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan *types.ClassOptionalOutput2)
+	channel := make(chan **types.ClassOptionalOutput2)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnClassOptionalOutput2", encoded)
 	if err != nil {
 		close(channel)
@@ -2648,14 +2648,14 @@ func (*stream) FnClassOptionalOutput2(ctx context.Context, input string) <-chan 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(*types.ClassOptionalOutput2)
+				channel <- (*result.Data).(**types.ClassOptionalOutput2)
 			}
 		}
 	}()
 	return channel
 }
 
-func FnEnumListOutput(ctx context.Context, input string) (*[]types.EnumOutput, error) {
+func FnEnumListOutput(ctx context.Context, input string) ([]types.EnumOutput, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -2678,7 +2678,7 @@ func FnEnumListOutput(ctx context.Context, input string) (*[]types.EnumOutput, e
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) FnEnumListOutput(ctx context.Context, input string) <-chan []types.EnumOutput {
@@ -2734,16 +2734,16 @@ func FnEnumOutput(ctx context.Context, input string) (*types.EnumOutput, error) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.EnumOutput {
-		return (result).(types.EnumOutput)
+	castResult := func(result any) *types.EnumOutput {
+		return (result).(*types.EnumOutput)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnEnumOutput(ctx context.Context, input string) <-chan types.EnumOutput {
+func (*stream) FnEnumOutput(ctx context.Context, input string) <-chan *types.EnumOutput {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -2751,7 +2751,7 @@ func (*stream) FnEnumOutput(ctx context.Context, input string) <-chan types.Enum
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.EnumOutput)
+	channel := make(chan *types.EnumOutput)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnEnumOutput", encoded)
 	if err != nil {
 		close(channel)
@@ -2772,7 +2772,7 @@ func (*stream) FnEnumOutput(ctx context.Context, input string) <-chan types.Enum
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.EnumOutput)
+				channel <- (*result.Data).(*types.EnumOutput)
 			}
 		}
 	}()
@@ -2796,16 +2796,16 @@ func FnLiteralClassInputOutput(ctx context.Context, input types.LiteralClassHell
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.LiteralClassHello {
-		return *(result).(*types.LiteralClassHello)
+	castResult := func(result any) *types.LiteralClassHello {
+		return (result).(*types.LiteralClassHello)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnLiteralClassInputOutput(ctx context.Context, input types.LiteralClassHello) <-chan types.LiteralClassHello {
+func (*stream) FnLiteralClassInputOutput(ctx context.Context, input types.LiteralClassHello) <-chan *types.LiteralClassHello {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -2813,7 +2813,7 @@ func (*stream) FnLiteralClassInputOutput(ctx context.Context, input types.Litera
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.LiteralClassHello)
+	channel := make(chan *types.LiteralClassHello)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnLiteralClassInputOutput", encoded)
 	if err != nil {
 		close(channel)
@@ -2834,7 +2834,7 @@ func (*stream) FnLiteralClassInputOutput(ctx context.Context, input types.Litera
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.LiteralClassHello)
+				channel <- (*result.Data).(*types.LiteralClassHello)
 			}
 		}
 	}()
@@ -2858,16 +2858,16 @@ func FnLiteralUnionClassInputOutput(ctx context.Context, input types.Union__Lite
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Union__LiteralClassOne__LiteralClassTwo {
-		return *(result).(*types.Union__LiteralClassOne__LiteralClassTwo)
+	castResult := func(result any) *types.Union__LiteralClassOne__LiteralClassTwo {
+		return (result).(*types.Union__LiteralClassOne__LiteralClassTwo)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnLiteralUnionClassInputOutput(ctx context.Context, input types.Union__LiteralClassOne__LiteralClassTwo) <-chan types.Union__LiteralClassOne__LiteralClassTwo {
+func (*stream) FnLiteralUnionClassInputOutput(ctx context.Context, input types.Union__LiteralClassOne__LiteralClassTwo) <-chan *types.Union__LiteralClassOne__LiteralClassTwo {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -2875,7 +2875,7 @@ func (*stream) FnLiteralUnionClassInputOutput(ctx context.Context, input types.U
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Union__LiteralClassOne__LiteralClassTwo)
+	channel := make(chan *types.Union__LiteralClassOne__LiteralClassTwo)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnLiteralUnionClassInputOutput", encoded)
 	if err != nil {
 		close(channel)
@@ -2896,7 +2896,7 @@ func (*stream) FnLiteralUnionClassInputOutput(ctx context.Context, input types.U
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Union__LiteralClassOne__LiteralClassTwo)
+				channel <- (*result.Data).(*types.Union__LiteralClassOne__LiteralClassTwo)
 			}
 		}
 	}()
@@ -2920,16 +2920,16 @@ func FnNamedArgsSingleStringOptional(ctx context.Context, myString *string) (*st
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnNamedArgsSingleStringOptional(ctx context.Context, myString *string) <-chan string {
+func (*stream) FnNamedArgsSingleStringOptional(ctx context.Context, myString *string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myString": myString},
 	}
@@ -2937,7 +2937,7 @@ func (*stream) FnNamedArgsSingleStringOptional(ctx context.Context, myString *st
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnNamedArgsSingleStringOptional", encoded)
 	if err != nil {
 		close(channel)
@@ -2958,7 +2958,7 @@ func (*stream) FnNamedArgsSingleStringOptional(ctx context.Context, myString *st
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -2982,16 +2982,16 @@ func FnOutputBool(ctx context.Context, input string) (*bool, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) bool {
-		return (result).(bool)
+	castResult := func(result any) *bool {
+		return (result).(*bool)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnOutputBool(ctx context.Context, input string) <-chan bool {
+func (*stream) FnOutputBool(ctx context.Context, input string) <-chan *bool {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -2999,7 +2999,7 @@ func (*stream) FnOutputBool(ctx context.Context, input string) <-chan bool {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan bool)
+	channel := make(chan *bool)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnOutputBool", encoded)
 	if err != nil {
 		close(channel)
@@ -3020,7 +3020,7 @@ func (*stream) FnOutputBool(ctx context.Context, input string) <-chan bool {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(bool)
+				channel <- (*result.Data).(*bool)
 			}
 		}
 	}()
@@ -3044,16 +3044,16 @@ func FnOutputClass(ctx context.Context, input string) (*types.TestOutputClass, e
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.TestOutputClass {
-		return *(result).(*types.TestOutputClass)
+	castResult := func(result any) *types.TestOutputClass {
+		return (result).(*types.TestOutputClass)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnOutputClass(ctx context.Context, input string) <-chan types.TestOutputClass {
+func (*stream) FnOutputClass(ctx context.Context, input string) <-chan *types.TestOutputClass {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3061,7 +3061,7 @@ func (*stream) FnOutputClass(ctx context.Context, input string) <-chan types.Tes
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.TestOutputClass)
+	channel := make(chan *types.TestOutputClass)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnOutputClass", encoded)
 	if err != nil {
 		close(channel)
@@ -3082,14 +3082,14 @@ func (*stream) FnOutputClass(ctx context.Context, input string) <-chan types.Tes
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.TestOutputClass)
+				channel <- (*result.Data).(*types.TestOutputClass)
 			}
 		}
 	}()
 	return channel
 }
 
-func FnOutputClassList(ctx context.Context, input string) (*[]types.TestOutputClass, error) {
+func FnOutputClassList(ctx context.Context, input string) ([]types.TestOutputClass, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3112,7 +3112,7 @@ func FnOutputClassList(ctx context.Context, input string) (*[]types.TestOutputCl
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) FnOutputClassList(ctx context.Context, input string) <-chan []types.TestOutputClass {
@@ -3168,16 +3168,16 @@ func FnOutputClassNested(ctx context.Context, input string) (*types.TestClassNes
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.TestClassNested {
-		return *(result).(*types.TestClassNested)
+	castResult := func(result any) *types.TestClassNested {
+		return (result).(*types.TestClassNested)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnOutputClassNested(ctx context.Context, input string) <-chan types.TestClassNested {
+func (*stream) FnOutputClassNested(ctx context.Context, input string) <-chan *types.TestClassNested {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3185,7 +3185,7 @@ func (*stream) FnOutputClassNested(ctx context.Context, input string) <-chan typ
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.TestClassNested)
+	channel := make(chan *types.TestClassNested)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnOutputClassNested", encoded)
 	if err != nil {
 		close(channel)
@@ -3206,7 +3206,7 @@ func (*stream) FnOutputClassNested(ctx context.Context, input string) <-chan typ
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.TestClassNested)
+				channel <- (*result.Data).(*types.TestClassNested)
 			}
 		}
 	}()
@@ -3230,16 +3230,16 @@ func FnOutputClassWithEnum(ctx context.Context, input string) (*types.TestClassW
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.TestClassWithEnum {
-		return *(result).(*types.TestClassWithEnum)
+	castResult := func(result any) *types.TestClassWithEnum {
+		return (result).(*types.TestClassWithEnum)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnOutputClassWithEnum(ctx context.Context, input string) <-chan types.TestClassWithEnum {
+func (*stream) FnOutputClassWithEnum(ctx context.Context, input string) <-chan *types.TestClassWithEnum {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3247,7 +3247,7 @@ func (*stream) FnOutputClassWithEnum(ctx context.Context, input string) <-chan t
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.TestClassWithEnum)
+	channel := make(chan *types.TestClassWithEnum)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnOutputClassWithEnum", encoded)
 	if err != nil {
 		close(channel)
@@ -3268,7 +3268,7 @@ func (*stream) FnOutputClassWithEnum(ctx context.Context, input string) <-chan t
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.TestClassWithEnum)
+				channel <- (*result.Data).(*types.TestClassWithEnum)
 			}
 		}
 	}()
@@ -3292,16 +3292,16 @@ func FnOutputInt(ctx context.Context, input string) (*int64, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) int64 {
-		return (result).(int64)
+	castResult := func(result any) *int64 {
+		return (result).(*int64)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnOutputInt(ctx context.Context, input string) <-chan int64 {
+func (*stream) FnOutputInt(ctx context.Context, input string) <-chan *int64 {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3309,7 +3309,7 @@ func (*stream) FnOutputInt(ctx context.Context, input string) <-chan int64 {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan int64)
+	channel := make(chan *int64)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnOutputInt", encoded)
 	if err != nil {
 		close(channel)
@@ -3330,7 +3330,7 @@ func (*stream) FnOutputInt(ctx context.Context, input string) <-chan int64 {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(int64)
+				channel <- (*result.Data).(*int64)
 			}
 		}
 	}()
@@ -3354,16 +3354,16 @@ func FnOutputLiteralBool(ctx context.Context, input string) (*bool, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) bool {
-		return (result).(bool)
+	castResult := func(result any) *bool {
+		return (result).(*bool)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnOutputLiteralBool(ctx context.Context, input string) <-chan bool {
+func (*stream) FnOutputLiteralBool(ctx context.Context, input string) <-chan *bool {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3371,7 +3371,7 @@ func (*stream) FnOutputLiteralBool(ctx context.Context, input string) <-chan boo
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan bool)
+	channel := make(chan *bool)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnOutputLiteralBool", encoded)
 	if err != nil {
 		close(channel)
@@ -3392,7 +3392,7 @@ func (*stream) FnOutputLiteralBool(ctx context.Context, input string) <-chan boo
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(bool)
+				channel <- (*result.Data).(*bool)
 			}
 		}
 	}()
@@ -3416,16 +3416,16 @@ func FnOutputLiteralInt(ctx context.Context, input string) (*int, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) int {
-		return (result).(int)
+	castResult := func(result any) *int {
+		return (result).(*int)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnOutputLiteralInt(ctx context.Context, input string) <-chan int {
+func (*stream) FnOutputLiteralInt(ctx context.Context, input string) <-chan *int {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3433,7 +3433,7 @@ func (*stream) FnOutputLiteralInt(ctx context.Context, input string) <-chan int 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan int)
+	channel := make(chan *int)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnOutputLiteralInt", encoded)
 	if err != nil {
 		close(channel)
@@ -3454,7 +3454,7 @@ func (*stream) FnOutputLiteralInt(ctx context.Context, input string) <-chan int 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(int)
+				channel <- (*result.Data).(*int)
 			}
 		}
 	}()
@@ -3478,16 +3478,16 @@ func FnOutputLiteralString(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnOutputLiteralString(ctx context.Context, input string) <-chan string {
+func (*stream) FnOutputLiteralString(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3495,7 +3495,7 @@ func (*stream) FnOutputLiteralString(ctx context.Context, input string) <-chan s
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnOutputLiteralString", encoded)
 	if err != nil {
 		close(channel)
@@ -3516,14 +3516,14 @@ func (*stream) FnOutputLiteralString(ctx context.Context, input string) <-chan s
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
 	return channel
 }
 
-func FnOutputStringList(ctx context.Context, input string) (*[]string, error) {
+func FnOutputStringList(ctx context.Context, input string) ([]string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3546,7 +3546,7 @@ func FnOutputStringList(ctx context.Context, input string) (*[]string, error) {
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) FnOutputStringList(ctx context.Context, input string) <-chan []string {
@@ -3602,16 +3602,16 @@ func FnTestAliasedEnumOutput(ctx context.Context, input string) (*types.TestEnum
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.TestEnum {
-		return (result).(types.TestEnum)
+	castResult := func(result any) *types.TestEnum {
+		return (result).(*types.TestEnum)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnTestAliasedEnumOutput(ctx context.Context, input string) <-chan types.TestEnum {
+func (*stream) FnTestAliasedEnumOutput(ctx context.Context, input string) <-chan *types.TestEnum {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3619,7 +3619,7 @@ func (*stream) FnTestAliasedEnumOutput(ctx context.Context, input string) <-chan
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.TestEnum)
+	channel := make(chan *types.TestEnum)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnTestAliasedEnumOutput", encoded)
 	if err != nil {
 		close(channel)
@@ -3640,7 +3640,7 @@ func (*stream) FnTestAliasedEnumOutput(ctx context.Context, input string) <-chan
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.TestEnum)
+				channel <- (*result.Data).(*types.TestEnum)
 			}
 		}
 	}()
@@ -3664,16 +3664,16 @@ func FnTestClassAlias(ctx context.Context, input string) (*types.TestClassAlias,
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.TestClassAlias {
-		return *(result).(*types.TestClassAlias)
+	castResult := func(result any) *types.TestClassAlias {
+		return (result).(*types.TestClassAlias)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnTestClassAlias(ctx context.Context, input string) <-chan types.TestClassAlias {
+func (*stream) FnTestClassAlias(ctx context.Context, input string) <-chan *types.TestClassAlias {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -3681,7 +3681,7 @@ func (*stream) FnTestClassAlias(ctx context.Context, input string) <-chan types.
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.TestClassAlias)
+	channel := make(chan *types.TestClassAlias)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnTestClassAlias", encoded)
 	if err != nil {
 		close(channel)
@@ -3702,7 +3702,7 @@ func (*stream) FnTestClassAlias(ctx context.Context, input string) <-chan types.
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.TestClassAlias)
+				channel <- (*result.Data).(*types.TestClassAlias)
 			}
 		}
 	}()
@@ -3726,16 +3726,16 @@ func FnTestNamedArgsSingleEnum(ctx context.Context, myArg types.NamedArgsSingleE
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) FnTestNamedArgsSingleEnum(ctx context.Context, myArg types.NamedArgsSingleEnum) <-chan string {
+func (*stream) FnTestNamedArgsSingleEnum(ctx context.Context, myArg types.NamedArgsSingleEnum) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myArg": myArg},
 	}
@@ -3743,7 +3743,7 @@ func (*stream) FnTestNamedArgsSingleEnum(ctx context.Context, myArg types.NamedA
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "FnTestNamedArgsSingleEnum", encoded)
 	if err != nil {
 		close(channel)
@@ -3764,7 +3764,7 @@ func (*stream) FnTestNamedArgsSingleEnum(ctx context.Context, myArg types.NamedA
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -3788,16 +3788,16 @@ func GetDataType(ctx context.Context, text string) (*types.RaysData, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.RaysData {
-		return *(result).(*types.RaysData)
+	castResult := func(result any) *types.RaysData {
+		return (result).(*types.RaysData)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) GetDataType(ctx context.Context, text string) <-chan types.RaysData {
+func (*stream) GetDataType(ctx context.Context, text string) <-chan *types.RaysData {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"text": text},
 	}
@@ -3805,7 +3805,7 @@ func (*stream) GetDataType(ctx context.Context, text string) <-chan types.RaysDa
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.RaysData)
+	channel := make(chan *types.RaysData)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "GetDataType", encoded)
 	if err != nil {
 		close(channel)
@@ -3826,7 +3826,7 @@ func (*stream) GetDataType(ctx context.Context, text string) <-chan types.RaysDa
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.RaysData)
+				channel <- (*result.Data).(*types.RaysData)
 			}
 		}
 	}()
@@ -3850,16 +3850,16 @@ func GetOrderInfo(ctx context.Context, email types.Email) (*types.OrderInfo, err
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.OrderInfo {
-		return *(result).(*types.OrderInfo)
+	castResult := func(result any) *types.OrderInfo {
+		return (result).(*types.OrderInfo)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) GetOrderInfo(ctx context.Context, email types.Email) <-chan types.OrderInfo {
+func (*stream) GetOrderInfo(ctx context.Context, email types.Email) <-chan *types.OrderInfo {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"email": email},
 	}
@@ -3867,7 +3867,7 @@ func (*stream) GetOrderInfo(ctx context.Context, email types.Email) <-chan types
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.OrderInfo)
+	channel := make(chan *types.OrderInfo)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "GetOrderInfo", encoded)
 	if err != nil {
 		close(channel)
@@ -3888,7 +3888,7 @@ func (*stream) GetOrderInfo(ctx context.Context, email types.Email) <-chan types
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.OrderInfo)
+				channel <- (*result.Data).(*types.OrderInfo)
 			}
 		}
 	}()
@@ -3912,16 +3912,16 @@ func GetQuery(ctx context.Context, query string) (*types.SearchParams, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.SearchParams {
-		return *(result).(*types.SearchParams)
+	castResult := func(result any) *types.SearchParams {
+		return (result).(*types.SearchParams)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) GetQuery(ctx context.Context, query string) <-chan types.SearchParams {
+func (*stream) GetQuery(ctx context.Context, query string) <-chan *types.SearchParams {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"query": query},
 	}
@@ -3929,7 +3929,7 @@ func (*stream) GetQuery(ctx context.Context, query string) <-chan types.SearchPa
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.SearchParams)
+	channel := make(chan *types.SearchParams)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "GetQuery", encoded)
 	if err != nil {
 		close(channel)
@@ -3950,14 +3950,14 @@ func (*stream) GetQuery(ctx context.Context, query string) <-chan types.SearchPa
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.SearchParams)
+				channel <- (*result.Data).(*types.SearchParams)
 			}
 		}
 	}()
 	return channel
 }
 
-func InOutEnumMapKey(ctx context.Context, i1 map[types.MapKey]string, i2 map[types.MapKey]string) (*map[types.MapKey]string, error) {
+func InOutEnumMapKey(ctx context.Context, i1 map[types.MapKey]string, i2 map[types.MapKey]string) (map[types.MapKey]string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"i1": i1, "i2": i2},
 	}
@@ -3980,7 +3980,7 @@ func InOutEnumMapKey(ctx context.Context, i1 map[types.MapKey]string, i2 map[typ
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) InOutEnumMapKey(ctx context.Context, i1 map[types.MapKey]string, i2 map[types.MapKey]string) <-chan map[types.MapKey]string {
@@ -4019,7 +4019,7 @@ func (*stream) InOutEnumMapKey(ctx context.Context, i1 map[types.MapKey]string, 
 	return channel
 }
 
-func InOutLiteralStringUnionMapKey(ctx context.Context, i1 map[types.Union__string_one__string_two__string_three__string_four]string, i2 map[types.Union__string_one__string_two__string_three__string_four]string) (*map[types.Union__string_one__string_two__string_three__string_four]string, error) {
+func InOutLiteralStringUnionMapKey(ctx context.Context, i1 map[types.Union__string_one__string_two__string_three__string_four]string, i2 map[types.Union__string_one__string_two__string_three__string_four]string) (map[types.Union__string_one__string_two__string_three__string_four]string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"i1": i1, "i2": i2},
 	}
@@ -4042,7 +4042,7 @@ func InOutLiteralStringUnionMapKey(ctx context.Context, i1 map[types.Union__stri
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) InOutLiteralStringUnionMapKey(ctx context.Context, i1 map[types.Union__string_one__string_two__string_three__string_four]string, i2 map[types.Union__string_one__string_two__string_three__string_four]string) <-chan map[types.Union__string_one__string_two__string_three__string_four]string {
@@ -4081,7 +4081,7 @@ func (*stream) InOutLiteralStringUnionMapKey(ctx context.Context, i1 map[types.U
 	return channel
 }
 
-func InOutSingleLiteralStringMapKey(ctx context.Context, m map[string]string) (*map[string]string, error) {
+func InOutSingleLiteralStringMapKey(ctx context.Context, m map[string]string) (map[string]string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"m": m},
 	}
@@ -4104,7 +4104,7 @@ func InOutSingleLiteralStringMapKey(ctx context.Context, m map[string]string) (*
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) InOutSingleLiteralStringMapKey(ctx context.Context, m map[string]string) <-chan map[string]string {
@@ -4160,16 +4160,16 @@ func JsonTypeAliasCycle(ctx context.Context, input types.JsonValue) (*types.Json
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.JsonValue {
-		return (result).(types.JsonValue)
+	castResult := func(result any) *types.JsonValue {
+		return (result).(*types.JsonValue)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) JsonTypeAliasCycle(ctx context.Context, input types.JsonValue) <-chan types.JsonValue {
+func (*stream) JsonTypeAliasCycle(ctx context.Context, input types.JsonValue) <-chan *types.JsonValue {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -4177,7 +4177,7 @@ func (*stream) JsonTypeAliasCycle(ctx context.Context, input types.JsonValue) <-
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.JsonValue)
+	channel := make(chan *types.JsonValue)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "JsonTypeAliasCycle", encoded)
 	if err != nil {
 		close(channel)
@@ -4198,7 +4198,7 @@ func (*stream) JsonTypeAliasCycle(ctx context.Context, input types.JsonValue) <-
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.JsonValue)
+				channel <- (*result.Data).(*types.JsonValue)
 			}
 		}
 	}()
@@ -4222,16 +4222,16 @@ func LLMEcho(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) LLMEcho(ctx context.Context, input string) <-chan string {
+func (*stream) LLMEcho(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -4239,7 +4239,7 @@ func (*stream) LLMEcho(ctx context.Context, input string) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "LLMEcho", encoded)
 	if err != nil {
 		close(channel)
@@ -4260,7 +4260,7 @@ func (*stream) LLMEcho(ctx context.Context, input string) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -4284,16 +4284,16 @@ func LiteralUnionsTest(ctx context.Context, input string) (*types.Union__int_1__
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Union__int_1__bool_true__string_string_output {
-		return *(result).(*types.Union__int_1__bool_true__string_string_output)
+	castResult := func(result any) *types.Union__int_1__bool_true__string_string_output {
+		return (result).(*types.Union__int_1__bool_true__string_string_output)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) LiteralUnionsTest(ctx context.Context, input string) <-chan types.Union__int_1__bool_true__string_string_output {
+func (*stream) LiteralUnionsTest(ctx context.Context, input string) <-chan *types.Union__int_1__bool_true__string_string_output {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -4301,7 +4301,7 @@ func (*stream) LiteralUnionsTest(ctx context.Context, input string) <-chan types
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Union__int_1__bool_true__string_string_output)
+	channel := make(chan *types.Union__int_1__bool_true__string_string_output)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "LiteralUnionsTest", encoded)
 	if err != nil {
 		close(channel)
@@ -4322,7 +4322,7 @@ func (*stream) LiteralUnionsTest(ctx context.Context, input string) <-chan types
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Union__int_1__bool_true__string_string_output)
+				channel <- (*result.Data).(*types.Union__int_1__bool_true__string_string_output)
 			}
 		}
 	}()
@@ -4346,16 +4346,16 @@ func MakeBlockConstraint(ctx context.Context) (*types.Checked[types.BlockConstra
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Checked[types.BlockConstraint] {
-		return (result).(types.Checked[types.BlockConstraint])
+	castResult := func(result any) *types.Checked[types.BlockConstraint] {
+		return (result).(*types.Checked[types.BlockConstraint])
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) MakeBlockConstraint(ctx context.Context) <-chan types.Checked[types.BlockConstraint] {
+func (*stream) MakeBlockConstraint(ctx context.Context) <-chan *types.Checked[types.BlockConstraint] {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -4363,7 +4363,7 @@ func (*stream) MakeBlockConstraint(ctx context.Context) <-chan types.Checked[typ
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Checked[types.BlockConstraint])
+	channel := make(chan *types.Checked[types.BlockConstraint])
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "MakeBlockConstraint", encoded)
 	if err != nil {
 		close(channel)
@@ -4384,7 +4384,7 @@ func (*stream) MakeBlockConstraint(ctx context.Context) <-chan types.Checked[typ
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Checked[types.BlockConstraint])
+				channel <- (*result.Data).(*types.Checked[types.BlockConstraint])
 			}
 		}
 	}()
@@ -4408,16 +4408,16 @@ func MakeClassWithBlockDone(ctx context.Context) (*types.ClassWithBlockDone, err
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.ClassWithBlockDone {
-		return *(result).(*types.ClassWithBlockDone)
+	castResult := func(result any) *types.ClassWithBlockDone {
+		return (result).(*types.ClassWithBlockDone)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) MakeClassWithBlockDone(ctx context.Context) <-chan types.ClassWithBlockDone {
+func (*stream) MakeClassWithBlockDone(ctx context.Context) <-chan *types.ClassWithBlockDone {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -4425,7 +4425,7 @@ func (*stream) MakeClassWithBlockDone(ctx context.Context) <-chan types.ClassWit
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.ClassWithBlockDone)
+	channel := make(chan *types.ClassWithBlockDone)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "MakeClassWithBlockDone", encoded)
 	if err != nil {
 		close(channel)
@@ -4446,7 +4446,7 @@ func (*stream) MakeClassWithBlockDone(ctx context.Context) <-chan types.ClassWit
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.ClassWithBlockDone)
+				channel <- (*result.Data).(*types.ClassWithBlockDone)
 			}
 		}
 	}()
@@ -4470,16 +4470,16 @@ func MakeClassWithExternalDone(ctx context.Context) (*types.ClassWithoutDone, er
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.ClassWithoutDone {
-		return (result).(types.ClassWithoutDone)
+	castResult := func(result any) *types.ClassWithoutDone {
+		return (result).(*types.ClassWithoutDone)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) MakeClassWithExternalDone(ctx context.Context) <-chan types.ClassWithoutDone {
+func (*stream) MakeClassWithExternalDone(ctx context.Context) <-chan *types.ClassWithoutDone {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -4487,7 +4487,7 @@ func (*stream) MakeClassWithExternalDone(ctx context.Context) <-chan types.Class
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.ClassWithoutDone)
+	channel := make(chan *types.ClassWithoutDone)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "MakeClassWithExternalDone", encoded)
 	if err != nil {
 		close(channel)
@@ -4508,7 +4508,7 @@ func (*stream) MakeClassWithExternalDone(ctx context.Context) <-chan types.Class
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.ClassWithoutDone)
+				channel <- (*result.Data).(*types.ClassWithoutDone)
 			}
 		}
 	}()
@@ -4532,16 +4532,16 @@ func MakeNestedBlockConstraint(ctx context.Context) (*types.NestedBlockConstrain
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.NestedBlockConstraint {
-		return *(result).(*types.NestedBlockConstraint)
+	castResult := func(result any) *types.NestedBlockConstraint {
+		return (result).(*types.NestedBlockConstraint)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) MakeNestedBlockConstraint(ctx context.Context) <-chan types.NestedBlockConstraint {
+func (*stream) MakeNestedBlockConstraint(ctx context.Context) <-chan *types.NestedBlockConstraint {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -4549,7 +4549,7 @@ func (*stream) MakeNestedBlockConstraint(ctx context.Context) <-chan types.Neste
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.NestedBlockConstraint)
+	channel := make(chan *types.NestedBlockConstraint)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "MakeNestedBlockConstraint", encoded)
 	if err != nil {
 		close(channel)
@@ -4570,7 +4570,7 @@ func (*stream) MakeNestedBlockConstraint(ctx context.Context) <-chan types.Neste
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.NestedBlockConstraint)
+				channel <- (*result.Data).(*types.NestedBlockConstraint)
 			}
 		}
 	}()
@@ -4594,16 +4594,16 @@ func MakeSemanticContainer(ctx context.Context) (*types.SemanticContainer, error
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.SemanticContainer {
-		return *(result).(*types.SemanticContainer)
+	castResult := func(result any) *types.SemanticContainer {
+		return (result).(*types.SemanticContainer)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) MakeSemanticContainer(ctx context.Context) <-chan types.SemanticContainer {
+func (*stream) MakeSemanticContainer(ctx context.Context) <-chan *types.SemanticContainer {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -4611,7 +4611,7 @@ func (*stream) MakeSemanticContainer(ctx context.Context) <-chan types.SemanticC
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.SemanticContainer)
+	channel := make(chan *types.SemanticContainer)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "MakeSemanticContainer", encoded)
 	if err != nil {
 		close(channel)
@@ -4632,14 +4632,14 @@ func (*stream) MakeSemanticContainer(ctx context.Context) <-chan types.SemanticC
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.SemanticContainer)
+				channel <- (*result.Data).(*types.SemanticContainer)
 			}
 		}
 	}()
 	return channel
 }
 
-func MapAlias(ctx context.Context, m map[string][]string) (*map[string][]string, error) {
+func MapAlias(ctx context.Context, m map[string][]string) (map[string][]string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"m": m},
 	}
@@ -4662,7 +4662,7 @@ func MapAlias(ctx context.Context, m map[string][]string) (*map[string][]string,
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) MapAlias(ctx context.Context, m map[string][]string) <-chan map[string][]string {
@@ -4718,16 +4718,16 @@ func MergeAliasAttributes(ctx context.Context, money int64) (*types.MergeAttrs, 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.MergeAttrs {
-		return *(result).(*types.MergeAttrs)
+	castResult := func(result any) *types.MergeAttrs {
+		return (result).(*types.MergeAttrs)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) MergeAliasAttributes(ctx context.Context, money int64) <-chan types.MergeAttrs {
+func (*stream) MergeAliasAttributes(ctx context.Context, money int64) <-chan *types.MergeAttrs {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"money": money},
 	}
@@ -4735,7 +4735,7 @@ func (*stream) MergeAliasAttributes(ctx context.Context, money int64) <-chan typ
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.MergeAttrs)
+	channel := make(chan *types.MergeAttrs)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "MergeAliasAttributes", encoded)
 	if err != nil {
 		close(channel)
@@ -4756,7 +4756,7 @@ func (*stream) MergeAliasAttributes(ctx context.Context, money int64) <-chan typ
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.MergeAttrs)
+				channel <- (*result.Data).(*types.MergeAttrs)
 			}
 		}
 	}()
@@ -4780,16 +4780,16 @@ func MyFunc(ctx context.Context, input string) (*types.DynamicOutput, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.DynamicOutput {
-		return *(result).(*types.DynamicOutput)
+	castResult := func(result any) *types.DynamicOutput {
+		return (result).(*types.DynamicOutput)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) MyFunc(ctx context.Context, input string) <-chan types.DynamicOutput {
+func (*stream) MyFunc(ctx context.Context, input string) <-chan *types.DynamicOutput {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -4797,7 +4797,7 @@ func (*stream) MyFunc(ctx context.Context, input string) <-chan types.DynamicOut
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.DynamicOutput)
+	channel := make(chan *types.DynamicOutput)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "MyFunc", encoded)
 	if err != nil {
 		close(channel)
@@ -4818,7 +4818,7 @@ func (*stream) MyFunc(ctx context.Context, input string) <-chan types.DynamicOut
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.DynamicOutput)
+				channel <- (*result.Data).(*types.DynamicOutput)
 			}
 		}
 	}()
@@ -4842,16 +4842,16 @@ func NestedAlias(ctx context.Context, c types.Union__int__string__bool__float__L
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Union__int__string__bool__float__List__string__Map__string_List__string {
-		return *(result).(*types.Union__int__string__bool__float__List__string__Map__string_List__string)
+	castResult := func(result any) *types.Union__int__string__bool__float__List__string__Map__string_List__string {
+		return (result).(*types.Union__int__string__bool__float__List__string__Map__string_List__string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) NestedAlias(ctx context.Context, c types.Union__int__string__bool__float__List__string__Map__string_List__string) <-chan types.Union__int__string__bool__float__List__string__Map__string_List__string {
+func (*stream) NestedAlias(ctx context.Context, c types.Union__int__string__bool__float__List__string__Map__string_List__string) <-chan *types.Union__int__string__bool__float__List__string__Map__string_List__string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"c": c},
 	}
@@ -4859,7 +4859,7 @@ func (*stream) NestedAlias(ctx context.Context, c types.Union__int__string__bool
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Union__int__string__bool__float__List__string__Map__string_List__string)
+	channel := make(chan *types.Union__int__string__bool__float__List__string__Map__string_List__string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "NestedAlias", encoded)
 	if err != nil {
 		close(channel)
@@ -4880,7 +4880,7 @@ func (*stream) NestedAlias(ctx context.Context, c types.Union__int__string__bool
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Union__int__string__bool__float__List__string__Map__string_List__string)
+				channel <- (*result.Data).(*types.Union__int__string__bool__float__List__string__Map__string_List__string)
 			}
 		}
 	}()
@@ -4904,16 +4904,16 @@ func NullLiteralClassHello(ctx context.Context, s string) (*types.ClassForNullLi
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.ClassForNullLiteral {
-		return *(result).(*types.ClassForNullLiteral)
+	castResult := func(result any) *types.ClassForNullLiteral {
+		return (result).(*types.ClassForNullLiteral)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) NullLiteralClassHello(ctx context.Context, s string) <-chan types.ClassForNullLiteral {
+func (*stream) NullLiteralClassHello(ctx context.Context, s string) <-chan *types.ClassForNullLiteral {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"s": s},
 	}
@@ -4921,7 +4921,7 @@ func (*stream) NullLiteralClassHello(ctx context.Context, s string) <-chan types
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.ClassForNullLiteral)
+	channel := make(chan *types.ClassForNullLiteral)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "NullLiteralClassHello", encoded)
 	if err != nil {
 		close(channel)
@@ -4942,7 +4942,7 @@ func (*stream) NullLiteralClassHello(ctx context.Context, s string) <-chan types
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.ClassForNullLiteral)
+				channel <- (*result.Data).(*types.ClassForNullLiteral)
 			}
 		}
 	}()
@@ -4966,16 +4966,16 @@ func OpenAIWithAnthropicResponseHello(ctx context.Context, s string) (*string, e
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) OpenAIWithAnthropicResponseHello(ctx context.Context, s string) <-chan string {
+func (*stream) OpenAIWithAnthropicResponseHello(ctx context.Context, s string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"s": s},
 	}
@@ -4983,7 +4983,7 @@ func (*stream) OpenAIWithAnthropicResponseHello(ctx context.Context, s string) <
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "OpenAIWithAnthropicResponseHello", encoded)
 	if err != nil {
 		close(channel)
@@ -5004,14 +5004,14 @@ func (*stream) OpenAIWithAnthropicResponseHello(ctx context.Context, s string) <
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
 	return channel
 }
 
-func OptionalTest_Function(ctx context.Context, input string) (*[]*types.OptionalTest_ReturnType, error) {
+func OptionalTest_Function(ctx context.Context, input string) ([]*types.OptionalTest_ReturnType, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5034,7 +5034,7 @@ func OptionalTest_Function(ctx context.Context, input string) (*[]*types.Optiona
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) OptionalTest_Function(ctx context.Context, input string) <-chan []*types.OptionalTest_ReturnType {
@@ -5090,16 +5090,16 @@ func PredictAge(ctx context.Context, name string) (*types.FooAny, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.FooAny {
-		return *(result).(*types.FooAny)
+	castResult := func(result any) *types.FooAny {
+		return (result).(*types.FooAny)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PredictAge(ctx context.Context, name string) <-chan types.FooAny {
+func (*stream) PredictAge(ctx context.Context, name string) <-chan *types.FooAny {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"name": name},
 	}
@@ -5107,7 +5107,7 @@ func (*stream) PredictAge(ctx context.Context, name string) <-chan types.FooAny 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.FooAny)
+	channel := make(chan *types.FooAny)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PredictAge", encoded)
 	if err != nil {
 		close(channel)
@@ -5128,7 +5128,7 @@ func (*stream) PredictAge(ctx context.Context, name string) <-chan types.FooAny 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.FooAny)
+				channel <- (*result.Data).(*types.FooAny)
 			}
 		}
 	}()
@@ -5152,16 +5152,16 @@ func PredictAgeBare(ctx context.Context, inp string) (*types.Checked[int64], err
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Checked[int64] {
-		return (result).(types.Checked[int64])
+	castResult := func(result any) *types.Checked[int64] {
+		return (result).(*types.Checked[int64])
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PredictAgeBare(ctx context.Context, inp string) <-chan types.Checked[int64] {
+func (*stream) PredictAgeBare(ctx context.Context, inp string) <-chan *types.Checked[int64] {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"inp": inp},
 	}
@@ -5169,7 +5169,7 @@ func (*stream) PredictAgeBare(ctx context.Context, inp string) <-chan types.Chec
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Checked[int64])
+	channel := make(chan *types.Checked[int64])
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PredictAgeBare", encoded)
 	if err != nil {
 		close(channel)
@@ -5190,7 +5190,7 @@ func (*stream) PredictAgeBare(ctx context.Context, inp string) <-chan types.Chec
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Checked[int64])
+				channel <- (*result.Data).(*types.Checked[int64])
 			}
 		}
 	}()
@@ -5214,16 +5214,16 @@ func PrimitiveAlias(ctx context.Context, p types.Union__int__string__bool__float
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Union__int__string__bool__float {
-		return *(result).(*types.Union__int__string__bool__float)
+	castResult := func(result any) *types.Union__int__string__bool__float {
+		return (result).(*types.Union__int__string__bool__float)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PrimitiveAlias(ctx context.Context, p types.Union__int__string__bool__float) <-chan types.Union__int__string__bool__float {
+func (*stream) PrimitiveAlias(ctx context.Context, p types.Union__int__string__bool__float) <-chan *types.Union__int__string__bool__float {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"p": p},
 	}
@@ -5231,7 +5231,7 @@ func (*stream) PrimitiveAlias(ctx context.Context, p types.Union__int__string__b
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Union__int__string__bool__float)
+	channel := make(chan *types.Union__int__string__bool__float)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PrimitiveAlias", encoded)
 	if err != nil {
 		close(channel)
@@ -5252,7 +5252,7 @@ func (*stream) PrimitiveAlias(ctx context.Context, p types.Union__int__string__b
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Union__int__string__bool__float)
+				channel <- (*result.Data).(*types.Union__int__string__bool__float)
 			}
 		}
 	}()
@@ -5276,16 +5276,16 @@ func PromptTestClaude(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PromptTestClaude(ctx context.Context, input string) <-chan string {
+func (*stream) PromptTestClaude(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5293,7 +5293,7 @@ func (*stream) PromptTestClaude(ctx context.Context, input string) <-chan string
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PromptTestClaude", encoded)
 	if err != nil {
 		close(channel)
@@ -5314,7 +5314,7 @@ func (*stream) PromptTestClaude(ctx context.Context, input string) <-chan string
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -5338,16 +5338,16 @@ func PromptTestClaudeChat(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PromptTestClaudeChat(ctx context.Context, input string) <-chan string {
+func (*stream) PromptTestClaudeChat(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5355,7 +5355,7 @@ func (*stream) PromptTestClaudeChat(ctx context.Context, input string) <-chan st
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PromptTestClaudeChat", encoded)
 	if err != nil {
 		close(channel)
@@ -5376,7 +5376,7 @@ func (*stream) PromptTestClaudeChat(ctx context.Context, input string) <-chan st
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -5400,16 +5400,16 @@ func PromptTestClaudeChatNoSystem(ctx context.Context, input string) (*string, e
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PromptTestClaudeChatNoSystem(ctx context.Context, input string) <-chan string {
+func (*stream) PromptTestClaudeChatNoSystem(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5417,7 +5417,7 @@ func (*stream) PromptTestClaudeChatNoSystem(ctx context.Context, input string) <
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PromptTestClaudeChatNoSystem", encoded)
 	if err != nil {
 		close(channel)
@@ -5438,7 +5438,7 @@ func (*stream) PromptTestClaudeChatNoSystem(ctx context.Context, input string) <
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -5462,16 +5462,16 @@ func PromptTestOpenAI(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PromptTestOpenAI(ctx context.Context, input string) <-chan string {
+func (*stream) PromptTestOpenAI(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5479,7 +5479,7 @@ func (*stream) PromptTestOpenAI(ctx context.Context, input string) <-chan string
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PromptTestOpenAI", encoded)
 	if err != nil {
 		close(channel)
@@ -5500,7 +5500,7 @@ func (*stream) PromptTestOpenAI(ctx context.Context, input string) <-chan string
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -5524,16 +5524,16 @@ func PromptTestOpenAIChat(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PromptTestOpenAIChat(ctx context.Context, input string) <-chan string {
+func (*stream) PromptTestOpenAIChat(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5541,7 +5541,7 @@ func (*stream) PromptTestOpenAIChat(ctx context.Context, input string) <-chan st
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PromptTestOpenAIChat", encoded)
 	if err != nil {
 		close(channel)
@@ -5562,7 +5562,7 @@ func (*stream) PromptTestOpenAIChat(ctx context.Context, input string) <-chan st
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -5586,16 +5586,16 @@ func PromptTestOpenAIChatNoSystem(ctx context.Context, input string) (*string, e
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PromptTestOpenAIChatNoSystem(ctx context.Context, input string) <-chan string {
+func (*stream) PromptTestOpenAIChatNoSystem(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5603,7 +5603,7 @@ func (*stream) PromptTestOpenAIChatNoSystem(ctx context.Context, input string) <
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PromptTestOpenAIChatNoSystem", encoded)
 	if err != nil {
 		close(channel)
@@ -5624,7 +5624,7 @@ func (*stream) PromptTestOpenAIChatNoSystem(ctx context.Context, input string) <
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -5648,16 +5648,16 @@ func PromptTestStreaming(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) PromptTestStreaming(ctx context.Context, input string) <-chan string {
+func (*stream) PromptTestStreaming(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5665,7 +5665,7 @@ func (*stream) PromptTestStreaming(ctx context.Context, input string) <-chan str
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "PromptTestStreaming", encoded)
 	if err != nil {
 		close(channel)
@@ -5686,7 +5686,7 @@ func (*stream) PromptTestStreaming(ctx context.Context, input string) <-chan str
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -5710,16 +5710,16 @@ func RecursiveAliasCycle(ctx context.Context, input types.RecAliasOne) (*types.R
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.RecAliasOne {
-		return (result).(types.RecAliasOne)
+	castResult := func(result any) *types.RecAliasOne {
+		return (result).(*types.RecAliasOne)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) RecursiveAliasCycle(ctx context.Context, input types.RecAliasOne) <-chan types.RecAliasOne {
+func (*stream) RecursiveAliasCycle(ctx context.Context, input types.RecAliasOne) <-chan *types.RecAliasOne {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5727,7 +5727,7 @@ func (*stream) RecursiveAliasCycle(ctx context.Context, input types.RecAliasOne)
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.RecAliasOne)
+	channel := make(chan *types.RecAliasOne)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "RecursiveAliasCycle", encoded)
 	if err != nil {
 		close(channel)
@@ -5748,7 +5748,7 @@ func (*stream) RecursiveAliasCycle(ctx context.Context, input types.RecAliasOne)
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.RecAliasOne)
+				channel <- (*result.Data).(*types.RecAliasOne)
 			}
 		}
 	}()
@@ -5772,16 +5772,16 @@ func RecursiveClassWithAliasIndirection(ctx context.Context, cls types.NodeWithA
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.NodeWithAliasIndirection {
-		return *(result).(*types.NodeWithAliasIndirection)
+	castResult := func(result any) *types.NodeWithAliasIndirection {
+		return (result).(*types.NodeWithAliasIndirection)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) RecursiveClassWithAliasIndirection(ctx context.Context, cls types.NodeWithAliasIndirection) <-chan types.NodeWithAliasIndirection {
+func (*stream) RecursiveClassWithAliasIndirection(ctx context.Context, cls types.NodeWithAliasIndirection) <-chan *types.NodeWithAliasIndirection {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"cls": cls},
 	}
@@ -5789,7 +5789,7 @@ func (*stream) RecursiveClassWithAliasIndirection(ctx context.Context, cls types
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.NodeWithAliasIndirection)
+	channel := make(chan *types.NodeWithAliasIndirection)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "RecursiveClassWithAliasIndirection", encoded)
 	if err != nil {
 		close(channel)
@@ -5810,7 +5810,7 @@ func (*stream) RecursiveClassWithAliasIndirection(ctx context.Context, cls types
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.NodeWithAliasIndirection)
+				channel <- (*result.Data).(*types.NodeWithAliasIndirection)
 			}
 		}
 	}()
@@ -5834,16 +5834,16 @@ func RecursiveUnionTest(ctx context.Context, input types.RecursiveUnion) (*types
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.RecursiveUnion {
-		return (result).(types.RecursiveUnion)
+	castResult := func(result any) *types.RecursiveUnion {
+		return (result).(*types.RecursiveUnion)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) RecursiveUnionTest(ctx context.Context, input types.RecursiveUnion) <-chan types.RecursiveUnion {
+func (*stream) RecursiveUnionTest(ctx context.Context, input types.RecursiveUnion) <-chan *types.RecursiveUnion {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -5851,7 +5851,7 @@ func (*stream) RecursiveUnionTest(ctx context.Context, input types.RecursiveUnio
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.RecursiveUnion)
+	channel := make(chan *types.RecursiveUnion)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "RecursiveUnionTest", encoded)
 	if err != nil {
 		close(channel)
@@ -5872,7 +5872,7 @@ func (*stream) RecursiveUnionTest(ctx context.Context, input types.RecursiveUnio
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.RecursiveUnion)
+				channel <- (*result.Data).(*types.RecursiveUnion)
 			}
 		}
 	}()
@@ -5896,16 +5896,16 @@ func ReturnAliasWithMergedAttributes(ctx context.Context, money int64) (*types.C
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Checked[int64] {
-		return (result).(types.Checked[int64])
+	castResult := func(result any) *types.Checked[int64] {
+		return (result).(*types.Checked[int64])
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ReturnAliasWithMergedAttributes(ctx context.Context, money int64) <-chan types.Checked[int64] {
+func (*stream) ReturnAliasWithMergedAttributes(ctx context.Context, money int64) <-chan *types.Checked[int64] {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"money": money},
 	}
@@ -5913,7 +5913,7 @@ func (*stream) ReturnAliasWithMergedAttributes(ctx context.Context, money int64)
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Checked[int64])
+	channel := make(chan *types.Checked[int64])
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ReturnAliasWithMergedAttributes", encoded)
 	if err != nil {
 		close(channel)
@@ -5934,7 +5934,7 @@ func (*stream) ReturnAliasWithMergedAttributes(ctx context.Context, money int64)
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Checked[int64])
+				channel <- (*result.Data).(*types.Checked[int64])
 			}
 		}
 	}()
@@ -5958,16 +5958,16 @@ func ReturnFailingAssert(ctx context.Context, inp int64) (*int64, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) int64 {
-		return (result).(int64)
+	castResult := func(result any) *int64 {
+		return (result).(*int64)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ReturnFailingAssert(ctx context.Context, inp int64) <-chan int64 {
+func (*stream) ReturnFailingAssert(ctx context.Context, inp int64) <-chan *int64 {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"inp": inp},
 	}
@@ -5975,7 +5975,7 @@ func (*stream) ReturnFailingAssert(ctx context.Context, inp int64) <-chan int64 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan int64)
+	channel := make(chan *int64)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ReturnFailingAssert", encoded)
 	if err != nil {
 		close(channel)
@@ -5996,7 +5996,7 @@ func (*stream) ReturnFailingAssert(ctx context.Context, inp int64) <-chan int64 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(int64)
+				channel <- (*result.Data).(*int64)
 			}
 		}
 	}()
@@ -6020,16 +6020,16 @@ func ReturnJsonEntry(ctx context.Context, s string) (*types.JsonTemplate, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.JsonTemplate {
-		return (result).(types.JsonTemplate)
+	castResult := func(result any) *types.JsonTemplate {
+		return (result).(*types.JsonTemplate)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ReturnJsonEntry(ctx context.Context, s string) <-chan types.JsonTemplate {
+func (*stream) ReturnJsonEntry(ctx context.Context, s string) <-chan *types.JsonTemplate {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"s": s},
 	}
@@ -6037,7 +6037,7 @@ func (*stream) ReturnJsonEntry(ctx context.Context, s string) <-chan types.JsonT
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.JsonTemplate)
+	channel := make(chan *types.JsonTemplate)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ReturnJsonEntry", encoded)
 	if err != nil {
 		close(channel)
@@ -6058,7 +6058,7 @@ func (*stream) ReturnJsonEntry(ctx context.Context, s string) <-chan types.JsonT
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.JsonTemplate)
+				channel <- (*result.Data).(*types.JsonTemplate)
 			}
 		}
 	}()
@@ -6082,16 +6082,16 @@ func ReturnMalformedConstraints(ctx context.Context, a int64) (*types.MalformedC
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.MalformedConstraints {
-		return *(result).(*types.MalformedConstraints)
+	castResult := func(result any) *types.MalformedConstraints {
+		return (result).(*types.MalformedConstraints)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) ReturnMalformedConstraints(ctx context.Context, a int64) <-chan types.MalformedConstraints {
+func (*stream) ReturnMalformedConstraints(ctx context.Context, a int64) <-chan *types.MalformedConstraints {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"a": a},
 	}
@@ -6099,7 +6099,7 @@ func (*stream) ReturnMalformedConstraints(ctx context.Context, a int64) <-chan t
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.MalformedConstraints)
+	channel := make(chan *types.MalformedConstraints)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "ReturnMalformedConstraints", encoded)
 	if err != nil {
 		close(channel)
@@ -6120,7 +6120,7 @@ func (*stream) ReturnMalformedConstraints(ctx context.Context, a int64) <-chan t
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.MalformedConstraints)
+				channel <- (*result.Data).(*types.MalformedConstraints)
 			}
 		}
 	}()
@@ -6144,16 +6144,16 @@ func SchemaDescriptions(ctx context.Context, input string) (*types.Schema, error
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Schema {
-		return *(result).(*types.Schema)
+	castResult := func(result any) *types.Schema {
+		return (result).(*types.Schema)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) SchemaDescriptions(ctx context.Context, input string) <-chan types.Schema {
+func (*stream) SchemaDescriptions(ctx context.Context, input string) <-chan *types.Schema {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -6161,7 +6161,7 @@ func (*stream) SchemaDescriptions(ctx context.Context, input string) <-chan type
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Schema)
+	channel := make(chan *types.Schema)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "SchemaDescriptions", encoded)
 	if err != nil {
 		close(channel)
@@ -6182,7 +6182,7 @@ func (*stream) SchemaDescriptions(ctx context.Context, input string) <-chan type
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Schema)
+				channel <- (*result.Data).(*types.Schema)
 			}
 		}
 	}()
@@ -6206,16 +6206,16 @@ func SimpleRecursiveListAlias(ctx context.Context, input types.RecursiveListAlia
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.RecursiveListAlias {
-		return (result).(types.RecursiveListAlias)
+	castResult := func(result any) *types.RecursiveListAlias {
+		return (result).(*types.RecursiveListAlias)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) SimpleRecursiveListAlias(ctx context.Context, input types.RecursiveListAlias) <-chan types.RecursiveListAlias {
+func (*stream) SimpleRecursiveListAlias(ctx context.Context, input types.RecursiveListAlias) <-chan *types.RecursiveListAlias {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -6223,7 +6223,7 @@ func (*stream) SimpleRecursiveListAlias(ctx context.Context, input types.Recursi
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.RecursiveListAlias)
+	channel := make(chan *types.RecursiveListAlias)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "SimpleRecursiveListAlias", encoded)
 	if err != nil {
 		close(channel)
@@ -6244,7 +6244,7 @@ func (*stream) SimpleRecursiveListAlias(ctx context.Context, input types.Recursi
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.RecursiveListAlias)
+				channel <- (*result.Data).(*types.RecursiveListAlias)
 			}
 		}
 	}()
@@ -6268,16 +6268,16 @@ func SimpleRecursiveMapAlias(ctx context.Context, input types.RecursiveMapAlias)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.RecursiveMapAlias {
-		return (result).(types.RecursiveMapAlias)
+	castResult := func(result any) *types.RecursiveMapAlias {
+		return (result).(*types.RecursiveMapAlias)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) SimpleRecursiveMapAlias(ctx context.Context, input types.RecursiveMapAlias) <-chan types.RecursiveMapAlias {
+func (*stream) SimpleRecursiveMapAlias(ctx context.Context, input types.RecursiveMapAlias) <-chan *types.RecursiveMapAlias {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -6285,7 +6285,7 @@ func (*stream) SimpleRecursiveMapAlias(ctx context.Context, input types.Recursiv
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.RecursiveMapAlias)
+	channel := make(chan *types.RecursiveMapAlias)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "SimpleRecursiveMapAlias", encoded)
 	if err != nil {
 		close(channel)
@@ -6306,7 +6306,7 @@ func (*stream) SimpleRecursiveMapAlias(ctx context.Context, input types.Recursiv
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.RecursiveMapAlias)
+				channel <- (*result.Data).(*types.RecursiveMapAlias)
 			}
 		}
 	}()
@@ -6330,16 +6330,16 @@ func StreamBigNumbers(ctx context.Context, digits int64) (*types.BigNumbers, err
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.BigNumbers {
-		return *(result).(*types.BigNumbers)
+	castResult := func(result any) *types.BigNumbers {
+		return (result).(*types.BigNumbers)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) StreamBigNumbers(ctx context.Context, digits int64) <-chan types.BigNumbers {
+func (*stream) StreamBigNumbers(ctx context.Context, digits int64) <-chan *types.BigNumbers {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"digits": digits},
 	}
@@ -6347,7 +6347,7 @@ func (*stream) StreamBigNumbers(ctx context.Context, digits int64) <-chan types.
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.BigNumbers)
+	channel := make(chan *types.BigNumbers)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "StreamBigNumbers", encoded)
 	if err != nil {
 		close(channel)
@@ -6368,7 +6368,7 @@ func (*stream) StreamBigNumbers(ctx context.Context, digits int64) <-chan types.
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.BigNumbers)
+				channel <- (*result.Data).(*types.BigNumbers)
 			}
 		}
 	}()
@@ -6392,16 +6392,16 @@ func StreamFailingAssertion(ctx context.Context, theme string, length int64) (*t
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.TwoStoriesOneTitle {
-		return *(result).(*types.TwoStoriesOneTitle)
+	castResult := func(result any) *types.TwoStoriesOneTitle {
+		return (result).(*types.TwoStoriesOneTitle)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) StreamFailingAssertion(ctx context.Context, theme string, length int64) <-chan types.TwoStoriesOneTitle {
+func (*stream) StreamFailingAssertion(ctx context.Context, theme string, length int64) <-chan *types.TwoStoriesOneTitle {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"theme": theme, "length": length},
 	}
@@ -6409,7 +6409,7 @@ func (*stream) StreamFailingAssertion(ctx context.Context, theme string, length 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.TwoStoriesOneTitle)
+	channel := make(chan *types.TwoStoriesOneTitle)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "StreamFailingAssertion", encoded)
 	if err != nil {
 		close(channel)
@@ -6430,7 +6430,7 @@ func (*stream) StreamFailingAssertion(ctx context.Context, theme string, length 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.TwoStoriesOneTitle)
+				channel <- (*result.Data).(*types.TwoStoriesOneTitle)
 			}
 		}
 	}()
@@ -6454,16 +6454,16 @@ func StreamFailingCheck(ctx context.Context, theme string, length int64) (*types
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.TwoStoriesOneTitleCheck {
-		return *(result).(*types.TwoStoriesOneTitleCheck)
+	castResult := func(result any) *types.TwoStoriesOneTitleCheck {
+		return (result).(*types.TwoStoriesOneTitleCheck)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) StreamFailingCheck(ctx context.Context, theme string, length int64) <-chan types.TwoStoriesOneTitleCheck {
+func (*stream) StreamFailingCheck(ctx context.Context, theme string, length int64) <-chan *types.TwoStoriesOneTitleCheck {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"theme": theme, "length": length},
 	}
@@ -6471,7 +6471,7 @@ func (*stream) StreamFailingCheck(ctx context.Context, theme string, length int6
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.TwoStoriesOneTitleCheck)
+	channel := make(chan *types.TwoStoriesOneTitleCheck)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "StreamFailingCheck", encoded)
 	if err != nil {
 		close(channel)
@@ -6492,7 +6492,7 @@ func (*stream) StreamFailingCheck(ctx context.Context, theme string, length int6
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.TwoStoriesOneTitleCheck)
+				channel <- (*result.Data).(*types.TwoStoriesOneTitleCheck)
 			}
 		}
 	}()
@@ -6516,16 +6516,16 @@ func StreamOneBigNumber(ctx context.Context, digits int64) (*int64, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) int64 {
-		return (result).(int64)
+	castResult := func(result any) *int64 {
+		return (result).(*int64)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) StreamOneBigNumber(ctx context.Context, digits int64) <-chan int64 {
+func (*stream) StreamOneBigNumber(ctx context.Context, digits int64) <-chan *int64 {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"digits": digits},
 	}
@@ -6533,7 +6533,7 @@ func (*stream) StreamOneBigNumber(ctx context.Context, digits int64) <-chan int6
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan int64)
+	channel := make(chan *int64)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "StreamOneBigNumber", encoded)
 	if err != nil {
 		close(channel)
@@ -6554,14 +6554,14 @@ func (*stream) StreamOneBigNumber(ctx context.Context, digits int64) <-chan int6
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(int64)
+				channel <- (*result.Data).(*int64)
 			}
 		}
 	}()
 	return channel
 }
 
-func StreamUnionIntegers(ctx context.Context, digits int64) (*[]types.Union__int__string, error) {
+func StreamUnionIntegers(ctx context.Context, digits int64) ([]types.Union__int__string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"digits": digits},
 	}
@@ -6584,7 +6584,7 @@ func StreamUnionIntegers(ctx context.Context, digits int64) (*[]types.Union__int
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) StreamUnionIntegers(ctx context.Context, digits int64) <-chan []types.Union__int__string {
@@ -6640,16 +6640,16 @@ func StreamingCompoundNumbers(ctx context.Context, digits int64, yapping bool) (
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.CompoundBigNumbers {
-		return *(result).(*types.CompoundBigNumbers)
+	castResult := func(result any) *types.CompoundBigNumbers {
+		return (result).(*types.CompoundBigNumbers)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) StreamingCompoundNumbers(ctx context.Context, digits int64, yapping bool) <-chan types.CompoundBigNumbers {
+func (*stream) StreamingCompoundNumbers(ctx context.Context, digits int64, yapping bool) <-chan *types.CompoundBigNumbers {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"digits": digits, "yapping": yapping},
 	}
@@ -6657,7 +6657,7 @@ func (*stream) StreamingCompoundNumbers(ctx context.Context, digits int64, yappi
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.CompoundBigNumbers)
+	channel := make(chan *types.CompoundBigNumbers)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "StreamingCompoundNumbers", encoded)
 	if err != nil {
 		close(channel)
@@ -6678,7 +6678,7 @@ func (*stream) StreamingCompoundNumbers(ctx context.Context, digits int64, yappi
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.CompoundBigNumbers)
+				channel <- (*result.Data).(*types.CompoundBigNumbers)
 			}
 		}
 	}()
@@ -6702,16 +6702,16 @@ func StructureDocument1559(ctx context.Context, document_txt string) (*types.Doc
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Document1559 {
-		return *(result).(*types.Document1559)
+	castResult := func(result any) *types.Document1559 {
+		return (result).(*types.Document1559)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) StructureDocument1559(ctx context.Context, document_txt string) <-chan types.Document1559 {
+func (*stream) StructureDocument1559(ctx context.Context, document_txt string) <-chan *types.Document1559 {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"document_txt": document_txt},
 	}
@@ -6719,7 +6719,7 @@ func (*stream) StructureDocument1559(ctx context.Context, document_txt string) <
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Document1559)
+	channel := make(chan *types.Document1559)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "StructureDocument1559", encoded)
 	if err != nil {
 		close(channel)
@@ -6740,7 +6740,7 @@ func (*stream) StructureDocument1559(ctx context.Context, document_txt string) <
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Document1559)
+				channel <- (*result.Data).(*types.Document1559)
 			}
 		}
 	}()
@@ -6764,16 +6764,16 @@ func TakeRecAliasDep(ctx context.Context, input types.RecursiveAliasDependency) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.RecursiveAliasDependency {
-		return *(result).(*types.RecursiveAliasDependency)
+	castResult := func(result any) *types.RecursiveAliasDependency {
+		return (result).(*types.RecursiveAliasDependency)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TakeRecAliasDep(ctx context.Context, input types.RecursiveAliasDependency) <-chan types.RecursiveAliasDependency {
+func (*stream) TakeRecAliasDep(ctx context.Context, input types.RecursiveAliasDependency) <-chan *types.RecursiveAliasDependency {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -6781,7 +6781,7 @@ func (*stream) TakeRecAliasDep(ctx context.Context, input types.RecursiveAliasDe
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.RecursiveAliasDependency)
+	channel := make(chan *types.RecursiveAliasDependency)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TakeRecAliasDep", encoded)
 	if err != nil {
 		close(channel)
@@ -6802,7 +6802,7 @@ func (*stream) TakeRecAliasDep(ctx context.Context, input types.RecursiveAliasDe
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.RecursiveAliasDependency)
+				channel <- (*result.Data).(*types.RecursiveAliasDependency)
 			}
 		}
 	}()
@@ -6826,16 +6826,16 @@ func TellStory(ctx context.Context, story string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TellStory(ctx context.Context, story string) <-chan string {
+func (*stream) TellStory(ctx context.Context, story string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"story": story},
 	}
@@ -6843,7 +6843,7 @@ func (*stream) TellStory(ctx context.Context, story string) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TellStory", encoded)
 	if err != nil {
 		close(channel)
@@ -6864,7 +6864,7 @@ func (*stream) TellStory(ctx context.Context, story string) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -6888,16 +6888,16 @@ func TestAnthropic(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAnthropic(ctx context.Context, input string) <-chan string {
+func (*stream) TestAnthropic(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -6905,7 +6905,7 @@ func (*stream) TestAnthropic(ctx context.Context, input string) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAnthropic", encoded)
 	if err != nil {
 		close(channel)
@@ -6926,7 +6926,7 @@ func (*stream) TestAnthropic(ctx context.Context, input string) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -6950,16 +6950,16 @@ func TestAnthropicShorthand(ctx context.Context, input string) (*string, error) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAnthropicShorthand(ctx context.Context, input string) <-chan string {
+func (*stream) TestAnthropicShorthand(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -6967,7 +6967,7 @@ func (*stream) TestAnthropicShorthand(ctx context.Context, input string) <-chan 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAnthropicShorthand", encoded)
 	if err != nil {
 		close(channel)
@@ -6988,7 +6988,7 @@ func (*stream) TestAnthropicShorthand(ctx context.Context, input string) <-chan 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7012,16 +7012,16 @@ func TestAws(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAws(ctx context.Context, input string) <-chan string {
+func (*stream) TestAws(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7029,7 +7029,7 @@ func (*stream) TestAws(ctx context.Context, input string) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAws", encoded)
 	if err != nil {
 		close(channel)
@@ -7050,7 +7050,7 @@ func (*stream) TestAws(ctx context.Context, input string) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7074,16 +7074,16 @@ func TestAwsClaude37(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAwsClaude37(ctx context.Context, input string) <-chan string {
+func (*stream) TestAwsClaude37(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7091,7 +7091,7 @@ func (*stream) TestAwsClaude37(ctx context.Context, input string) <-chan string 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAwsClaude37", encoded)
 	if err != nil {
 		close(channel)
@@ -7112,7 +7112,7 @@ func (*stream) TestAwsClaude37(ctx context.Context, input string) <-chan string 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7136,16 +7136,16 @@ func TestAwsInferenceProfile(ctx context.Context, input string) (*string, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAwsInferenceProfile(ctx context.Context, input string) <-chan string {
+func (*stream) TestAwsInferenceProfile(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7153,7 +7153,7 @@ func (*stream) TestAwsInferenceProfile(ctx context.Context, input string) <-chan
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAwsInferenceProfile", encoded)
 	if err != nil {
 		close(channel)
@@ -7174,7 +7174,7 @@ func (*stream) TestAwsInferenceProfile(ctx context.Context, input string) <-chan
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7198,16 +7198,16 @@ func TestAwsInvalidAccessKey(ctx context.Context, input string) (*string, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAwsInvalidAccessKey(ctx context.Context, input string) <-chan string {
+func (*stream) TestAwsInvalidAccessKey(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7215,7 +7215,7 @@ func (*stream) TestAwsInvalidAccessKey(ctx context.Context, input string) <-chan
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAwsInvalidAccessKey", encoded)
 	if err != nil {
 		close(channel)
@@ -7236,7 +7236,7 @@ func (*stream) TestAwsInvalidAccessKey(ctx context.Context, input string) <-chan
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7260,16 +7260,16 @@ func TestAwsInvalidProfile(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAwsInvalidProfile(ctx context.Context, input string) <-chan string {
+func (*stream) TestAwsInvalidProfile(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7277,7 +7277,7 @@ func (*stream) TestAwsInvalidProfile(ctx context.Context, input string) <-chan s
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAwsInvalidProfile", encoded)
 	if err != nil {
 		close(channel)
@@ -7298,7 +7298,7 @@ func (*stream) TestAwsInvalidProfile(ctx context.Context, input string) <-chan s
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7322,16 +7322,16 @@ func TestAwsInvalidRegion(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAwsInvalidRegion(ctx context.Context, input string) <-chan string {
+func (*stream) TestAwsInvalidRegion(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7339,7 +7339,7 @@ func (*stream) TestAwsInvalidRegion(ctx context.Context, input string) <-chan st
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAwsInvalidRegion", encoded)
 	if err != nil {
 		close(channel)
@@ -7360,7 +7360,7 @@ func (*stream) TestAwsInvalidRegion(ctx context.Context, input string) <-chan st
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7384,16 +7384,16 @@ func TestAwsInvalidSessionToken(ctx context.Context, input string) (*string, err
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAwsInvalidSessionToken(ctx context.Context, input string) <-chan string {
+func (*stream) TestAwsInvalidSessionToken(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7401,7 +7401,7 @@ func (*stream) TestAwsInvalidSessionToken(ctx context.Context, input string) <-c
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAwsInvalidSessionToken", encoded)
 	if err != nil {
 		close(channel)
@@ -7422,7 +7422,7 @@ func (*stream) TestAwsInvalidSessionToken(ctx context.Context, input string) <-c
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7446,16 +7446,16 @@ func TestAzure(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAzure(ctx context.Context, input string) <-chan string {
+func (*stream) TestAzure(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7463,7 +7463,7 @@ func (*stream) TestAzure(ctx context.Context, input string) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAzure", encoded)
 	if err != nil {
 		close(channel)
@@ -7484,7 +7484,7 @@ func (*stream) TestAzure(ctx context.Context, input string) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7508,16 +7508,16 @@ func TestAzureFailure(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAzureFailure(ctx context.Context, input string) <-chan string {
+func (*stream) TestAzureFailure(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7525,7 +7525,7 @@ func (*stream) TestAzureFailure(ctx context.Context, input string) <-chan string
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAzureFailure", encoded)
 	if err != nil {
 		close(channel)
@@ -7546,7 +7546,7 @@ func (*stream) TestAzureFailure(ctx context.Context, input string) <-chan string
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7570,16 +7570,16 @@ func TestAzureO1NoMaxTokens(ctx context.Context, input string) (*string, error) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAzureO1NoMaxTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestAzureO1NoMaxTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7587,7 +7587,7 @@ func (*stream) TestAzureO1NoMaxTokens(ctx context.Context, input string) <-chan 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAzureO1NoMaxTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -7608,7 +7608,7 @@ func (*stream) TestAzureO1NoMaxTokens(ctx context.Context, input string) <-chan 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7632,16 +7632,16 @@ func TestAzureO1WithMaxCompletionTokens(ctx context.Context, input string) (*str
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAzureO1WithMaxCompletionTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestAzureO1WithMaxCompletionTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7649,7 +7649,7 @@ func (*stream) TestAzureO1WithMaxCompletionTokens(ctx context.Context, input str
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAzureO1WithMaxCompletionTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -7670,7 +7670,7 @@ func (*stream) TestAzureO1WithMaxCompletionTokens(ctx context.Context, input str
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7694,16 +7694,16 @@ func TestAzureO1WithMaxTokens(ctx context.Context, input string) (*string, error
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAzureO1WithMaxTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestAzureO1WithMaxTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7711,7 +7711,7 @@ func (*stream) TestAzureO1WithMaxTokens(ctx context.Context, input string) <-cha
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAzureO1WithMaxTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -7732,7 +7732,7 @@ func (*stream) TestAzureO1WithMaxTokens(ctx context.Context, input string) <-cha
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7756,16 +7756,16 @@ func TestAzureO3NoMaxTokens(ctx context.Context, input string) (*string, error) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAzureO3NoMaxTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestAzureO3NoMaxTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7773,7 +7773,7 @@ func (*stream) TestAzureO3NoMaxTokens(ctx context.Context, input string) <-chan 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAzureO3NoMaxTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -7794,7 +7794,7 @@ func (*stream) TestAzureO3NoMaxTokens(ctx context.Context, input string) <-chan 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7818,16 +7818,16 @@ func TestAzureO3WithMaxCompletionTokens(ctx context.Context, input string) (*str
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAzureO3WithMaxCompletionTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestAzureO3WithMaxCompletionTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7835,7 +7835,7 @@ func (*stream) TestAzureO3WithMaxCompletionTokens(ctx context.Context, input str
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAzureO3WithMaxCompletionTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -7856,7 +7856,7 @@ func (*stream) TestAzureO3WithMaxCompletionTokens(ctx context.Context, input str
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7880,16 +7880,16 @@ func TestAzureWithMaxTokens(ctx context.Context, input string) (*string, error) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestAzureWithMaxTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestAzureWithMaxTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -7897,7 +7897,7 @@ func (*stream) TestAzureWithMaxTokens(ctx context.Context, input string) <-chan 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestAzureWithMaxTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -7918,7 +7918,7 @@ func (*stream) TestAzureWithMaxTokens(ctx context.Context, input string) <-chan 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -7942,16 +7942,16 @@ func TestCaching(ctx context.Context, input string, not_cached string) (*string,
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestCaching(ctx context.Context, input string, not_cached string) <-chan string {
+func (*stream) TestCaching(ctx context.Context, input string, not_cached string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input, "not_cached": not_cached},
 	}
@@ -7959,7 +7959,7 @@ func (*stream) TestCaching(ctx context.Context, input string, not_cached string)
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestCaching", encoded)
 	if err != nil {
 		close(channel)
@@ -7980,7 +7980,7 @@ func (*stream) TestCaching(ctx context.Context, input string, not_cached string)
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -8004,16 +8004,16 @@ func TestFallbackClient(ctx context.Context) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFallbackClient(ctx context.Context) <-chan string {
+func (*stream) TestFallbackClient(ctx context.Context) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -8021,7 +8021,7 @@ func (*stream) TestFallbackClient(ctx context.Context) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFallbackClient", encoded)
 	if err != nil {
 		close(channel)
@@ -8042,7 +8042,7 @@ func (*stream) TestFallbackClient(ctx context.Context) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -8066,16 +8066,16 @@ func TestFallbackStrategy(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFallbackStrategy(ctx context.Context, input string) <-chan string {
+func (*stream) TestFallbackStrategy(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -8083,7 +8083,7 @@ func (*stream) TestFallbackStrategy(ctx context.Context, input string) <-chan st
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFallbackStrategy", encoded)
 	if err != nil {
 		close(channel)
@@ -8104,7 +8104,7 @@ func (*stream) TestFallbackStrategy(ctx context.Context, input string) <-chan st
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -8128,16 +8128,16 @@ func TestFallbackToShorthand(ctx context.Context, input string) (*string, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFallbackToShorthand(ctx context.Context, input string) <-chan string {
+func (*stream) TestFallbackToShorthand(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -8145,7 +8145,7 @@ func (*stream) TestFallbackToShorthand(ctx context.Context, input string) <-chan
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFallbackToShorthand", encoded)
 	if err != nil {
 		close(channel)
@@ -8166,7 +8166,7 @@ func (*stream) TestFallbackToShorthand(ctx context.Context, input string) <-chan
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -8190,16 +8190,16 @@ func TestFnNamedArgsSingleBool(ctx context.Context, myBool bool) (*string, error
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFnNamedArgsSingleBool(ctx context.Context, myBool bool) <-chan string {
+func (*stream) TestFnNamedArgsSingleBool(ctx context.Context, myBool bool) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myBool": myBool},
 	}
@@ -8207,7 +8207,7 @@ func (*stream) TestFnNamedArgsSingleBool(ctx context.Context, myBool bool) <-cha
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFnNamedArgsSingleBool", encoded)
 	if err != nil {
 		close(channel)
@@ -8228,7 +8228,7 @@ func (*stream) TestFnNamedArgsSingleBool(ctx context.Context, myBool bool) <-cha
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -8252,16 +8252,16 @@ func TestFnNamedArgsSingleClass(ctx context.Context, myArg types.NamedArgsSingle
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFnNamedArgsSingleClass(ctx context.Context, myArg types.NamedArgsSingleClass) <-chan string {
+func (*stream) TestFnNamedArgsSingleClass(ctx context.Context, myArg types.NamedArgsSingleClass) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myArg": myArg},
 	}
@@ -8269,7 +8269,7 @@ func (*stream) TestFnNamedArgsSingleClass(ctx context.Context, myArg types.Named
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFnNamedArgsSingleClass", encoded)
 	if err != nil {
 		close(channel)
@@ -8290,7 +8290,7 @@ func (*stream) TestFnNamedArgsSingleClass(ctx context.Context, myArg types.Named
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -8314,16 +8314,16 @@ func TestFnNamedArgsSingleEnumList(ctx context.Context, myArg []types.NamedArgsS
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFnNamedArgsSingleEnumList(ctx context.Context, myArg []types.NamedArgsSingleEnumList) <-chan string {
+func (*stream) TestFnNamedArgsSingleEnumList(ctx context.Context, myArg []types.NamedArgsSingleEnumList) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myArg": myArg},
 	}
@@ -8331,7 +8331,7 @@ func (*stream) TestFnNamedArgsSingleEnumList(ctx context.Context, myArg []types.
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFnNamedArgsSingleEnumList", encoded)
 	if err != nil {
 		close(channel)
@@ -8352,7 +8352,7 @@ func (*stream) TestFnNamedArgsSingleEnumList(ctx context.Context, myArg []types.
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -8376,16 +8376,16 @@ func TestFnNamedArgsSingleFloat(ctx context.Context, myFloat float64) (*string, 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFnNamedArgsSingleFloat(ctx context.Context, myFloat float64) <-chan string {
+func (*stream) TestFnNamedArgsSingleFloat(ctx context.Context, myFloat float64) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myFloat": myFloat},
 	}
@@ -8393,7 +8393,7 @@ func (*stream) TestFnNamedArgsSingleFloat(ctx context.Context, myFloat float64) 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFnNamedArgsSingleFloat", encoded)
 	if err != nil {
 		close(channel)
@@ -8414,7 +8414,7 @@ func (*stream) TestFnNamedArgsSingleFloat(ctx context.Context, myFloat float64) 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -8438,16 +8438,16 @@ func TestFnNamedArgsSingleInt(ctx context.Context, myInt int64) (*string, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFnNamedArgsSingleInt(ctx context.Context, myInt int64) <-chan string {
+func (*stream) TestFnNamedArgsSingleInt(ctx context.Context, myInt int64) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myInt": myInt},
 	}
@@ -8455,7 +8455,7 @@ func (*stream) TestFnNamedArgsSingleInt(ctx context.Context, myInt int64) <-chan
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFnNamedArgsSingleInt", encoded)
 	if err != nil {
 		close(channel)
@@ -8476,14 +8476,14 @@ func (*stream) TestFnNamedArgsSingleInt(ctx context.Context, myInt int64) <-chan
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
 	return channel
 }
 
-func TestFnNamedArgsSingleMapStringToClass(ctx context.Context, myMap map[string]types.StringToClassEntry) (*map[string]types.StringToClassEntry, error) {
+func TestFnNamedArgsSingleMapStringToClass(ctx context.Context, myMap map[string]types.StringToClassEntry) (map[string]types.StringToClassEntry, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myMap": myMap},
 	}
@@ -8506,7 +8506,7 @@ func TestFnNamedArgsSingleMapStringToClass(ctx context.Context, myMap map[string
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) TestFnNamedArgsSingleMapStringToClass(ctx context.Context, myMap map[string]types.StringToClassEntry) <-chan map[string]types.StringToClassEntry {
@@ -8545,7 +8545,7 @@ func (*stream) TestFnNamedArgsSingleMapStringToClass(ctx context.Context, myMap 
 	return channel
 }
 
-func TestFnNamedArgsSingleMapStringToMap(ctx context.Context, myMap map[string]map[string]string) (*map[string]map[string]string, error) {
+func TestFnNamedArgsSingleMapStringToMap(ctx context.Context, myMap map[string]map[string]string) (map[string]map[string]string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myMap": myMap},
 	}
@@ -8568,7 +8568,7 @@ func TestFnNamedArgsSingleMapStringToMap(ctx context.Context, myMap map[string]m
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) TestFnNamedArgsSingleMapStringToMap(ctx context.Context, myMap map[string]map[string]string) <-chan map[string]map[string]string {
@@ -8607,7 +8607,7 @@ func (*stream) TestFnNamedArgsSingleMapStringToMap(ctx context.Context, myMap ma
 	return channel
 }
 
-func TestFnNamedArgsSingleMapStringToString(ctx context.Context, myMap map[string]string) (*map[string]string, error) {
+func TestFnNamedArgsSingleMapStringToString(ctx context.Context, myMap map[string]string) (map[string]string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myMap": myMap},
 	}
@@ -8630,7 +8630,7 @@ func TestFnNamedArgsSingleMapStringToString(ctx context.Context, myMap map[strin
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) TestFnNamedArgsSingleMapStringToString(ctx context.Context, myMap map[string]string) <-chan map[string]string {
@@ -8686,16 +8686,16 @@ func TestFnNamedArgsSingleString(ctx context.Context, myString string) (*string,
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFnNamedArgsSingleString(ctx context.Context, myString string) <-chan string {
+func (*stream) TestFnNamedArgsSingleString(ctx context.Context, myString string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myString": myString},
 	}
@@ -8703,7 +8703,7 @@ func (*stream) TestFnNamedArgsSingleString(ctx context.Context, myString string)
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFnNamedArgsSingleString", encoded)
 	if err != nil {
 		close(channel)
@@ -8724,7 +8724,7 @@ func (*stream) TestFnNamedArgsSingleString(ctx context.Context, myString string)
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -8748,16 +8748,16 @@ func TestFnNamedArgsSingleStringArray(ctx context.Context, myStringArray []strin
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestFnNamedArgsSingleStringArray(ctx context.Context, myStringArray []string) <-chan string {
+func (*stream) TestFnNamedArgsSingleStringArray(ctx context.Context, myStringArray []string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myStringArray": myStringArray},
 	}
@@ -8765,7 +8765,7 @@ func (*stream) TestFnNamedArgsSingleStringArray(ctx context.Context, myStringArr
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestFnNamedArgsSingleStringArray", encoded)
 	if err != nil {
 		close(channel)
@@ -8786,14 +8786,14 @@ func (*stream) TestFnNamedArgsSingleStringArray(ctx context.Context, myStringArr
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
 	return channel
 }
 
-func TestFnNamedArgsSingleStringList(ctx context.Context, myArg []string) (*[]string, error) {
+func TestFnNamedArgsSingleStringList(ctx context.Context, myArg []string) ([]string, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"myArg": myArg},
 	}
@@ -8816,7 +8816,7 @@ func TestFnNamedArgsSingleStringList(ctx context.Context, myArg []string) (*[]st
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
 func (*stream) TestFnNamedArgsSingleStringList(ctx context.Context, myArg []string) <-chan []string {
@@ -8872,824 +8872,16 @@ func TestGemini(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestGemini(ctx context.Context, input string) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGemini", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestGeminiOpenAiGeneric(ctx context.Context) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestGeminiOpenAiGeneric", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestGeminiOpenAiGeneric(ctx context.Context) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGeminiOpenAiGeneric", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestGeminiSystem(ctx context.Context, input string) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestGeminiSystem", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestGeminiSystem(ctx context.Context, input string) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGeminiSystem", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestGeminiSystemAsChat(ctx context.Context, input string) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestGeminiSystemAsChat", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestGeminiSystemAsChat(ctx context.Context, input string) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGeminiSystemAsChat", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestGroq(ctx context.Context, input string) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestGroq", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestGroq(ctx context.Context, input string) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGroq", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestImageInput(ctx context.Context, img any) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"img": img},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestImageInput", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestImageInput(ctx context.Context, img any) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"img": img},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestImageInput", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestImageInputAnthropic(ctx context.Context, img any) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"img": img},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestImageInputAnthropic", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestImageInputAnthropic(ctx context.Context, img any) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"img": img},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestImageInputAnthropic", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestImageListInput(ctx context.Context, imgs []any) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"imgs": imgs},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestImageListInput", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestImageListInput(ctx context.Context, imgs []any) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"imgs": imgs},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestImageListInput", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestMemory(ctx context.Context, input string) (*types.TestMemoryOutput, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestMemory", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) types.TestMemoryOutput {
-		return *(result).(*types.TestMemoryOutput)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestMemory(ctx context.Context, input string) <-chan types.TestMemoryOutput {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan types.TestMemoryOutput)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestMemory", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(types.TestMemoryOutput)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestMulticlassNamedArgs(ctx context.Context, myArg types.NamedArgsSingleClass, myArg2 types.NamedArgsSingleClass) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"myArg": myArg, "myArg2": myArg2},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestMulticlassNamedArgs", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestMulticlassNamedArgs(ctx context.Context, myArg types.NamedArgsSingleClass, myArg2 types.NamedArgsSingleClass) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"myArg": myArg, "myArg2": myArg2},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestMulticlassNamedArgs", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestNamedArgsLiteralBool(ctx context.Context, myBool bool) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"myBool": myBool},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestNamedArgsLiteralBool", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestNamedArgsLiteralBool(ctx context.Context, myBool bool) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"myBool": myBool},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestNamedArgsLiteralBool", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestNamedArgsLiteralInt(ctx context.Context, myInt int) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"myInt": myInt},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestNamedArgsLiteralInt", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestNamedArgsLiteralInt(ctx context.Context, myInt int) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"myInt": myInt},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestNamedArgsLiteralInt", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestNamedArgsLiteralString(ctx context.Context, myString string) (*string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"myString": myString},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestNamedArgsLiteralString", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	castResult := func(result any) string {
-		return (result).(string)
-	}
-
-	casted := castResult(*result.Data)
-
-	return &casted, nil
-}
-
-func (*stream) TestNamedArgsLiteralString(ctx context.Context, myString string) <-chan string {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"myString": myString},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	channel := make(chan string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestNamedArgsLiteralString", encoded)
-	if err != nil {
-		close(channel)
-		return channel
-	}
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				close(channel)
-				return
-			case result, ok := <-raw:
-				if !ok {
-					close(channel)
-					return
-				}
-				if result.Error != nil {
-					close(channel)
-					return
-				}
-				channel <- (*result.Data).(string)
-			}
-		}
-	}()
-	return channel
-}
-
-func TestOllama(ctx context.Context, input string) (**string, error) {
-	args := baml.BamlFunctionArguments{
-		Kwargs: map[string]any{"input": input},
-	}
-	encoded, err := baml.EncodeRoot(args)
-	if err != nil {
-		panic(err)
-	}
-	result, err := bamlRuntime.CallFunction(ctx, "TestOllama", encoded)
-	if err != nil {
-		return nil, err
-	}
-
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
 	castResult := func(result any) *string {
-		return castOptional(result, func(item any) string {
-			return (item).(string)
-		})
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOllama(ctx context.Context, input string) <-chan *string {
+func (*stream) TestGemini(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -9698,7 +8890,7 @@ func (*stream) TestOllama(ctx context.Context, input string) <-chan *string {
 		panic(err)
 	}
 	channel := make(chan *string)
-	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOllama", encoded)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGemini", encoded)
 	if err != nil {
 		close(channel)
 		return channel
@@ -9725,6 +8917,814 @@ func (*stream) TestOllama(ctx context.Context, input string) <-chan *string {
 	return channel
 }
 
+func TestGeminiOpenAiGeneric(ctx context.Context) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestGeminiOpenAiGeneric", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestGeminiOpenAiGeneric(ctx context.Context) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGeminiOpenAiGeneric", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestGeminiSystem(ctx context.Context, input string) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestGeminiSystem", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestGeminiSystem(ctx context.Context, input string) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGeminiSystem", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestGeminiSystemAsChat(ctx context.Context, input string) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestGeminiSystemAsChat", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestGeminiSystemAsChat(ctx context.Context, input string) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGeminiSystemAsChat", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestGroq(ctx context.Context, input string) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestGroq", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestGroq(ctx context.Context, input string) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestGroq", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestImageInput(ctx context.Context, img any) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"img": img},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestImageInput", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestImageInput(ctx context.Context, img any) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"img": img},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestImageInput", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestImageInputAnthropic(ctx context.Context, img any) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"img": img},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestImageInputAnthropic", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestImageInputAnthropic(ctx context.Context, img any) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"img": img},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestImageInputAnthropic", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestImageListInput(ctx context.Context, imgs []any) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"imgs": imgs},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestImageListInput", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestImageListInput(ctx context.Context, imgs []any) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"imgs": imgs},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestImageListInput", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestMemory(ctx context.Context, input string) (*types.TestMemoryOutput, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestMemory", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *types.TestMemoryOutput {
+		return (result).(*types.TestMemoryOutput)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestMemory(ctx context.Context, input string) <-chan *types.TestMemoryOutput {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *types.TestMemoryOutput)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestMemory", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*types.TestMemoryOutput)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestMulticlassNamedArgs(ctx context.Context, myArg types.NamedArgsSingleClass, myArg2 types.NamedArgsSingleClass) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"myArg": myArg, "myArg2": myArg2},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestMulticlassNamedArgs", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestMulticlassNamedArgs(ctx context.Context, myArg types.NamedArgsSingleClass, myArg2 types.NamedArgsSingleClass) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"myArg": myArg, "myArg2": myArg2},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestMulticlassNamedArgs", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestNamedArgsLiteralBool(ctx context.Context, myBool bool) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"myBool": myBool},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestNamedArgsLiteralBool", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestNamedArgsLiteralBool(ctx context.Context, myBool bool) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"myBool": myBool},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestNamedArgsLiteralBool", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestNamedArgsLiteralInt(ctx context.Context, myInt int) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"myInt": myInt},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestNamedArgsLiteralInt", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestNamedArgsLiteralInt(ctx context.Context, myInt int) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"myInt": myInt},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestNamedArgsLiteralInt", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestNamedArgsLiteralString(ctx context.Context, myString string) (*string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"myString": myString},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestNamedArgsLiteralString", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) *string {
+		return (result).(*string)
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestNamedArgsLiteralString(ctx context.Context, myString string) <-chan *string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"myString": myString},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan *string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestNamedArgsLiteralString", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(*string)
+			}
+		}
+	}()
+	return channel
+}
+
+func TestOllama(ctx context.Context, input string) (**string, error) {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	result, err := bamlRuntime.CallFunction(ctx, "TestOllama", encoded)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.Error != nil {
+		return nil, result.Error
+	}
+
+	castResult := func(result any) **string {
+		return castOptional(result, func(item any) *string {
+			return (item).(*string)
+		})
+	}
+
+	casted := castResult(*result.Data)
+
+	return casted, nil
+}
+
+func (*stream) TestOllama(ctx context.Context, input string) <-chan **string {
+	args := baml.BamlFunctionArguments{
+		Kwargs: map[string]any{"input": input},
+	}
+	encoded, err := baml.EncodeRoot(args)
+	if err != nil {
+		panic(err)
+	}
+	channel := make(chan **string)
+	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOllama", encoded)
+	if err != nil {
+		close(channel)
+		return channel
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				close(channel)
+				return
+			case result, ok := <-raw:
+				if !ok {
+					close(channel)
+					return
+				}
+				if result.Error != nil {
+					close(channel)
+					return
+				}
+				channel <- (*result.Data).(**string)
+			}
+		}
+	}()
+	return channel
+}
+
 func TestOllamaHaiku(ctx context.Context, input string) (*types.Haiku, error) {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
@@ -9742,16 +9742,16 @@ func TestOllamaHaiku(ctx context.Context, input string) (*types.Haiku, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.Haiku {
-		return *(result).(*types.Haiku)
+	castResult := func(result any) *types.Haiku {
+		return (result).(*types.Haiku)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOllamaHaiku(ctx context.Context, input string) <-chan types.Haiku {
+func (*stream) TestOllamaHaiku(ctx context.Context, input string) <-chan *types.Haiku {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -9759,7 +9759,7 @@ func (*stream) TestOllamaHaiku(ctx context.Context, input string) <-chan types.H
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.Haiku)
+	channel := make(chan *types.Haiku)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOllamaHaiku", encoded)
 	if err != nil {
 		close(channel)
@@ -9780,7 +9780,7 @@ func (*stream) TestOllamaHaiku(ctx context.Context, input string) <-chan types.H
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.Haiku)
+				channel <- (*result.Data).(*types.Haiku)
 			}
 		}
 	}()
@@ -9804,16 +9804,16 @@ func TestOpenAI(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAI(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAI(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -9821,7 +9821,7 @@ func (*stream) TestOpenAI(ctx context.Context, input string) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAI", encoded)
 	if err != nil {
 		close(channel)
@@ -9842,7 +9842,7 @@ func (*stream) TestOpenAI(ctx context.Context, input string) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -9866,16 +9866,16 @@ func TestOpenAIDummyClient(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAIDummyClient(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAIDummyClient(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -9883,7 +9883,7 @@ func (*stream) TestOpenAIDummyClient(ctx context.Context, input string) <-chan s
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAIDummyClient", encoded)
 	if err != nil {
 		close(channel)
@@ -9904,7 +9904,7 @@ func (*stream) TestOpenAIDummyClient(ctx context.Context, input string) <-chan s
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -9928,16 +9928,16 @@ func TestOpenAIGPT4oMini(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAIGPT4oMini(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAIGPT4oMini(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -9945,7 +9945,7 @@ func (*stream) TestOpenAIGPT4oMini(ctx context.Context, input string) <-chan str
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAIGPT4oMini", encoded)
 	if err != nil {
 		close(channel)
@@ -9966,7 +9966,7 @@ func (*stream) TestOpenAIGPT4oMini(ctx context.Context, input string) <-chan str
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -9990,16 +9990,16 @@ func TestOpenAILegacyProvider(ctx context.Context, input string) (*string, error
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAILegacyProvider(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAILegacyProvider(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10007,7 +10007,7 @@ func (*stream) TestOpenAILegacyProvider(ctx context.Context, input string) <-cha
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAILegacyProvider", encoded)
 	if err != nil {
 		close(channel)
@@ -10028,7 +10028,7 @@ func (*stream) TestOpenAILegacyProvider(ctx context.Context, input string) <-cha
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10052,16 +10052,16 @@ func TestOpenAIO1NoMaxTokens(ctx context.Context, input string) (*string, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAIO1NoMaxTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAIO1NoMaxTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10069,7 +10069,7 @@ func (*stream) TestOpenAIO1NoMaxTokens(ctx context.Context, input string) <-chan
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAIO1NoMaxTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -10090,7 +10090,7 @@ func (*stream) TestOpenAIO1NoMaxTokens(ctx context.Context, input string) <-chan
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10114,16 +10114,16 @@ func TestOpenAIO1WithMaxCompletionTokens(ctx context.Context, input string) (*st
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAIO1WithMaxCompletionTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAIO1WithMaxCompletionTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10131,7 +10131,7 @@ func (*stream) TestOpenAIO1WithMaxCompletionTokens(ctx context.Context, input st
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAIO1WithMaxCompletionTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -10152,7 +10152,7 @@ func (*stream) TestOpenAIO1WithMaxCompletionTokens(ctx context.Context, input st
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10176,16 +10176,16 @@ func TestOpenAIO1WithMaxTokens(ctx context.Context, input string) (*string, erro
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAIO1WithMaxTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAIO1WithMaxTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10193,7 +10193,7 @@ func (*stream) TestOpenAIO1WithMaxTokens(ctx context.Context, input string) <-ch
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAIO1WithMaxTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -10214,7 +10214,7 @@ func (*stream) TestOpenAIO1WithMaxTokens(ctx context.Context, input string) <-ch
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10238,16 +10238,16 @@ func TestOpenAIShorthand(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAIShorthand(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAIShorthand(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10255,7 +10255,7 @@ func (*stream) TestOpenAIShorthand(ctx context.Context, input string) <-chan str
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAIShorthand", encoded)
 	if err != nil {
 		close(channel)
@@ -10276,7 +10276,7 @@ func (*stream) TestOpenAIShorthand(ctx context.Context, input string) <-chan str
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10300,16 +10300,16 @@ func TestOpenAIWithFinishReasonError(ctx context.Context, input string) (*string
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAIWithFinishReasonError(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAIWithFinishReasonError(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10317,7 +10317,7 @@ func (*stream) TestOpenAIWithFinishReasonError(ctx context.Context, input string
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAIWithFinishReasonError", encoded)
 	if err != nil {
 		close(channel)
@@ -10338,7 +10338,7 @@ func (*stream) TestOpenAIWithFinishReasonError(ctx context.Context, input string
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10362,16 +10362,16 @@ func TestOpenAIWithMaxTokens(ctx context.Context, input string) (*string, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAIWithMaxTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAIWithMaxTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10379,7 +10379,7 @@ func (*stream) TestOpenAIWithMaxTokens(ctx context.Context, input string) <-chan
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAIWithMaxTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -10400,7 +10400,7 @@ func (*stream) TestOpenAIWithMaxTokens(ctx context.Context, input string) <-chan
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10424,16 +10424,16 @@ func TestOpenAIWithNullMaxTokens(ctx context.Context, input string) (*string, er
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenAIWithNullMaxTokens(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenAIWithNullMaxTokens(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10441,7 +10441,7 @@ func (*stream) TestOpenAIWithNullMaxTokens(ctx context.Context, input string) <-
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenAIWithNullMaxTokens", encoded)
 	if err != nil {
 		close(channel)
@@ -10462,7 +10462,7 @@ func (*stream) TestOpenAIWithNullMaxTokens(ctx context.Context, input string) <-
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10486,16 +10486,16 @@ func TestOpenRouterMistralSmall3_1_24b(ctx context.Context, input string) (*stri
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestOpenRouterMistralSmall3_1_24b(ctx context.Context, input string) <-chan string {
+func (*stream) TestOpenRouterMistralSmall3_1_24b(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10503,7 +10503,7 @@ func (*stream) TestOpenRouterMistralSmall3_1_24b(ctx context.Context, input stri
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestOpenRouterMistralSmall3_1_24b", encoded)
 	if err != nil {
 		close(channel)
@@ -10524,7 +10524,7 @@ func (*stream) TestOpenRouterMistralSmall3_1_24b(ctx context.Context, input stri
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10548,16 +10548,16 @@ func TestRetryConstant(ctx context.Context) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestRetryConstant(ctx context.Context) <-chan string {
+func (*stream) TestRetryConstant(ctx context.Context) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -10565,7 +10565,7 @@ func (*stream) TestRetryConstant(ctx context.Context) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestRetryConstant", encoded)
 	if err != nil {
 		close(channel)
@@ -10586,7 +10586,7 @@ func (*stream) TestRetryConstant(ctx context.Context) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10610,16 +10610,16 @@ func TestRetryExponential(ctx context.Context) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestRetryExponential(ctx context.Context) <-chan string {
+func (*stream) TestRetryExponential(ctx context.Context) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -10627,7 +10627,7 @@ func (*stream) TestRetryExponential(ctx context.Context) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestRetryExponential", encoded)
 	if err != nil {
 		close(channel)
@@ -10648,7 +10648,7 @@ func (*stream) TestRetryExponential(ctx context.Context) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10672,16 +10672,16 @@ func TestRoundRobinStrategy(ctx context.Context, input string) (*string, error) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestRoundRobinStrategy(ctx context.Context, input string) <-chan string {
+func (*stream) TestRoundRobinStrategy(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10689,7 +10689,7 @@ func (*stream) TestRoundRobinStrategy(ctx context.Context, input string) <-chan 
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestRoundRobinStrategy", encoded)
 	if err != nil {
 		close(channel)
@@ -10710,7 +10710,7 @@ func (*stream) TestRoundRobinStrategy(ctx context.Context, input string) <-chan 
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10734,16 +10734,16 @@ func TestSingleFallbackClient(ctx context.Context) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestSingleFallbackClient(ctx context.Context) <-chan string {
+func (*stream) TestSingleFallbackClient(ctx context.Context) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -10751,7 +10751,7 @@ func (*stream) TestSingleFallbackClient(ctx context.Context) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestSingleFallbackClient", encoded)
 	if err != nil {
 		close(channel)
@@ -10772,7 +10772,7 @@ func (*stream) TestSingleFallbackClient(ctx context.Context) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10796,16 +10796,16 @@ func TestThinking(ctx context.Context, input string) (*types.CustomStory, error)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.CustomStory {
-		return *(result).(*types.CustomStory)
+	castResult := func(result any) *types.CustomStory {
+		return (result).(*types.CustomStory)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestThinking(ctx context.Context, input string) <-chan types.CustomStory {
+func (*stream) TestThinking(ctx context.Context, input string) <-chan *types.CustomStory {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10813,7 +10813,7 @@ func (*stream) TestThinking(ctx context.Context, input string) <-chan types.Cust
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.CustomStory)
+	channel := make(chan *types.CustomStory)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestThinking", encoded)
 	if err != nil {
 		close(channel)
@@ -10834,7 +10834,7 @@ func (*stream) TestThinking(ctx context.Context, input string) <-chan types.Cust
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.CustomStory)
+				channel <- (*result.Data).(*types.CustomStory)
 			}
 		}
 	}()
@@ -10858,16 +10858,16 @@ func TestUniverseQuestion(ctx context.Context, question types.UniverseQuestionIn
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.UniverseQuestion {
-		return *(result).(*types.UniverseQuestion)
+	castResult := func(result any) *types.UniverseQuestion {
+		return (result).(*types.UniverseQuestion)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestUniverseQuestion(ctx context.Context, question types.UniverseQuestionInput) <-chan types.UniverseQuestion {
+func (*stream) TestUniverseQuestion(ctx context.Context, question types.UniverseQuestionInput) <-chan *types.UniverseQuestion {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"question": question},
 	}
@@ -10875,7 +10875,7 @@ func (*stream) TestUniverseQuestion(ctx context.Context, question types.Universe
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.UniverseQuestion)
+	channel := make(chan *types.UniverseQuestion)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestUniverseQuestion", encoded)
 	if err != nil {
 		close(channel)
@@ -10896,7 +10896,7 @@ func (*stream) TestUniverseQuestion(ctx context.Context, question types.Universe
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.UniverseQuestion)
+				channel <- (*result.Data).(*types.UniverseQuestion)
 			}
 		}
 	}()
@@ -10920,16 +10920,16 @@ func TestVertex(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestVertex(ctx context.Context, input string) <-chan string {
+func (*stream) TestVertex(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10937,7 +10937,7 @@ func (*stream) TestVertex(ctx context.Context, input string) <-chan string {
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestVertex", encoded)
 	if err != nil {
 		close(channel)
@@ -10958,7 +10958,7 @@ func (*stream) TestVertex(ctx context.Context, input string) <-chan string {
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -10982,16 +10982,16 @@ func TestVertexClaude(ctx context.Context, input string) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestVertexClaude(ctx context.Context, input string) <-chan string {
+func (*stream) TestVertexClaude(ctx context.Context, input string) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -10999,7 +10999,7 @@ func (*stream) TestVertexClaude(ctx context.Context, input string) <-chan string
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestVertexClaude", encoded)
 	if err != nil {
 		close(channel)
@@ -11020,7 +11020,7 @@ func (*stream) TestVertexClaude(ctx context.Context, input string) <-chan string
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -11044,16 +11044,16 @@ func TestVertexWithSystemInstructions(ctx context.Context) (*string, error) {
 		return nil, result.Error
 	}
 
-	castResult := func(result any) string {
-		return (result).(string)
+	castResult := func(result any) *string {
+		return (result).(*string)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) TestVertexWithSystemInstructions(ctx context.Context) <-chan string {
+func (*stream) TestVertexWithSystemInstructions(ctx context.Context) <-chan *string {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{},
 	}
@@ -11061,7 +11061,7 @@ func (*stream) TestVertexWithSystemInstructions(ctx context.Context) <-chan stri
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan string)
+	channel := make(chan *string)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "TestVertexWithSystemInstructions", encoded)
 	if err != nil {
 		close(channel)
@@ -11082,7 +11082,7 @@ func (*stream) TestVertexWithSystemInstructions(ctx context.Context) <-chan stri
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(string)
+				channel <- (*result.Data).(*string)
 			}
 		}
 	}()
@@ -11106,16 +11106,16 @@ func UnionTest_Function(ctx context.Context, input types.Union__string__bool) (*
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.UnionTest_ReturnType {
-		return *(result).(*types.UnionTest_ReturnType)
+	castResult := func(result any) *types.UnionTest_ReturnType {
+		return (result).(*types.UnionTest_ReturnType)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) UnionTest_Function(ctx context.Context, input types.Union__string__bool) <-chan types.UnionTest_ReturnType {
+func (*stream) UnionTest_Function(ctx context.Context, input types.Union__string__bool) <-chan *types.UnionTest_ReturnType {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -11123,7 +11123,7 @@ func (*stream) UnionTest_Function(ctx context.Context, input types.Union__string
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.UnionTest_ReturnType)
+	channel := make(chan *types.UnionTest_ReturnType)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "UnionTest_Function", encoded)
 	if err != nil {
 		close(channel)
@@ -11144,7 +11144,7 @@ func (*stream) UnionTest_Function(ctx context.Context, input types.Union__string
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.UnionTest_ReturnType)
+				channel <- (*result.Data).(*types.UnionTest_ReturnType)
 			}
 		}
 	}()
@@ -11168,16 +11168,16 @@ func UseBlockConstraint(ctx context.Context, inp types.BlockConstraintForParam) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) int64 {
-		return (result).(int64)
+	castResult := func(result any) *int64 {
+		return (result).(*int64)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) UseBlockConstraint(ctx context.Context, inp types.BlockConstraintForParam) <-chan int64 {
+func (*stream) UseBlockConstraint(ctx context.Context, inp types.BlockConstraintForParam) <-chan *int64 {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"inp": inp},
 	}
@@ -11185,7 +11185,7 @@ func (*stream) UseBlockConstraint(ctx context.Context, inp types.BlockConstraint
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan int64)
+	channel := make(chan *int64)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "UseBlockConstraint", encoded)
 	if err != nil {
 		close(channel)
@@ -11206,7 +11206,7 @@ func (*stream) UseBlockConstraint(ctx context.Context, inp types.BlockConstraint
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(int64)
+				channel <- (*result.Data).(*int64)
 			}
 		}
 	}()
@@ -11230,16 +11230,16 @@ func UseMaintainFieldOrder(ctx context.Context, input types.MaintainFieldOrder) 
 		return nil, result.Error
 	}
 
-	castResult := func(result any) types.MaintainFieldOrder {
-		return *(result).(*types.MaintainFieldOrder)
+	castResult := func(result any) *types.MaintainFieldOrder {
+		return (result).(*types.MaintainFieldOrder)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) UseMaintainFieldOrder(ctx context.Context, input types.MaintainFieldOrder) <-chan types.MaintainFieldOrder {
+func (*stream) UseMaintainFieldOrder(ctx context.Context, input types.MaintainFieldOrder) <-chan *types.MaintainFieldOrder {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"input": input},
 	}
@@ -11247,7 +11247,7 @@ func (*stream) UseMaintainFieldOrder(ctx context.Context, input types.MaintainFi
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan types.MaintainFieldOrder)
+	channel := make(chan *types.MaintainFieldOrder)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "UseMaintainFieldOrder", encoded)
 	if err != nil {
 		close(channel)
@@ -11268,7 +11268,7 @@ func (*stream) UseMaintainFieldOrder(ctx context.Context, input types.MaintainFi
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(types.MaintainFieldOrder)
+				channel <- (*result.Data).(*types.MaintainFieldOrder)
 			}
 		}
 	}()
@@ -11292,16 +11292,16 @@ func UseMalformedConstraints(ctx context.Context, a types.MalformedConstraints2)
 		return nil, result.Error
 	}
 
-	castResult := func(result any) int64 {
-		return (result).(int64)
+	castResult := func(result any) *int64 {
+		return (result).(*int64)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) UseMalformedConstraints(ctx context.Context, a types.MalformedConstraints2) <-chan int64 {
+func (*stream) UseMalformedConstraints(ctx context.Context, a types.MalformedConstraints2) <-chan *int64 {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"a": a},
 	}
@@ -11309,7 +11309,7 @@ func (*stream) UseMalformedConstraints(ctx context.Context, a types.MalformedCon
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan int64)
+	channel := make(chan *int64)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "UseMalformedConstraints", encoded)
 	if err != nil {
 		close(channel)
@@ -11330,7 +11330,7 @@ func (*stream) UseMalformedConstraints(ctx context.Context, a types.MalformedCon
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(int64)
+				channel <- (*result.Data).(*int64)
 			}
 		}
 	}()
@@ -11354,16 +11354,16 @@ func UseNestedBlockConstraint(ctx context.Context, inp types.NestedBlockConstrai
 		return nil, result.Error
 	}
 
-	castResult := func(result any) int64 {
-		return (result).(int64)
+	castResult := func(result any) *int64 {
+		return (result).(*int64)
 	}
 
 	casted := castResult(*result.Data)
 
-	return &casted, nil
+	return casted, nil
 }
 
-func (*stream) UseNestedBlockConstraint(ctx context.Context, inp types.NestedBlockConstraintForParam) <-chan int64 {
+func (*stream) UseNestedBlockConstraint(ctx context.Context, inp types.NestedBlockConstraintForParam) <-chan *int64 {
 	args := baml.BamlFunctionArguments{
 		Kwargs: map[string]any{"inp": inp},
 	}
@@ -11371,7 +11371,7 @@ func (*stream) UseNestedBlockConstraint(ctx context.Context, inp types.NestedBlo
 	if err != nil {
 		panic(err)
 	}
-	channel := make(chan int64)
+	channel := make(chan *int64)
 	raw, err := bamlRuntime.CallFunctionStream(ctx, "UseNestedBlockConstraint", encoded)
 	if err != nil {
 		close(channel)
@@ -11392,7 +11392,7 @@ func (*stream) UseNestedBlockConstraint(ctx context.Context, inp types.NestedBlo
 					close(channel)
 					return
 				}
-				channel <- (*result.Data).(int64)
+				channel <- (*result.Data).(*int64)
 			}
 		}
 	}()


### PR DESCRIPTION
This change will allow primitives to be returned from client functions directly (tested it works locally)

It also updates the signature to return `[]types.Blah` instead of `*[]types.Blah` which is correct as go slices/maps are always pointers.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Client functions now return pointers for all types except slices and maps, updating function signatures and return types across multiple files.
> 
>   - **Behavior**:
>     - Client functions now return pointers for all types except slices and maps.
>     - Updates function signatures to return `[]types.Blah` instead of `*[]types.Blah`.
>   - **Code Changes**:
>     - Modified `cast_value()` in `generate_types.rs` to handle slices and maps without pointers.
>     - Updated `GoFunction` struct in `mod.rs` to use `GoType` for `return_type`.
>     - Adjusted function templates in `client.go.j2` to reflect new return types.
>     - Updated return types in `client.go` for various functions to return pointers, except for slices and maps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for d1eea9a1ed6d079285686d46301c0577b89e7ec4. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->