### PR TITLE
fix cffi build

### DIFF
--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -138,14 +138,14 @@ jobs:
           echo "target dir is: ${{ env.TARGET_DIR }}"
 
     
-      # # Build the CLI - Always use static-ssl features
-      # - name: Build CLI Binary
-      #   # This single step now handles all builds
-      #   run: >
-      #     ${{ env.CARGO }} build --release --bin baml-cli ${{ env.TARGET_FLAGS }}
-      #     --features static-ssl
-      #     --no-default-features
-      #   working-directory: engine
+      # Build the CLI - Always use static-ssl features
+      - name: Build CLI Binary
+        # This single step now handles all builds
+        run: >
+          ${{ env.CARGO }} build --release --bin baml-cli ${{ env.TARGET_FLAGS }}
+          --features static-ssl
+          --no-default-features
+        working-directory: engine
 
       - name: Build CFFI Library
         shell: bash
@@ -166,7 +166,7 @@ jobs:
           export GOBIN=$GOPATH/bin
           export PATH=$PATH:$GOROOT:$GOPATH:$GOBIN
           
-          ${{ env.CARGO }} build -p baml_cffi ${{ env.TARGET_FLAGS }}
+          ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
         # Skip this step on Windows runners
         if: matrix._.os != 'windows-2022'

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -72,14 +72,6 @@ jobs:
       #   run: |
       #     ci/ubuntu-install-packages
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '1.24.4'
-      - name: Install protoc
-        run: go install github.com/golang/protobuf/protoc-gen-go@latest
-
-      - name: call protoc-gen-go
-        run: protoc-gen-go --version
       
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -92,6 +84,14 @@ jobs:
       
       - name: Install protoc-gen-go
         run: go install github.com/golang/protobuf/protoc-gen-go@latest
+
+      - name: Add protoc-gen-go to path
+        run: |
+          echo 'export PATH=$PATH:$HOME/go/bin' >> $GITHUB_ENV
+          echo 'export PATH=$PATH:$HOME/go/bin' >> $GITHUB_PATH
+
+      - name: Call protoc-gen-go
+        run: protoc-gen-go --version
       
       - name: Use Cross
         if: contains(matrix._.os, 'ubuntu')

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -87,11 +87,20 @@ jobs:
 
       - name: Add protoc-gen-go to path
         run: |
-          echo 'export PATH=$PATH:$HOME/go/bin' >> $GITHUB_ENV
-          echo 'export PATH=$PATH:$HOME/go/bin' >> $GITHUB_PATH
+          echo "$HOME/go/bin" >> $GITHUB_PATH
+          # Also set for current step
+          export PATH="$PATH:$HOME/go/bin"
+          echo "PATH=$PATH:$HOME/go/bin" >> $GITHUB_ENV
 
-      # - name: Call protoc-gen-go
-      #   run: protoc-gen-go --version
+      - name: Test protoc-gen-go availability
+        run: |
+          echo "Current PATH: $PATH"
+          echo "Go bin directory contents:"
+          ls -la $HOME/go/bin/
+          echo "Testing protoc-gen-go..."
+          protoc-gen-go --version
+          echo "Which protoc-gen-go:"
+          which protoc-gen-go
       
       - name: Use Cross
         if: contains(matrix._.os, 'ubuntu')

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -94,13 +94,16 @@ jobs:
           ls -la .cargo/bin
 
       - name: Test protoc-gen-go availability
+        id: protoc_gen_go_setup
         shell: bash
         run: |
           echo "Current PATH: $PATH"
           echo "Go bin directory contents:"
           ls -la $HOME/go/bin/
           echo "Which protoc-gen-go:"
-          which protoc-gen-go
+          PROTOC_GEN_GO_PATH=$(which protoc-gen-go)
+          echo "Found protoc-gen-go at: $PROTOC_GEN_GO_PATH"
+          echo "protoc_gen_go_path=$PROTOC_GEN_GO_PATH" >> $GITHUB_OUTPUT
           echo "Testing protoc can find protoc-gen-go plugin..."
           # Test that protoc can find the go plugin (this will show an error about missing .proto file, but that's expected)
           protoc --go_out=/tmp --help | grep -q "go_out" && echo "✅ protoc recognizes --go_out flag" || echo "❌ protoc does not recognize --go_out flag"
