### PR TITLE
store strings in the vm

### DIFF
--- a/engine/baml-compiler/CLAUDE.md
+++ b/engine/baml-compiler/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Overview
+
+The baml-compiler is a Rust crate that compiles BAML (Basically a Made-up Language) source code into bytecode for execution by the BAML VM. It's part of a larger monorepo that includes the BAML runtime, language clients, and tooling.
+
+## Common Development Commands
+
+### Building and Testing the Compiler
+
+```bash
+# Build the compiler
+cargo build
+
+# Run compiler tests
+cargo test
+
+# Format code
+cargo fmt
+
+# Run linter
+cargo clippy
+
+# Build with watch mode (from repository root)
+../../tools/build . --watch
+
+# Run tests with watch mode
+../../tools/build . --test
+```
+
+### Working with the Full BAML Stack
+
+From the repository root (`/home/greghale/code/baml/`):
+
+```bash
+# Build all Rust components
+cd engine && cargo build
+
+# Run all Rust tests
+cd engine && cargo test --lib
+
+# Build and test specific component
+./tools/build engine/baml-compiler --test
+
+# Run integration tests
+cd integ-tests && ./run-tests.sh
+```
+
+## Architecture
+
+### Compiler Structure
+
+The baml-compiler transforms BAML source code → AST → Bytecode:
+
+1. **Parser** (from parser-database) → AST
+2. **Validation** (from baml-core) → Validated IR
+3. **Compiler** (this crate) → VM Bytecode
+
+Key files:
+- `src/lib.rs` - Main compiler entry point and bytecode generation
+- Dependencies on:
+  - `internal-baml-core` - IR and validation
+  - `internal-baml-parser-database` - Parsing and AST
+  - `baml-vm` - Bytecode definitions
+
+### Bytecode Instructions
+
+The compiler generates stack-based bytecode with instructions like:
+- `LoadConst`, `LoadVar`, `LoadGlobal` - Load values
+- `Call`, `Return` - Function calls
+- `Jump`, `JumpIfFalse` - Control flow
+- `AllocArray`, `Pop` - Data structures
+
+### Current Limitations
+
+Several features are marked as `todo!()` in the implementation:
+- Raw strings
+- Maps
+- Class constructors
+- Lambdas
+- Loops (for, while)
+
+## Working with BAML Code
+
+BAML is a domain-specific language for building reliable AI workflows. When modifying the compiler:
+
+1. Changes to bytecode generation affect the VM execution
+2. New language features require updates to:
+   - Parser (in parser-database)
+   - IR/validation (in baml-core)
+   - Compiler (this crate)
+   - VM (in baml-vm)
+
+3. Test changes using integration tests in `/integ-tests/`
+
+## Testing Individual Components
+
+```bash
+# Run a specific test
+cargo test test_name
+
+# Run tests with output
+cargo test -- --nocapture
+
+# Run only compiler tests (not workspace)
+cargo test --package baml-compiler
+```
+
+## Related Components
+
+When working on the compiler, you may need to understand:
+- `baml-lib/parser-database/` - How BAML is parsed
+- `baml-lib/baml-core/` - The IR and type system
+- `baml-vm/` - How bytecode is executed
+- `baml-runtime/` - How the runtime orchestrates execution

--- a/engine/baml-compiler/src/lib.rs
+++ b/engine/baml-compiler/src/lib.rs
@@ -44,6 +44,12 @@ struct Compiler<'g> {
 
     /// Bytecode to generate.
     bytecode: Bytecode,
