### PR TITLE
add for loops to expr language

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
@@ -310,7 +310,7 @@ pub trait IRHelperExtended: IRSemanticStreamingHelper {
                 let new_items = items
                     .into_iter()
                     .map(|i| {
-                        item_type(self, &field_type, &i)
+                        item_type(self, &field_type)
                             .ok_or(anyhow::anyhow!("Could not infer child type"))
                             .and_then(|item_type| self.distribute_type_with_meta(i, item_type))
                     })
@@ -938,10 +938,9 @@ impl IRSemanticStreamingHelper for IntermediateRepr {
 /// should declare as the `item_type` in the case of unions that
 /// admit multiple different children. (Perhaps a union of all the
 /// child-having variants?).
-pub fn item_type<'ir, 'a, T: std::fmt::Debug>(
+pub fn item_type<'ir, 'a>(
     ir: &'ir (impl IRHelperExtended + ?Sized),
     field_type: &'a FieldType,
-    baml_child_values: &BamlValueWithMeta<T>,
 ) -> Option<FieldType> {
     let res = match ir.distribute_metadata(field_type).0 {
         FieldType::Class(_) => None,
@@ -949,15 +948,15 @@ pub fn item_type<'ir, 'a, T: std::fmt::Debug>(
         FieldType::List(inner) => Some(*inner.clone()),
         FieldType::Literal(_) => None,
         FieldType::Map(k, v) => Some(*v.clone()),
-        FieldType::Optional(inner) => item_type(ir, &*inner, baml_child_values),
+        FieldType::Optional(inner) => item_type(ir, &*inner),
         FieldType::Primitive(_) => None,
         FieldType::RecursiveTypeAlias(alias_name) => ir
             .recursive_alias_definition(alias_name)
-            .and_then(|resolved_type| item_type(ir, resolved_type, baml_child_values)),
+            .and_then(|resolved_type| item_type(ir, resolved_type)),
         FieldType::Union(variants) => {
             let variant_children = variants
                 .iter()
-                .filter_map(|variant| item_type(ir, variant, baml_child_values))
+                .filter_map(|variant| item_type(ir, variant))
                 .collect::<Vec<_>>();
             match variant_children.len() {
                 0 => None,
@@ -967,7 +966,7 @@ pub fn item_type<'ir, 'a, T: std::fmt::Debug>(
         }
         FieldType::Tuple(_) => None,
         FieldType::Arrow(_) => None,
-        FieldType::WithMetadata { base, .. } => item_type(ir, base, baml_child_values),
+        FieldType::WithMetadata { base, .. } => item_type(ir, base),
     };
     res
 }
@@ -1684,37 +1683,21 @@ mod subtype_tests {
             (),
         );
         assert_eq!(
-            item_type(
-                &ir,
-                &FieldType::RecursiveTypeAlias("A".to_string()),
-                &example_a
-            ),
+            item_type(&ir, &FieldType::RecursiveTypeAlias("A".to_string()),),
             Some(FieldType::RecursiveTypeAlias("A".to_string()))
         );
         assert_eq!(
-            item_type(
-                &ir,
-                &FieldType::RecursiveTypeAlias("B".to_string()),
-                &example_b
-            ),
+            item_type(&ir, &FieldType::RecursiveTypeAlias("B".to_string()),),
             Some(FieldType::List(Box::new(FieldType::RecursiveTypeAlias(
                 "B".to_string()
             ))))
         );
         assert_eq!(
-            item_type(
-                &ir,
-                &FieldType::RecursiveTypeAlias("C".to_string()),
-                &example_c
-            ),
+            item_type(&ir, &FieldType::RecursiveTypeAlias("C".to_string()),),
             Some(FieldType::RecursiveTypeAlias("C".to_string()))
         );
         assert_eq!(
-            item_type(
-                &ir,
-                &FieldType::RecursiveTypeAlias("JsonValue".to_string()),
-                &example_json
-            ),
+            item_type(&ir, &FieldType::RecursiveTypeAlias("JsonValue".to_string()),),
             Some(FieldType::Union(vec![
                 FieldType::RecursiveTypeAlias("JsonValue".to_string()),
                 FieldType::RecursiveTypeAlias("JsonValue".to_string())

--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -221,8 +221,9 @@ fn convert_function_body(
     db: &ParserDatabase,
 ) -> Result<Expr<ExprMetadata>> {
     function_body.expr.repr(db).map(|fn_body| {
-        let expr = function_body
-            .stmts
+        let mut stmts = function_body.stmts.clone();
+        stmts.reverse();
+        let expr = stmts
             .iter()
             .fold(fn_body, |acc, stmt| match stmt.body.repr(db) {
                 Ok(stmt_expr) => Expr::Let(
@@ -396,6 +397,21 @@ impl WithRepr<Expr<ExprMetadata>> for ast::Expression {
                     else_.map(|e| Arc::new(e)),
                     (span.clone(), None),
                 ))
+            }
+            ast::Expression::ForLoop {
+                identifier,
+                iterator,
+                body,
+                span,
+            } => {
+                let iterator = iterator.repr(db)?;
+                let body = convert_function_body(body.clone(), db)?;
+                Ok(Expr::ForLoop {
+                    item: identifier.to_string(),
+                    iterable: Arc::new(iterator),
+                    body: Arc::new(body),
+                    meta: (span.clone(), None),
+                })
             }
         }
     }
@@ -1719,6 +1735,29 @@ pub fn annotate_variable(
                 new_else.map(|e| Arc::new(e)),
                 meta.clone(),
             )
+        }
+        Expr::ForLoop {
+            item,
+            iterable,
+            body,
+            meta,
+        } => {
+            let new_iterable = annotate_variable(
+                target.clone(),
+                r#type.clone(),
+                Arc::unwrap_or_clone(iterable.clone()),
+            );
+            let new_body = annotate_variable(
+                target.clone(),
+                r#type.clone(),
+                Arc::unwrap_or_clone(body.clone()),
+            );
+            Expr::ForLoop {
+                item: item.clone(),
+                iterable: Arc::new(new_iterable),
+                body: Arc::new(new_body),
+                meta: meta.clone(),
+            }
         }
     }
 }

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_fns.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_fns.rs
@@ -161,5 +161,19 @@ fn validate_expression(ctx: &mut Context<'_>, expr: &Expression, scope: &HashSet
                 validate_expression(ctx, else_, scope);
             }
         }
+        Expression::ForLoop {
+            identifier,
+            iterator,
+            body,
+            span,
+        } => {
+            validate_expression(ctx, iterator, scope);
+            let mut body_scope = scope.clone();
+            body_scope.insert(identifier.to_string());
+            for stmt in body.stmts.iter() {
+                validate_stmt(ctx, stmt, &mut body_scope);
+                validate_expression(ctx, &stmt.body, &body_scope);
+            }
+        }
     }
 }

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
@@ -4,6 +4,7 @@ use baml_types::TypeValue;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::ir::ir_helpers::item_type;
 use crate::ir::IntermediateRepr;
 use crate::ir::{repr::initial_context, IRHelper};
 use crate::validate::validation_pipeline::context::Context;
@@ -16,6 +17,10 @@ use internal_baml_diagnostics::{DatamodelError, Diagnostics, Span};
 
 use crate::ir::IRHelperExtended;
 
+/// Chcek the types of all expressions in the IR.
+/// It relies on the types previously inferred and added to the expression metadata.
+/// TODO: move this to a compiler pass, so that it transforms IR to IR.
+/// TODO: Implement it directly in terms of the bidirectional typing algorithm.
 pub fn typecheck_exprs(ctx: &mut Context<'_>) -> Result<()> {
     let null_configuration = Configuration::new();
     if let Ok(ir) = IntermediateRepr::from_parser_database(ctx.db, null_configuration) {
@@ -65,46 +70,52 @@ pub fn typecheck_exprs(ctx: &mut Context<'_>) -> Result<()> {
                 &typing_context,
                 &expr_fn_with_types,
             )?;
+            // deeply_check_inference(&expr_fn_with_types)?;
+        }
+
+        for toplevel_assignment in ir.toplevel_assignments.iter() {
+            typecheck_in_context(
+                &ir,
+                &mut ctx.diagnostics,
+                &typing_context,
+                &toplevel_assignment.elem.expr.elem,
+            )?;
         }
     }
     Ok(())
 }
 
+/// A helper function for `typecheck_exprs`. It typechecks a given expression,
+/// within a typing_context (Γ) of types for variables.
 pub fn typecheck_in_context(
     ir: &IntermediateRepr,
     diagnostics: &mut Diagnostics,
     typing_context: &HashMap<String, FieldType>,
     expr: &Expr<ExprMetadata>,
 ) -> Result<()> {
+    eprintln!("expr: {:?}", expr);
     match expr {
         Expr::Atom(atom) => {
             // Atoms always typecheck.
-            Ok(())
+            //  Ok(())
         }
         Expr::LLMFunction(llm_function, args, _) => {
             // Bare functions always typecheck.
-            Ok(())
+            // Ok(())
         }
         Expr::FreeVar(var, (var_span, maybe_type)) => {
             if let Some(var_type) = maybe_type {
                 if let Some(ctx_type) = typing_context.get(var) {
-                    if ir.is_subtype(&ctx_type, var_type) {
-                        Ok(())
-                    } else {
+                    if !ir.is_subtype(&ctx_type, var_type) {
                         diagnostics.push_error(DatamodelError::new_validation_error(
                             "Type mismatch",
                             var_span.clone(),
                         ));
-                        Ok(())
                     }
-                } else {
-                    Ok(())
                 }
-            } else {
-                Ok(())
             }
         }
-        Expr::BoundVar(_, _) => Ok(()),
+        Expr::BoundVar(_, _) => {}
         Expr::Lambda(arity, body, (span, maybe_type)) => {
             // (\(x,y) -> x + y) : (Int,Int) -> Int
             if let Some(FieldType::Arrow(arrow)) = maybe_type {
@@ -140,7 +151,6 @@ pub fn typecheck_in_context(
                 }
                 typecheck_in_context(ir, diagnostics, &inner_context, &opened_body)?;
             }
-            Ok(())
         }
         // (\[x,y] -> x + y) (1,2)
         // ([Int,Int] -> Int) ([Int,Int]
@@ -169,10 +179,16 @@ pub fn typecheck_in_context(
                     );
                 }
             }
-            Ok(())
         }
-        Expr::Let(let_expr, _, _, _) => Ok(()),
-        Expr::ArgsTuple(args, _) => Ok(()),
+        Expr::Let(binder, value, body, meta) => {
+            typecheck_in_context(ir, diagnostics, typing_context, value)?;
+            let mut body_context = typing_context.clone();
+            if let Some(value_type) = value.meta().1.clone() {
+                body_context.insert(binder.to_string(), value_type);
+            }
+            typecheck_in_context(ir, diagnostics, &body_context, body)?;
+        }
+        Expr::ArgsTuple(args, _) => {}
         Expr::List(items, meta) => {
             for item in items.iter() {
                 if let Some(item_type) = item.meta().1.as_ref() {
@@ -186,7 +202,6 @@ pub fn typecheck_in_context(
                 }
                 typecheck_in_context(ir, diagnostics, typing_context, item)?;
             }
-            Ok(())
         }
         Expr::Map(items, meta) => {
             if let Some(map_type) = meta.1.as_ref() {
@@ -214,7 +229,6 @@ pub fn typecheck_in_context(
                     ));
                 }
             }
-            Ok(())
         }
         Expr::ClassConstructor {
             name,
@@ -248,7 +262,6 @@ pub fn typecheck_in_context(
                     meta.0.clone(),
                 ));
             }
-            Ok(())
         }
         Expr::If(cond, then, else_, meta) => {
             if !compatible_as_subtype(
@@ -263,9 +276,34 @@ pub fn typecheck_in_context(
             }
             // TODO: Check that then and else have the same type? Or, if they're compatible,
             // who should be a subtype of who?
-            Ok(())
         }
+        Expr::ForLoop {
+            item,
+            iterable,
+            body,
+            meta,
+        } => {
+            let iterable_type_ok: bool = match &iterable.meta().1 {
+                Some(FieldType::List(_)) => true,
+                _ => false, // TODO: Aliases.
+            };
+            if !iterable_type_ok {
+                diagnostics.push_error(DatamodelError::new_validation_error(
+                    "For loop must iterato over a list",
+                    iterable.meta().0.clone(),
+                ));
+            }
+        }
+    };
+
+    // Finally, assert that we know the type of the whole expression.
+    if expr.meta().1.is_none() {
+        return Err(anyhow::anyhow!(
+            "type inference failed for expression: {}",
+            expr.dump_str()
+        ));
     }
+    Ok(())
 }
 
 // fn is_subtype(ir: &IntermediateRepr, a: &ExprType, b: &ExprType) -> bool {
@@ -303,6 +341,7 @@ pub fn infer_types_in_context(
     typing_context: &mut HashMap<String, FieldType>,
     expr: Arc<Expr<ExprMetadata>>,
 ) -> Arc<Expr<ExprMetadata>> {
+    eprintln!("infer_types_in_context: {}", expr.dump_str());
     match expr.as_ref() {
         Expr::FreeVar(ref var_name, (span, maybe_type)) => {
             // Assign variables from the context.
@@ -324,9 +363,11 @@ pub fn infer_types_in_context(
             expr.clone()
         }
         Expr::Let(ref var_name, expr, ref body, _) => {
+            eprintln!("handling let: {:?}", expr);
             let new_expr = infer_types_in_context(typing_context, expr.clone());
             let new_body = infer_types_in_context(typing_context, body.clone());
             if let Some(ref expr_ty) = new_expr.meta().1 {
+                eprintln!("inserting into typing context: {:?}", expr_ty);
                 typing_context.insert(var_name.to_string(), expr_ty.clone());
             }
             let new_meta = (expr.meta().0.clone(), new_body.meta().1.clone());
@@ -470,6 +511,55 @@ pub fn infer_types_in_context(
             }
             Arc::new(Expr::If(new_cond, new_then, new_else, new_meta))
         }
+        Expr::ForLoop {
+            item,
+            iterable,
+            body,
+            meta,
+        } => {
+            let mut body_context = typing_context.clone();
+            // TODO: Handle aliases. To do this, we will need access to the IR.
+            // We can't have access to the IR until we introduce compiler passes,
+            // otherwise there is a borrowing issue. (To see why, try taking an immutable
+            // reference to `repr` in `from_parser_database`).
+            let item_ty = iterable.meta().1.as_ref().and_then(|t| match t {
+                FieldType::List(inner) => Some(inner),
+                _ => None,
+            });
+            if let Some(item_ty) = item_ty {
+                body_context.insert(item.to_string(), *item_ty.clone());
+            }
+            let new_iterable = infer_types_in_context(typing_context, iterable.clone());
+            let new_body = infer_types_in_context(typing_context, body.clone());
+            Arc::new(Expr::ForLoop {
+                item: item.clone(),
+                iterable: iterable.clone(),
+                body: new_body,
+                meta: meta.clone(),
+            })
+        }
+    }
+}
+
+fn deeply_check_inference(expr: &Expr<ExprMetadata>) -> Result<()> {
+    let mut untyped_subexprs = Vec::new();
+    for subexpr in expr.into_iter() {
+        if subexpr.meta().1.is_none() {
+            untyped_subexprs.push(subexpr);
+        }
+    }
+    if untyped_subexprs.is_empty() {
+        Ok(())
+    } else {
+        let error_message = untyped_subexprs
+            .iter()
+            .map(|e| e.dump_str())
+            .collect::<Vec<_>>()
+            .join(",\n");
+        Err(anyhow::anyhow!(
+            "type inference failed for expressions:\n{}",
+            error_message
+        ))
     }
 }
 

--- a/engine/baml-lib/baml-types/src/expr.rs
+++ b/engine/baml-lib/baml-types/src/expr.rs
@@ -1,5 +1,6 @@
 // use moniker::{Binder, BoundTerm, Scope, Var};
 use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 use crate::{field_type::FieldType, BamlMap, BamlValueWithMeta};
@@ -30,6 +31,12 @@ pub enum Expr<T> {
     If(Arc<Expr<T>>, Arc<Expr<T>>, Option<Arc<Expr<T>>>, T),
     Let(Name, Arc<Expr<T>>, Arc<Expr<T>>, T), // let name = expr in body
     ArgsTuple(Vec<Expr<T>>, T),
+    ForLoop {
+        item: Name, // An identifier. TODO: Generalize to left-hand-side. i.e. name or other pattern.
+        iterable: Arc<Expr<T>>,
+        body: Arc<Expr<T>>,
+        meta: T,
+    },
 }
 
 pub type Name = String;
@@ -78,6 +85,7 @@ impl<T: Clone + std::fmt::Debug> Expr<T> {
             Expr::ArgsTuple(_, meta) => meta,
             Expr::Let(_, _, _, meta) => meta,
             Expr::If(_, _, _, meta) => meta,
+            Expr::ForLoop { meta, .. } => meta,
         }
     }
 
@@ -95,6 +103,7 @@ impl<T: Clone + std::fmt::Debug> Expr<T> {
             Expr::Let(_, _, _, meta) => meta,
             Expr::ArgsTuple(_, meta) => meta,
             Expr::If(_, _, _, meta) => meta,
+            Expr::ForLoop { meta, .. } => meta,
         }
     }
 
