### PR TITLE
fix VSCode Proxy Handling due to v2 -> v3 for npm:http-proxy-middleware

### DIFF
--- a/typescript/vscode-ext/packages/vscode/src/extension.ts
+++ b/typescript/vscode-ext/packages/vscode/src/extension.ts
@@ -22,6 +22,7 @@ let highlightRanges: vscode.Range[] = []
 
 import type { Express } from 'express'
 import StatusBarPanel from './panels/StatusBarPanel'
+import { Socket } from 'net'
 
 export function activate(context: vscode.ExtensionContext) {
   console.log('BAML extension activating')
@@ -60,71 +61,75 @@ export function activate(context: vscode.ExtensionContext) {
 
   app.use(
     createProxyMiddleware({
-      changeOrigin: true,
+      changeOrigin: true, // leave prependPath = true (default)
+      /** Inspect and (maybe) rewrite the path. */
       pathRewrite: (path, req) => {
-        console.log('reqmethod', req.method)
-
-        // Remove the path in the case of images. Since we request things differently for image GET requests, where we add the url to localhost:4500/actual-url.png
-        // to prevent caching issues with Rust reqwest.
-        // But for normal completion POST requests, we always call localhost:4500.
-        // The original url is always in baml-original-url header.
-
-        // Check for file extensions and set path to empty string.
-        if (/\.[a-zA-Z0-9]+$/.test(path) && req.method === 'GET') {
+        // If the path looks like an image (xyz.png …) and it's a GET → blank it.
+        if (/\.[a-z0-9]+$/i.test(path) && req.method === 'GET') {
+          console.log('[PROXY] Image request detected, clearing path:', path)
           return ''
         }
-        // Remove trailing slash
-        if (path.endsWith('/')) {
-          return path.slice(0, -1)
-        }
-        return path
+
+        // Remove trailing slash so we don't end up with "//".
+        const out = path.endsWith('/') ? path.slice(0, -1) : path
+        return out
       },
+
+      /** Dynamically choose target and massage req.url. */
       router: (req) => {
-        // Extract the original target URL from the custom header
-        let originalUrl = req.headers['baml-original-url']
-        if (typeof originalUrl === 'string') {
-          // For some reason, Node doesn't like deleting headers in the proxyReq function.
-          delete req.headers['baml-original-url']
-          delete req.headers['origin']
-
-          // Ensure the URL does not end with a slash
-          console.log('originalUrl1', originalUrl)
-          if (originalUrl.endsWith('/')) {
-            originalUrl = originalUrl.slice(0, -1)
-          }
-          console.log('returning original url', originalUrl)
-          // return new URL(originalUrl).toString()
-
-          return originalUrl
-        } else {
-          console.log('baml-original-url header is missing or invalid')
-          throw new Error('baml-original-url header is missing or invalid')
+        const raw = req.headers['baml-original-url']
+        if (typeof raw !== 'string') {
+          throw new Error('missing baml-original-url header')
         }
-      },
-      logger: console,
-      on: {
-        proxyReq: (proxyReq, req, res) => {
-          // const bamlOriginalUrl = req.headers['baml-original-url']
-          // if (typeof bamlOriginalUrl === 'string') {
-          //   const targetUrl = new URL(bamlOriginalUrl)
-          //   // Copy all original headers except those we want to modify/remove
-          //   Object.entries(req.headers).forEach(([key, value]) => {
-          //     if (key !== 'host' && key !== 'origin' && key !== 'baml-original-url') {
-          //       proxyReq.setHeader(key, value)
-          //     }
-          //   })
-          //   // Set the correct origin and host headers
-          //   proxyReq.setHeader('origin', targetUrl.origin)
-          //   proxyReq.setHeader('host', targetUrl.host)
-          // }
-        },
-        proxyRes: (proxyRes, req, res) => {
-          proxyRes.headers['Access-Control-Allow-Origin'] = '*'
-        },
-        error: (error, req, res) => {
-          console.error('proxy error:', error)
 
-          res.end(JSON.stringify({ error: error }))
+        // Clean up headers the upstream may reject
+        delete req.headers['baml-original-url']
+        delete req.headers['origin']
+
+        // Strip trailing slash on header value, then parse
+        const cleanRaw = raw.endsWith('/') ? raw.slice(0, -1) : raw
+        const url = new URL(cleanRaw)
+
+        // Base path to prepend *if necessary*
+        const basePath = url.pathname.replace(/\/$/, '') // '/compat/v1' → '/compat/v1'
+        if (!req.url) {
+          throw new Error('missing req.url')
+        }
+
+        // Guard against double-prefixing
+        if (basePath && !req.url.startsWith(basePath)) {
+          // Ensure there's exactly one slash between basePath and existing path
+          req.url = basePath + (req.url.startsWith('/') ? '' : '/') + req.url
+        }
+
+        console.log('[PROXY]', req.method, req.url, '→', url.origin)
+
+        // Tell HPM to proxy to the origin only (scheme + host)
+        return url.origin // e.g. "https://api.llama.com"
+      },
+
+      logger: console,
+
+      on: {
+        /** Add CORS header. */
+        proxyRes: (proxyRes, req) => {
+          proxyRes.headers['access-control-allow-origin'] = '*'
+          console.log('[PROXY]', req.method, req.url, '←', proxyRes.statusCode)
+        },
+
+        /** Robust error reporter with type-guard. */
+        error: (err, req, res) => {
+          console.error('[PROXY ERROR]', req.method, req.url, ':', err.message)
+
+          if ('writeHead' in res) {
+            const svr = res
+            if (!svr.headersSent) {
+              svr.writeHead(500, { 'content-type': 'application/json' })
+            }
+            svr.end(JSON.stringify({ error: err.message }))
+          } else if (res instanceof Socket) {
+            res.destroy()
+          }
         },
       },
     }),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves proxy handling in `extension.ts` for VSCode extension to support `http-proxy-middleware` v3, including path rewriting, dynamic target selection, and enhanced error handling.
> 
>   - **Proxy Handling**:
>     - Updated `pathRewrite` to clear paths for image GET requests and remove trailing slashes in `extension.ts`.
>     - Enhanced `router` to dynamically choose target based on `baml-original-url` header, ensuring no double-prefixing.
>     - Improved error handling in `error` event to robustly report errors and handle socket destruction.
>   - **Misc**:
>     - Added CORS header in `proxyRes` event to allow all origins.
>     - Added logging for proxy requests and responses for better debugging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 31ec83d9ce9bf03cfa35bf7c63acd365a1b525d6. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->