### PR TITLE
fix: pass in env vars for cli tests

### DIFF
--- a/engine/baml-runtime/src/cli/testing.rs
+++ b/engine/baml-runtime/src/cli/testing.rs
@@ -124,7 +124,8 @@ impl TestArgs {
             }
         }
 
-        let runtime = BamlRuntime::from_directory(&from, std::env::vars().collect())?;
+        let env_vars = std::env::vars().collect::<HashMap<String, String>>();
+        let runtime = BamlRuntime::from_directory(&from, env_vars.clone())?;
         let runtime = std::sync::Arc::new(runtime);
 
         let test_execution_args = TestFilter::from(
@@ -151,6 +152,7 @@ impl TestArgs {
                     *parallel,
                     output_format,
                     if *junit { Some(junit_path) } else { None },
+                    &env_vars,
                 )
                 .await
             {

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -411,14 +411,8 @@ impl BamlRuntime {
     where
         F: Fn(FunctionResult),
     {
-        log::info!("env vars1: {:#?}", env_vars.clone());
 
         baml_log::set_from_env(&env_vars).unwrap();
-        baml_log::info!("env vars: {:#?}", env_vars.clone());
-        log::info!("env vars2: {:#?}", env_vars.clone());
-        for (key, value) in env_vars.iter() {
-            log::info!("env var: {} = {}", key, value);
-        }
 
         let call = self
             .tracer_wrapper

--- a/engine/baml-runtime/src/test_executor/mod.rs
+++ b/engine/baml-runtime/src/test_executor/mod.rs
@@ -45,6 +45,7 @@ pub trait TestExecutor {
         max_concurrency: usize,
         output_format: &crate::cli::testing::OutputFormat,
         junit_path: Option<&String>,
+        env_vars: &HashMap<String, String>,
     ) -> TestRunStatus;
 }
 
@@ -180,6 +181,7 @@ impl TestExecutor for BamlRuntime {
         max_concurrency: usize,
         output_format: &crate::cli::testing::OutputFormat,
         junit_path: Option<&String>,
+        env_vars: &HashMap<String, String>,
     ) -> TestRunStatus {
         let renderer = AggregateRenderer::new(output_format, junit_path);
         let selected_tests = self
@@ -219,6 +221,7 @@ impl TestExecutor for BamlRuntime {
                 let runtime = self.clone();
                 let function_name = fn_name.to_string();
                 let test_name = tt_name.to_string();
+                let env_vars = env_vars.clone();
                 let fut = tokio::spawn(async move {
                     let _permit = semaphore.acquire().await.unwrap();
                     let ctx_manager = runtime.create_ctx_manager(
@@ -233,7 +236,7 @@ impl TestExecutor for BamlRuntime {
                         TestExecutionStatus::Running,
                     ));
                     let (result, _) = runtime
-                        .run_test(&function_name, &test_name, &ctx_manager, Some(|_| {}), None, HashMap::new())
+                        .run_test(&function_name, &test_name, &ctx_manager, Some(|_| {}), None, env_vars)
                         .await;
                     let duration = start_instant.elapsed();
                     let _ = tx.send((


### PR DESCRIPTION
A bug was introduced in #1949 which was not injecting env vars for `baml-cli test`
This PR fixes that by passing in the environment variables.

Fixes #2051 

<img width="880" alt="image" src="https://github.com/user-attachments/assets/6df90bcc-4ef7-4d7c-9d68-e938957ef0e3" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes bug in `baml-cli test` by passing environment variables to `BamlRuntime` and `TestExecutor`.
> 
>   - **Behavior**:
>     - Fixes bug in `baml-cli test` by passing environment variables to `BamlRuntime::from_directory` and `TestExecutor::cli_run_tests`.
>     - Collects environment variables into `HashMap` and passes them to `BamlRuntime` and `TestExecutor`.
>   - **Functions**:
>     - Updates `BamlRuntime::from_directory` in `lib.rs` to accept `env_vars`.
>     - Updates `TestExecutor::cli_run_tests` in `test_executor/mod.rs` to accept `env_vars`.
>   - **Misc**:
>     - Removes redundant logging of environment variables in `lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for db380e267a581febc9a21aab161c2c5b2d741d54. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->