### PR TITLE
Add call_with_metrics endpoint to `baml-cli serve`

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -2220,6 +2220,9 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "encode_unicode"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -59,7 +59,7 @@ dashmap = "5.5.3"
 derive-new = "0.7"
 derive_builder = "0.20.0"
 derive_more = { version = "0.99.18", features = ["constructor"] }
-either = "1.8.1"
+either = { version = "1.8.1", features = ["serde"] }
 env_logger = "0.11.3"
 futures = { version = "0.3.30", features = ["executor"] }
 http = "1.1.0"

--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -36,6 +36,7 @@ use std::{path::PathBuf, sync::Arc, task::Poll};
 use tokio::{net::TcpListener, sync::RwLock};
 use tokio_stream::StreamExt;
 
+use crate::tracingv2::storage::storage::Collector;
 use crate::{
     client_registry::ClientRegistry, errors::ExposedError, internal::llm_client::LLMResponse,
     BamlRuntime, FunctionResult, RuntimeContextManager,
@@ -172,6 +173,12 @@ enum AuthEnforcementMode {
     EnforceAndFail(String),
 }
 
+#[derive(Clone)]
+enum BamlCallCollector {
+    None,
+    WithCollector(Arc<Collector>),
+}
+
 impl Server {
     pub async fn new(src_dir: PathBuf, port: u16) -> Result<(Arc<Self>, TcpListener)> {
         let tcp_listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", port))
@@ -266,6 +273,17 @@ impl Server {
 
         let s = self.clone();
         let app = app.route(
+            "/call_with_metrics/:msg",
+            post(
+                move |extract::Path(b_fn): extract::Path<String>,
+                      extract::Json(b_args): extract::Json<serde_json::Value>| async move {
+                    s.clone().baml_call_with_metrics_axum(b_fn, b_args).await
+                },
+            ),
+        );
+
+        let s = self.clone();
+        let app = app.route(
             "/stream/:msg",
             post(
                 move |extract::Path(b_fn): extract::Path<String>,
@@ -324,6 +342,7 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
         b_fn: String,
         b_args: serde_json::Value,
         b_options: Option<BamlOptions>,
+        baml_call_collector: BamlCallCollector,
     ) -> Response {
         let args = match parse_args(&b_fn, b_args) {
             Ok(args) => args,
@@ -339,8 +358,14 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
                 || std::env::vars().collect(),
                 |options| options.env(),
             );
+
+        let collectors = match baml_call_collector.clone() {
+            BamlCallCollector::None => None,
+            BamlCallCollector::WithCollector(collector) => Some(vec![collector]),
+        };
+
         let (result, _trace_id) = locked
-            .call_function(b_fn, &args, &Default::default(), None, client_registry.as_ref(), None, env_vars)
+            .call_function(b_fn, &args, &Default::default(), None, client_registry.as_ref(), collectors, env_vars)
             .await;
 
         match result {
@@ -349,7 +374,23 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
                     match function_result.result_with_constraints_content() {
                         // Just because the LLM returned 2xx doesn't mean that it returned parse-able content!
                         Ok(parsed) => {
-                            (StatusCode::OK, Json(parsed.serialize_final())).into_response()
+                            let body = match baml_call_collector {
+                                BamlCallCollector::None => Json(either::Either::Left(parsed.serialize_final())),
+                                BamlCallCollector::WithCollector(collector) =>{
+                                    let log = collector.last_function_log();
+                                    let metrics = log.map(|mut log| {
+                                        json!({
+                                            "usage": log.usage(),
+                                            "timing": log.timing(),
+                                        })
+                                    });
+                                    Json(either::Either::Right(json!({
+                                        "response": parsed.serialize_final(),
+                                        "metrics": metrics,
+                                    })))
+                                },
+                            };
+                            (StatusCode::OK, body).into_response()
                         }
                         Err(e) => {
                             if let Some(ExposedError::ValidationError {
@@ -390,20 +431,33 @@ Tip: test that the server is up using `curl http://localhost:{}/_debug/ping`
         }
     }
 
+    fn parse_baml_options_from_args(
+        b_args: &serde_json::Value,
+    ) -> Result<Option<BamlOptions>, BamlError> {
+        b_args
+            .get("__baml_options__")
+            .map(BamlOptions::deserialize)
+            .transpose()
+            .map_err(|e| BamlError::InvalidArgument {
+                message: format!("Failed to parse __baml_options__: {}", e),
+            })
+    }
+
     async fn baml_call_axum(self: Arc<Self>, b_fn: String, b_args: serde_json::Value) -> Response {
-        let mut b_options = None;
-        if let Some(options_value) = b_args.get("__baml_options__") {
-            match BamlOptions::deserialize(options_value) {
-                Ok(opts) => b_options = Some(opts),
-                Err(e) => {
-                    return BamlError::InvalidArgument {
-                        message: format!("Failed to parse __baml_options__: {}", e),
-                    }
-                    .into_response()
-                }
-            }
-        }
-        self.baml_call(b_fn, b_args, b_options).await
+        let b_options = match Self::parse_baml_options_from_args(&b_args)  {
+            Ok(opts) => opts,
+            Err(e) => return e.into_response(),
+        };
+        self.baml_call(b_fn, b_args, b_options, BamlCallCollector::None).await
+    }
+
+    async fn baml_call_with_metrics_axum(self: Arc<Self>, b_fn: String, b_args: serde_json::Value) -> Response {
+        let b_options = match Self::parse_baml_options_from_args(&b_args)  {
+            Ok(opts) => opts,
+            Err(e) => return e.into_response(),
+        };
+        let collector = Arc::new(Collector::new(None));
+        self.baml_call(b_fn, b_args, b_options, BamlCallCollector::WithCollector(collector.clone())).await
     }
 
     fn baml_stream(


### PR DESCRIPTION
My initial attempt at implementing #1887, comments welcome
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `/call_with_metrics/:msg` endpoint to BAML CLI server to handle calls with metrics using `Collector`.
> 
>   - **Behavior**:
>     - Adds `/call_with_metrics/:msg` endpoint in `mod.rs` to handle calls with metrics.
>     - Uses `Collector` to gather metrics and include them in the response.
>   - **Functions**:
>     - Adds `baml_call_with_metrics_axum()` in `mod.rs` to process requests to the new endpoint.
>     - Modifies `baml_call()` to accept `BamlCallCollector` and include metrics in the response if applicable.
>   - **Dependencies**:
>     - Updates `either` crate in `Cargo.toml` and `Cargo.lock` to include `serde` feature.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for cd11c9b698d4ffc2ece6196e5c7e357d1655551f. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->