### PR TITLE
Remove for loops from top level assignments

### DIFF
--- a/engine/baml-lib/ast/src/ast/expr.rs
+++ b/engine/baml-lib/ast/src/ast/expr.rs
@@ -4,7 +4,8 @@ use baml_types::{TypeValue, UnresolvedValue};
 use internal_baml_diagnostics::Diagnostics;
 
 use crate::ast::{
-    ArgumentsList, BlockArgs, Expression, ExpressionBlock, FieldType, Identifier, Span, Stmt,
+    ArgumentsList, BlockArgs, Expression, ExpressionBlock, FieldType, Identifier, LetStmt, Span,
+    Stmt,
 };
 
 /// A function definition.
@@ -21,5 +22,5 @@ pub struct ExprFn {
 /// E.g. (at top-level in source file) `let x = 1;`
 #[derive(Debug, Clone)]
 pub struct TopLevelAssignment {
-    pub stmt: Stmt,
+    pub stmt: LetStmt,
 }

--- a/engine/baml-lib/ast/src/ast/top.rs
+++ b/engine/baml-lib/ast/src/ast/top.rs
@@ -114,7 +114,7 @@ impl WithIdentifier for Top {
             Top::Generator(x) => x.identifier(),
             Top::TestCase(x) => x.identifier(),
             Top::RetryPolicy(x) => x.identifier(),
-            Top::TopLevelAssignment(x) => x.stmt.identifier(),
+            Top::TopLevelAssignment(x) => &x.stmt.identifier,
             Top::ExprFn(x) => &x.name,
         }
     }
@@ -132,7 +132,7 @@ impl WithSpan for Top {
             Top::Generator(gen) => gen.span(),
             Top::TestCase(test) => test.span(),
             Top::RetryPolicy(retry) => retry.span(),
-            Top::TopLevelAssignment(asmnt) => asmnt.stmt.span(),
+            Top::TopLevelAssignment(asmnt) => &asmnt.stmt.span,
             Top::ExprFn(function) => &function.span,
         }
     }

