### PR TITLE
add build step to fix integ tests workflow

### DIFF
--- a/.github/workflows/integ-tests.yml
+++ b/.github/workflows/integ-tests.yml
@@ -88,6 +88,11 @@ jobs:
       - name: setup TS
         run: pnpm install --frozen-lockfile
         working-directory: engine/language_client_typescript
+      
+      # This step is necessary to guarantee that the language server has a frontend to embed.
+      - name: Build web-panel for language server
+        run: bash ./scripts/build.sh
+        working-directory: engine/language_server
 
       - name: Run all integ tests
         run: |


### PR DESCRIPTION
@sxlijin I was able to fix the workflow

https://github.com/BoundaryML/baml/actions/runs/15981217679/job/45075798488

The step still fails but that's because of a python test failing.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a build step to the integration tests workflow to build the web-panel for the language server.
> 
>   - **Workflow Changes**:
>     - Adds a build step in `.github/workflows/integ-tests.yml` to build the web-panel for the language server using `bash ./scripts/build.sh` in `engine/language_server`.
>   - **Context**:
>     - The workflow still fails due to a Python test failure, unrelated to the added build step.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 795fc8ba0d968d04ef7506e387cafe9ca2248a6c. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->