### PR TITLE
Fix bug where LSP crashed when a baml file not in a baml_src was opened

### DIFF
--- a/engine/language_server/src/server/api.rs
+++ b/engine/language_server/src/server/api.rs
@@ -134,6 +134,10 @@ pub(super) fn request<'a>(req: lsp_server::Request) -> Task<'a> {
                         .map_err(|e| anyhow::anyhow!("Failed to parse JSON: {e}"))?;
                     let url = Url::parse(&params.project_id)
                         .map_err(|e| anyhow::anyhow!("Failed to parse URL: {e}"))?;
+                    if !url.to_string().contains("baml_src") {
+                        return Ok(());
+                    }
+
                     let project = session
                         .get_or_create_project(&url.to_file_path().unwrap())
                         .expect("Already checked for project's existence");

--- a/engine/language_server/src/server/api/notifications/did_change.rs
+++ b/engine/language_server/src/server/api/notifications/did_change.rs
@@ -28,6 +28,10 @@ impl SyncNotificationHandler for DidChangeTextDocumentHandler {
         let start_time_total = Instant::now();
 
         let url = params.text_document.uri;
+        if !url.to_string().contains("baml_src") {
+            return Ok(());
+        }
+
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;

--- a/engine/language_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/engine/language_server/src/server/api/notifications/did_change_watched_files.rs
@@ -21,6 +21,14 @@ impl super::SyncNotificationHandler for DidChangeWatchedFiles {
         params: types::DidChangeWatchedFilesParams,
     ) -> Result<()> {
         tracing::info!("#### DidChangeWatchedFiles {:?}", params.changes);
+        if !params
+            .changes
+            .iter()
+            .any(|change| change.uri.to_string().contains("baml_src"))
+        {
+            return Ok(());
+        }
+
         // Filter out CHANGED events - only process CREATED and DELETED
         let filtered_changes: Vec<_> = params
             .changes

--- a/engine/language_server/src/server/api/notifications/did_close.rs
+++ b/engine/language_server/src/server/api/notifications/did_close.rs
@@ -27,8 +27,11 @@ impl SyncNotificationHandler for DidCloseTextDocumentHandler {
         _requester: &mut Requester,
         params: DidCloseTextDocumentParams,
     ) -> Result<()> {
-        tracing::info!("------------ DidCloseTextDocumentHandler");
         let url = params.text_document.uri;
+        if !url.to_string().contains("baml_src") {
+            return Ok(());
+        }
+
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;

--- a/engine/language_server/src/server/api/notifications/did_open.rs
+++ b/engine/language_server/src/server/api/notifications/did_open.rs
@@ -27,6 +27,9 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
         tracing::info!("DidOpenTextDocumentHandler");
 
         let url = params.text_document.uri;
+        if !url.to_string().contains("baml_src") {
+            return Ok(());
+        }
 
         // TODO: do this when server initializes instead of every time a file is opened
         // note this just schedules the task. It will run after the current task is done.

--- a/engine/language_server/src/server/api/notifications/did_save_text_document.rs
+++ b/engine/language_server/src/server/api/notifications/did_save_text_document.rs
@@ -23,6 +23,10 @@ impl super::SyncNotificationHandler for DidSaveTextDocument {
     ) -> Result<()> {
         tracing::info!("Did save text document---------");
         let url = params.text_document.uri;
+        if !url.to_string().contains("baml_src") {
+            return Ok(());
+        }
+
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;

--- a/engine/language_server/src/server/api/requests/code_lens.rs
+++ b/engine/language_server/src/server/api/requests/code_lens.rs
@@ -26,6 +26,10 @@ impl SyncRequestHandler for CodeLens {
     ) -> Result<Option<Vec<lsp_types::CodeLens>>> {
         tracing::info!("CodeLens request");
         let url = params.text_document.uri.clone();
+        if !url.to_string().contains("baml_src") {
+            return Ok(None);
+        }
+
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;

--- a/engine/language_server/src/server/api/requests/completion.rs
+++ b/engine/language_server/src/server/api/requests/completion.rs
@@ -20,6 +20,11 @@ impl SyncRequestHandler for Completion {
         _requester: &mut Requester,
         params: CompletionParams,
     ) -> Result<Option<lsp_types::CompletionResponse>> {
+        let url = params.text_document_position.text_document.uri;
+        if !url.to_string().contains("baml_src") {
+            return Ok(None);
+        }
+
         // TODO: Enable this only if you
         // 1. test on windows, with chinese characters
         // 2. Modify position_utils.rs to use byte offsets to account for chinese/multibyte characters

--- a/engine/language_server/src/server/api/requests/diagnostic.rs
+++ b/engine/language_server/src/server/api/requests/diagnostic.rs
@@ -4,7 +4,8 @@ use std::sync::{Arc, Mutex};
 use lsp_types::request::DocumentDiagnosticRequest;
 use lsp_types::{
     DocumentDiagnosticParams, DocumentDiagnosticReport, DocumentDiagnosticReportResult,
-    FullDocumentDiagnosticReport, RelatedFullDocumentDiagnosticReport, Url,
+    FullDocumentDiagnosticReport, RelatedFullDocumentDiagnosticReport,
+    RelatedUnchangedDocumentDiagnosticReport, UnchangedDocumentDiagnosticReport, Url,
 };
 
 use crate::baml_project::Project;
@@ -48,6 +49,17 @@ impl SyncRequestHandler for DocumentDiagnosticRequestHandler {
         params: DocumentDiagnosticParams,
     ) -> Result<DocumentDiagnosticReportResult> {
         let url = params.text_document.uri.clone();
+        if !url.to_string().contains("baml_src") {
+            return Ok(DocumentDiagnosticReportResult::Report(
+                DocumentDiagnosticReport::Unchanged(RelatedUnchangedDocumentDiagnosticReport {
+                    related_documents: None,
+                    unchanged_document_diagnostic_report: UnchangedDocumentDiagnosticReport {
+                        result_id: "".to_string(),
+                    },
+                }),
+            ));
+        }
+
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;

--- a/engine/language_server/src/server/api/requests/format.rs
+++ b/engine/language_server/src/server/api/requests/format.rs
@@ -20,6 +20,11 @@ impl SyncRequestHandler for DocumentFormatting {
         _requester: &mut Requester,
         params: DocumentFormattingParams,
     ) -> Result<Option<Vec<lsp_types::TextEdit>>> {
+        let url = params.text_document.uri;
+        if !url.to_string().contains("baml_src") {
+            return Ok(None);
+        }
+
         // let url = &params.text_document.uri;
         // let path = url
         //     .to_file_path()

--- a/engine/language_server/src/server/api/requests/go_to_definition.rs
+++ b/engine/language_server/src/server/api/requests/go_to_definition.rs
@@ -29,6 +29,10 @@ impl SyncRequestHandler for GotoDefinition {
             .text_document
             .uri
             .clone();
+        if !url.to_string().contains("baml_src") {
+            return Ok(None);
+        }
+
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;

--- a/engine/language_server/src/server/api/requests/hover.rs
+++ b/engine/language_server/src/server/api/requests/hover.rs
@@ -19,6 +19,10 @@ impl SyncRequestHandler for Hover {
         params: HoverParams,
     ) -> Result<Option<types::Hover>> {
         let url = &params.text_document_position_params.text_document.uri;
+        if !url.to_string().contains("baml_src") {
+            return Ok(None);
+        }
+
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;

--- a/engine/language_server/src/server/api/requests/rename.rs
+++ b/engine/language_server/src/server/api/requests/rename.rs
@@ -26,6 +26,10 @@ impl SyncRequestHandler for Rename {
         params: RenameParams,
     ) -> Result<Option<lsp_types::WorkspaceEdit>> {
         let url = params.text_document_position.text_document.uri;
+        if !url.to_string().contains("baml_src") {
+            return Ok(None);
+        }
+
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix LSP crash by ensuring operations only on files within `baml_src` across various handlers.
> 
>   - **Behavior**:
>     - Added checks in `api.rs`, `did_change.rs`, `did_change_watched_files.rs`, `did_close.rs`, `did_open.rs`, `did_save_text_document.rs`, `code_lens.rs`, `completion.rs`, `diagnostic.rs`, `format.rs`, `go_to_definition.rs`, `hover.rs`, and `rename.rs` to ensure operations are only performed on files within `baml_src`.
>     - If a file is not in `baml_src`, the functions return early without processing.
>   - **Notifications**:
>     - `DidChangeTextDocumentHandler`, `DidChangeWatchedFiles`, `DidCloseTextDocumentHandler`, `DidOpenTextDocumentHandler`, and `DidSaveTextDocument` now check for `baml_src` in file paths.
>   - **Requests**:
>     - `CodeLens`, `Completion`, `DocumentDiagnosticRequestHandler`, `DocumentFormatting`, `GotoDefinition`, `Hover`, and `Rename` handlers now include checks for `baml_src` in file paths.
>   - **Misc**:
>     - Added an empty `test.baml` file in `integ-tests/` for integration testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for a6035c2f4ce1a5e5e0c0fddd045cb5e00637e5f6. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->