### PR TITLE
Add typechecking for class constructors

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/builtin.rs
+++ b/engine/baml-lib/baml-core/src/ir/builtin.rs
@@ -1,10 +1,10 @@
+use super::repr::{Class, ExprFunction, Field, Node, NodeAttributes};
+use crate::{ir::repr::IntermediateRepr, Configuration};
 use baml_types::{
     expr::{Builtin, Expr, ExprMetadata},
     Arrow, FieldType,
 };
 use internal_baml_diagnostics::Span;
-
-use super::repr::{Class, ExprFunction, Node, NodeAttributes};
 
 pub mod functions {
     pub const FETCH_VALUE: &str = "std::fetch_value";
@@ -12,6 +12,25 @@ pub mod functions {
 
 pub mod classes {
     pub const REQUEST: &str = "std::Request";
+}
+
+/// Builtins are exposed through a separate IR, which can be combined with
+/// the user's IR via `IntermediateRepr::extend`.
+pub fn builtin_ir() -> IntermediateRepr {
+    IntermediateRepr {
+        enums: vec![],
+        classes: builtin_classes(),
+        type_aliases: vec![],
+        functions: vec![],
+        expr_fns: vec![],
+        toplevel_assignments: vec![],
+        clients: vec![],
+        retry_policies: vec![],
+        template_strings: vec![],
+        finite_recursive_cycles: vec![],
+        structural_recursive_alias_cycles: vec![],
+        configuration: Configuration::default(),
+    }
 }
 
 fn builtin<T, const N: usize>(elems: [T; N]) -> Vec<Node<T>> {
@@ -26,20 +45,44 @@ fn builtin<T, const N: usize>(elems: [T; N]) -> Vec<Node<T>> {
 
 pub fn builtin_classes() -> Vec<Node<Class>> {
     builtin([Class {
-        name: String::from(functions::FETCH_VALUE),
+        name: String::from(classes::REQUEST),
         docstring: None,
-        static_fields: vec![],
-        inputs: vec![
-            (String::from("base_url"), FieldType::string()),
-            (
-                String::from("headers"),
-                FieldType::map(FieldType::string(), FieldType::string()),
-            ),
-            (
-                String::from("query_params"),
-                FieldType::map(FieldType::string(), FieldType::string()),
-            ),
+        static_fields: vec![
+            Node {
+                attributes: NodeAttributes::default(),
+                elem: Field {
+                    name: String::from("base_url"),
+                    r#type: Node {
+                        elem: FieldType::string(),
+                        attributes: NodeAttributes::default(),
+                    },
+                    docstring: None,
+                },
+            },
+            Node {
+                attributes: NodeAttributes::default(),
+                elem: Field {
+                    name: String::from("headers"),
+                    r#type: Node {
+                        elem: FieldType::map(FieldType::string(), FieldType::string()),
+                        attributes: NodeAttributes::default(),
+                    },
+                    docstring: None,
+                },
+            },
+            Node {
+                attributes: NodeAttributes::default(),
+                elem: Field {
+                    name: String::from("query_params"),
+                    r#type: Node {
+                        elem: FieldType::map(FieldType::string(), FieldType::string()),
+                        attributes: NodeAttributes::default(),
+                    },
+                    docstring: None,
+                },
+            },
         ],
+        inputs: vec![],
     }])
 }
 

--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -31,7 +31,7 @@ use serde::Serialize;
 use crate::validate::validation_pipeline::validations::expr_typecheck::infer_types_in_context;
 use crate::Configuration;
 
-use super::builtin::{builtin_classes, builtin_generic_fn, is_builtin_identifier};
+use super::builtin::{builtin_classes, builtin_generic_fn, builtin_ir, is_builtin_identifier};
 
 /// This class represents the intermediate representation of the BAML AST.
 /// It is a representation of the BAML AST that is easier to work with than the
@@ -39,26 +39,26 @@ use super::builtin::{builtin_classes, builtin_generic_fn, is_builtin_identifier}
 /// code in any target language.
 #[derive(Debug)]
 pub struct IntermediateRepr {
-    enums: Vec<Node<Enum>>,
-    classes: Vec<Node<Class>>,
-    type_aliases: Vec<Node<TypeAlias>>,
+    pub enums: Vec<Node<Enum>>,
+    pub classes: Vec<Node<Class>>,
+    pub type_aliases: Vec<Node<TypeAlias>>,
     pub functions: Vec<Node<Function>>,
     pub expr_fns: Vec<Node<ExprFunction>>,
     pub toplevel_assignments: Vec<Node<TopLevelAssignment>>,
-    clients: Vec<Node<Client>>,
-    retry_policies: Vec<Node<RetryPolicy>>,
-    template_strings: Vec<Node<TemplateString>>,
+    pub clients: Vec<Node<Client>>,
+    pub retry_policies: Vec<Node<RetryPolicy>>,
+    pub template_strings: Vec<Node<TemplateString>>,
 
     /// Strongly connected components of the dependency graph (finite cycles).
-    finite_recursive_cycles: Vec<IndexSet<String>>,
+    pub finite_recursive_cycles: Vec<IndexSet<String>>,
 
     /// Type alias cycles introduced by lists and maps.
     ///
     /// These are the only allowed cycles, because lists and maps introduce a
     /// level of indirection that makes the cycle finite.
-    structural_recursive_alias_cycles: Vec<IndexMap<String, FieldType>>,
+    pub structural_recursive_alias_cycles: Vec<IndexMap<String, FieldType>>,
 
-    configuration: Configuration,
+    pub configuration: Configuration,
 }
 
 #[derive(Debug)]
@@ -176,7 +176,6 @@ impl WithRepr<ExprFunction> for ExprFnWalker<'_> {
 
 impl WithRepr<Function> for ExprFnWalker<'_> {
     fn repr(&self, db: &ParserDatabase) -> Result<Function> {
-        // TODO: Drop weird default (replace by better validation).
         let body = convert_function_body(self.expr_fn().body.to_owned(), db)?;
         let args = self
             .expr_fn()
@@ -468,19 +467,20 @@ impl IntermediateRepr {
             });
         }
 
-        // self.walk_functions().filter_map(
-        //     |f| f.client_name()
-        // ).map(|c| c.required_env_vars())
-
-        // // for any functions, check for shorthand env vars
-        // self.functions
-        //     .iter()
-        //     .filter_map(|f| f.elem.configs())
-        //     .into_iter()
-        //     .flatten()
-        //     .flat_map(|(expr)| expr.client.required_env_vars())
-        //     .collect()
         env_vars
+    }
+
+    /// Extend the IR with another IR.
+    pub fn extend(&mut self, other: IntermediateRepr) {
+        self.enums.extend(other.enums);
+        self.classes.extend(other.classes);
+        self.type_aliases.extend(other.type_aliases);
+        self.functions.extend(other.functions);
+        self.expr_fns.extend(other.expr_fns);
+        self.toplevel_assignments.extend(other.toplevel_assignments);
+        self.clients.extend(other.clients);
+        self.retry_policies.extend(other.retry_policies);
+        self.template_strings.extend(other.template_strings);
     }
 
     /// Returns a list of all the recursive cycles in the IR.