@@ -112,6 +121,7 @@ impl<T: Clone + std::fmt::Debug> Expr<T> {
             Expr::ArgsTuple(_, meta) => meta,
             Expr::Let(_, _, _, meta) => meta,
             Expr::If(_, _, _, meta) => meta,
+            Expr::ForLoop { meta, .. } => meta,
         }
     }
 }
@@ -187,6 +197,19 @@ impl<T: Clone + std::fmt::Debug> Expr<T> {
                     cond.dump_str(),
                     then.dump_str(),
                     else_.as_ref().map(|e| e.dump_str()).unwrap_or_default()
+                )
+            }
+            Expr::ForLoop {
+                item,
+                iterable,
+                body,
+                ..
+            } => {
+                format!(
+                    "For {} in {} {{ {} }}",
+                    item,
+                    iterable.dump_str(),
+                    body.dump_str()
                 )
             }
         }
@@ -288,6 +311,21 @@ impl<T: Clone + std::fmt::Debug> Expr<T> {
                 cond1.temporary_same_state(cond2) && then1.temporary_same_state(then2) && else_same
             }
             (Expr::If(_, _, _, _), _) => false,
+            (
+                Expr::ForLoop {
+                    item: i1,
+                    iterable: iter1,
+                    body: body1,
+                    ..
+                },
+                Expr::ForLoop {
+                    item: i2,
+                    iterable: iter2,
+                    body: body2,
+                    ..
+                },
+            ) => i1 == i2 && iter1.temporary_same_state(iter2) && body1.temporary_same_state(body2),
+            (Expr::ForLoop { .. }, _) => false,
         }
     }
 }
