### PR TITLE
pretty print bytecode

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -922,7 +922,7 @@ dependencies = [
 
 [[package]]
 name = "baml-compiler"
-version = "0.200.0"
+version = "0.201.0"
 dependencies = [
  "anyhow",
  "baml-vm",
@@ -1303,10 +1303,11 @@ dependencies = [
 
 [[package]]
 name = "baml-vm"
-version = "0.200.0"
+version = "0.201.0"
 dependencies = [
  "anyhow",
  "baml-compiler",
+ "colored 2.2.0",
  "internal-baml-core",
  "internal-baml-diagnostics",
  "internal-baml-parser-database",

--- a/engine/baml-vm/Cargo.toml
+++ b/engine/baml-vm/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 description = "BAML Virtual Machine"
 license-file.workspace = true
 
+[dependencies]
+colored = "2.1.0"
+
 [lints.clippy]
 new_without_default = "allow"
 

--- a/engine/baml-vm/src/debug.rs
+++ b/engine/baml-vm/src/debug.rs
@@ -22,6 +22,8 @@
 //!
 //! ```
 
+use colored::*;
+
 use crate::{Function, Instruction, Object, Value};
 
 /// Context aware instruction display.
@@ -145,6 +147,24 @@ pub fn display_value(value: &Value, objects: &[Object]) -> String {
 /// See [`display_bytecode`] for more information.
 const COLUMN_MARGIN: usize = 3;
 
+/// Get color for instruction based on its type
+fn get_instruction_color(instruction: &Instruction) -> Color {
+    match instruction {
+        Instruction::LoadConst(_)
+        | Instruction::LoadVar(_)
+        | Instruction::LoadGlobal(_)
+        | Instruction::LoadField(_) => Color::Blue,
+        Instruction::StoreVar(_) | Instruction::StoreGlobal(_) | Instruction::StoreField(_) => {
+            Color::Green
+        }
+        Instruction::Jump(_) | Instruction::JumpIfFalse(_) => Color::Yellow,
+        Instruction::Call(_) => Color::Magenta,
+        Instruction::Return => Color::Red,
+        Instruction::AllocInstance(_) | Instruction::AllocArray(_) => Color::Cyan,
+        Instruction::Pop | Instruction::EndBlock(_) => Color::BrightBlack,
+    }
+}
+
 /// Print the bytecode of a function in a readable table format.
 ///
 /// Format is [LINE, IP, INSTRUCTION, METADATA]. Something like this:
@@ -181,6 +201,8 @@ pub fn display_bytecode(
     let mut chars_count = Vec::new();
     // Max width of each column. [usize, usize, usize, usize]
     let mut widths = [0; 4];
+    // Store instruction colors for each row
+    let mut row_colors = Vec::new();
 
     // Track the last line number we printed
     let mut last_line: usize = 0;
@@ -224,12 +246,15 @@ pub fn display_bytecode(
 
         rows.push(row);
         chars_count.push(char_count);
+        row_colors.push(get_instruction_color(
+            &function.bytecode.instructions[instruction_ptr],
+        ));
     }
 
     let mut table = String::new();
 
     // Print the table.
-    for (row, char_count) in rows.iter().zip(chars_count) {
+    for ((row, char_count), color) in rows.iter().zip(chars_count).zip(row_colors) {
         for (i, col) in row.iter().enumerate() {
             let mut width = widths[i];
 
@@ -240,9 +265,18 @@ pub fn display_bytecode(
                 width = 0;
             }
 
-            // Trick to avoid allocating unnecessary strings with format!().
-            // Just use the table buffer directly.
-            table.push_str(col);
+            // Apply color based on column
+            let colored_text = match i {
+                0 => col.bright_black().to_string(),      // Line numbers in gray
+                1 => col.white().to_string(),             // IP in white
+                2 => col.color(color).bold().to_string(), // Instruction with type-based color
+                3 => col.bright_cyan().to_string(),       // Metadata in cyan
+                _ => col.to_string(),
+            };
+
+            // For colored strings, we need to use the actual character count
+            // not the length with ANSI codes
+            table.push_str(&colored_text);
             for _ in char_count[i]..width {
                 table.push(' ');
             }

--- a/engine/baml-vm/src/debug.rs
+++ b/engine/baml-vm/src/debug.rs
@@ -22,6 +22,8 @@
 //!
 //! ```
 
+use std::io::IsTerminal;
+
 use colored::*;
 
 use crate::{Function, Instruction, Object, Value};
@@ -253,6 +255,9 @@ pub fn display_bytecode(
 
     let mut table = String::new();
 
+    // Check if stdout is a TTY to determine whether to use colors
+    let use_colors = std::io::stdout().is_terminal();
+
     // Print the table.
     for ((row, char_count), color) in rows.iter().zip(chars_count).zip(row_colors) {
         for (i, col) in row.iter().enumerate() {
@@ -265,13 +270,17 @@ pub fn display_bytecode(
                 width = 0;
             }
 
-            // Apply color based on column
-            let colored_text = match i {
-                0 => col.bright_black().to_string(),      // Line numbers in gray
-                1 => col.white().to_string(),             // IP in white
-                2 => col.color(color).bold().to_string(), // Instruction with type-based color
-                3 => col.bright_cyan().to_string(),       // Metadata in cyan
-                _ => col.to_string(),
+            // Apply color based on column, only if output is to a TTY
+            let colored_text = if use_colors {
+                match i {
+                    0 => col.bright_black().to_string(),      // Line numbers in gray
+                    1 => col.white().to_string(),             // IP in white
+                    2 => col.color(color).bold().to_string(), // Instruction with type-based color
+                    3 => col.bright_cyan().to_string(),       // Metadata in cyan
+                    _ => col.to_string(),
+                }
+            } else {
+                col.to_string() // No colors when not writing to TTY
             };
 
             // For colored strings, we need to use the actual character count


### PR DESCRIPTION
100% vibe coded to pretty print instructions based on their type.

<img width="443" height="223" alt="image" src="https://github.com/user-attachments/assets/4630630d-6b2a-478e-abde-ed2d356658c5" />

<img width="443" height="223" alt="image" src="https://github.com/user-attachments/assets/679fa3cb-e6c8-4414-ab97-35a5000185c7" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add color-coded pretty printing for bytecode instructions in BAML VM using the `colored` crate.
> 
>   - **Behavior**:
>     - `display_bytecode()` in `debug.rs` now pretty prints bytecode with colors based on instruction type.
>     - Uses `colored` crate to apply colors if output is to a TTY.
>   - **Functions**:
>     - Adds `get_instruction_color()` in `debug.rs` to map instructions to colors.
>   - **Dependencies**:
>     - Adds `colored = "2.1.0"` to `Cargo.toml`.
>   - **Versioning**:
>     - Updates `baml-vm` and `baml-compiler` versions in `Cargo.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ef0124edb45eef86f20ac467c3df9e99a84e1f7d. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->