### PR TITLE
Fix prompt-fiddle highlighting

### DIFF
--- a/engine/baml-lib/ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/ast/src/parser/datamodel.pest
@@ -233,11 +233,11 @@ top_level_assignment = { stmt }
 expr_fn = { ("function" | "fn") ~ identifier ~ named_argument_list ~ ARROW? ~ field_type_chain? ~ expr_block }
 
 // Body of a function (including curly brackets).
-expr_block = { BLOCK_OPEN ~ NEWLINE? ~ (stmt ~ NEWLINE)* ~ expression ~ NEWLINE? ~ BLOCK_CLOSE }
+expr_block = { BLOCK_OPEN ~ NEWLINE? ~ (stmt | comment_block | empty_lines)* ~ expression ~ NEWLINE? ~ BLOCK_CLOSE }
 
 // Statement.
 // Currently the only statement is a let-binding.
-stmt = { let_expr ~ SEMICOLON? }
+stmt = { let_expr ~ SEMICOLON? ~ trailing_comment? ~ NEWLINE? }
 
 // Let-binding statement.
 let_expr = { "let" ~ identifier ~ "=" ~ expression }

--- a/engine/baml-lib/ast/src/parser/parse_expr.rs
+++ b/engine/baml-lib/ast/src/parser/parse_expr.rs
@@ -146,6 +146,14 @@ pub fn parse_expr_block(token: Pair<'_>, diagnostics: &mut Diagnostics) -> Optio
             Rule::NEWLINE => {
                 continue;
             }
+            Rule::comment_block => {
+                // Skip comments in function bodies
+                continue;
+            }
+            Rule::empty_lines => {
+                // Skip empty lines in function bodies
+                continue;
+            }
             _ => {
                 diagnostics.push_error(DatamodelError::new_static(
                     "Internal Error: Parser only allows statements and expressions in function body.",

--- a/engine/baml-lib/baml/tests/validation_files/expr/builtin.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/builtin.baml
@@ -21,6 +21,18 @@ function GetTodoMissingTypeArg() -> Todo {
   })
 }
 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/builtin.baml:8
+//    | 
+//  7 | 
+//  8 | function GetTodo() -> Todo {
+//    | 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/builtin.baml:16
+//    | 
+// 15 | 
+// 16 | function GetTodoMissingTypeArg() -> Todo {
+//    | 
 // error: Generic function std::fetch_value must have a type argument. Try adding a type argument like this: std::fetch_value<Type>
 //   -->  expr/builtin.baml:17
 //    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/constructors.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/constructors.baml
@@ -20,3 +20,26 @@ class Person {
   age int
   poem string
 }
+
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/constructors.baml:6
+//    | 
+//  5 | 
+//  6 | let x = MyClass { a: 1, b: "2" };
+//    | 
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/constructors.baml:8
+//    | 
+//  7 | 
+//  8 | let y = MyClass { a: 1, ..x };
+//    | 
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/constructors.baml:11
+//    | 
+// 10 | 
+// 11 | let default_person = Person {
+// 12 |     name: "John Doe",
+// 13 |     age: 20,
+// 14 |     poem: "Never was there a man more plain."
+// 15 | };
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/constructors_invalid.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/constructors_invalid.baml
@@ -18,6 +18,12 @@ fn Foo() -> Bar {
   x
 }
 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/constructors_invalid.baml:6
+//    | 
+//  5 | 
+//  6 | fn Foo() -> Bar {
+//    | 
 // error: Error validating: Bar.a expected type int, but found string
 //   -->  expr/constructors_invalid.baml:7
 //    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/constructors_nested.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/constructors_nested.baml
@@ -8,6 +8,12 @@ class Bar {
 
 let x = Foo { bar: Bar { name: 10 }};
 
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/constructors_nested.baml:9
+//    | 
+//  8 | 
+//  9 | let x = Foo { bar: Bar { name: 10 }};
+//    | 
 // error: Error validating: Bar.name expected type string, but found int
 //   -->  expr/constructors_nested.baml:9
 //    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/expr_fn.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/expr_fn.baml
@@ -4,6 +4,7 @@ function Foo(x: int) -> int {
 }
 
 fn Bar(x: int) -> int {
+    // test
     let y = x;
     x
 }
@@ -14,3 +15,16 @@ test TestBar {
         x 1
     }
 }
+
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/expr_fn.baml:1
+//    | 
+//    | 
+//  1 | function Foo(x: int) -> int {
+//    | 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/expr_fn.baml:6
+//    | 
+//  5 | 
+//  6 | fn Bar(x: int) -> int {
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/expr_full.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/expr_full.baml
@@ -1,4 +1,3 @@
-
 function MakePoem(length: int) -> string {
     client GPT4o
     prompt #"Write a poem {{ length }} lines long."#
@@ -69,3 +68,38 @@ test TestMakePoem() {
     functions [MakePoem]
     args { length 4 }
 }
+
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/expr_full.baml:27
+//    | 
+// 26 | 
+// 27 | function Pipeline() -> string {
+//    | 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/expr_full.baml:37
+//    | 
+// 36 | 
+// 37 | function Pyramid() -> string {
+//    | 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/expr_full.baml:41
+//    | 
+// 40 | 
+// 41 | function OuterPyramid() -> string {
+//    | 
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/expr_full.baml:19
+//    | 
+// 18 | 
+// 19 | let poem = MakePoem(10);
+//    | 
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/expr_full.baml:21
+//    | 
+// 20 | 
+// 21 | let another = {
+// 22 |   let x = MakePoem(10);
+// 23 |   let y = MakePoem(5);
+// 24 |   CombinePoems(x,y)
+// 25 | };
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/expr_list.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/expr_list.baml
@@ -5,3 +5,16 @@ function Id(x: int) -> int {
 function Go(x: int) -> int[] {
  [x, Id(x), 3]
 }
+
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/expr_list.baml:1
+//    | 
+//    | 
+//  1 | function Id(x: int) -> int {
+//    | 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/expr_list.baml:5
+//    | 
+//  4 | 
+//  5 | function Go(x: int) -> int[] {
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/expr_small.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/expr_small.baml
@@ -1,3 +1,10 @@
 function A(x: int) -> int {
     x
 }
+
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/expr_small.baml:1
+//    | 
+//    | 
+//  1 | function A(x: int) -> int {
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/for_loop.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/for_loop.baml
@@ -6,6 +6,18 @@ function Foo() -> int {
 
 let x = for (i in "hi") { b };
 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/for_loop.baml:1
+//    | 
+//    | 
+//  1 | function Foo() -> int {
+//    | 
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/for_loop.baml:7
+//    | 
+//  6 | 
+//  7 | let x = for (i in "hi") { b };
+//    | 
 // error: Error validating: For loop must iterate over a list
 //   -->  expr/for_loop.baml:3
 //    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/if.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/if.baml
@@ -5,3 +5,10 @@ let z = if true {
 } else {
     13
 };
+
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/if.baml:1
+//    | 
+//    | 
+//  1 | let x = if true { 1 } else { 2 };
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/missing_semicolons.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/missing_semicolons.baml
@@ -11,10 +11,12 @@ let x = 1
 //    | 
 //  2 | function Foo(x: int) -> int {
 //  3 |     let y = "hello"
+//  4 |     x
 //    | 
 // error: Statement must end with a semicolon.
 //   -->  expr/missing_semicolons.baml:7
 //    | 
 //  6 | 
 //  7 | let x = 1
+//  8 | 
 //    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/mixed_pipeline.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/mixed_pipeline.baml
@@ -14,3 +14,10 @@ client<llm> GPT4o {
     api_key env.OPENAI_API_KEY
   }
 }
+
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/mixed_pipeline.baml:6
+//    | 
+//  5 | 
+//  6 | function UseLLM(x: int) -> int {
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/top_level_binding.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/top_level_binding.baml
@@ -4,3 +4,19 @@ let y = {
     let b = 2;
     [1,2,3]
 };
+
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/top_level_binding.baml:1
+//    | 
+//    | 
+//  1 | let x = 1;
+//    | 
+// warning: Variable assignment is experimental, and will break in the future.
+//   -->  expr/top_level_binding.baml:3
+//    | 
+//  2 | 
+//  3 | let y = {
+//  4 |     let b = 2;
+//  5 |     [1,2,3]
+//  6 | };
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/expr/unknown_name.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/unknown_name.baml
@@ -13,6 +13,24 @@ function Go3(x:int) -> int {
     Unknown(x)
 }
 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/unknown_name.baml:1
+//    | 
+//    | 
+//  1 | function Go(x: int) -> int {
+//    | 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/unknown_name.baml:6
+//    | 
+//  5 | 
+//  6 | function Go2(x: int) -> int {
+//    | 
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  expr/unknown_name.baml:12
+//    | 
+// 11 | 
+// 12 | function Go3(x:int) -> int {
+//    | 
 // error: Unknown variable a
 //   -->  expr/unknown_name.baml:2
 //    | 

--- a/typescript/codemirror-lang-baml/package.json
+++ b/typescript/codemirror-lang-baml/package.json
@@ -4,7 +4,7 @@
   "description": "BAML language support for CodeMirror",
   "packageManager": "pnpm@9.12.0",
   "scripts": {
-    "test": "mocha test/test.js",
+    "test": "mocha test/test.cjs",
     "prepare": "rollup -c"
   },
   "type": "module",

--- a/typescript/codemirror-lang-baml/src/syntax.grammar
+++ b/typescript/codemirror-lang-baml/src/syntax.grammar
@@ -56,13 +56,12 @@ FunctionArg {
   IdentifierDecl ":" TypeExpr
 }
 FunctionValueAtom {
-  LiteralDecl | PromptExpr
+  LiteralDecl | PromptExpr | IdentifierDecl
 }
 FunctionValueExpr {
   FunctionValueAtom |
   "{" LetDecl* FunctionValueExpr "}" |
-  IdentifierDecl "(" (FunctionValueExpr ("," FunctionValueExpr)*)? ")" |
-  ClassConstructor
+  IdentifierDecl "(" (FunctionValueExpr ("," FunctionValueExpr)*)? ")"
 }
 
 ClassConstructor {
@@ -74,15 +73,18 @@ ClassConstructorField {
 }
 FunctionTupleValue { (ClientKeyword | PromptKeyword) FunctionValueAtom }
 
-ConfigValueExpr { LiteralDecl | PromptExpr | UnquotedString | "{" ConfigTupleValue* "}" }
+ConfigValueExpr { LiteralDecl | PromptExpr | UnquotedString | ListValue | ConfigMap }
 ConfigTupleValue { IdentifierDecl ConfigValueExpr }
+
+ListValue { "[" (IdentifierDecl ("," IdentifierDecl)*)? "]" }
+ConfigMap { "{" ConfigTupleValue* "}" }
 
 ClientDecl {
   "client<llm>" IdentifierDecl "{" ConfigTupleValue* "}"
 }
 
 TestDecl {
-  "test" IdentifierDecl "{" (BlockAttribute | FunctionTupleValue | TypeBuilderDecl)* "}"
+  "test" IdentifierDecl "{" (BlockAttribute | ConfigTupleValue | TypeBuilderDecl)* "}"
 }
 
 LiteralDecl { NumericLiteral | QuotedString }

--- a/typescript/codemirror-lang-baml/src/syntax.grammar
+++ b/typescript/codemirror-lang-baml/src/syntax.grammar
@@ -28,7 +28,7 @@ ComplexTypeExpr {
 MapTypeExpr { MapIdentifier "<" ComplexTypeExpr "," ComplexTypeExpr ">"}
 ListTypeExpr { ComplexTypeExpr"[]" }
 OptionalTypeExpr { ComplexTypeExpr"?" }
-SimpleTypeExpr { ListTypeExpr | OptionalTypeExpr | MapTypeExpr!MapOverIdentifier | IdentifierDecl }
+SimpleTypeExpr { ListTypeExpr | OptionalTypeExpr | MapTypeExpr!MapOverIdentifier | IdentifierDecl | LiteralDecl }
 UnionTypeExpr { TypeExpr!TypeUnion"|"TypeExpr }
 
 @precedence {

--- a/typescript/codemirror-lang-baml/src/syntax.grammar
+++ b/typescript/codemirror-lang-baml/src/syntax.grammar
@@ -48,8 +48,8 @@ BlockAttribute {
 }
 
 FunctionDecl {
-  "function" IdentifierDecl "(" FunctionArgs ")" "->" TypeExpr
-  "{" (FunctionTupleValue | LetDecl | FunctionValueAtom)* "}"
+  ("function" | FnKeyword) IdentifierDecl "(" FunctionArgs ")" ("->" TypeExpr)?
+  "{" (FunctionTupleValue | LetDecl | FunctionValueExpr)* "}"
 }
 FunctionArgs { (FunctionArg ",")* FunctionArg? }
 FunctionArg {
@@ -61,7 +61,16 @@ FunctionValueAtom {
 FunctionValueExpr {
   FunctionValueAtom |
   "{" LetDecl* FunctionValueExpr "}" |
-  IdentifierDecl "(" (FunctionValueExpr ("," FunctionValueExpr)*)? ")"
+  IdentifierDecl "(" (FunctionValueExpr ("," FunctionValueExpr)*)? ")" |
+  ClassConstructor
+}
+
+ClassConstructor {
+  IdentifierDecl "{" (ClassConstructorField ("," ClassConstructorField)*)? "}"
+}
+
+ClassConstructorField {
+  IdentifierDecl ":" FunctionValueExpr
 }
 FunctionTupleValue { (ClientKeyword | PromptKeyword) FunctionValueAtom }
 
@@ -90,10 +99,11 @@ LetDecl { LetKeyword IdentifierDecl "=" FunctionValueExpr ";"}
     NumericLiteral, QuotedString, UnquotedString, UnquotedAttributeValue
   }
   @precedence {
-    MapIdentifier, TypeBuilderKeyword, ClientKeyword, PromptKeyword, LetKeyword, IdentifierDecl, UnquotedAttributeValue
+    MapIdentifier, TypeBuilderKeyword, ClientKeyword, PromptKeyword, LetKeyword, FnKeyword, IdentifierDecl, UnquotedAttributeValue
   }
 
   LetKeyword { "let" }
+  FnKeyword { "fn" }
   ClientKeyword { "client" }
   PromptKeyword { "prompt" }
   TypeBuilderKeyword { "type_builder" }

--- a/typescript/codemirror-lang-baml/test/cases/class-declarations.txt
+++ b/typescript/codemirror-lang-baml/test/cases/class-declarations.txt
@@ -1,0 +1,128 @@
+# Simple class
+
+class User {
+  name string
+  age int
+}
+
+==>
+
+Baml(Decl(ClassDecl(
+  IdentifierDecl,
+  "{",
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
+  "}"
+)))
+
+# Class with optional fields
+
+class Profile {
+  bio string?
+  website string?
+}
+
+==>
+
+Baml(Decl(ClassDecl(
+  IdentifierDecl,
+  "{",
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(OptionalTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))),
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(OptionalTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))),
+  "}"
+)))
+
+# Class with field attributes
+
+class Document {
+  title string @description("Document title")
+  content string @alias("body")
+}
+
+==>
+
+Baml(Decl(ClassDecl(
+  IdentifierDecl,
+  "{",
+  ClassField(
+    IdentifierDecl,
+    TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+    FieldAttribute(IdentifierDecl, AttributeValue(QuotedString))
+  ),
+  ClassField(
+    IdentifierDecl,
+    TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+    FieldAttribute(IdentifierDecl, AttributeValue(QuotedString))
+  ),
+  "}"
+)))
+
+# Class with block attributes
+
+class ApiResponse {
+  @@description("Standard API response")
+  data string
+  error string?
+}
+
+==>
+
+Baml(Decl(ClassDecl(
+  IdentifierDecl,
+  "{",
+  BlockAttribute(IdentifierDecl, AttributeValue(QuotedString)),
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(OptionalTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))),
+  "}"
+)))
+
+# Class with array fields
+
+class Team {
+  members User[]
+  tags string[]
+}
+
+==>
+
+Baml(Decl(ClassDecl(
+  IdentifierDecl,
+  "{",
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(ListTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))),
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(ListTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))),
+  "}"
+)))
+
+# Class with map fields
+
+class Config {
+  settings map<string, string>
+  metadata map<string, int>
+}
+
+==>
+
+Baml(Decl(ClassDecl(
+  IdentifierDecl,
+  "{",
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(MapTypeExpr(MapIdentifier, ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)), ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))),
+  ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(MapTypeExpr(MapIdentifier, ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)), ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))),
+  "}"
+)))
+
+# Class with union types
+
+class Result {
+  value string | int
+  status "success" | "error"
+}
+
+==>
+
+Baml(Decl(ClassDecl(
+  IdentifierDecl,
+  "{",
+  ClassField(IdentifierDecl, TypeExpr(UnionTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)), "|", ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
+  ClassField(IdentifierDecl, TypeExpr(UnionTypeExpr(ComplexTypeExpr(SimpleTypeExpr(LiteralDecl(QuotedString))), "|", ComplexTypeExpr(SimpleTypeExpr(LiteralDecl(QuotedString)))))),
+  "}"
+)))