@@ -500,10 +500,7 @@ impl IntermediateRepr {
     }
 
     pub fn walk_classes(&self) -> impl Iterator<Item = Walker<'_, &Node<Class>>> {
-        self.classes
-            .iter()
-            .filter(|c| !is_builtin_identifier(&c.elem.name))
-            .map(|e| Walker { ir: self, item: e })
+        self.classes.iter().map(|e| Walker { ir: self, item: e })
     }
 
     pub fn walk_type_aliases(&self) -> impl ExactSizeIterator<Item = Walker<'_, &Node<TypeAlias>>> {
@@ -668,6 +665,10 @@ impl IntermediateRepr {
             let inferred_expr = infer_types_in_context(&mut typing_context, Arc::new(expr));
             expr_fn.elem.expr = Arc::unwrap_or_clone(inferred_expr);
         }
+
+        // Strip out builtin classes.
+        repr.classes
+            .retain(|c| !is_builtin_identifier(&c.elem.name));
 
         Ok(repr)
     }
@@ -1372,6 +1373,7 @@ pub struct Class {
     pub static_fields: Vec<Node<Field>>,
 
     /// Parameters to the class definition.
+    /// Note that this is a future feature, not something we currently use.
     pub inputs: Vec<(String, FieldType)>,
 
     /// Docstring.

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/context.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/context.rs
@@ -1,4 +1,5 @@
 use crate::PreviewFeature;
+use baml_types::FieldType;
 use enumflags2::BitFlags;
 use internal_baml_diagnostics::{DatamodelError, DatamodelWarning, Diagnostics};
 

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
@@ -4,6 +4,7 @@ use baml_types::TypeValue;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::ir::builtin::builtin_ir;
 use crate::ir::IRHelper;
 use crate::ir::IntermediateRepr;
 use crate::validate::validation_pipeline::context::Context;
@@ -16,12 +17,15 @@ use internal_baml_diagnostics::{DatamodelError, Diagnostics, Span};
 
 use crate::ir::IRHelperExtended;
 
+// TODO: Move this out of the validation pipeline into a separate IR->IR pass.
+// That will allow us to remove the internal `from_parser_database` call.
 pub fn typecheck_exprs(ctx: &mut Context<'_>) -> Result<()> {
     let null_configuration = Configuration::new();
 
-    let Ok(ir) = IntermediateRepr::from_parser_database(ctx.db, null_configuration) else {
+    let Ok(mut ir) = IntermediateRepr::from_parser_database(ctx.db, null_configuration) else {
         return Ok(());
     };
+    ir.extend(builtin_ir());
 
     let mut typing_context: HashMap<String, FieldType> = ir
         .expr_fns
@@ -80,6 +84,7 @@ pub fn typecheck_in_context(
     typing_context: &HashMap<String, FieldType>,
     expr: &Expr<ExprMetadata>,
 ) -> Result<()> {
+    eprintln!("TYPECHECKING: {:?}", expr.dump_str());
     match expr {
         Expr::Atom(atom) => {
             // Atoms always typecheck.
@@ -182,7 +187,13 @@ pub fn typecheck_in_context(
             }
             Ok(())
         }
-        Expr::Let(let_expr, _, _, _) => Ok(()),
+        Expr::Let(name, value, body, _meta) => {
+            typecheck_in_context(ir, diagnostics, typing_context, value)?;
+            let mut new_typing_context = typing_context.clone();
+            new_typing_context.insert(name.to_string(), value.meta().1.clone().unwrap());
+            typecheck_in_context(ir, diagnostics, &new_typing_context, body)?;
+            Ok(())
+        }
         Expr::ArgsTuple(args, _) => Ok(()),
         Expr::List(items, meta) => {
             for item in items.iter() {
@@ -234,24 +245,69 @@ pub fn typecheck_in_context(
             meta,
         } => {
             if let Ok(class_walker) = ir.find_class(name) {
+                // Typecheck each field in the constructor.
                 for (field_name, field_value) in fields.iter() {
                     let maybe_field_type = field_value.meta().1.clone();
                     if let Some(field_type) = maybe_field_type {
                         if let Some(field_walker) = class_walker.find_field(field_name) {
+                            // panic!("SOME FIELD TYPE FOUND: {:?}", field_walker.r#type());
                             if !compatible_as_subtype(
                                 ir,
                                 &Some(field_walker.r#type().clone()),
-                                &Some(field_type),
+                                &Some(field_type.clone()),
                             ) {
+                                // panic!("INCOMPATIBLE");
                                 diagnostics.push_error(DatamodelError::new_validation_error(
-                                    "Type mismatch in class constructor",
-                                    meta.0.clone(),
+                                    &format!(
+                                        "{}.{} expected type {}, but found {}",
+                                        name,
+                                        field_name,
+                                        field_walker.r#type(),
+                                        field_type
+                                    ),
+                                    field_value.meta().0.clone(),
                                 ));
                             }
+                        } else {
+                            diagnostics.push_error(DatamodelError::new_validation_error(
+                                &format!("Class {} has no field {}", name, field_name),
+                                field_value.meta().0.clone(),
+                            ));
                         }
                     }
                 }
+
+                // Check that all fields are present.
+                if spread.is_none() {
+                    let missing_fields = class_walker
+                        .walk_fields()
+                        .filter_map(|f| {
+                            if !fields.contains_key(f.name()) {
+                                Some(f.name().to_string())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    if !missing_fields.is_empty() {
+                        diagnostics.push_error(DatamodelError::new_validation_error(
+                            &format!(
+                                "Class {} is missing fields: {}",
+                                name,
+                                missing_fields.join(", ")
+                            ),
+                            meta.0.clone(),
+                        ));
+                    }
+                }
+            } else {
+                diagnostics.push_error(DatamodelError::new_validation_error(
+                    &format!("Unknown class: {}", name),
+                    meta.0.clone(),
+                ));
             }
+
+            // Typecheck the spread.
             let spread_type = spread.as_ref().and_then(|s| s.meta().1.clone());
             if !compatible_as_subtype(ir, &meta.1, &spread_type) {
                 diagnostics.push_error(DatamodelError::new_validation_error(
@@ -259,6 +315,7 @@ pub fn typecheck_in_context(
                     meta.0.clone(),
                 ));
             }
+
             Ok(())
         }
         Expr::If(cond, then, else_, meta) => {

--- a/engine/baml-lib/baml-types/src/field_type/mod.rs
+++ b/engine/baml-lib/baml-types/src/field_type/mod.rs
@@ -5,6 +5,29 @@ use itertools::Itertools;
 
 mod builder;
 
+/// FieldType represents the type of either a class field or a function arg.
+/// TODO: Rename to `BamlType` or `Type`.
+#[derive(serde::Serialize, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FieldType {
+    Primitive(TypeValue),
+    Enum(String),
+    Literal(LiteralValue),
+    Class(String),
+    List(Box<FieldType>),
+    Map(Box<FieldType>, Box<FieldType>),
+    Union(Vec<FieldType>),
+    Tuple(Vec<FieldType>),
+    Optional(Box<FieldType>),
+    RecursiveTypeAlias(String),
+    Arrow(Box<Arrow>),
+    Generic(String),
+    WithMetadata {
+        base: Box<FieldType>,
+        constraints: Vec<Constraint>,
+        streaming_behavior: StreamingBehavior,
+    },
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, Eq, Hash)]
 pub enum TypeValue {
     String,
@@ -73,28 +96,6 @@ impl std::fmt::Display for LiteralValue {
             LiteralValue::Bool(bool) => write!(f, "{bool}"),
         }
     }
-}
-
-/// FieldType represents the type of either a class field or a function arg.
-#[derive(serde::Serialize, Debug, Clone, PartialEq, Eq, Hash)]
-pub enum FieldType {
-    Primitive(TypeValue),
-    Enum(String),
-    Literal(LiteralValue),
-    Class(String),
-    List(Box<FieldType>),
-    Map(Box<FieldType>, Box<FieldType>),
-    Union(Vec<FieldType>),
-    Tuple(Vec<FieldType>),
-    Optional(Box<FieldType>),
-    RecursiveTypeAlias(String),
-    Arrow(Box<Arrow>),
-    Generic(String),
-    WithMetadata {
-        base: Box<FieldType>,
-        constraints: Vec<Constraint>,
-        streaming_behavior: StreamingBehavior,
-    },
 }
 
 pub trait HasFieldType {

--- a/engine/baml-lib/baml/tests/validation_files/expr/constructors_invalid.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/constructors_invalid.baml
@@ -1,0 +1,50 @@
+class Bar {
+    a int
+    b string
+}
+
+fn Foo() -> Bar {
+  let x = Bar { a: "hello", c: 12 };
+  let req_bad = std::Request { 
+    base_url: 10,
+    headers: {},
+    query_params: { a 10 },
+  };
+  let req_good = std::Request {
+    base_url: "https://example.com",
+    headers: { Authorization "Bearer mytoken" },
+    query_params: { foo "bar" },
+  };
+  x
+}
+
+// error: Error validating: std::Request.base_url expected type string, but found int
+//   -->  expr/constructors_invalid.baml:9
+//    | 
+//  8 |   let req_bad = std::Request { 
+//  9 |     base_url: 10,
+//    | 
+// error: Error validating: std::Request.query_params expected type map<string, string>, but found map<string, int>
+//   -->  expr/constructors_invalid.baml:11
+//    | 
+// 10 |     headers: {},
+// 11 |     query_params: { a 10 },
+//    | 
+// error: Error validating: Bar.a expected type int, but found string
+//   -->  expr/constructors_invalid.baml:7
+//    | 
+//  6 | fn Foo() -> Bar {
+//  7 |   let x = Bar { a: "hello", c: 12 };
+//    | 
+// error: Error validating: Class Bar has no field c
+//   -->  expr/constructors_invalid.baml:7
+//    | 
+//  6 | fn Foo() -> Bar {
+//  7 |   let x = Bar { a: "hello", c: 12 };
+//    | 
+// error: Error validating: Class Bar is missing fields: b
+//   -->  expr/constructors_invalid.baml:7
+//    | 
+//  6 | fn Foo() -> Bar {
+//  7 |   let x = Bar { a: "hello", c: 12 };
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/if.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/if.baml
@@ -1,2 +1,7 @@
 let x = if true { 1 } else { 2 };
 let y = if false { 1 };
+let z = if true {
+    12
+} else {
+    13
+};

--- a/engine/baml-lib/schema-ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/schema-ast/src/parser/datamodel.pest
@@ -247,7 +247,9 @@ fn_args = { expression? ~ ("," ~ expression)* }
 fn_app = { identifier ~ "(" ~ fn_args ~ ")" }
 
 // If expression.
-if_expression = { "if" ~ expression ~ "{" ~ expression ~ "}" ~ ( "else" ~ "{" ~ expression ~ "}" )? }
+if_expression = { "if" ~ expression ~ NEWLINE? ~
+   "{"~ NEWLINE? ~ expression ~ NEWLINE? ~ "}" ~
+   ( "else" ~ "{"~ NEWLINE? ~ expression ~ NEWLINE? ~ "}" )? }
 
 // Anonymous function.
 lambda = { named_argument_list ~ "=>" ~ expression }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add type checking for class constructors, ensuring field types match and all required fields are present, with tests and parser updates.
> 
>   - **Type Checking**:
>     - Adds type checking for class constructors in `expr_typecheck.rs`, ensuring field types match expected types and all required fields are present.
>     - Handles missing fields and unknown classes with error diagnostics.
>   - **Intermediate Representation**:
>     - Introduces `builtin_ir()` in `builtin.rs` to provide built-in classes and functions.
>     - Modifies `IntermediateRepr` in `repr.rs` to include public fields for type checking.
>   - **Tests**:
>     - Adds `constructors_invalid.baml` to test invalid class constructor scenarios.
>     - Updates `if.baml` to test if expressions with newlines.
>   - **Parser**:
>     - Updates `datamodel.pest` to allow newlines in if expressions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for da25dce03b7fd73fe64ffef047d7adb3b134f109. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->