--- a/engine/baml-lib/ast/src/parser/parse.rs
+++ b/engine/baml-lib/ast/src/parser/parse.rs
@@ -424,7 +424,7 @@ mod tests {
         let (ast, _) = parse(Path::new(path), &source).unwrap();
         match ast.tops.as_slice() {
             [Top::TopLevelAssignment(x)] => {
-                assert_eq!(x.stmt.identifier().name(), "x");
+                assert_eq!(x.stmt.identifier.name(), "x");
             }
             _ => panic!("Expected a single top level assignment."),
         }
@@ -445,8 +445,8 @@ mod tests {
             [Top::TopLevelAssignment(x)] => {
                 dbg!(&x);
                 dbg!(&x.stmt);
-                assert_eq!(x.stmt.identifier().name(), "x");
-                match &x.stmt.body() {
+                assert_eq!(x.stmt.identifier.name(), "x");
+                match &x.stmt.expr {
                     Expression::ExprBlock(ExpressionBlock { stmts, expr }, _) => {
                         assert_eq!(stmts.len(), 1);
                         assert_eq!(stmts[0].identifier().name(), "y");

--- a/engine/baml-lib/ast/src/parser/parse_expr.rs
+++ b/engine/baml-lib/ast/src/parser/parse_expr.rs
@@ -61,7 +61,16 @@ pub fn parse_top_level_assignment(
     assert_correct_parser!(token, Rule::top_level_assignment);
     let mut tokens = token.into_inner();
     let stmt = parse_statement(tokens.next()?, diagnostics)?;
-    Some(TopLevelAssignment { stmt })
+
+    let Stmt::Let(let_stmt) = stmt else {
+        diagnostics.push_error(DatamodelError::new_static(
+            "for loops are not allowed at top level, only let statements are allowed",
+            stmt.span().clone(),
+        ));
+        return None;
+    };
+
+    Some(TopLevelAssignment { stmt: let_stmt })
 }
 
 pub fn parse_for_loop(token: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<Stmt> {

--- a/engine/baml-lib/ast/src/parser/parse_expr.rs
+++ b/engine/baml-lib/ast/src/parser/parse_expr.rs
@@ -62,15 +62,18 @@ pub fn parse_top_level_assignment(
     let mut tokens = token.into_inner();
     let stmt = parse_statement(tokens.next()?, diagnostics)?;
 
-    let Stmt::Let(let_stmt) = stmt else {
-        diagnostics.push_error(DatamodelError::new_static(
-            "for loops are not allowed at top level, only let statements are allowed",
-            stmt.span().clone(),
-        ));
-        return None;
-    };
+    match parse_statement(tokens.next()?, diagnostics)? {
+        Stmt::Let(stmt) => Some(TopLevelAssignment { stmt }),
 
-    Some(TopLevelAssignment { stmt: let_stmt })
+        Stmt::ForLoop(_) => {
+            diagnostics.push_error(DatamodelError::new_static(
+                "for loops are not allowed at top level, only let statements are allowed",
+                stmt.span().clone(),
+            ));
+
+            None
+        }
+    }
 }
 
 pub fn parse_for_loop(token: Pair<'_>, diagnostics: &mut Diagnostics) -> Option<Stmt> {

--- a/engine/baml-lib/ast/src/parser/parse_expr.rs
+++ b/engine/baml-lib/ast/src/parser/parse_expr.rs
@@ -60,7 +60,6 @@ pub fn parse_top_level_assignment(
 ) -> Option<expr::TopLevelAssignment> {
     assert_correct_parser!(token, Rule::top_level_assignment);
     let mut tokens = token.into_inner();
-    let stmt = parse_statement(tokens.next()?, diagnostics)?;
 
     match parse_statement(tokens.next()?, diagnostics)? {
         Stmt::Let(stmt) => Some(TopLevelAssignment { stmt }),

--- a/engine/baml-lib/ast/src/parser/parse_expr.rs
+++ b/engine/baml-lib/ast/src/parser/parse_expr.rs
@@ -64,10 +64,10 @@ pub fn parse_top_level_assignment(
     match parse_statement(tokens.next()?, diagnostics)? {
         Stmt::Let(stmt) => Some(TopLevelAssignment { stmt }),
 
-        Stmt::ForLoop(_) => {
+        Stmt::ForLoop(stmt) => {
             diagnostics.push_error(DatamodelError::new_static(
                 "for loops are not allowed at top level, only let statements are allowed",
-                stmt.span().clone(),
+                stmt.span.clone(),
             ));
 
             None

--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -177,10 +177,10 @@ impl WithRepr<TopLevelAssignment> for TopLevelAssignmentWalker<'_> {
         let name = self
             .top_level_assignment()
             .stmt
-            .identifier()
+            .identifier
             .name()
             .to_string();
-        let expr = self.top_level_assignment().stmt.body().repr(db)?;
+        let expr = self.top_level_assignment().stmt.expr.repr(db)?;
         Ok(TopLevelAssignment {
             name: Node {
                 elem: name,

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_fns.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_fns.rs
@@ -89,11 +89,8 @@ pub(super) fn validate_expr_fns(ctx: &mut Context<'_>) {
             "Variable assignment is experimental, and will break in the future.".to_string(),
             toplevel_assignment.expr().span().clone(),
         ));
-        validate_stmt(
-            ctx,
-            &toplevel_assignment.top_level_assignment().stmt,
-            &scope,
-        );
+
+        validate_expression(ctx, toplevel_assignment.expr(), &scope);
     }
 }
 

--- a/engine/baml-lib/parser-database/src/walkers/expr_fn.rs
+++ b/engine/baml-lib/parser-database/src/walkers/expr_fn.rs
@@ -10,7 +10,7 @@ pub type TopLevelAssignmentWalker<'db> = Walker<'db, ast::TopLevelAssignmentId>;
 impl<'db> TopLevelAssignmentWalker<'db> {
     /// Returns the name of the top level assignment.
     pub fn name(&self) -> &str {
-        self.db.ast[self.id].stmt.identifier().name()
+        self.db.ast[self.id].stmt.identifier.name()
     }
 
     /// Return the AST node for the top level assignment.
@@ -20,7 +20,7 @@ impl<'db> TopLevelAssignmentWalker<'db> {
 
     /// Returns the expression of the top level assignment.
     pub fn expr(&self) -> &ast::Expression {
-        self.db.ast[self.id].stmt.body()
+        &self.db.ast[self.id].stmt.expr
     }
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `for` loops from top-level assignments, allowing only `let` statements, with updates to parsing, validation, and representation logic.
> 
>   - **Behavior**:
>     - Disallow `for` loops in top-level assignments, only `let` statements are allowed (`parse_expr.rs`).
>     - Add error logging for `for` loops at top level (`parse_expr.rs`).
>   - **AST Changes**:
>     - Change `TopLevelAssignment` to use `LetStmt` instead of `Stmt` (`expr.rs`).
>     - Update `TopLevelAssignment` handling in `Top` enum (`top.rs`).
>   - **Parser Changes**:
>     - Modify `parse_top_level_assignment` to handle `LetStmt` and log errors for `ForLoopStmt` (`parse_expr.rs`).
>     - Update tests to reflect changes in top-level assignment parsing (`parse.rs`).
>   - **Validation**:
>     - Update `validate_expr_fns` to validate expressions in top-level assignments (`expr_fns.rs`).
>   - **IR Changes**:
>     - Update `TopLevelAssignmentWalker` to reflect changes in `TopLevelAssignment` structure (`expr_fn.rs`, `repr.rs`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for bb79a010b2c39eba7097f5c900e2af01e1605751. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->