@@ -385,6 +423,17 @@ impl Expr<ExprMetadata> {
                 free_vars
             }
             Expr::ArgsTuple(args, _) => args.iter().flat_map(|a| a.free_vars()).collect(),
+            Expr::ForLoop {
+                item,
+                iterable,
+                body,
+                ..
+            } => {
+                let mut free_vars = iterable.free_vars();
+                free_vars.extend(body.free_vars());
+                free_vars.insert(item.clone());
+                free_vars
+            }
         }
     }
 
@@ -473,6 +522,17 @@ impl<T: Clone> Expr<T> {
                 args.iter().map(|e| e.open(target, new_name)).collect(),
                 m.clone(),
             ),
+            Expr::ForLoop {
+                item,
+                iterable,
+                body,
+                meta,
+            } => Expr::ForLoop {
+                item: item.clone(),
+                iterable: Arc::new(iterable.open(target, new_name)),
+                body: Arc::new(body.open(target, new_name)),
+                meta: meta.clone(),
+            },
         }
     }
 
@@ -543,6 +603,105 @@ impl<T: Clone> Expr<T> {
                 args.iter().map(|e| e.close(new_index, target)).collect(),
                 m.clone(),
             ),
+            Expr::ForLoop {
+                item,
+                iterable,
+                body,
+                meta,
+            } => Expr::ForLoop {
+                item: item.clone(),
+                iterable: Arc::new(iterable.close(new_index, target)),
+                body: Arc::new(body.close(new_index, target)),
+                meta: meta.clone(),
+            },
         }
     }
 }