--- a/typescript/codemirror-lang-baml/test/cases/class-declarations.txt
+++ b/typescript/codemirror-lang-baml/test/cases/class-declarations.txt
@@ -122,7 +122,7 @@ class Result {
 Baml(Decl(ClassDecl(
   IdentifierDecl,
   "{",
-  ClassField(IdentifierDecl, TypeExpr(UnionTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)), "|", ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
-  ClassField(IdentifierDecl, TypeExpr(UnionTypeExpr(ComplexTypeExpr(SimpleTypeExpr(LiteralDecl(QuotedString))), "|", ComplexTypeExpr(SimpleTypeExpr(LiteralDecl(QuotedString)))))),
+  ClassField(IdentifierDecl, TypeExpr(UnionTypeExpr(TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))), TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))))),
+  ClassField(IdentifierDecl, TypeExpr(UnionTypeExpr(TypeExpr(ComplexTypeExpr(SimpleTypeExpr(LiteralDecl(QuotedString)))), TypeExpr(ComplexTypeExpr(SimpleTypeExpr(LiteralDecl(QuotedString))))))),
   "}"
 )))

--- a/typescript/codemirror-lang-baml/test/cases/enum-declarations.txt
+++ b/typescript/codemirror-lang-baml/test/cases/enum-declarations.txt
@@ -1,0 +1,117 @@
+# Simple enum
+
+enum Status {
+  Active
+  Inactive
+  Pending
+}
+
+==>
+
+Baml(Decl(EnumDecl(
+  IdentifierDecl,
+  "{",
+  EnumValueDecl(IdentifierDecl),
+  EnumValueDecl(IdentifierDecl),
+  EnumValueDecl(IdentifierDecl),
+  "}"
+)))
+
+# Enum with attributes
+
+enum Priority {
+  High @alias("high")
+  Medium @alias("medium")
+  Low @alias("low")
+}
+
+==>
+
+Baml(Decl(EnumDecl(
+  IdentifierDecl,
+  "{",
+  EnumValueDecl(IdentifierDecl, FieldAttribute(IdentifierDecl, AttributeValue(QuotedString))),
+  EnumValueDecl(IdentifierDecl, FieldAttribute(IdentifierDecl, AttributeValue(QuotedString))),
+  EnumValueDecl(IdentifierDecl, FieldAttribute(IdentifierDecl, AttributeValue(QuotedString))),
+  "}"
+)))
+
+# Enum with block attributes
+
+enum ErrorCode {
+  @@description("Standard error codes")
+  NotFound
+  Unauthorized
+  InternalError
+}
+
+==>
+
+Baml(Decl(EnumDecl(
+  IdentifierDecl,
+  "{",
+  BlockAttribute(IdentifierDecl, AttributeValue(QuotedString)),
+  EnumValueDecl(IdentifierDecl),
+  EnumValueDecl(IdentifierDecl),
+  EnumValueDecl(IdentifierDecl),
+  "}"
+)))
+
+# Enum with multiple attributes
+
+enum UserRole {
+  Admin @alias("admin") @description("Full access")
+  User @alias("user") @description("Limited access")
+  Guest @alias("guest") @description("Read only")
+}
+
+==>
+
+Baml(Decl(EnumDecl(
+  IdentifierDecl,
+  "{",
+  EnumValueDecl(
+    IdentifierDecl,
+    FieldAttribute(IdentifierDecl, AttributeValue(QuotedString)),
+    FieldAttribute(IdentifierDecl, AttributeValue(QuotedString))
+  ),
+  EnumValueDecl(
+    IdentifierDecl,
+    FieldAttribute(IdentifierDecl, AttributeValue(QuotedString)),
+    FieldAttribute(IdentifierDecl, AttributeValue(QuotedString))
+  ),
+  EnumValueDecl(
+    IdentifierDecl,
+    FieldAttribute(IdentifierDecl, AttributeValue(QuotedString)),
+    FieldAttribute(IdentifierDecl, AttributeValue(QuotedString))
+  ),
+  "}"
+)))
+
+# Single value enum
+
+enum Boolean {
+  True
+}
+
+==>
+
+Baml(Decl(EnumDecl(
+  IdentifierDecl,
+  "{",
+  EnumValueDecl(IdentifierDecl),
+  "}"
+)))
+
+# Empty enum (edge case)
+
+enum Empty {
+}
+
+==>
+
+Baml(Decl(EnumDecl(
+  IdentifierDecl,
+  "{",
+  "}"
+)))

