### PR TITLE
[bug] Propertly escape env vars from VSCode -> BAML runtime

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/vertex/wasm_auth.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/vertex/wasm_auth.rs
@@ -54,7 +54,9 @@ impl VertexAuth {
     pub async fn token(&self, scopes: &[&str]) -> Result<Arc<Token>> {
         match &self.0 {
             Some(service_account) => {
-                let token = service_account.get_oauth2_token().await?;
+                let token = service_account.get_oauth2_token().await.context(
+                    "Failed to get OAuth2 token from provided service account credentials",
+                )?;
                 Ok(Arc::new(token))
             }
             None => {

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -50,6 +50,8 @@ type JsResult<T> = core::result::Result<T, JsError>;
 
 #[wasm_bindgen(start)]
 pub fn on_wasm_init() {
+    // TODO: set LOG_LEVEL to ::Debug if you wish to see logs.
+    // this is disabled by default because its slows down release mode builds.
     cfg_if::cfg_if! {
         if #[cfg(debug_assertions)] {
             const LOG_LEVEL: log::Level = log::Level::Info;

--- a/typescript/packages/playground-common/src/components/api-keys-dialog/atoms.ts
+++ b/typescript/packages/playground-common/src/components/api-keys-dialog/atoms.ts
@@ -114,7 +114,7 @@ export const userApiKeysAtom = atom(
       envKeyValues
         .map(([k, v]) => [k, v])
         .filter(([k]) => k !== 'BOUNDARY_PROXY_URL'),
-    );
+    ) as Record<string, string>;
     console.log('userApiKeysAtom getter:', { envKeyValues, result });
     return result;
   },
@@ -170,7 +170,15 @@ export const apiKeysAtom = atom(
     }
 
     const { proxyEnabled, proxyUrl } = get(proxyUrlAtom);
-    const userEnvVars = get(userApiKeysAtom);
+    const userEnvVarsUnescaped = get(userApiKeysAtom);
+
+    // escape env vars that may have \n,\t in them
+    // we don't replace \" because its a bit trickier, but if users report bugs, we should fix this.
+    const userEnvVars = Object.fromEntries(
+      Object.entries(userEnvVarsUnescaped).map(([key, value]) => [key, value.replaceAll('\n', '\\n').replaceAll('\t', '\\t')]),
+    );
+
+    console.log('userEnvVars', userEnvVars);
 
     if (!proxyEnabled) {
       // if proxy is not enabled, just return user vars without BOUNDARY_PROXY_URL


### PR DESCRIPTION
This is relevant when users paste in JSON blobs for credentials.

Also improved error message:

users now get:
<img width="539" height="359" alt="Screenshot 2025-07-14 at 4 19 47 PM" src="https://github.com/user-attachments/assets/8212b638-57a6-4163-a839-1cd2f07ac637" />

Json strings are also parsed:
<img width="964" height="16" alt="Screenshot 2025-07-14 at 4 20 56 PM" src="https://github.com/user-attachments/assets/3e572097-2e4e-4939-b412-b96def9db6fa" />

before we'd read newlines as `\n` now we convert to `\\n` which fixes the issues since we do 2 levels of casting