### PR TITLE
fix typechecking for for loops

### DIFF
--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
@@ -17,7 +17,7 @@ use internal_baml_diagnostics::{DatamodelError, Diagnostics, Span};
 
 use crate::ir::IRHelperExtended;
 
-/// Chcek the types of all expressions in the IR.
+/// Check the types of all expressions in the IR.
 /// It relies on the types previously inferred and added to the expression metadata.
 /// TODO: move this to a compiler pass, so that it transforms IR to IR.
 /// TODO: Implement it directly in terms of the bidirectional typing algorithm.
@@ -289,7 +289,7 @@ pub fn typecheck_in_context(
             };
             if !iterable_type_ok {
                 diagnostics.push_error(DatamodelError::new_validation_error(
-                    "For loop must iterato over a list",
+                    "For loop must iterate over a list",
                     iterable.meta().0.clone(),
                 ));
             }
@@ -305,24 +305,6 @@ pub fn typecheck_in_context(
     }
     Ok(())
 }
-
-// fn is_subtype(ir: &IntermediateRepr, a: &ExprType, b: &ExprType) -> bool {
-//     match (a, b) {
-//         (ExprType::Atom(a), ExprType::Atom(b)) => ir.is_subtype(a, b),
-//         (ExprType::Arrow(a), ExprType::Arrow(b)) => {
-//             let a_arrow = a.as_ref();
-//             let b_arrow = b.as_ref();
-//             let return_type_ok = is_subtype(ir, &a_arrow.body_type, &b_arrow.body_type);
-//             let arg_types_ok = a_arrow
-//                 .param_types
-//                 .iter()
-//                 .zip(b_arrow.param_types.iter())
-//                 .all(|(a, b)| is_subtype(ir, b, a));
-//             return_type_ok && arg_types_ok
-//         }
-//         _ => false,
-//     }
-// }
 
 fn compatible_as_subtype(
     ir: &IntermediateRepr,
@@ -531,6 +513,12 @@ pub fn infer_types_in_context(
             }
             let new_iterable = infer_types_in_context(typing_context, iterable.clone());
             let new_body = infer_types_in_context(typing_context, body.clone());
+            let mut new_meta = meta.clone();
+            new_meta.1 = new_body
+                .meta()
+                .1
+                .as_ref()
+                .map(|body_type| FieldType::List(Box::new(body_type.clone())));
             Arc::new(Expr::ForLoop {
                 item: item.clone(),
                 iterable: iterable.clone(),

--- a/engine/baml-runtime/src/eval_expr.rs
+++ b/engine/baml-runtime/src/eval_expr.rs
@@ -511,29 +511,6 @@ pub async fn eval_to_value_or_llm_call<'a>(
             l @ Expr::ForLoop { .. } => {
                 let res = Box::pin(beta_reduce(env, &l, false)).await?;
                 current_expr = res;
-                // match iterable.as_ref() {
-                //     Expr::List(items, _) => {
-                //         let mut results: Vec<BamlValueWithMeta<()>> = Vec::new();
-                //         for item in items {
-                //             let result = Box::pin(eval_to_value(env, item))
-                //                 .await?
-                //                 .ok_or(anyhow::anyhow!("Expected to evaluate to value"))?;
-                //             results.push(result);
-                //         }
-                //         // let field_type = results[0].meta();
-                //         return Ok(ExprEvalResult::Value {
-                //             value: BamlValueWithMeta::List(results, ()),
-                //             field_type: FieldType::List(Box::new(FieldType::Primitive(
-                //                 TypeValue::String,
-                //             ))), // TOOD: This is wrong!
-                //         });
-                //     }
-                //     _ => {
-                //         return Err(anyhow::anyhow!(
-                //         "Iterable was not a list. This should have been caught during typechecking"
-                //     ))
-                //     }
-                // }
             }
         }
     }
@@ -807,14 +784,22 @@ test Go {
   args {}
 }
 
+class Poem {
+  title string
+  body string
+}
+
 function PoemAbout(topic: string) -> string {
   client GPT4o
   prompt #"Write a 10-word poem about {{ topic }}"#
 }
 
-function Poems() -> string [] {
+function Poems() -> Poem[] {
   for (t in ["cats", "birds", "love", "rain"]) {
-    PoemAbout(t)
+    Poem {
+      title: t,
+      body: PoemAbout(t)
+    }
   }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes typechecking for `for` loops to ensure they iterate over lists and updates type inference and evaluation accordingly.
> 
>   - **Typechecking**:
>     - Fixes typechecking for `for` loops in `expr_typecheck.rs`, ensuring they iterate over lists.
>     - Updates `infer_types_in_context()` to infer list types for `for` loop bodies.
>   - **Evaluation**:
>     - Updates `eval_to_value_or_llm_call()` in `eval_expr.rs` to handle `for` loops by beta reducing them.
>   - **Misc**:
>     - Fixes typo in `expr_typecheck.rs` ("iterato" to "iterate").
>     - Adds `Poem` class and updates `Poems()` function in `eval_expr.rs` to return `Poem[]` instead of `string[]`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for eaba622f9c6fa572a362249e9db6ed823f3c1e25. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->