### PR TITLE
Fix the jsonish bug with no newline before object field

### DIFF
--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -19,6 +19,15 @@ pub struct JsonParseState {
     pub completed_values: Vec<(&'static str, Value, Vec<Fixes>)>,
 }
 
+#[derive(Clone, Debug)]
+enum Pos {
+    InNothing,     // 0
+    Unknown,       // 1
+    InObjectKey,   // 2
+    InObjectValue, // 3
+    InArray,       // 4
+}
+
 impl JsonParseState {
     pub fn new() -> Self {
         JsonParseState {
@@ -128,26 +137,26 @@ impl JsonParseState {
         &mut self,
         mut next: Peekable<impl Iterator<Item = (usize, char)>>,
     ) -> CloseStringResult {
-        let pos = if self.collection_stack.len() >= 2 {
+        let pos: Pos = if self.collection_stack.len() >= 2 {
             self.collection_stack
                 .get(self.collection_stack.len() - 2)
                 .map(|(c, _)| match c {
                     JsonCollection::Object(keys, values, _) => {
                         if keys.len() == values.len() {
-                            2
+                            Pos::InObjectKey
                         } else {
-                            3
+                            Pos::InObjectValue
                         }
                     }
-                    JsonCollection::Array(_, _) => 4,
-                    _ => 1,
+                    JsonCollection::Array(_, _) => Pos::InArray,
+                    _ => Pos::Unknown,
                 })
                 .unwrap()
         } else {
-            0
+            Pos::InNothing
         };
         match pos {
-            0 => {
+            Pos::InNothing => {
                 // in nothing, so perhaps the first '{' or '[' is the start of a new object or array
                 let mut counter = 0;
                 for (idx, c) in next.by_ref() {
@@ -164,8 +173,8 @@ impl JsonParseState {
                 }
                 CloseStringResult::Close(counter, CompletionState::Incomplete)
             }
-            1 => CloseStringResult::Continue,
-            2 => {
+            Pos::Unknown => CloseStringResult::Continue, // Todo - what is this enum supposed to be called? (Not Unknown)
+            Pos::InObjectKey => {
                 // in object key
                 let mut counter = 0;
                 for (idx, c) in next.by_ref() {
@@ -179,7 +188,7 @@ impl JsonParseState {
                 }
                 CloseStringResult::Close(counter, CompletionState::Incomplete)
             }
-            3 => {
+            Pos::InObjectValue => {
                 // in object value
                 let mut counter = 0;
                 while let Some((idx, c)) = next.next() {
@@ -198,7 +207,11 @@ impl JsonParseState {
                             let is_bool = current_value.trim().eq_ignore_ascii_case("true")
                                 || current_value.trim().eq_ignore_ascii_case("false");
                             let is_null = current_value.trim().eq_ignore_ascii_case("null");
-                            let is_possible_value = is_numeric || is_bool || is_null;
+                            // let looks_like_code = current_value.contains(" ");
+                            let is_identifier =
+                                !(current_value.contains(" ") || current_value.contains("("));
+                            let is_possible_value =
+                                is_numeric || is_bool || is_null || is_identifier;
 
                             if let Some((_, next_c)) = next.peek() {
                                 match next_c {
@@ -291,7 +304,7 @@ impl JsonParseState {
                 }
                 CloseStringResult::Close(counter, CompletionState::Incomplete)
             }
-            4 => {
+            Pos::InArray => {
                 // in array
                 let mut counter = 0;
                 for (idx, c) in next {
@@ -307,7 +320,6 @@ impl JsonParseState {
                 counter += 1; // Indicate that we called next() one time after the final `Some`.
                 CloseStringResult::Close(counter, CompletionState::Incomplete)
             }
-            _ => unreachable!("Invalid position"),
         }
     }
 

--- a/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
+++ b/engine/baml-lib/jsonish/src/jsonish/parser/fixing_parser/json_parse_state.rs
@@ -173,7 +173,7 @@ impl JsonParseState {
                 }
                 CloseStringResult::Close(counter, CompletionState::Incomplete)
             }
-            Pos::Unknown => CloseStringResult::Continue, // Todo - what is this enum supposed to be called? (Not Unknown)
+            Pos::Unknown => CloseStringResult::Continue,
             Pos::InObjectKey => {
                 // in object key
                 let mut counter = 0;
@@ -207,7 +207,6 @@ impl JsonParseState {
                             let is_bool = current_value.trim().eq_ignore_ascii_case("true")
                                 || current_value.trim().eq_ignore_ascii_case("false");
                             let is_null = current_value.trim().eq_ignore_ascii_case("null");
-                            // let looks_like_code = current_value.contains(" ");
                             let is_identifier =
                                 !(current_value.contains(" ") || current_value.contains("("));
                             let is_possible_value =

--- a/engine/baml-lib/jsonish/src/tests/test_class.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_class.rs
@@ -1490,7 +1490,6 @@ test_partial_deserializer_streaming!(
     }
 );
 
-
 test_deserializer!(
   test_string_in_object_with_unescaped_quotes,
   r#"class Foo {
@@ -1600,5 +1599,27 @@ test_partial_deserializer_streaming!(
   {
     "rec_one": vec!["and then i said \"hi\", \"and also \"bye"],
     "rec_two": []
+  }
+);
+
+test_deserializer!(
+  test_enum_without_leading_newline,
+  r#"enum Foo {
+    FOO
+    BAR
+  }
+
+  class WithFoo {
+    foo Foo
+    name string
+  }
+  "#,
+  r#"
+    {foo:FOO, name: "Greg"}
+  "#,
+  FieldType::Class("WithFoo".to_string()),
+  {
+    "foo": "FOO",
+    "name": "Greg"
   }
 );


### PR DESCRIPTION
Fix the jsonish bug with no newline before object field
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes JSON parser bug for object fields without newline and adds test for enum parsing without leading newline.
> 
>   - **Behavior**:
>     - Fixes bug in `should_close_unescaped_string()` in `json_parse_state.rs` to handle object fields without a newline.
>     - Adds handling for identifiers as possible values in `should_close_unescaped_string()`.
>   - **Enums**:
>     - Introduces `Pos` enum in `json_parse_state.rs` to manage parsing states: `InNothing`, `Unknown`, `InObjectKey`, `InObjectValue`, `InArray`.
>   - **Tests**:
>     - Adds `test_enum_without_leading_newline` in `test_class.rs` to verify parsing of enums without leading newline.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 4e473770fc7022c5f126fca6a84d60413dc27d72. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->