@@ -148,11 +151,12 @@ jobs:
       - name: Build CFFI Library
         shell: bash
         env:
-          PROTOC_GEN_GO_PATH: /home/runner/go/bin/protoc-gen-go
+          PROTOC_GEN_GO_PATH: ${{ steps.protoc_gen_go_setup.outputs.protoc_gen_go_path }}
         run: |
+          echo "Using PROTOC_GEN_GO_PATH: $PROTOC_GEN_GO_PATH"
           # We must use PROTOC_GEN_GO_PATH to explicitly tell the build script
           # where to find the plugin, as the cross-compile environment is isolated.
-          ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
+          ${{ env.CARGO }} build --debug -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
         # Skip this step on Windows runners
         if: matrix._.os != 'windows-2022'

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -73,6 +73,8 @@ jobs:
       #     ci/ubuntu-install-packages
 
       - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.4'
       - name: Install protoc
         run: go install github.com/golang/protobuf/protoc-gen-go@latest
 

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -73,10 +73,7 @@ jobs:
       #     ci/ubuntu-install-packages
 
       
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          target: ${{ matrix._.target }}
+    
       
       - uses: actions/setup-go@v5
         with:
@@ -104,6 +101,11 @@ jobs:
           echo "Testing protoc can find protoc-gen-go plugin..."
           # Test that protoc can find the go plugin (this will show an error about missing .proto file, but that's expected)
           protoc --go_out=/tmp --help | grep -q "go_out" && echo "✅ protoc recognizes --go_out flag" || echo "❌ protoc does not recognize --go_out flag"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: ${{ matrix._.target }}
       
       - name: Use Cross
         if: contains(matrix._.os, 'ubuntu')

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -122,14 +122,14 @@ jobs:
           workspaces: engine
           prefix-key: "v5-rust-${{ matrix._.target }}"
 
-      # Build the CLI - Always use static-ssl features
-      - name: Build CLI Binary
-        # This single step now handles all builds
-        run: >
-          ${{ env.CARGO }} build --release --bin baml-cli ${{ env.TARGET_FLAGS }}
-          --features static-ssl
-          --no-default-features
-        working-directory: engine
+      # # Build the CLI - Always use static-ssl features
+      # - name: Build CLI Binary
+      #   # This single step now handles all builds
+      #   run: >
+      #     ${{ env.CARGO }} build --release --bin baml-cli ${{ env.TARGET_FLAGS }}
+      #     --features static-ssl
+      #     --no-default-features
+      #   working-directory: engine
 
       - name: Build CFFI Library
         run: >

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -76,7 +76,10 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix._.target }}
-      
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine
+          prefix-key: "v5-rust-${{ matrix._.target }}"
       - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
@@ -134,11 +137,7 @@ jobs:
           echo "target flag is: ${{ env.TARGET_FLAGS }}"
           echo "target dir is: ${{ env.TARGET_DIR }}"
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: engine
-          prefix-key: "v5-rust-${{ matrix._.target }}"
-
+    
       # # Build the CLI - Always use static-ssl features
       # - name: Build CLI Binary
       #   # This single step now handles all builds

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -147,12 +147,12 @@ jobs:
 
       - name: Build CFFI Library
         shell: bash
+        env:
+          PROTOC_GEN_GO_PATH: /home/runner/go/bin/protoc-gen-go
         run: |
-          # Install protoc-gen-go
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          # We must prepend our local .cargo/bin to the PATH to ensure the vendored
-          # protoc used by the build script can find our locally installed protoc-gen-go.
-          PATH=$(pwd)/.cargo/bin:$PATH ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
+          # We must use PROTOC_GEN_GO_PATH to explicitly tell the build script
+          # where to find the plugin, as the cross-compile environment is isolated.
+          ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
         # Skip this step on Windows runners
         if: matrix._.os != 'windows-2022'

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -146,8 +146,14 @@ jobs:
       #   working-directory: engine
 
       - name: Build CFFI Library