--- a/typescript/codemirror-lang-baml/test/cases/expr-fn-declarations.txt
+++ b/typescript/codemirror-lang-baml/test/cases/expr-fn-declarations.txt
@@ -84,3 +84,75 @@ Baml(Decl(LetDecl(
   IdentifierDecl,
   FunctionValueExpr(FunctionValueAtom(LiteralDecl(NumericLiteral)))
 )))
+
+# Expression function with comments
+
+function CommentedFunction(x: int) -> int {
+  // This is a comment before let binding
+  let y = x; // This is a trailing comment
+  
+  // This is a comment before the return expression
+  y // Return y with trailing comment
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  TrailingComment,
+  LetDecl(LetKeyword, IdentifierDecl, FunctionValueExpr(FunctionValueAtom(IdentifierDecl))),
+  TrailingComment,
+  TrailingComment,
+  FunctionValueExpr(FunctionValueAtom(IdentifierDecl, TrailingComment)),
+  "}"
+)))
+
+# Function with multiline comments
+
+fn MultilineComments(x: string) -> string {
+  {// This is a multiline comment
+     that spans multiple lines //}
+  x
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  FnKeyword,
+  IdentifierDecl,
+  FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  MultilineComment,
+  FunctionValueExpr(FunctionValueAtom(IdentifierDecl)),
+  "}"
+)))
+
+# Function with mixed comments
+
+function MixedComments() -> int {
+  // Single line comment
+  {// Multiline comment //}
+  let value = 42; // Trailing comment
+  // Final comment
+  value
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  FunctionArgs,
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  TrailingComment,
+  MultilineComment,
+  LetDecl(LetKeyword, IdentifierDecl, FunctionValueExpr(FunctionValueAtom(LiteralDecl(NumericLiteral)))),
+  TrailingComment,
+  TrailingComment,
+  FunctionValueExpr(FunctionValueAtom(IdentifierDecl)),
+  "}"
+)))

