### PR TITLE
update expect in unit test and revert log level change

### DIFF
--- a/engine/baml-lib/baml/tests/validation_files/client/bad_response_format.baml
+++ b/engine/baml-lib/baml/tests/validation_files/client/bad_response_format.baml
@@ -22,7 +22,7 @@ client<llm> MyClient3 {
   }
 }
 
-// error: client_response_type must be one of "openai", "anthropic", "google", or "vertex". Got: invalid
+// error: client_response_type must be one of "openai", "openai-responses", "anthropic", "google", or "vertex". Got: invalid
 //   -->  client/bad_response_format.baml:5
 //    | 
 //  4 |     model "gpt-4o"

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -54,7 +54,7 @@ pub fn on_wasm_init() {
         if #[cfg(debug_assertions)] {
             const LOG_LEVEL: log::Level = log::Level::Debug;
         } else {
-            const LOG_LEVEL: log::Level = log::Level::Debug;
+            const LOG_LEVEL: log::Level = log::Level::Info;
         }
     };
     // I dont think we need this line anymore -- seems to break logging if you add it.


### PR DESCRIPTION
 - Updates expectations for a validation test and also reverts a log change introduced in #2103 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update validation test expectation and revert log level change in `mod.rs`.
> 
>   - **Validation Test**:
>     - Updates expected `client_response_type` values in `bad_response_format.baml` to include "openai-responses".
>   - **Logging**:
>     - Reverts log level from `Debug` to `Info` in `on_wasm_init()` in `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c004b5610fe546d38e3349f76cb7f58ac5a6bcf9. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->