### PR TITLE
chore: lock baml-ids version to 0.0.1

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "baml-ids"
-version = "0.89.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "serde",

--- a/engine/baml-ids/Cargo.toml
+++ b/engine/baml-ids/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "baml-ids"
-version.workspace = true
+version = "0.0.1"
 authors.workspace = true
 license-file.workspace = true
 description = "Typesafe IDs for BAML backends and runtime"


### PR DESCRIPTION
Needed to prevent Cargo.lock churn in studio2.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Locks `baml-ids` version to `0.0.1` in `Cargo.toml` to prevent `Cargo.lock` churn in `studio2`.
> 
>   - **Version Lock**:
>     - Locks `baml-ids` version to `0.0.1` in `Cargo.toml` to prevent `Cargo.lock` churn in `studio2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 5ad972338e6f70d6e368bcf04da212246c97c625. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->