--- a/typescript/codemirror-lang-baml/test/cases/expr-fn-declarations.txt
+++ b/typescript/codemirror-lang-baml/test/cases/expr-fn-declarations.txt
@@ -1,0 +1,88 @@
+# Simple expression function with function keyword
+
+function Foo(x: int) -> int {
+  let y = x;
+  x
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  LetDecl(LetKeyword, IdentifierDecl, "=", FunctionValueExpr(IdentifierDecl), ";"),
+  FunctionValueExpr(IdentifierDecl),
+  "}"
+)))
+
+# Simple expression function with fn keyword
+
+fn Bar(x: int) -> int {
+  x
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  FnKeyword,
+  IdentifierDecl,
+  FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  FunctionValueExpr(IdentifierDecl),
+  "}"
+)))
+
+# Expression function with no return type
+
+fn NoReturn(x: string) {
+  let result = x;
+  result
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  FnKeyword,
+  IdentifierDecl,
+  FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
+  "{",
+  LetDecl(LetKeyword, IdentifierDecl, "=", FunctionValueExpr(IdentifierDecl), ";"),
+  FunctionValueExpr(IdentifierDecl),
+  "}"
+)))
+
+# Expression function with function calls
+
+function Pipeline() -> string {
+  let x = MakePoem(6);
+  x
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  FunctionArgs,
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  LetDecl(LetKeyword, IdentifierDecl, "=", FunctionValueExpr(IdentifierDecl, "(", FunctionValueExpr(FunctionValueAtom(LiteralDecl(NumericLiteral))), ")"), ";"),
+  FunctionValueExpr(IdentifierDecl),
+  "}"
+)))
+
+# Top-level let assignment
+
+let globalValue = 42;
+
+==>
+
+Baml(Decl(LetDecl(
+  LetKeyword,
+  IdentifierDecl,
+  "=",
+  FunctionValueExpr(FunctionValueAtom(LiteralDecl(NumericLiteral))),
+  ";"
+)))