+
+/// An iterator over the sub-expressions of an expression.
+impl <'a, T: 'a> IntoIterator for &'a Expr<T> {
+    type Item = &'a Expr<T>;
+    type IntoIter = ExprIterator<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ExprIterator::new(self)
+    }
+}
+
+/// An iterator over the sub-expressions of an expression.
+pub struct ExprIterator<'a, T> {
+    pub stack: VecDeque<&'a Expr<T>>,
+}
+
+impl <'a, T> ExprIterator<'a, T> {
+    fn new(root: &'a Expr<T>) -> Self {
+        let mut stack = VecDeque::new();
+        stack.push_back(root);
+        Self { stack}
+    }
+}
+
+impl<'a, T: 'a> Iterator for ExprIterator<'a, T> {
+    type Item = &'a Expr<T>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(expr) = self.stack.pop_back() {
+            // For exprs with sub-exprs, push the sub-exprs onto the stack.
+            match expr {
+                Expr::Atom(_) => {}
+                Expr::List(items, _) => {
+                    for item in items.iter() {
+                        self.stack.push_back(item);
+                    }
+                }
+                Expr::Map(entries, _) => {
+                    for (_, value) in entries.iter() {
+                        self.stack.push_back(value);
+                    }
+                }
+                Expr::ClassConstructor { fields, spread, .. } => {
+                    for (_, value) in fields.iter() {
+                        self.stack.push_back(value);
+                    }
+                    if let Some(spread) = spread {
+                        self.stack.push_back(spread);
+                    }
+                }
+                Expr::LLMFunction(_, _, _) => {}
+                Expr::FreeVar(_, _) => {}
+                Expr::BoundVar(_, _) => {}
+                Expr::Lambda(_, body, _) => {
+                    self.stack.push_back(body);
+                }
+                Expr::App(f, x, _) => {
+                    self.stack.push_back(f);
+                    self.stack.push_back(x);
+                }
+                Expr::If(cond, then, else_, _) => {
+                    self.stack.push_back(cond);
+                    self.stack.push_back(then);
+                    if let Some(else_) = else_ {
+                        self.stack.push_back(else_);
+                    }
+                }
+                Expr::Let(_, expr, body, _) => {
+                    self.stack.push_back(expr);
+                    self.stack.push_back(body);
+                }
+                Expr::ArgsTuple(args, _) => {
+                    for arg in args.iter() {
+                        self.stack.push_back(arg);
+                    }
+                }
+                Expr::ForLoop { iterable, body, .. } => {
+                    self.stack.push_back(iterable);
+                    self.stack.push_back(body);
+                }
+            }
+            Some(&expr)
+        } else {
+            None
+        }
+    }
+}
+