-        run: >
-          PATH=$HOME/go/bin:$PATH ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
+        shell: bash
+        env:
+          PROTOC_ARGS: --plugin=protoc-gen-go=$HOME/go/bin/protoc-gen-go
+        run: |
+          # The PROTOC_ARGS env var is used by prost-build to pass arguments to protoc.
+          # We use it to explicitly tell the vendored protoc where to find the go plugin,
+          # as the cross-compile environment does not inherit the PATH correctly.
+          ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
         # Skip this step on Windows runners
         if: matrix._.os != 'windows-2022'

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -147,7 +147,7 @@ jobs:
 
       - name: Build CFFI Library
         run: >
-          ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
+          PATH=$HOME/go/bin:$PATH ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
         # Skip this step on Windows runners
         if: matrix._.os != 'windows-2022'

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -72,23 +72,26 @@ jobs:
       #   run: |
       #     ci/ubuntu-install-packages
 
-      
-    
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          target: ${{ matrix._.target }}
       
       - uses: actions/setup-go@v5
         with:
           go-version: '1.21'
       
-      - name: Install protoc-gen-go
-        run: go install github.com/golang/protobuf/protoc-gen-go@latest
-
-      - name: Add protoc-gen-go to path
+      - name: Install protoc-gen-go into .cargo/bin
         shell: bash
         run: |
-          echo "$HOME/go/bin" >> $GITHUB_PATH
-          # Also set for current step
-          export PATH="$PATH:$HOME/go/bin"
-          echo "PATH=$PATH:$HOME/go/bin" >> $GITHUB_ENV
+          # The cross-compile environment sanitizes the PATH, so we install the plugin
+          # directly into a directory that is guaranteed to be in the PATH for cargo.
+          # We also create a symlink from the go/bin to the cargo/bin for consistency.
+          mkdir -p .cargo/bin
+          go install github.com/golang/protobuf/protoc-gen-go@latest
+          cp "$HOME/go/bin/protoc-gen-go" ".cargo/bin/"
+          echo "Installed protoc-gen-go into .cargo/bin:"
+          ls -la .cargo/bin
 
       - name: Test protoc-gen-go availability
         shell: bash
@@ -102,10 +105,7 @@ jobs:
           # Test that protoc can find the go plugin (this will show an error about missing .proto file, but that's expected)
           protoc --go_out=/tmp --help | grep -q "go_out" && echo "✅ protoc recognizes --go_out flag" || echo "❌ protoc does not recognize --go_out flag"
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: stable
-          target: ${{ matrix._.target }}
+  
       
       - name: Use Cross
         if: contains(matrix._.os, 'ubuntu')
@@ -147,13 +147,12 @@ jobs:
 
       - name: Build CFFI Library
         shell: bash
-        env:
-          PROTOC_ARGS: --plugin=protoc-gen-go=$HOME/go/bin/protoc-gen-go
         run: |
-          # The PROTOC_ARGS env var is used by prost-build to pass arguments to protoc.
-          # We use it to explicitly tell the vendored protoc where to find the go plugin,
-          # as the cross-compile environment does not inherit the PATH correctly.
-          ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
+          # Install protoc-gen-go
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          # We must prepend our local .cargo/bin to the PATH to ensure the vendored
+          # protoc used by the build script can find our locally installed protoc-gen-go.
+          PATH=$(pwd)/.cargo/bin:$PATH ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
         # Skip this step on Windows runners
         if: matrix._.os != 'windows-2022'

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -156,6 +156,9 @@ jobs:
           echo "Using PROTOC_GEN_GO_PATH: $PROTOC_GEN_GO_PATH"
           # We must use PROTOC_GEN_GO_PATH to explicitly tell the build script
           # where to find the plugin, as the cross-compile environment is isolated.
+          export GOPATH=$HOME/go
+          export GOBIN=$GOPATH/bin
+          export PATH=$PATH:$GOROOT:$GOPATH:$GOBIN
           ${{ env.CARGO }} build -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
         # Skip this step on Windows runners

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -90,8 +90,8 @@ jobs:
           echo 'export PATH=$PATH:$HOME/go/bin' >> $GITHUB_ENV
           echo 'export PATH=$PATH:$HOME/go/bin' >> $GITHUB_PATH
 
