### PR TITLE
Fix move `baml_src` directory LSP crash

### DIFF
--- a/engine/language_server/src/session.rs
+++ b/engine/language_server/src/session.rs
@@ -201,10 +201,20 @@ impl Session {
 
     pub fn reload(&mut self, notifier: Option<Notifier>) -> anyhow::Result<()> {
         tracing::info!("Reloading session");
-        let project_updates: Vec<HashMap<_, _>> = self
-            .baml_src_projects
-            .lock()
-            .unwrap()
+        let mut baml_src_projects = self.baml_src_projects.lock().unwrap();
+
+        // Drop moved "baml_src" directories, otherwise the project_updates
+        // code below will fail trying to read directories that no longer exist.
+        let removed_baml_src_dirs = baml_src_projects
+            .keys()
+            .filter(|project_root| !project_root.exists())
+            .cloned()
+            .collect::<Vec<_>>();
+        for baml_src_dir in &removed_baml_src_dirs {
+            baml_src_projects.remove(baml_src_dir);
+        }
+
+        let project_updates: Vec<HashMap<_, _>> = baml_src_projects
             .iter_mut()
             .map(|(_project_root, project)| {
                 let files_map = project
@@ -225,6 +235,10 @@ impl Session {
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
         tracing::info!("Initial reload of {} files", project_updates.len());
+
+        // Guard no longer used. We can drop now instead of waiting for the end
+        // of scope.
+        drop(baml_src_projects);
 
         let files: Vec<(DocumentKey, String)> = project_updates
             .into_iter()

--- a/engine/language_server/src/tests.rs
+++ b/engine/language_server/src/tests.rs
@@ -1,343 +1,339 @@
-#[cfg(test)]
-mod tests {
+use std::{num::NonZeroUsize, thread};
 
-    use std::{num::NonZeroUsize, thread};
+use crossbeam_channel::{Receiver, Sender};
+use log::LevelFilter;
+use lsp_server::Message;
+use serde_json::json;
 
-    use crossbeam_channel::{Receiver, Sender};
-    use log::LevelFilter;
-    use lsp_server::Message;
-    use serde_json::json;
+use crate::server::{connection::ConnectionInitializer, Server};
 
-    use crate::server::{connection::ConnectionInitializer, Server};
+pub struct TestServer {
+    pub thread_join_handle: thread::JoinHandle<()>,
+    pub sender: Sender<Message>,
+    pub receiver: Receiver<Message>,
+}
 
-    pub struct TestServer {
-        pub thread_join_handle: thread::JoinHandle<()>,
-        pub sender: Sender<Message>,
-        pub receiver: Receiver<Message>,
+impl TestServer {
+    pub fn req_respond(
+        &self,
+        req: lsp_server::Message,
+    ) -> Result<lsp_server::Message, anyhow::Error> {
+        self.sender.send(req)?;
+        let resp = self.receiver.recv()?;
+        Ok(resp)
     }
+}
 
-    impl TestServer {
-        pub fn req_respond(
-            &self,
-            req: lsp_server::Message,
-        ) -> Result<lsp_server::Message, anyhow::Error> {
-            self.sender.send(req)?;
-            let resp = self.receiver.recv()?;
-            Ok(resp)
-        }
-    }
+struct TestCase {
+    /// Files to load at initialization time.
+    files: Vec<(String, String)>,
+    /// A list of pairs of client message, and expected server response messages.
+    interactions: Vec<(Message, Vec<Message>)>,
+}
 
-    struct TestCase {
-        /// Files to load at initialization time.
-        files: Vec<(String, String)>,
-        /// A list of pairs of client message, and expected server response messages.
-        interactions: Vec<(Message, Vec<Message>)>,
-    }
-
-    impl TestCase {
-        pub fn run(self) -> anyhow::Result<()> {
-            simple_logging::log_to_file("test.log", LevelFilter::Info).unwrap();
-            eprintln!("new_test_server");
-            let test_server = new_test_server(NonZeroUsize::new(1).unwrap())?;
-            eprintln!("about to loop");
-            for (file_name, file_content) in self.files {
-                test_server.sender.send(lsp_server::Message::Notification(
-                    lsp_server::Notification {
-                        method: "textDocument/didOpen".to_string(),
-                        params: json!({
-                          "textDocument": {
-                            "uri": format!("file:///{}", file_name),
-                            "languageId": "baml",
-                            "version": 1,
-                            "text": file_content
-                          }
-                        }),
-                    },
-                ))?;
-
-                // Consume the post-opening notification.
-                // eprintln!("Awaiting didOpen notif");
-                // let did_open_notification = test_server.receiver.recv();
-                // eprintln!("Got didOpen notif");
-                // dbg!(&did_open_notification);
-                // eprintln!("Await next notification");
-                let next_notification = test_server.receiver.recv();
-                eprintln!("Got next notif");
-                dbg!(&next_notification);
-            }
-
-            for (req, expected_responses) in self.interactions {
-                test_server.sender.send(req)?;
-                for expected_response in expected_responses {
-                    let response = test_server.receiver.recv()?;
-                    match (&response, expected_response) {
-                        (lsp_server::Message::Response(r1), lsp_server::Message::Response(r2)) => {
-                            assert_eq!(r1.result, r2.result);
-                        }
-                        (_, lsp_server::Message::Response(r2)) => {
-                            panic!("Expected response {r2:?}, got {response:?}");
-                        }
-                        (
-                            lsp_server::Message::Notification(n1),
-                            lsp_server::Message::Notification(n2),
-                        ) => {
-                            assert_eq!(n1.method, n2.method);
-                            assert_eq!(n1.params, n2.params);
-                        }
-                        (_, lsp_server::Message::Notification(n2)) => {
-                            panic!("Expected notification {n2:?}, got {response:?}");
-                        }
-                        _ => panic!("Should only expect responses and notifications."),
-                    }
-                }
-            }
-            test_server.thread_join_handle.join().unwrap();
-            Ok(())
-        }
-
-        pub fn mk_simple() -> Self {
-            TestCase {
-                files: vec![("test.baml".to_string(), SINGLE_FILE.to_string())],
-                interactions: vec![],
-            }
-        }
-    }
-
-    pub fn new_test_server(worker_threads: NonZeroUsize) -> anyhow::Result<TestServer> {
-        let initialize = lsp_server::Message::Request(lsp_server::Request {
-            id: lsp_server::RequestId::from(1),
-            method: "initialize".to_string(),
-            params: neovim_initialize_params(),
-        });
-        let (server_connection, client_connection) = lsp_server::Connection::memory();
-
-        client_connection.sender.send(initialize).unwrap();
-        let thread_join_handle = thread::spawn(move || {
-            let connection = ConnectionInitializer::new(server_connection);
-            let (id, init_params) = connection.initialize_start().unwrap();
-
-            let client_capabilities = init_params.capabilities.clone();
-            let position_encoding = Server::find_best_position_encoding(&client_capabilities);
-            let server_capabilities = Server::server_capabilities(position_encoding);
-
-            let connection = connection
-                .initialize_finish(
-                    id,
-                    &server_capabilities,
-                    crate::SERVER_NAME,
-                    crate::version(),
-                )
-                .unwrap();
-
-            let server =
-                Server::new_with_connection(worker_threads, connection, init_params).unwrap();
-            server.run().unwrap();
-        });
-
-        let _handshake = client_connection.receiver.recv()?;
-        client_connection
-            .sender
-            .send(lsp_server::Message::Notification(
+impl TestCase {
+    pub fn run(self) -> anyhow::Result<()> {
+        simple_logging::log_to_file("test.log", LevelFilter::Info).unwrap();
+        eprintln!("new_test_server");
+        let test_server = new_test_server(NonZeroUsize::new(1).unwrap())?;
+        eprintln!("about to loop");
+        for (file_name, file_content) in self.files {
+            test_server.sender.send(lsp_server::Message::Notification(
                 lsp_server::Notification {
-                    method: "initialized".to_string(),
-                    params: json!({}),
+                    method: "textDocument/didOpen".to_string(),
+                    params: json!({
+                      "textDocument": {
+                        "uri": format!("file:///{}", file_name),
+                        "languageId": "baml",
+                        "version": 1,
+                        "text": file_content
+                      }
+                    }),
                 },
             ))?;
 
-        Ok(TestServer {
-            thread_join_handle,
-            sender: client_connection.sender,
-            receiver: client_connection.receiver,
-        })
+            // Consume the post-opening notification.
+            // eprintln!("Awaiting didOpen notif");
+            // let did_open_notification = test_server.receiver.recv();
+            // eprintln!("Got didOpen notif");
+            // dbg!(&did_open_notification);
+            // eprintln!("Await next notification");
+            let next_notification = test_server.receiver.recv();
+            eprintln!("Got next notif");
+            dbg!(&next_notification);
+        }
+
+        for (req, expected_responses) in self.interactions {
+            test_server.sender.send(req)?;
+            for expected_response in expected_responses {
+                let response = test_server.receiver.recv()?;
+                match (&response, expected_response) {
+                    (lsp_server::Message::Response(r1), lsp_server::Message::Response(r2)) => {
+                        assert_eq!(r1.result, r2.result);
+                    }
+                    (_, lsp_server::Message::Response(r2)) => {
+                        panic!("Expected response {r2:?}, got {response:?}");
+                    }
+                    (
+                        lsp_server::Message::Notification(n1),
+                        lsp_server::Message::Notification(n2),
+                    ) => {
+                        assert_eq!(n1.method, n2.method);
+                        assert_eq!(n1.params, n2.params);
+                    }
+                    (_, lsp_server::Message::Notification(n2)) => {
+                        panic!("Expected notification {n2:?}, got {response:?}");
+                    }
+                    _ => panic!("Should only expect responses and notifications."),
+                }
+            }
+        }
+        test_server.thread_join_handle.join().unwrap();
+        Ok(())
     }
 
-    fn neovim_initialize_params() -> serde_json::Value {
-        let pwd = env!("CARGO_MANIFEST_DIR");
-        json!({
-            "workspaceFolders": [{
-                "name": pwd,
-                "uri": format!("file://{}", pwd)
-            }],
-            "trace": "off",
-            "capabilities": {
-                "workspace": {
-                    "workspaceFolders": true,
-                    "applyEdit": true,
-                    "workspaceEdit": {
-                        "resourceOperations": ["rename", "create", "delete"]
-                    },
-                    "semanticTokens": {
-                        "refreshSupport": true
-                    },
-                    "symbol": {
-                        "dynamicRegistration": false,
-                        "symbolKind": {
-                            "valueSet": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]
-                        }
-                    },
-                    "configuration": true,
-                    "didChangeConfiguration": {
-                        "dynamicRegistration": false
-                    },
-                    "didChangeWatchedFiles": {
-                        "dynamicRegistration": true,
-                        "relativePatternSupport": true
-                    },
-                    "inlayHint": {
-                        "refreshSupport": true
+    pub fn mk_simple() -> Self {
+        TestCase {
+            files: vec![("test.baml".to_string(), SINGLE_FILE.to_string())],
+            interactions: vec![],
+        }
+    }
+}
+
+pub fn new_test_server(worker_threads: NonZeroUsize) -> anyhow::Result<TestServer> {
+    let initialize = lsp_server::Message::Request(lsp_server::Request {
+        id: lsp_server::RequestId::from(1),
+        method: "initialize".to_string(),
+        params: neovim_initialize_params(),
+    });
+    let (server_connection, client_connection) = lsp_server::Connection::memory();
+
+    client_connection.sender.send(initialize).unwrap();
+    let thread_join_handle = thread::spawn(move || {
+        let connection = ConnectionInitializer::new(server_connection);
+        let (id, init_params) = connection.initialize_start().unwrap();
+
+        let client_capabilities = init_params.capabilities.clone();
+        let position_encoding = Server::find_best_position_encoding(&client_capabilities);
+        let server_capabilities = Server::server_capabilities(position_encoding);
+
+        let connection = connection
+            .initialize_finish(
+                id,
+                &server_capabilities,
+                crate::SERVER_NAME,
+                crate::version(),
+            )
+            .unwrap();
+
+        let server = Server::new_with_connection(worker_threads, connection, init_params).unwrap();
+        server.run().unwrap();
+    });
+
+    let _handshake = client_connection.receiver.recv()?;
+    client_connection
+        .sender
+        .send(lsp_server::Message::Notification(
+            lsp_server::Notification {
+                method: "initialized".to_string(),
+                params: json!({}),
+            },
+        ))?;
+
+    Ok(TestServer {
+        thread_join_handle,
+        sender: client_connection.sender,
+        receiver: client_connection.receiver,
+    })
+}
+
+fn neovim_initialize_params() -> serde_json::Value {
+    let pwd = env!("CARGO_MANIFEST_DIR");
+    json!({
+        "workspaceFolders": [{
+            "name": pwd,
+            "uri": format!("file://{}", pwd)
+        }],
+        "trace": "off",
+        "capabilities": {
+            "workspace": {
+                "workspaceFolders": true,
+                "applyEdit": true,
+                "workspaceEdit": {
+                    "resourceOperations": ["rename", "create", "delete"]
+                },
+                "semanticTokens": {
+                    "refreshSupport": true
+                },
+                "symbol": {
+                    "dynamicRegistration": false,
+                    "symbolKind": {
+                        "valueSet": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]
                     }
                 },
-                "window": {
-                    "showDocument": {
-                        "support": true
-                    },
-                    "workDoneProgress": true,
-                    "showMessage": {
-                        "messageActionItem": {
-                            "additionalPropertiesSupport": false
-                        }
-                    }
+                "configuration": true,
+                "didChangeConfiguration": {
+                    "dynamicRegistration": false
                 },
-                "textDocument": {
-                    "diagnostic": {
-                        "dynamicRegistration": false
-                    },
-                    "formatting": {
-                        "dynamicRegistration": true
-                    },
-                    "rangeFormatting": {
-                        "dynamicRegistration": true
-                    },
-                    "completion": {
-                        "contextSupport": false,
-                        "completionItemKind": {
-                            "valueSet": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]
-                        },
-                        "completionList": {
-                            "itemDefaults": ["editRange", "insertTextFormat", "insertTextMode", "data"]
-                        },
-                        "completionItem": {
-                            "preselectSupport": false,
-                            "deprecatedSupport": false,
-                            "documentationFormat": ["markdown", "plaintext"],
-                            "snippetSupport": false,
-                            "commitCharactersSupport": false
-                        },
-                        "dynamicRegistration": false
-                    },
-                    "declaration": {
-                        "linkSupport": true
-                    },
-                    "definition": {
-                        "linkSupport": true,
-                        "dynamicRegistration": true
-                    },
-                    "implementation": {
-                        "linkSupport": true
-                    },
-                    "typeDefinition": {
-                        "linkSupport": true
-                    },
-                    "inlayHint": {
-                        "dynamicRegistration": true,
-                        "resolveSupport": {
-                            "properties": ["textEdits", "tooltip", "location", "command"]
-                        }
-                    },
-                    "signatureHelp": {
-                        "dynamicRegistration": false,
-                        "signatureInformation": {
-                            "documentationFormat": ["markdown", "plaintext"],
-                            "activeParameterSupport": true,
-                            "parameterInformation": {
-                                "labelOffsetSupport": true
-                            }
-                        }
-                    },
-                    "semanticTokens": {
-                        "formats": ["relative"],
-                        "requests": {
-                            "full": {
-                                "delta": true
-                            },
-                            "range": false
-                        },
-                        "overlappingTokenSupport": true,
-                        "multilineTokenSupport": false,
-                        "serverCancelSupport": false,
-                        "augmentsSyntaxTokens": true,
-                        "tokenModifiers": ["declaration", "definition", "readonly", "static", "deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary"],
-                        "dynamicRegistration": false,
-                        "tokenTypes": ["namespace", "type", "class", "enum", "interface", "struct", "typeParameter", "parameter", "variable", "property", "enumMember", "event", "function", "method", "macro", "keyword", "modifier", "comment", "string", "number", "regexp", "operator", "decorator"]
-                    },
-                    "hover": {
-                        "dynamicRegistration": true,
-                        "contentFormat": ["markdown", "plaintext"]
-                    },
-                    "documentSymbol": {
-                        "symbolKind": {
-                            "valueSet": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]
-                        },
-                        "hierarchicalDocumentSymbolSupport": true,
-                        "dynamicRegistration": false
-                    },
-                    "callHierarchy": {
-                        "dynamicRegistration": false
-                    },
-                    "synchronization": {
-                        "didSave": true,
-                        "willSaveWaitUntil": true,
-                        "dynamicRegistration": false,
-                        "willSave": true
-                    },
-                    "publishDiagnostics": {
-                        "relatedInformation": true,
-                        "tagSupport": {
-                            "valueSet": [1,2]
-                        },
-                        "dataSupport": true
-                    },
-                    "codeAction": {
-                        "isPreferredSupport": true,
-                        "dataSupport": true,
-                        "codeActionLiteralSupport": {
-                            "codeActionKind": {
-                                "valueSet": ["", "quickfix", "refactor", "refactor.extract", "refactor.inline", "refactor.rewrite", "source", "source.organizeImports"]
-                            }
-                        },
-                        "dynamicRegistration": true,
-                        "resolveSupport": {
-                            "properties": ["edit"]
-                        }
-                    },
-                    "references": {
-                        "dynamicRegistration": false
-                    },
-                    "rename": {
-                        "dynamicRegistration": true,
-                        "prepareSupport": true
-                    },
-                    "documentHighlight": {
-                        "dynamicRegistration": false
-                    }
+                "didChangeWatchedFiles": {
+                    "dynamicRegistration": true,
+                    "relativePatternSupport": true
                 },
-                "general": {
-                    "positionEncodings": ["utf-16"]
+                "inlayHint": {
+                    "refreshSupport": true
                 }
             },
-            "clientInfo": {
-                "version": "0.10.4",
-                "name": "Neovim"
+            "window": {
+                "showDocument": {
+                    "support": true
+                },
+                "workDoneProgress": true,
+                "showMessage": {
+                    "messageActionItem": {
+                        "additionalPropertiesSupport": false
+                    }
+                }
             },
-            "rootPath": pwd,
-            "rootUri": format!("file://{}", pwd),
-            "initializationOptions": {},
-            "workDoneToken": "1",
-            "processId": 81093
-        })
-    }
+            "textDocument": {
+                "diagnostic": {
+                    "dynamicRegistration": false
+                },
+                "formatting": {
+                    "dynamicRegistration": true
+                },
+                "rangeFormatting": {
+                    "dynamicRegistration": true
+                },
+                "completion": {
+                    "contextSupport": false,
+                    "completionItemKind": {
+                        "valueSet": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25]
+                    },
+                    "completionList": {
+                        "itemDefaults": ["editRange", "insertTextFormat", "insertTextMode", "data"]
+                    },
+                    "completionItem": {
+                        "preselectSupport": false,
+                        "deprecatedSupport": false,
+                        "documentationFormat": ["markdown", "plaintext"],
+                        "snippetSupport": false,
+                        "commitCharactersSupport": false
+                    },
+                    "dynamicRegistration": false
+                },
+                "declaration": {
+                    "linkSupport": true
+                },
+                "definition": {
+                    "linkSupport": true,
+                    "dynamicRegistration": true
+                },
+                "implementation": {
+                    "linkSupport": true
+                },
+                "typeDefinition": {
+                    "linkSupport": true
+                },
+                "inlayHint": {
+                    "dynamicRegistration": true,
+                    "resolveSupport": {
+                        "properties": ["textEdits", "tooltip", "location", "command"]
+                    }
+                },
+                "signatureHelp": {
+                    "dynamicRegistration": false,
+                    "signatureInformation": {
+                        "documentationFormat": ["markdown", "plaintext"],
+                        "activeParameterSupport": true,
+                        "parameterInformation": {
+                            "labelOffsetSupport": true
+                        }
+                    }
+                },
+                "semanticTokens": {
+                    "formats": ["relative"],
+                    "requests": {
+                        "full": {
+                            "delta": true
+                        },
+                        "range": false
+                    },
+                    "overlappingTokenSupport": true,
+                    "multilineTokenSupport": false,
+                    "serverCancelSupport": false,
+                    "augmentsSyntaxTokens": true,
+                    "tokenModifiers": ["declaration", "definition", "readonly", "static", "deprecated", "abstract", "async", "modification", "documentation", "defaultLibrary"],
+                    "dynamicRegistration": false,
+                    "tokenTypes": ["namespace", "type", "class", "enum", "interface", "struct", "typeParameter", "parameter", "variable", "property", "enumMember", "event", "function", "method", "macro", "keyword", "modifier", "comment", "string", "number", "regexp", "operator", "decorator"]
+                },
+                "hover": {
+                    "dynamicRegistration": true,
+                    "contentFormat": ["markdown", "plaintext"]
+                },
+                "documentSymbol": {
+                    "symbolKind": {
+                        "valueSet": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26]
+                    },
+                    "hierarchicalDocumentSymbolSupport": true,
+                    "dynamicRegistration": false
+                },
+                "callHierarchy": {
+                    "dynamicRegistration": false
+                },
+                "synchronization": {
+                    "didSave": true,
+                    "willSaveWaitUntil": true,
+                    "dynamicRegistration": false,
+                    "willSave": true
+                },
+                "publishDiagnostics": {
+                    "relatedInformation": true,
+                    "tagSupport": {
+                        "valueSet": [1,2]
+                    },
+                    "dataSupport": true
+                },
+                "codeAction": {
+                    "isPreferredSupport": true,
+                    "dataSupport": true,
+                    "codeActionLiteralSupport": {
+                        "codeActionKind": {
+                            "valueSet": ["", "quickfix", "refactor", "refactor.extract", "refactor.inline", "refactor.rewrite", "source", "source.organizeImports"]
+                        }
+                    },
+                    "dynamicRegistration": true,
+                    "resolveSupport": {
+                        "properties": ["edit"]
+                    }
+                },
+                "references": {
+                    "dynamicRegistration": false
+                },
+                "rename": {
+                    "dynamicRegistration": true,
+                    "prepareSupport": true
+                },
+                "documentHighlight": {
+                    "dynamicRegistration": false
+                }
+            },
+            "general": {
+                "positionEncodings": ["utf-16"]
+            }
+        },
+        "clientInfo": {
+            "version": "0.10.4",
+            "name": "Neovim"
+        },
+        "rootPath": pwd,
+        "rootUri": format!("file://{}", pwd),
+        "initializationOptions": {},
+        "workDoneToken": "1",
+        "processId": 81093
+    })
+}
 
-    static SINGLE_FILE: &str = r##"
+static SINGLE_FILE: &str = r##"
 client<llm> GPT4 {
   provider openai
   options {
@@ -360,7 +356,7 @@ function Succ(inp: int) -> Foo {
   client GPT3
   prompt #"
     The successor of {{ inp }}.
-    {{ ctx.output_format }}   
+    {{ ctx.output_format }}
   "#
 }
 
@@ -370,11 +366,10 @@ test TestSucc {
 }
 "##;
 
-    // This test can be useful for local debugging. But it can't run in CI
-    // or as part of the ful test suite because it requires Ctrl-C to
-    // terminate.
-    // #[test]
-    fn test_initialization() {
-        TestCase::mk_simple().run().unwrap()
-    }
+// This test can be useful for local debugging. But it can't run in CI
+// or as part of the ful test suite because it requires Ctrl-C to
+// terminate.
+// #[test]
+fn test_initialization() {
+    TestCase::mk_simple().run().unwrap()
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix crash in LSP by removing non-existent `baml_src` directories in `session.rs` during reload.
> 
>   - **Behavior**:
>     - In `session.rs`, `reload()` now removes non-existent `baml_src` directories before processing updates to prevent crashes.
>     - Drops `baml_src_projects` lock early in `reload()` after use.
>   - **Tests**:
>     - Minor formatting and refactoring in `tests.rs` for better readability.
>     - Removed unnecessary module-level `#[cfg(test)]` in `tests.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 44ff35dab03de2134e17d4b33849fbf45b9fcba7. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->