### PR TITLE
Redact headers when sent to boundary studio

### DIFF
--- a/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
@@ -566,7 +566,7 @@ impl TracePublisher {
                 Ok(())
             }
             Err(e) => {
-                log::info!("Failed to upload batch of {} events: {}", batch.len(), e);
+                log::info!("Failed to upload batch of {} events: {:?}", batch.len(), e);
                 // If batch size is at or below minimum, give up
                 if batch.len() <= min_batch_size {
                     log::info!(

--- a/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/trace_data.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/trace_data.rs
@@ -2,7 +2,10 @@ use std::borrow::Cow;
 
 use anyhow::Result;
 use baml_rpc::RpcClientDetails;
-use baml_types::{tracing::events::{FunctionType, redact_headers}, type_meta, HasType};
+use baml_types::{
+    tracing::events::{redact_headers, FunctionType},
+    type_meta, HasType,
+};
 
 use super::{IntoRpcEvent, TypeLookup};
 

--- a/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/trace_data.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/trace_data.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use anyhow::Result;
 use baml_rpc::RpcClientDetails;
-use baml_types::{tracing::events::FunctionType, type_meta, HasType};
+use baml_types::{tracing::events::{FunctionType, redact_headers}, type_meta, HasType};
 
 use super::{IntoRpcEvent, TypeLookup};
 
@@ -213,7 +213,7 @@ impl<'a> IntoRpcEvent<'a, baml_rpc::runtime_api::IntermediateData<'a>>
             http_request_id: self.id.to_string(),
             url: self.url().to_string(),
             method: self.method().to_string(),
-            headers: self.headers().clone(),
+            headers: redact_headers(self.headers().clone()),
             body: self.body().to_rpc_event(lookup),
         }
     }
@@ -229,7 +229,7 @@ impl<'a> IntoRpcEvent<'a, baml_rpc::runtime_api::IntermediateData<'a>>
         baml_rpc::runtime_api::IntermediateData::RawLLMResponse {
             http_request_id: self.request_id.to_string(),
             status: self.status,
-            headers: self.headers().cloned(),
+            headers: self.headers().cloned().map(redact_headers),
             body: self.body.to_rpc_event(lookup),
             client_details: RpcClientDetails {
                 name: self.client_details.name.clone(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Redact headers in HTTP requests and responses and improve error logging in `TracePublisher`.
> 
>   - **Behavior**:
>     - Redact headers in `HTTPRequest` and `HTTPResponse` using `redact_headers()` in `trace_data.rs`.
>     - Log detailed error information in `TracePublisher::process_batch_recursive()` in `publisher.rs`.
>   - **Functions**:
>     - Modify `to_rpc_event()` for `HTTPRequest` and `HTTPResponse` to use `redact_headers()` in `trace_data.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f3fbab045f1fae1130d60dc8b7c39750568c2dfd. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->