### PR TITLE
Increase batch size of publisher thread

### DIFF
--- a/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
@@ -256,7 +256,7 @@ impl TracePublisher {
             .ast
             .env_var("BAML_TRACE_BATCH_SIZE")
             .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(12);
+            .unwrap_or(100);
 
         Self {
             rx,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase default `batch_size` from 12 to 100 in `TracePublisher` constructor in `publisher.rs`.
> 
>   - **Behavior**:
>     - Increase default `batch_size` from 12 to 100 in `TracePublisher` constructor in `publisher.rs`. This affects the number of trace events processed in a batch before sending.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for bc22f6c4d6a3d34349a10b4f3cce9f6126588e83. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->