--- a/typescript/codemirror-lang-baml/test/cases/expr-fn-declarations.txt
+++ b/typescript/codemirror-lang-baml/test/cases/expr-fn-declarations.txt
@@ -12,8 +12,8 @@ Baml(Decl(FunctionDecl(
   FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
   TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
   "{",
-  LetDecl(LetKeyword, IdentifierDecl, "=", FunctionValueExpr(IdentifierDecl), ";"),
-  FunctionValueExpr(IdentifierDecl),
+  LetDecl(LetKeyword, IdentifierDecl, FunctionValueExpr(FunctionValueAtom(IdentifierDecl))),
+  FunctionValueExpr(FunctionValueAtom(IdentifierDecl)),
   "}"
 )))
 
@@ -31,7 +31,7 @@ Baml(Decl(FunctionDecl(
   FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
   TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
   "{",
-  FunctionValueExpr(IdentifierDecl),
+  FunctionValueExpr(FunctionValueAtom(IdentifierDecl)),
   "}"
 )))
 
@@ -49,8 +49,8 @@ Baml(Decl(FunctionDecl(
   IdentifierDecl,
   FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
   "{",
-  LetDecl(LetKeyword, IdentifierDecl, "=", FunctionValueExpr(IdentifierDecl), ";"),
-  FunctionValueExpr(IdentifierDecl),
+  LetDecl(LetKeyword, IdentifierDecl, FunctionValueExpr(FunctionValueAtom(IdentifierDecl))),
+  FunctionValueExpr(FunctionValueAtom(IdentifierDecl)),
   "}"
 )))
 