--- a/engine/baml-lib/baml/tests/validation_files/expr/for_loop.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/for_loop.baml
@@ -1,0 +1,9 @@
+function Foo() -> int {
+  let yyyyyyyy = [1, 2, 3];
+  let x = for (i in yyyyyyyy) { i };
+  x
+}
+
+let x = for (i in "hi") { b };
+
+// BLAH

--- a/engine/baml-lib/schema-ast/src/ast/expression.rs
+++ b/engine/baml-lib/schema-ast/src/ast/expression.rs
@@ -125,6 +125,12 @@ pub enum Expression {
         Option<Box<Expression>>,
         Span,
     ),
+    ForLoop {
+        identifier: Identifier,
+        iterator: Box<Expression>,
+        body: ExpressionBlock,
+        span: Span,
+    },
 }
 
 impl fmt::Display for Expression {
@@ -191,6 +197,14 @@ impl fmt::Display for Expression {
                 Some(else_) => write!(f, "if {cond} {{ {then} }} else {{ {else_} }}"),
                 None => write!(f, "if {cond} {{ {then} }}"),
             },
+            Expression::ForLoop {
+                identifier,
+                iterator,
+                body,
+                ..
+            } => {
+                write!(f, "for ({identifier} in {iterator}) {{ {body} }}")
+            }
         }
     }
 }
