### PR TITLE
fix muslcc build

### DIFF
--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -48,8 +48,9 @@ jobs:
 
           - target: x86_64-unknown-linux-musl
             host: ubuntu-22.04
+            # muslcc url needs to change eventually. https://github.com/elixir-sqlite/exqlite/issues/327
             before: |
-              curl -LO https://musl.cc/x86_64-linux-musl-cross.tgz
+              curl -LO https://musl.cc.timfish.dev/x86_64-linux-musl-cross.tgz
               tar -xzf x86_64-linux-musl-cross.tgz
               echo "$PWD/x86_64-linux-musl-cross/bin" >> $GITHUB_PATH
 
@@ -63,8 +64,9 @@ jobs:
 
           - target: aarch64-unknown-linux-musl
             host: ubuntu-22.04
+            # muslcc url needs to change eventually. https://github.com/elixir-sqlite/exqlite/issues/327
             before: |
-              curl -LO https://musl.cc/aarch64-linux-musl-cross.tgz
+              curl -LO https://musl.cc.timfish.dev/aarch64-linux-musl-cross.tgz
               tar -xzf aarch64-linux-musl-cross.tgz
               echo "$PWD/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
               cat >>$GITHUB_ENV <<EOF


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update muslcc download URL in GitHub Actions workflow for musl targets.
> 
>   - **Build Process**:
>     - Update muslcc download URL in `build-typescript-release.reusable.yaml` for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets.
>     - New URL: `https://musl.cc.timfish.dev` instead of `https://musl.cc`.
>     - Adds comments indicating the URL may need future changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for bea37f8db836aec25fe6777a4e9d730397875c40. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->