### PR TITLE
Fix fatal log line showing up with publisher not started

### DIFF
--- a/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
@@ -54,9 +54,10 @@ fn get_publish_channel(
     {
         let Some(join_handle) = PUBLISHING_TASK.get() else {
             if !allow_missing {
-                baml_log::fatal_once!(
-                    "Tracing publisher not started. Report this bug to the BAML team."
-                );
+                // baml_log::fatal_once!(
+                //     "Tracing publisher not started. Report this bug to the BAML team."
+                // );
+                // TODO: redo this logic -- we dont start the publisher if there's no api key for example.
             }
             return None;
         };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Commented out fatal log line in `get_publish_channel` in `publisher.rs` to prevent logging when publisher is not started, with a TODO to revisit logic.
> 
>   - **Logging**:
>     - Commented out `baml_log::fatal_once!` in `get_publish_channel` in `publisher.rs` to prevent fatal log when publisher is not started.
>     - Added TODO comment to revisit logic for cases like missing API key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 2d96e11e2658688d6bda617a43f7276454672cb4. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->