@@ -223,6 +237,7 @@ impl Expression {
             }
         }
     }
+
     pub fn as_array(&self) -> Option<(&[Expression], &Span)> {
         match self {
             Expression::Array(arr, span) => Some((arr, span)),
@@ -305,6 +320,7 @@ impl Expression {
             Self::FnApp(_, _, span) => span,
             Self::ExprBlock(_, span) => span,
             Self::If(_, _, _, span) => span,
+            Self::ForLoop { span, .. } => span,
         }
     }
 
@@ -334,6 +350,7 @@ impl Expression {
             Expression::FnApp(_, _, _) => "function_application",
             Expression::ExprBlock(_, _) => "expression_block",
             Expression::If(_, _, _, _) => "if_expression",
+            Expression::ForLoop { .. } => "for_loop",
         }
     }
 
@@ -423,6 +440,25 @@ impl Expression {
                 }
             }
             (If(_, _, _, _), _) => panic!("Types do not match: {self:?} and {other:?}"),
+            (
+                ForLoop {
+                    identifier: id1,
+                    iterator: it1,
+                    body: d1,
+                    ..
+                },
+                ForLoop {
+                    identifier: id2,
+                    iterator: it2,
+                    body: d2,
+                    ..
+                },
+            ) => {
+                id1.assert_eq_up_to_span(&id2);
+                it1.assert_eq_up_to_span(&it2);
+                d1.assert_eq_up_to_span(&d2);
+            }
+            (ForLoop { .. }, _) => panic!("Types do not match: {self:?} and {other:?}"),
         }
     }
 
@@ -514,6 +550,7 @@ impl Expression {
             Expression::FnApp(_, _, _) => None,  // Is this right?
             Expression::ExprBlock(_, _) => None, // Is this right?
             Expression::If(_, _, _, _) => None,
+            Expression::ForLoop { .. } => None,
         }
     }
 }

--- a/engine/baml-lib/schema-ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/schema-ast/src/parser/datamodel.pest
@@ -113,6 +113,7 @@ jinja_block_close = _{ "}}" }
 jinja_body        =  { (!(jinja_block_open | jinja_block_close) ~ ANY)* }
 jinja_expression  =  { jinja_block_open ~ jinja_body ~ jinja_block_close }
 expression        =  {
+    for_loop |
     fn_app |
     if_expression |
     lambda |
@@ -246,6 +247,12 @@ fn_app = { identifier ~ "(" ~ expression? ~ ("," ~ expression)* ~ ")" }
 
 // If expression.
 if_expression = { "if" ~ expression ~ "{" ~ expression ~ "}" ~ ( "else" ~ "{" ~ expression ~ "}" )? }
+
+// For loop, e.g.
+// for (r in resumes) {
+//   ExtractResume(x)   
+// }
+for_loop = { "for" ~ "(" ~ identifier ~ "in" ~ expression ~ ")" ~ expr_block }
 
 // Anonymous function.
 lambda = { named_argument_list ~ "=>" ~ expression }

--- a/engine/baml-lib/schema-ast/src/parser/parse_expr.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_expr.rs
@@ -210,3 +210,18 @@ pub fn parse_if_expression(token: Pair<'_>, diagnostics: &mut Diagnostics) -> Op
         span,
     ))
 }
