### PR TITLE
Add http request id to stream events to be able to merge them on the backend

### DIFF
--- a/engine/baml-rpc/src/runtime_api/trace_event.rs
+++ b/engine/baml-rpc/src/runtime_api/trace_event.rs
@@ -130,6 +130,7 @@ pub enum IntermediateData<'a> {
         client_details: RpcClientDetails,
     },
     RawLLMResponseStream {
+        http_request_id: String,
         event: Event<'a>,
     },
     LLMResponse {

--- a/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
@@ -256,7 +256,7 @@ impl TracePublisher {
             .ast
             .env_var("BAML_TRACE_BATCH_SIZE")
             .and_then(|s| s.parse::<usize>().ok())
-            .unwrap_or(100);
+            .unwrap_or(200);
 
         Self {
             rx,

--- a/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/trace_data.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/trace_data.rs
@@ -251,6 +251,7 @@ impl<'a> IntoRpcEvent<'a, baml_rpc::runtime_api::IntermediateData<'a>>
         lookup: &(impl TypeLookup + ?Sized),
     ) -> baml_rpc::runtime_api::IntermediateData<'a> {
         baml_rpc::runtime_api::IntermediateData::RawLLMResponseStream {
+            http_request_id: self.request_id.to_string(),
             event: baml_rpc::runtime_api::Event {
                 raw: Cow::Borrowed(&self.event.data),
             },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `http_request_id` to `RawLLMResponseStream` and increase default batch size in `TracePublisher`.
> 
>   - **Behavior**:
>     - Add `http_request_id` to `RawLLMResponseStream` in `IntermediateData` in `trace_event.rs`.
>     - Update `to_rpc_event` in `trace_data.rs` to include `http_request_id` for `HTTPResponseStream`.
>   - **Configuration**:
>     - Change default `BAML_TRACE_BATCH_SIZE` from 100 to 200 in `TracePublisher` in `publisher.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 2233d2a67ed1fa8f3345add666a3339d160cc5ef. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->