### PR TITLE
remove extra printf debugging

### DIFF
--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
@@ -93,7 +93,6 @@ pub fn typecheck_in_context(
     typing_context: &HashMap<String, FieldType>,
     expr: &Expr<ExprMetadata>,
 ) -> Result<()> {
-    eprintln!("expr: {:?}", expr);
     match expr {
         Expr::Atom(atom) => {
             // Atoms always typecheck.
@@ -323,7 +322,6 @@ pub fn infer_types_in_context(
     typing_context: &mut HashMap<String, FieldType>,
     expr: Arc<Expr<ExprMetadata>>,
 ) -> Arc<Expr<ExprMetadata>> {
-    eprintln!("infer_types_in_context: {}", expr.dump_str());
     match expr.as_ref() {
         Expr::FreeVar(ref var_name, (span, maybe_type)) => {
             // Assign variables from the context.
@@ -345,11 +343,9 @@ pub fn infer_types_in_context(
             expr.clone()
         }
         Expr::Let(ref var_name, expr, ref body, _) => {
-            eprintln!("handling let: {:?}", expr);
             let new_expr = infer_types_in_context(typing_context, expr.clone());
             let new_body = infer_types_in_context(typing_context, body.clone());
             if let Some(ref expr_ty) = new_expr.meta().1 {
-                eprintln!("inserting into typing context: {:?}", expr_ty);
                 typing_context.insert(var_name.to_string(), expr_ty.clone());
             }
             let new_meta = (expr.meta().0.clone(), new_body.meta().1.clone());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unnecessary debug print statements from `expr_typecheck.rs`.
> 
>   - **Debugging**:
>     - Remove `eprintln!("expr: {:?}", expr);` from `typecheck_in_context()`.
>     - Remove `eprintln!("infer_types_in_context: {}", expr.dump_str());` from `infer_types_in_context()`.
>     - Remove `eprintln!("handling let: {:?}", expr);` and `eprintln!("inserting into typing context: {:?}", expr_ty);` from `infer_types_in_context()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 895caf315eedfe7860e77e5cf3a8920b7ebf608a. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->