+
+pub fn parse_for_loop(token: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<Expression> {
+    assert_correct_parser!(token, Rule::for_loop);
+    let span = diagnostics.span(token.as_span());
+    let mut tokens = token.into_inner();
+    let identifier = parse_identifier(tokens.next()?, diagnostics);
+    let iterator = parse_expression(tokens.next()?, diagnostics)?;
+    let body = parse_expr_block(tokens.next()?, diagnostics)?;
+    Some(Expression::ForLoop {
+        identifier,
+        iterator: Box::new(iterator),
+        body,
+        span,
+    })
+}

--- a/engine/baml-lib/schema-ast/src/parser/parse_expression.rs
+++ b/engine/baml-lib/schema-ast/src/parser/parse_expression.rs
@@ -1,6 +1,8 @@
 use super::{
     helpers::{parsing_catch_all, Pair},
-    parse_expr::{parse_expr_block, parse_fn_app, parse_if_expression, parse_lambda},
+    parse_expr::{
+        parse_expr_block, parse_fn_app, parse_for_loop, parse_if_expression, parse_lambda,
+    },
     parse_identifier::parse_identifier,
     Rule,
 };
@@ -39,6 +41,7 @@ pub(crate) fn parse_expression(
         Rule::class_constructor => Some(parse_class_constructor(first_child, diagnostics)),
         Rule::fn_app => parse_fn_app(first_child, diagnostics),
         Rule::lambda => parse_lambda(first_child, diagnostics),
+        Rule::for_loop => parse_for_loop(first_child, diagnostics),
         Rule::expr_block => {
             let res = parse_expr_block(first_child, diagnostics);
             res

--- a/engine/baml-runtime/src/eval_expr.rs
+++ b/engine/baml-runtime/src/eval_expr.rs
@@ -133,6 +133,21 @@ fn subst<'a>(
                 meta.clone(),
             ))
         }
+        Expr::ForLoop {
+            item,
+            iterable,
+            body,
+            meta,
+        } => {
+            let new_iterable = subst(iterable, var_name, val, env)?;
+            let new_body = subst(body, var_name, val, env)?;
+            Ok(Expr::ForLoop {
+                item: item.clone(),
+                iterable: Arc::new(new_iterable),
+                body: Arc::new(new_body),
+                meta: meta.clone(),
+            })
+        }
     };
     let res = res?;
     Ok(res)
@@ -145,6 +160,7 @@ async fn beta_reduce<'a>(
     expr: &Expr<ExprMetadata>,
     eval_final_llm_fn: bool,
 ) -> anyhow::Result<Expr<ExprMetadata>> {
+    eprintln!("BETA_REDUCE\n{}\n", expr.dump_str());
     match expr {
         Expr::Atom(_) => Ok(expr.clone()),
         Expr::Let(name, value, body, meta) => {
@@ -311,6 +327,35 @@ async fn beta_reduce<'a>(
                 meta.clone(),
             ))
         }
+        Expr::ForLoop {
+            item,
+            iterable,
+            body,
+            meta,
+        } => match iterable.as_ref() {
+            Expr::List(iterable_items, meta) => {
+                let new_index = VarIndex {
+                    de_bruijn: 0,
+                    tuple: 0,
+                };
+                let closed_body = body.close(&new_index, item);
+                let unevaluated_results = iterable_items
+                    .iter()
+                    .map(|iterable_item| subst(&closed_body, &new_index, iterable_item, env))
+                    .collect::<anyhow::Result<Vec<_>>>()?;
+                Ok(Expr::List(unevaluated_results, meta.clone()))
+            }
+            _ => {
+                let new_iterable = Box::pin(beta_reduce(env, iterable, eval_final_llm_fn)).await?;
+                let new_body = Box::pin(beta_reduce(env, body, eval_final_llm_fn)).await?;
+                Ok(Expr::ForLoop {
+                    item: item.clone(),
+                    iterable: Arc::new(new_iterable),
+                    body: Arc::new(new_body),
+                    meta: meta.clone(),
+                })
+            }
+        },
         _ => panic!("Tried to beta reduce a {}", expr.dump_str()), // Err(anyhow::anyhow!("Not an application: {:?}", expr)),
     }
 }
@@ -463,6 +508,33 @@ pub async fn eval_to_value_or_llm_call<'a>(
             Expr::ArgsTuple(_, _) => {
                 return Err(anyhow::anyhow!("Bare args tuple found"));
             }
