### PR TITLE
Fix bug where empty string for boundary_base_url would not set the default url

### DIFF
--- a/engine/baml-runtime/src/tracing/api_wrapper/env_setup.rs
+++ b/engine/baml-runtime/src/tracing/api_wrapper/env_setup.rs
@@ -57,11 +57,31 @@ impl Config {
             .from_iter(env_vars.map(|(k, v)| (k.as_ref().to_string(), v.as_ref().to_string())));
 
         match config {
-            Ok(config) => Ok(config),
+            Ok(config) => Ok(config.normalize()),
             Err(err) => Err(anyhow::anyhow!(
                 "Failed to parse config from environment variables: {}",
                 err
             )),
         }
+    }
+
+    pub fn normalize(mut self) -> Self {
+        if self.base_url.is_empty() {
+            self.base_url = default_base_url();
+        }
+        if self.sessions_id.is_empty() {
+            self.sessions_id = default_sessions_id();
+        }
+        if self.stage.is_empty() {
+            self.stage = default_stage();
+        }
+        if self.host_name.is_empty() {
+            self.host_name = default_host_name();
+        }
+        if self.log_redaction_placeholder.is_empty() {
+            self.log_redaction_placeholder = default_redaction_placeholder();
+        }
+        // max_log_chunk_chars is usize, so no need to check for empty string
+        self
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes bug in `Config` where empty strings for certain fields would not set default values by adding a `normalize()` function.
> 
>   - **Behavior**:
>     - Fixes bug where empty `base_url` in `Config` would not set default URL by adding `normalize()` function.
>     - `normalize()` sets default values for `base_url`, `sessions_id`, `stage`, `host_name`, and `log_redaction_placeholder` if they are empty.
>   - **Functions**:
>     - Adds `normalize()` to `Config` in `env_setup.rs` to handle default value assignment.
>   - **Misc**:
>     - Calls `normalize()` in `from_env_vars()` to ensure defaults are set after parsing environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 21d68daad1736987a3f58e768d16ed98eb5cab4b. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->