@@ -68,8 +68,8 @@ Baml(Decl(FunctionDecl(
   FunctionArgs,
   TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
   "{",
-  LetDecl(LetKeyword, IdentifierDecl, "=", FunctionValueExpr(IdentifierDecl, "(", FunctionValueExpr(FunctionValueAtom(LiteralDecl(NumericLiteral))), ")"), ";"),
-  FunctionValueExpr(IdentifierDecl),
+  LetDecl(LetKeyword, IdentifierDecl, FunctionValueExpr(IdentifierDecl, FunctionValueExpr(FunctionValueAtom(LiteralDecl(NumericLiteral))))),
+  FunctionValueExpr(FunctionValueAtom(IdentifierDecl)),
   "}"
 )))
 
@@ -82,7 +82,5 @@ let globalValue = 42;
 Baml(Decl(LetDecl(
   LetKeyword,
   IdentifierDecl,
-  "=",
-  FunctionValueExpr(FunctionValueAtom(LiteralDecl(NumericLiteral))),
-  ";"
+  FunctionValueExpr(FunctionValueAtom(LiteralDecl(NumericLiteral)))
 )))

--- a/typescript/codemirror-lang-baml/test/cases/function-declarations.txt
+++ b/typescript/codemirror-lang-baml/test/cases/function-declarations.txt
@@ -1,0 +1,142 @@
+# Simple function
+
+function GetUser(id: string) -> User {
+  client GPT4
+  prompt #"
+    Get user with id: {{ id }}
+  "#
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),
+  FunctionTupleValue(PromptKeyword, FunctionValueAtom(PromptExpr(Document))),
+  "}"
+)))
+
+# Function with multiple arguments
+
+function CreatePost(title: string, content: string, author: User) -> Post {
+  client Claude
+  prompt #"
+    Create a post
+  "#
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  FunctionArgs(
+    FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
+    ",",
+    FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
+    ",",
+    FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))
+  ),
+  ")",
+  "->",
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),
+  FunctionTupleValue(PromptKeyword, FunctionValueAtom(PromptExpr(Document))),
+  "}"
+)))
+
+# Function with optional return type
+
+function SearchUsers(query: string) -> User[]? {
+  client GPT4
+  prompt #"
+    Search for users
+  "#
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(OptionalTypeExpr(ComplexTypeExpr(SimpleTypeExpr(ListTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))))),
+  "{",
+  FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),
+  FunctionTupleValue(PromptKeyword, FunctionValueAtom(PromptExpr(Document))),
+  "}"
+)))
+
+# Function with union return type
+
+function ProcessData(data: string) -> string | Error {
+  client GPT4
+  prompt #"
+    Process the data
+  "#
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
+  TypeExpr(UnionTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)), "|", ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
+  "{",
+  FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),
+  FunctionTupleValue(PromptKeyword, FunctionValueAtom(PromptExpr(Document))),
+  "}"
+)))
+
+# Function with array arguments
+
+function AnalyzeDocuments(docs: Document[], options: string[]) -> Analysis {
+  client Claude
+  prompt #"
+    Analyze documents
+  "#
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  FunctionArgs(
+    FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(ListTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))),
+    ",",
+    FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(ListTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))))))
+  ),
+  ")",
+  "->",
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),
+  FunctionTupleValue(PromptKeyword, FunctionValueAtom(PromptExpr(Document))),
+  "}"
+)))
+
+# Function with no arguments
+
+function GetCurrentTime() -> string {
+  client GPT4
+  prompt #"
+    What time is it?
+  "#
+}
+
+==>
+
+Baml(Decl(FunctionDecl(
+  IdentifierDecl,
+  "(",
+  FunctionArgs,
+  ")",
+  "->",
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
+  "{",
+  FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),
+  FunctionTupleValue(PromptKeyword, FunctionValueAtom(PromptExpr(Document))),
+  "}"
+)))

--- a/typescript/codemirror-lang-baml/test/cases/function-declarations.txt
+++ b/typescript/codemirror-lang-baml/test/cases/function-declarations.txt
@@ -2,9 +2,7 @@
 
 function GetUser(id: string) -> User {
   client GPT4
-  prompt #"
-    Get user with id: {{ id }}
-  "#
+  prompt #"Get user"#
 }
 
 ==>
@@ -34,13 +32,9 @@ Baml(Decl(FunctionDecl(
   IdentifierDecl,
   FunctionArgs(
     FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
-    ",",
     FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
-    ",",
     FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))
   ),
-  ")",
-  "->",
   TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
   "{",
   FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),
@@ -83,7 +77,7 @@ function ProcessData(data: string) -> string | Error {
 Baml(Decl(FunctionDecl(
   IdentifierDecl,
   FunctionArgs(FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
-  TypeExpr(UnionTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)), "|", ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
+  TypeExpr(UnionTypeExpr(TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))), TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))),
   "{",
   FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),
   FunctionTupleValue(PromptKeyword, FunctionValueAtom(PromptExpr(Document))),
@@ -105,11 +99,8 @@ Baml(Decl(FunctionDecl(
   IdentifierDecl,
   FunctionArgs(
     FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(ListTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))))))),
-    ",",
     FunctionArg(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(ListTypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))))))
   ),
-  ")",
-  "->",
   TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
   "{",
   FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),