+            l @ Expr::ForLoop { .. } => {
+                let res = Box::pin(beta_reduce(env, &l, false)).await?;
+                current_expr = res;
+                // match iterable.as_ref() {
+                //     Expr::List(items, _) => {
+                //         let mut results: Vec<BamlValueWithMeta<()>> = Vec::new();
+                //         for item in items {
+                //             let result = Box::pin(eval_to_value(env, item))
+                //                 .await?
+                //                 .ok_or(anyhow::anyhow!("Expected to evaluate to value"))?;
+                //             results.push(result);
+                //         }
+                //         // let field_type = results[0].meta();
+                //         return Ok(ExprEvalResult::Value {
+                //             value: BamlValueWithMeta::List(results, ()),
+                //             field_type: FieldType::List(Box::new(FieldType::Primitive(
+                //                 TypeValue::String,
+                //             ))), // TOOD: This is wrong!
+                //         });
+                //     }
+                //     _ => {
+                //         return Err(anyhow::anyhow!(
+                //         "Iterable was not a list. This should have been caught during typechecking"
+                //     ))
+                //     }
+                // }
+            }
         }
     }
     Err(anyhow::anyhow!("Max steps reached. {:?}", current_expr))
@@ -562,6 +634,16 @@ pub async fn eval_to_value<'a>(
                     _ => todo!("Type error"),
                 }
             }
+            // Expr::ForLoop{ item, iterable, body, meta } => {
+            //     match iterable.as_ref() {
+            //         Expr::List(items, _ ) => {
+            //             let mut results: Vec<BamlValueWithMeta<()>> = Vec::new();
+            //             for i in items {
+            //                 let result = Box::pin(eval_to_value(i))
+            //             }
+            //         }
+            //     }
+            // }
             other => {
                 // let new_expr = step(env, &other).await?;
                 let new_expr = Box::pin(beta_reduce(env, &other, true)).await?;
@@ -716,14 +798,32 @@ function Quiz(msg: string) -> bool {
   "#
 }
   
-  function Go() -> string {
-    if Quiz("The sky is green") { Echo("Hello") } else { Echo("World") }
+function Go() -> string {
+  if Quiz("The sky is green") { Echo("Hello") } else { Echo("World") }
+}
+
+test Go {
+  functions [Go]
+  args {}
+}
+
+function PoemAbout(topic: string) -> string {
+  client GPT4o
+  prompt #"Write a 10-word poem about {{ topic }}"#
+}
+
+function Poems() -> string [] {
+  for (t in ["cats", "birds", "love", "rain"]) {
+    PoemAbout(t)
   }
-  
-  test Go {
-    functions [Go]
-    args {}
-  }
+}
+
+test Poems {
+  functions [Poems]
+  args {}
+}
+
+
         "##,
         );
         // dbg!(&rt.inner.ir.find_function("OuterPyramid").unwrap().item);
@@ -736,7 +836,8 @@ function Quiz(msg: string) -> bool {
         dbg!(&f.item);
         let (res, _) = rt
             // .run_test("Second", "TestSecond", &ctx, Some(on_event))
-            .run_test("Go", "Go", &ctx, Some(on_event), None)
+            // .run_test("Go", "Go", &ctx, Some(on_event), None)
+            .run_test("Poems", "Poems", &ctx, Some(on_event), None)
             // .run_test("MakePerson", "TestMakePerson", &ctx, Some(on_event), None)
             // .run_test("CompareHaikus", "Test", &ctx, Some(on_event))
             // .run_test("LlmParseInt", "TestParse", &ctx, Some(on_event))


### PR DESCRIPTION
Check in a rudimentary for-loop implementation.

Typechecking doesn't work yet, and the loops only work if each loop body returns a string.

Following up with typechecking and correct return types soon.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add basic for-loop support to the expression language, including parsing, evaluation, and initial type checking.
> 
>   - **Behavior**:
>     - Adds basic for-loop support to the expression language, requiring loop bodies to return strings.
>     - Type checking and return types for for-loops are not yet implemented.
>   - **Parsing**:
>     - Updates `datamodel.pest` and `parse_expr.rs` to parse for-loops.
>     - Adds `parse_for_loop()` function in `parse_expr.rs`.
>   - **IR and Evaluation**:
>     - Modifies `Expr` enum in `expr.rs` to include `ForLoop` variant.
>     - Updates `eval_expr.rs` to handle `ForLoop` during evaluation.
>   - **Type Checking**:
>     - Updates `expr_typecheck.rs` to include basic type checking logic for for-loops.
>   - **Validation**:
>     - Updates `expr_fns.rs` to validate for-loop expressions.
>   - **Tests**:
>     - Adds `for_loop.baml` test file to validate for-loop parsing and evaluation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 601e8aba2b055ffd3f2d62927d40588d85ef7719. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->