### PR TITLE
add a pre-commit hook to run cargo fmt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,14 @@ Issues labeled `good first issue` are a good place to start.
 
 4. Run the integration tests.
 
+5. **Set up Git hooks (Recommended)**:
+   - Install the pre-commit hook to automatically format Rust code:
+     ```bash
+     ./tools/install-hooks
+     ```
+   - This hook will run `cargo fmt` with import organization before each commit
+   - If formatting changes are made, you'll need to review and re-commit the changes
+
 ## Running Integration Tests
 
 The integration tests verify BAML's functionality across multiple programming languages. Each language has its own test suite in the `integ-tests/` directory.

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+#
+# Pre-commit hook that runs cargo fmt with import organization
+#
+
+# Exit on any error
+set -e
+
+echo "Running cargo fmt with import organization..."
+
+# Get the repository root directory
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Change to the engine directory where Cargo.toml is located
+cd "$REPO_ROOT/engine"
+
+# Run cargo fmt with the specified configuration
+cargo fmt -- --config imports_granularity="Crate" --config group_imports="StdExternalCrate"
+
+# Change to repo root to check git diff
+cd "$REPO_ROOT"
+
+# Check if there are any formatting changes
+if ! git diff --quiet --exit-code; then
+    echo "Code has been formatted. Please review and add the changes:"
+    echo "  git add ."
+    echo "  git commit"
+    exit 1
+fi
+
+echo "Code formatting check passed." 

--- a/tools/hooks/pre-commit
+++ b/tools/hooks/pre-commit
@@ -28,4 +28,4 @@ if ! git diff --quiet --exit-code; then
     exit 1
 fi
 
-echo "Code formatting check passed." 
+echo "Code formatting check passed."

--- a/tools/install-hooks
+++ b/tools/install-hooks
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Install Git hooks for the BAML project
+#
+
+set -e
+
+# Get the repository root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+echo "Installing Git hooks..."
+
+# Copy hooks to .git/hooks/
+cp "$REPO_ROOT/tools/hooks/pre-commit" "$REPO_ROOT/.git/hooks/pre-commit"
+
+# Make sure they're executable
+chmod +x "$REPO_ROOT/.git/hooks/pre-commit"
+
+echo "✓ Pre-commit hook installed successfully!"
+echo ""
+echo "This hook will run 'cargo fmt' with import organization before each commit."
+echo "If formatting changes are made, you'll need to review and re-commit." 

--- a/tools/install-hooks
+++ b/tools/install-hooks
@@ -19,4 +19,5 @@ chmod +x "$REPO_ROOT/.git/hooks/pre-commit"
 echo "✓ Pre-commit hook installed successfully!"
 echo ""
 echo "This hook will run 'cargo fmt' with import organization before each commit."
-echo "If formatting changes are made, you'll need to review and re-commit." 
+echo "If formatting changes are made, you'll need to review and re-commit."
+ 


### PR DESCRIPTION
 -  Adds a pre-commit hook to run cargo fmt
 
 Install the pre-commit hook by running `./tools/install-hooks`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a pre-commit hook to run `cargo fmt` for Rust code formatting, with installation instructions in `CONTRIBUTING.md`.
> 
>   - **Pre-commit Hook**:
>     - Adds `pre-commit` hook in `tools/hooks/pre-commit` to run `cargo fmt` with import organization before each commit.
>     - If formatting changes occur, prompts user to review and re-commit.
>   - **Installation**:
>     - Adds `install-hooks` script in `tools/install-hooks` to install the pre-commit hook.
>     - Ensures the hook is executable and copies it to `.git/hooks/`.
>   - **Documentation**:
>     - Updates `CONTRIBUTING.md` to recommend setting up Git hooks and provide installation instructions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ef3afe008d2446521c7f8929864444c0121b264f. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->