### PR TITLE
Don't require semicolon after for loop

### DIFF
--- a/engine/baml-lib/ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/ast/src/parser/datamodel.pest
@@ -236,7 +236,7 @@ expr_block = { BLOCK_OPEN ~ NEWLINE? ~ (stmt | comment_block | empty_lines)* ~ e
 
 // Statement.
 // Currently the only statement is a let-binding.
-stmt = { (let_expr | for_loop) ~ SEMICOLON? ~ trailing_comment? ~ NEWLINE? }
+stmt = { ((let_expr ~ SEMICOLON?) | for_loop) ~ trailing_comment? ~ NEWLINE? }
 
 // Let-binding statement.
 let_expr = { "let" ~ identifier ~ "=" ~ expression }

--- a/engine/baml-lib/ast/src/parser/parse_expr.rs
+++ b/engine/baml-lib/ast/src/parser/parse_expr.rs
@@ -129,10 +129,12 @@ pub fn parse_statement(token: Pair<'_>, diagnostics: &mut Diagnostics) -> Option
     match maybe_semicolon {
         Some(p) if p.as_str() == ";" => {}
         _ => {
-            diagnostics.push_error(DatamodelError::new_static(
-                "Statement must end with a semicolon.",
-                span.clone(),
-            ));
+            if matches!(stmt, Some(Stmt::Let(_))) {
+                diagnostics.push_error(DatamodelError::new_static(
+                    "Statement must end with a semicolon.",
+                    span.clone(),
+                ));
+            }
         }
     }
 

--- a/engine/baml-lib/baml/tests/validation_files/expr/for_loop.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/for_loop.baml
@@ -1,26 +1,13 @@
-function Foo() -> int {
-  let yyyyyyyy = [1, 2, 3];
-  let x = for (i in yyyyyyyy) { i };
-  x
-}
+function Foo() -> int[] {
+  let list = [1, 2, 3];
+  for (i in list) { i + 1 }
 
-let x = for (i in "hi") { b };
+  list
+}
 
 // warning: Workflow functions are experimental, and will break in the future.
 //   -->  expr/for_loop.baml:1
 //    | 
 //    | 
-//  1 | function Foo() -> int {
-//    | 
-// warning: Variable assignment is experimental, and will break in the future.
-//   -->  expr/for_loop.baml:7
-//    | 
-//  6 | 
-//  7 | let x = for (i in "hi") { b };
-//    | 
-// error: Error validating: For loop must iterate over a list
-//   -->  expr/for_loop.baml:3
-//    | 
-//  2 |   let yyyyyyyy = [1, 2, 3];
-//  3 |   let x = for (i in yyyyyyyy) { i };
+//  1 | function Foo() -> int[] {
 //    | 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allow `for_loop` to not require a semicolon, while `let_expr` still does, updating grammar, parser, and tests.
> 
>   - **Grammar**:
>     - Updated `stmt` rule in `datamodel.pest` to allow `for_loop` without a semicolon.
>   - **Parser**:
>     - Modified `parse_statement()` in `parse_expr.rs` to only enforce semicolon for `let_expr`.
>   - **Tests**:
>     - Updated `for_loop.baml` to remove semicolon after `for_loop` and adjust function logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 83efb930d68b067e4181bb85f123154f14ccbdbc. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->