-      - name: Call protoc-gen-go
-        run: protoc-gen-go --version
+      # - name: Call protoc-gen-go
+      #   run: protoc-gen-go --version
       
       - name: Use Cross
         if: contains(matrix._.os, 'ubuntu')

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -86,6 +86,7 @@ jobs:
         run: go install github.com/golang/protobuf/protoc-gen-go@latest
 
       - name: Add protoc-gen-go to path
+        shell: bash
         run: |
           echo "$HOME/go/bin" >> $GITHUB_PATH
           # Also set for current step
@@ -93,14 +94,16 @@ jobs:
           echo "PATH=$PATH:$HOME/go/bin" >> $GITHUB_ENV
 
       - name: Test protoc-gen-go availability
+        shell: bash
         run: |
           echo "Current PATH: $PATH"
           echo "Go bin directory contents:"
           ls -la $HOME/go/bin/
-          echo "Testing protoc-gen-go..."
-          protoc-gen-go --version
           echo "Which protoc-gen-go:"
           which protoc-gen-go
+          echo "Testing protoc can find protoc-gen-go plugin..."
+          # Test that protoc can find the go plugin (this will show an error about missing .proto file, but that's expected)
+          protoc --go_out=/tmp --help | grep -q "go_out" && echo "✅ protoc recognizes --go_out flag" || echo "❌ protoc does not recognize --go_out flag"
       
       - name: Use Cross
         if: contains(matrix._.os, 'ubuntu')

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -12,7 +12,9 @@ on:
         type: boolean
         default: true
         required: false
-
+  push:
+    branches:
+      - protoc-fix
 env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
         
@@ -69,6 +71,13 @@ jobs:
       #   shell: bash
       #   run: |
       #     ci/ubuntu-install-packages
+
+      - uses: actions/setup-go@v5
+      - name: Install protoc
+        run: go install github.com/golang/protobuf/protoc-gen-go@latest
+
+      - name: call protoc-gen-go
+        run: protoc-gen-go --version
       
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -150,15 +150,23 @@ jobs:
 
       - name: Build CFFI Library
         shell: bash
-        env:
-          PROTOC_GEN_GO_PATH: ${{ steps.protoc_gen_go_setup.outputs.protoc_gen_go_path }}
         run: |
+          # Set the correct protoc-gen-go path based on whether we're using cross (Linux) or native build
+          if [[ "${{ env.CARGO }}" == "cross" ]]; then
+            # For cross builds (Linux), protoc-gen-go will be installed in the container at /usr/local/bin
+            export PROTOC_GEN_GO_PATH="/usr/local/bin/protoc-gen-go"
+          else
+            # For native builds (macOS), use the host path
+            export PROTOC_GEN_GO_PATH="${{ steps.protoc_gen_go_setup.outputs.protoc_gen_go_path }}"
+          fi
           echo "Using PROTOC_GEN_GO_PATH: $PROTOC_GEN_GO_PATH"
+          
           # We must use PROTOC_GEN_GO_PATH to explicitly tell the build script
           # where to find the plugin, as the cross-compile environment is isolated.
           export GOPATH=$HOME/go
           export GOBIN=$GOPATH/bin
           export PATH=$PATH:$GOROOT:$GOPATH:$GOBIN
+          
           ${{ env.CARGO }} build -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
         # Skip this step on Windows runners

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -156,7 +156,7 @@ jobs:
           echo "Using PROTOC_GEN_GO_PATH: $PROTOC_GEN_GO_PATH"
           # We must use PROTOC_GEN_GO_PATH to explicitly tell the build script
           # where to find the plugin, as the cross-compile environment is isolated.
-          ${{ env.CARGO }} build --debug -p baml_cffi ${{ env.TARGET_FLAGS }}
+          ${{ env.CARGO }} build -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
         # Skip this step on Windows runners
         if: matrix._.os != 'windows-2022'