+
+    /// Objects pool.
+    ///
+    /// Stores heap-allocated objects that are created during compilation,
+    /// such as string constants.
+    objects: &'g mut Vec<Object>,
 }
 
 impl<'g> Compiler<'g> {
@@ -51,12 +57,14 @@ impl<'g> Compiler<'g> {
     pub fn new(
         globals: &'g HashMap<String, usize>,
         classes: &'g HashMap<String, HashMap<String, usize>>,
+        objects: &'g mut Vec<Object>,
     ) -> Self {
         Self {
             globals,
             classes,
             locals: HashMap::new(),
             bytecode: Bytecode::new(),
+            objects,
         }
     }
 
@@ -187,7 +195,15 @@ impl<'g> Compiler<'g> {
                 self.emit(Instruction::LoadConst(index));
             }
 
-            Expression::StringValue(string, _span) => todo!(),
+            Expression::StringValue(string, _span) => {
+                // Allocate the string in the objects pool
+                self.objects.push(Object::String(string.to_string()));
+                let object_index = self.objects.len() - 1;
+
+                // Add a constant that points to the string object
+                let const_index = self.add_constant(Value::Object(object_index));
+                self.emit(Instruction::LoadConst(const_index));
+            }
 
             Expression::RawStringValue(raw_string) => todo!(),
 
@@ -452,8 +468,8 @@ pub fn compile(ast: ParserDatabase) -> anyhow::Result<(Vec<Object>, Vec<Value>)>
     let mut globals = Vec::with_capacity(resolved_globals.len());
 
     for function in ast.walk_expr_fns() {
-        let function =
-            Compiler::new(&resolved_globals, &resolved_classes).compile(function.expr_fn())?;
+        let function = Compiler::new(&resolved_globals, &resolved_classes, &mut objects)
+            .compile(function.expr_fn())?;
 
         // Add the function to the globals and objects pools.
         globals.push(Value::Object(objects.len()));
@@ -680,6 +696,18 @@ mod tests {
                     Instruction::Return,
                 ],
             )],
+        })
+    }
+
+    #[test]
+    fn function_returning_string() -> anyhow::Result<()> {
+        assert_compiles(Program {
+            source: "
+                fn main() -> string {
+                    \"hello\"
+                }
+            ",
+            expected: vec![("main", vec![Instruction::LoadConst(0), Instruction::Return])],
         })
     }
 }

--- a/engine/baml-vm/tests/vm.rs
+++ b/engine/baml-vm/tests/vm.rs
@@ -246,3 +246,64 @@ fn class_constructor_with_spread_operator() -> anyhow::Result<()> {
         },
     )
 }
+
+#[test]
+fn function_returning_string() -> anyhow::Result<()> {
+    assert_vm_executes_with_inspection(
+        Program {
+            source: "
+                fn main() -> string {
+                    \"hello\"
+                }
+            ",
+            function: "main",
+            expected: Value::Object(0),
+        },
+        |vm| {
+            let Object::String(string) = &vm.objects[0] else {
+                panic!("expected String, got {:?}", vm.objects[0]);
+            };
+
+            assert_eq!(string, "hello");
+
+            Ok(())
+        },
+    )
+}
+
+#[test]
+fn multiple_strings() -> anyhow::Result<()> {
+    assert_vm_executes_with_inspection(
+        Program {
+            source: "
+                fn get_greeting() -> string {
+                    \"Hello\"
+                }
+                
+                fn main() -> string {
+                    let greeting = get_greeting();
+                    let name = \"World\";
+                    greeting
+                }
+            ",
+            function: "main",
+            expected: Value::Object(0), // "Hello" should be the first string object
+        },
+        |vm| {
+            // Check that we have the expected strings in the objects pool
+            let strings: Vec<&str> = vm
+                .objects
+                .iter()
+                .filter_map(|obj| match obj {
+                    Object::String(s) => Some(s.as_str()),
+                    _ => None,
+                })
+                .collect();
+
+            assert!(strings.contains(&"Hello"));
+            assert!(strings.contains(&"World"));
+
+            Ok(())
+        },
+    )
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for storing string constants in the VM's object pool during compilation and update tests and documentation accordingly.
> 
>   - **Compiler Changes**:
>     - Add `objects` field to `Compiler` struct in `lib.rs` to store heap-allocated objects like string constants.
>     - Modify `compile_expression()` in `lib.rs` to handle `Expression::StringValue` by storing strings in the `objects` pool and emitting `LoadConst` instructions.
>   - **Testing**:
>     - Add `function_returning_string` and `multiple_strings` tests in `vm.rs` to verify string handling in the VM.
>   - **Documentation**:
>     - Add `CLAUDE.md` to provide guidance for working with the BAML compiler and related components.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for e1a726716bfc5f1396ff85a9489de63c616dac98. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->