### PR TITLE
Correctly infer Vertex AI base URL for location 'global' (#2014)

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/vertex_client.rs
@@ -218,14 +218,22 @@ impl RequestBuilder for VertexClient {
 
         let base_url = match &self.properties.base_url_or_location {
             BaseUrlOrLocation::BaseUrl(base_url) => base_url.to_string(),
-            BaseUrlOrLocation::Location(location) => format!(
-                "https://{location}-aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}/publishers/google/models",
-                location = location,
-                project_id = match self.properties.project_id.as_ref() {
-                    Some(project_id) => project_id.to_string(),
-                    None => vertex_auth.project_id().await?.to_string(),
-                }
-            ),
+            BaseUrlOrLocation::Location(location) => {
+                let domain = if location == "global" {
+                    "aiplatform.googleapis.com".to_string()
+                } else {
+                    format!("{location}-aiplatform.googleapis.com")
+                };
+                format!(
+                    "https://{domain}/v1/projects/{project_id}/locations/{location}/publishers/google/models",
+                    domain = domain,
+                    location = location,
+                    project_id = match self.properties.project_id.as_ref() {
+                        Some(project_id) => project_id.to_string(),
+                        None => vertex_auth.project_id().await?.to_string(),
+                    }
+                )
+            },
         };
 
         let baml_original_url = format!(

--- a/fern/03-reference/baml/clients/providers/vertex.mdx
+++ b/fern/03-reference/baml/clients/providers/vertex.mdx
@@ -117,6 +117,11 @@ You can use this to modify the `headers` and `base_url` for example.
   https://{LOCATION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/{LOCATION}/publishers/google/models/
   ```
 
+  If the location is `global`, the base URL will be:
+  ```
+  https://aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/global/publishers/google/models/
+  ```
+
   Can be used in lieu of the **`project_id`** and **`location`** fields, to manually set the request URL.
 </ParamField>
 


### PR DESCRIPTION
Closes #2014
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes base URL inference for Vertex AI 'global' location in `vertex_client.rs` and updates documentation in `vertex.mdx`.
> 
>   - **Behavior**:
>     - Corrects base URL inference for Vertex AI when location is 'global' in `vertex_client.rs`.
>     - Uses `aiplatform.googleapis.com` instead of `{location}-aiplatform.googleapis.com` for 'global'.
>   - **Documentation**:
>     - Updates `vertex.mdx` to document the base URL format for 'global' location.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for d9947c342ae409fe97469e4f42c634e13bb13787. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->