### PR TITLE
deeply typecheck class constructors

### DIFF
--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
@@ -250,10 +250,12 @@ pub fn typecheck_in_context(
                                     meta.0.clone(),
                                 ));
                             }
+                            typecheck_in_context(ir, diagnostics, typing_context, field_value)?;
                         }
                     }
                 }
             }
+
             let spread_type = spread.as_ref().and_then(|s| s.meta().1.clone());
             if !compatible_as_subtype(ir, &meta.1, &spread_type) {
                 diagnostics.push_error(DatamodelError::new_validation_error(

--- a/engine/baml-lib/baml/tests/validation_files/expr/constructors_nested.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/constructors_nested.baml
@@ -1,0 +1,16 @@
+class Foo {
+  bar Bar
+}
+
+class Bar {
+  name string
+}
+
+let x = Foo { bar: Bar { name: 10 }};
+
+// error: Error validating: Type mismatch in class constructor
+//   -->  expr/constructors_nested.baml:9
+//    | 
+//  8 | 
+//  9 | let x = Foo { bar: Bar { name: 10 }};
+//    | 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance type checking for nested fields in class constructors and add corresponding tests.
> 
>   - **Behavior**:
>     - In `expr_typecheck.rs`, `typecheck_in_context` now checks nested fields in `Expr::ClassConstructor`.
>     - Adds a call to `typecheck_in_context` for each field value in class constructors.
>   - **Tests**:
>     - Adds `constructors_nested.baml` to test nested class constructor type checking.
>     - Verifies type mismatch error for incorrect nested field types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for b6d0603fd0cb07744310858a4971377cee602a59. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->