@@ -130,10 +121,7 @@ function GetCurrentTime() -> string {
 
 Baml(Decl(FunctionDecl(
   IdentifierDecl,
-  "(",
   FunctionArgs,
-  ")",
-  "->",
   TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl))),
   "{",
   FunctionTupleValue(ClientKeyword, FunctionValueAtom(IdentifierDecl)),

--- a/typescript/codemirror-lang-baml/test/cases/misc-constructs.txt
+++ b/typescript/codemirror-lang-baml/test/cases/misc-constructs.txt
@@ -1,0 +1,97 @@
+# Type alias
+
+type UserId = string
+
+==>
+
+Baml(Decl(TypeAliasDecl(
+  IdentifierDecl,
+  TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))
+)))
+
+# Client declaration
+
+client<llm> GPT4 {
+  provider openai
+  model gpt-4
+}
+
+==>
+
+Baml(Decl(ClientDecl(
+  IdentifierDecl,
+  "{",
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(UnquotedString)),
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(UnquotedString)),
+  "}"
+)))
+
+# Template string declaration
+
+template_string MyPrompt() #"
+  Hello world
+"#
+
+==>
+
+Baml(Decl(TemplateStringDecl(
+  IdentifierDecl,
+  FunctionArgs,
+  PromptExpr(Document)
+)))
+
+# Retry policy declaration
+
+retry_policy DefaultRetry {
+  max_retries 3
+  delay_ms 1000
+}
+
+==>
+
+Baml(Decl(RetryPolicyDecl(
+  RetryPolicyKeyword,
+  IdentifierDecl,
+  "{",
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(LiteralDecl(NumericLiteral))),
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(LiteralDecl(NumericLiteral))),
+  "}"
+)))
+
+# Comments
+
+// This is a comment
+class User {
+  name string // trailing comment
+}
+
+==>
+
+Baml(
+  TrailingComment,
+  Decl(ClassDecl(
+    IdentifierDecl,
+    "{",
+    ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
+    "}"
+  ))
+)
+
+# Multiline comments
+
+{// This is a multiline comment //}
+enum Status {
+  Active
+}
+
+==>
+
+Baml(
+  MultilineComment,
+  Decl(EnumDecl(
+    IdentifierDecl,
+    "{",
+    EnumValueDecl(IdentifierDecl),
+    "}"
+  ))
+)

--- a/typescript/codemirror-lang-baml/test/cases/misc-constructs.txt
+++ b/typescript/codemirror-lang-baml/test/cases/misc-constructs.txt
@@ -73,6 +73,7 @@ Baml(
     IdentifierDecl,
     "{",
     ClassField(IdentifierDecl, TypeExpr(ComplexTypeExpr(SimpleTypeExpr(IdentifierDecl)))),
+    TrailingComment,
     "}"
   ))
 )

--- a/typescript/codemirror-lang-baml/test/cases/test-declarations.txt
+++ b/typescript/codemirror-lang-baml/test/cases/test-declarations.txt
@@ -1,0 +1,82 @@
+# Simple test block
+test Test1 {
+  functions [ExtractResume]
+  args {
+    resume_text #"
+      John Doe
+
+      Education
+      - University of California, Berkeley
+        - B.S. in Computer Science
+        - 2020
+
+      Skills
+      - Python
+      - Java
+      - C++
+    "#
+  }
+}
+
+==>
+
+Baml(Decl(TestDecl(
+  IdentifierDecl,
+  "{",
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(ListValue("[", IdentifierDecl, "]"))),
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(ConfigMap("{", ConfigTupleValue(IdentifierDecl, ConfigValueExpr(PromptExpr(Document))), "}"))),
+  "}"
+)))
+
+# Test with multiple functions
+test MultiTest {
+  functions [Func1, Func2, Func3]
+  args {
+    input "test input"
+    number 42
+  }
+}
+
+==>
+
+Baml(Decl(TestDecl(
+  IdentifierDecl,
+  "{",
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(ListValue("[", IdentifierDecl, IdentifierDecl, IdentifierDecl, "]"))),
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(ConfigMap("{", ConfigTupleValue(IdentifierDecl, ConfigValueExpr(LiteralDecl(QuotedString))), ConfigTupleValue(IdentifierDecl, ConfigValueExpr(LiteralDecl(NumericLiteral))), "}"))),
+  "}"
+)))
+
+# Test with block attributes
+test AttributeTest {
+  @@description("This test validates extraction")
+  functions [ExtractData]
+  args {
+    data "sample data"
+  }
+}
+
+==>
+
+Baml(Decl(TestDecl(
+  IdentifierDecl,
+  "{",
+  BlockAttribute(IdentifierDecl, AttributeValue(QuotedString)),
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(ListValue("[", IdentifierDecl, "]"))),
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(ConfigMap("{", ConfigTupleValue(IdentifierDecl, ConfigValueExpr(LiteralDecl(QuotedString))), "}"))),
+  "}"
+)))
+
+# Simple test without args
+test SimpleTest {
+  functions [BasicFunction]
+}
+
+==>
+
+Baml(Decl(TestDecl(
+  IdentifierDecl,
+  "{",
+  ConfigTupleValue(IdentifierDecl, ConfigValueExpr(ListValue("[", IdentifierDecl, "]"))),
+  "}"
+)))

--- a/typescript/codemirror-lang-baml/test/test.cjs
+++ b/typescript/codemirror-lang-baml/test/test.cjs
@@ -1,22 +1,23 @@
-const { fileTests } = require("@lezer/generator/test")
-const fs = require("fs")
-const path = require("path")
+const { fileTests } = require('@lezer/generator/test')
+const fs = require('fs')
+const path = require('path')
 
 // Import the CommonJS build
-const { BAMLLanguage } = require("../dist/index.cjs")
+const { BAMLLanguage } = require('../dist/index.cjs')
 
 // Find all test case files