--- a/engine/Cross.toml
+++ b/engine/Cross.toml
@@ -1,0 +1,46 @@
+# Cross.toml - Configuration for cross-compilation
+
+# Install Go and protoc-gen-go for Linux targets
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+  "apt-get update",
+  "apt-get install -y wget",
+  "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
+  "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
+  "export PATH=$PATH:/usr/local/go/bin",
+  "/usr/local/go/bin/go install github.com/golang/protobuf/protoc-gen-go@latest",
+  "cp /root/go/bin/protoc-gen-go /usr/local/bin/",
+]
+
+[target.x86_64-unknown-linux-musl]
+pre-build = [
+  "apk update",
+  "apk add wget",
+  "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
+  "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
+  "export PATH=$PATH:/usr/local/go/bin",
+  "/usr/local/go/bin/go install github.com/golang/protobuf/protoc-gen-go@latest",
+  "cp /root/go/bin/protoc-gen-go /usr/local/bin/",
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+  "apt-get update",
+  "apt-get install -y wget",
+  "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
+  "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
+  "export PATH=$PATH:/usr/local/go/bin",
+  "/usr/local/go/bin/go install github.com/golang/protobuf/protoc-gen-go@latest",
+  "cp /root/go/bin/protoc-gen-go /usr/local/bin/",
+]
+
+[target.aarch64-unknown-linux-musl]
+pre-build = [
+  "apk update",
+  "apk add wget",
+  "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
+  "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
+  "export PATH=$PATH:/usr/local/go/bin",
+  "/usr/local/go/bin/go install github.com/golang/protobuf/protoc-gen-go@latest",
+  "cp /root/go/bin/protoc-gen-go /usr/local/bin/",
+]

