### PR TITLE
Add `clippy` and `rustfmt` with import order configs to vscode on save

### DIFF
--- a/root-wasm32.code-workspace
+++ b/root-wasm32.code-workspace
@@ -1,6 +1,10 @@
 {
   "folders": [
     {
+      "name": "baml",
+      "path": "."
+    },
+    {
       "path": ".github"
     },
     {
@@ -8,6 +12,9 @@
     },
     {
       "path": "engine"
+    },
+    {
+      "path": "engine/baml-schema-wasm"
     },
     {
       "path": "integ-tests"
@@ -53,9 +60,17 @@
     "git.openDiffOnClick": true,
     "python.analysis.typeCheckingMode": "strict",
     "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
+    "rust-analyzer.check.command": "clippy",
     "rust-analyzer.procMacro.ignored": {
       "napi-derive": ["napi"]
     },
+    "rust-analyzer.rustfmt.overrideCommand": [
+      "rustfmt",
+      "--config",
+      "imports_granularity=Crate",
+      "--config",
+      "group_imports=StdExternalCrate"
+    ],
     "sorbet.enabled": true,
     "sorbet.lspConfigs": [
       {

--- a/root.code-workspace
+++ b/root.code-workspace
@@ -75,6 +75,14 @@
     "rust-analyzer.procMacro.ignored": {
       "napi-derive": ["napi"]
     },
+    "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.rustfmt.overrideCommand": [
+      "rustfmt",
+      "--config",
+      "imports_granularity=Crate",
+      "--config",
+      "group_imports=StdExternalCrate"
+    ],
     "sorbet.enabled": true,
     "sorbet.lspConfigs": [
       {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `clippy` and `rustfmt` configurations to VSCode workspace settings for Rust projects.
> 
>   - **VSCode Workspace Configuration**:
>     - Add `clippy` as the check command in `rust-analyzer` settings in `root-wasm32.code-workspace` and `root.code-workspace`.
>     - Configure `rustfmt` to use `imports_granularity=Crate` and `group_imports=StdExternalCrate` in both workspace files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ab077829bcff7a31d7e47f89daf9ac8fbfff1fad. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->