-const caseDir = path.join(__dirname, "cases")
-const testFiles = fs.readdirSync(caseDir)
-  .filter(f => f.endsWith(".txt"))
-  .map(f => path.join(caseDir, f))
+const caseDir = path.join(__dirname, 'cases')
+const testFiles = fs
+  .readdirSync(caseDir)
+  .filter((f) => f.endsWith('.txt'))
+  .map((f) => path.join(caseDir, f))
 
 // Run tests for each file
-describe("BAML Grammar Tests", () => {
+describe('BAML Grammar Tests', () => {
   for (const file of testFiles) {
-    const name = path.basename(file, ".txt")
+    const name = path.basename(file, '.txt')
     describe(name, () => {
-      for (const { name, run } of fileTests(fs.readFileSync(file, "utf8"), file))
+      for (const { name, run } of fileTests(fs.readFileSync(file, 'utf8'), file))
         it(name, () => run(BAMLLanguage.parser))
     })
   }

--- a/typescript/codemirror-lang-baml/test/test.cjs
+++ b/typescript/codemirror-lang-baml/test/test.cjs
@@ -1,0 +1,23 @@
+const { fileTests } = require("@lezer/generator/test")
+const fs = require("fs")
+const path = require("path")
+
+// Import the CommonJS build
+const { BAMLLanguage } = require("../dist/index.cjs")
+
+// Find all test case files
+const caseDir = path.join(__dirname, "cases")
+const testFiles = fs.readdirSync(caseDir)
+  .filter(f => f.endsWith(".txt"))
+  .map(f => path.join(caseDir, f))
+
+// Run tests for each file
+describe("BAML Grammar Tests", () => {
+  for (const file of testFiles) {
+    const name = path.basename(file, ".txt")
+    describe(name, () => {
+      for (const { name, run } of fileTests(fs.readFileSync(file, "utf8"), file))
+        it(name, () => run(BAMLLanguage.parser))
+    })
+  }
+})

--- a/typescript/codemirror-lang-baml/test/test.js
+++ b/typescript/codemirror-lang-baml/test/test.js
@@ -1,0 +1,24 @@
+import { fileTests } from "@lezer/generator/test"
+import { parser } from "../src/syntax.grammar.js"
+import * as fs from "fs"
+import * as path from "path"
+import { fileURLToPath } from "url"
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Find all test case files
+const caseDir = path.join(__dirname, "cases")
+const testFiles = fs.readdirSync(caseDir)
+  .filter(f => f.endsWith(".txt"))
+  .map(f => path.join(caseDir, f))
+
+// Run tests for each file
+describe("BAML Grammar Tests", () => {
+  for (const file of testFiles) {
+    const name = path.basename(file, ".txt")
+    describe(name, () => {
+      for (const { name, run } of fileTests(fs.readFileSync(file, "utf8"), file))
+        it(name, () => run(parser))
+    })
+  }
+})

--- a/typescript/codemirror-lang-baml/test/test.js
+++ b/typescript/codemirror-lang-baml/test/test.js
@@ -1,24 +1,24 @@
-import { fileTests } from "@lezer/generator/test"
-import { parser } from "../src/syntax.grammar.js"
-import * as fs from "fs"
-import * as path from "path"
-import { fileURLToPath } from "url"
+import { fileTests } from '@lezer/generator/test'
+import { parser } from '../src/syntax.grammar.js'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 // Find all test case files
-const caseDir = path.join(__dirname, "cases")
-const testFiles = fs.readdirSync(caseDir)
-  .filter(f => f.endsWith(".txt"))
-  .map(f => path.join(caseDir, f))
+const caseDir = path.join(__dirname, 'cases')
+const testFiles = fs
+  .readdirSync(caseDir)
+  .filter((f) => f.endsWith('.txt'))
+  .map((f) => path.join(caseDir, f))
 
 // Run tests for each file
-describe("BAML Grammar Tests", () => {
+describe('BAML Grammar Tests', () => {
   for (const file of testFiles) {
-    const name = path.basename(file, ".txt")
+    const name = path.basename(file, '.txt')
     describe(name, () => {
-      for (const { name, run } of fileTests(fs.readFileSync(file, "utf8"), file))
-        it(name, () => run(parser))
+      for (const { name, run } of fileTests(fs.readFileSync(file, 'utf8'), file)) it(name, () => run(parser))
     })
   }
 })


### PR DESCRIPTION
This was generated mostly with claude-code.

 - Add a lezer grammar test suite
 - Fix the lezer grammar
 - Add grammar rules for expression functions
 - Allow comments in expr fns

Before: 
<img width="517" alt="Screenshot 2025-06-27 at 9 57 44 PM" src="https://github.com/user-attachments/assets/65f62318-6ecc-46cd-a580-65e1b6496fae" />

After: 
<img width="531" alt="Screenshot 2025-06-27 at 11 07 33 PM" src="https://github.com/user-attachments/assets/7609503e-d831-45cd-96ad-4d8f4a107f54" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes BAML grammar issues and adds comprehensive test suite for improved language support.
> 
>   - **Grammar Fixes**:
>     - Fix `expr_block` in `datamodel.pest` to allow comments and empty lines in expression functions.
>     - Update `stmt` rule to allow trailing comments and optional newlines.
>     - Add grammar rules for expression functions in `syntax.grammar`.
>   - **Testing**:
>     - Add a lezer grammar test suite in `test/test.cjs` and `test/test.js`.
>     - Add test cases for class, enum, function, and expression function declarations in `test/cases/`.
>   - **Misc**:
>     - Update `package.json` to change test script to use `test/test.cjs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for df01047143bd288e078892c886f6af184e24093f. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->