--- a/engine/Cross.toml
+++ b/engine/Cross.toml
@@ -26,8 +26,8 @@ pre-build = [
 pre-build = [
   "apt-get update",
   "apt-get install -y wget",
-  "wget -q https://go.dev/dl/go1.21.13.linux-arm64.tar.gz",
-  "tar -xzf go1.21.13.linux-arm64.tar.gz -C /usr/local",
+  "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
+  "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
   "export PATH=$PATH:/usr/local/go/bin",
   "/usr/local/go/bin/go install github.com/golang/protobuf/protoc-gen-go@latest",
   "cp /root/go/bin/protoc-gen-go /usr/local/bin/",
@@ -36,8 +36,8 @@ pre-build = [
 [target.aarch64-unknown-linux-musl]
 pre-build = [
   "if command -v apk >/dev/null 2>&1; then apk update && apk add wget; elif command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y wget; elif command -v yum >/dev/null 2>&1; then yum install -y wget; fi",
-  "wget -q https://go.dev/dl/go1.21.13.linux-arm64.tar.gz",
-  "tar -xzf go1.21.13.linux-arm64.tar.gz -C /usr/local",
+  "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
+  "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
   "export PATH=$PATH:/usr/local/go/bin",
   "/usr/local/go/bin/go install github.com/golang/protobuf/protoc-gen-go@latest",
   "cp /root/go/bin/protoc-gen-go /usr/local/bin/",

--- a/engine/Cross.toml
+++ b/engine/Cross.toml
@@ -26,8 +26,8 @@ pre-build = [
 pre-build = [
   "apt-get update",
   "apt-get install -y wget",
-  "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
-  "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
+  "wget -q https://go.dev/dl/go1.21.13.linux-arm64.tar.gz",
+  "tar -xzf go1.21.13.linux-arm64.tar.gz -C /usr/local",
   "export PATH=$PATH:/usr/local/go/bin",
   "/usr/local/go/bin/go install github.com/golang/protobuf/protoc-gen-go@latest",
   "cp /root/go/bin/protoc-gen-go /usr/local/bin/",
@@ -36,8 +36,8 @@ pre-build = [
 [target.aarch64-unknown-linux-musl]
 pre-build = [
   "if command -v apk >/dev/null 2>&1; then apk update && apk add wget; elif command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y wget; elif command -v yum >/dev/null 2>&1; then yum install -y wget; fi",
-  "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
-  "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
+  "wget -q https://go.dev/dl/go1.21.13.linux-arm64.tar.gz",
+  "tar -xzf go1.21.13.linux-arm64.tar.gz -C /usr/local",
   "export PATH=$PATH:/usr/local/go/bin",
   "/usr/local/go/bin/go install github.com/golang/protobuf/protoc-gen-go@latest",
   "cp /root/go/bin/protoc-gen-go /usr/local/bin/",

--- a/engine/Cross.toml
+++ b/engine/Cross.toml
@@ -14,8 +14,7 @@ pre-build = [
 
 [target.x86_64-unknown-linux-musl]
 pre-build = [
-  "apk update",
-  "apk add wget",
+  "if command -v apk >/dev/null 2>&1; then apk update && apk add wget; elif command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y wget; elif command -v yum >/dev/null 2>&1; then yum install -y wget; fi",
   "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
   "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
   "export PATH=$PATH:/usr/local/go/bin",
@@ -36,8 +35,7 @@ pre-build = [
 
 [target.aarch64-unknown-linux-musl]
 pre-build = [
-  "apk update",
-  "apk add wget",
+  "if command -v apk >/dev/null 2>&1; then apk update && apk add wget; elif command -v apt-get >/dev/null 2>&1; then apt-get update && apt-get install -y wget; elif command -v yum >/dev/null 2>&1; then yum install -y wget; fi",
   "wget -q https://go.dev/dl/go1.21.13.linux-amd64.tar.gz",
   "tar -xzf go1.21.13.linux-amd64.tar.gz -C /usr/local",
   "export PATH=$PATH:/usr/local/go/bin",

--- a/engine/language_client_cffi/build.rs
+++ b/engine/language_client_cffi/build.rs
@@ -323,6 +323,13 @@ mod protoc_lang_out {
 }
 
 fn main() -> std::io::Result<()> {
+    #[cfg(target_os = "windows")]
+    println!("cargo:rustc-link-lib=dylib=ntdll");
+
+    // The last component of the target triple
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap();
+    let is_windows = target_os == "windows";
+
     // Re-run build.rs if these files change.
     println!("cargo:rerun-if-changed=types/cffi.fbs");
     println!("cargo:rerun-if-changed=types/cffi.proto");
@@ -348,10 +355,18 @@ fn main() -> std::io::Result<()> {
         //     ..Default::default()
         // };
 
-        protoc_lang_out::ProtocLangOut::new()
+        let mut protoc = protoc_lang_out::ProtocLangOut::new();
+        protoc
             .lang(lang)
             .input("types/cffi.proto")
-            .out_dir(lang_dir)
+            .out_dir(lang_dir);
+
+        // Allow overriding the protoc-gen-go plugin path
+        if let Ok(path) = std::env::var("PROTOC_GEN_GO_PATH") {
+            protoc.plugin(&path);
+        }
+
+        protoc
             .run()
             .unwrap_or_else(|_| panic!("Failed to generate {lang} bindings"));
     }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes CFFI build by updating `protoc-gen-go` installation and usage in build scripts and workflows.
> 
>   - **Build Process**:
>     - Updates `.github/workflows/build-cli-release.reusable.yaml` to install `protoc-gen-go` into `.cargo/bin` and test its availability.
>     - Adds `Cross.toml` for cross-compilation configuration, installing `protoc-gen-go` for various Linux targets.
>     - Modifies `build.rs` to allow overriding `protoc-gen-go` plugin path using `PROTOC_GEN_GO_PATH` environment variable.
>   - **Environment Setup**:
>     - Sets `PROTOC_GEN_GO_PATH` based on build environment (native vs cross) in `build-cli-release.reusable.yaml`.
>     - Ensures `protoc-gen-go` is available in the PATH for both native and cross-compilation.
>   - **Misc**:
>     - Adds `push` trigger for `protoc-fix` branch in `.github/workflows/build-cli-release.reusable.yaml`.
>     - Minor reordering of steps in `.github/workflows/build-cli-release.reusable.yaml` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ddf54bae58163ce378b113c8861f02246c0bef11. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->