### PR TITLE
remove build script

### DIFF
--- a/engine/language_server/build.rs
+++ b/engine/language_server/build.rs
@@ -2,9 +2,9 @@ use std::process::Command;
 
 fn main() {
     // Run the build script
-    let output = Command::new("bash")
-        .arg("scripts/build.sh")
-        .output()
-        .expect("Failed to execute build script");
-    println!("{}", String::from_utf8_lossy(&output.stdout));
+    // let output = Command::new("bash")
+    //     .arg("scripts/build.sh")
+    //     .output()
+    //     .expect("Failed to execute build script");
+    // println!("{}", String::from_utf8_lossy(&output.stdout));
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Comments out the build script execution in `engine/language_server/build.rs`, removing the script from the build process.
> 
>   - **Behavior**:
>     - Comments out the execution of `scripts/build.sh` in `engine/language_server/build.rs`, effectively removing the build script execution.
>     - The `Command::new("bash")` and related lines are commented out, preventing the script from running.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for deb751885415ad4436235333340923127899e57c. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->