### PR TITLE
apply suggestions by cargo fix to reduce warnings

### DIFF
--- a/engine/generators/languages/go/src/lib.rs
+++ b/engine/generators/languages/go/src/lib.rs
@@ -1,4 +1,4 @@
-use baml_types::{ir_type::TypeGeneric, TypeIR};
+use baml_types::ir_type::TypeGeneric;
 use dir_writer::{FileCollector, GeneratorArgs, IntermediateRepr, LanguageFeatures};
 use functions::{
     render_functions, render_functions_stream, render_runtime_code, render_source_files,

--- a/engine/generators/languages/python/src/ir_to_py/mod.rs
+++ b/engine/generators/languages/python/src/ir_to_py/mod.rs
@@ -1,7 +1,7 @@
 use baml_types::{
     baml_value::TypeLookups,
     ir_type::{TypeNonStreaming, TypeStreaming},
-    type_meta::{self, base::TypeMeta, stream::TypeMetaStreaming},
+    type_meta::{self, stream::TypeMetaStreaming},
     BamlMediaType, ConstraintLevel, TypeValue,
 };
 

--- a/engine/generators/languages/ruby/src/ir_to_rb/mod.rs
+++ b/engine/generators/languages/ruby/src/ir_to_rb/mod.rs
@@ -1,7 +1,7 @@
 use baml_types::{
     baml_value::TypeLookups,
     ir_type::{TypeNonStreaming, TypeStreaming},
-    type_meta::{self, base::TypeMeta, stream::TypeMetaStreaming},
+    type_meta::{self, stream::TypeMetaStreaming},
     BamlMediaType, ConstraintLevel, TypeValue,
 };
 

--- a/engine/generators/languages/typescript/src/ir_to_ts/mod.rs
+++ b/engine/generators/languages/typescript/src/ir_to_ts/mod.rs
@@ -1,7 +1,7 @@
 use baml_types::{
     baml_value::TypeLookups,
     ir_type::{TypeNonStreaming, TypeStreaming},
-    type_meta::{self, base::TypeMeta, stream::TypeMetaStreaming},
+    type_meta::{self, stream::TypeMetaStreaming},
     BamlMediaType, ConstraintLevel, TypeValue,
 };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Apply `cargo fix` suggestions to remove unused imports in Go, Python, Ruby, and TypeScript language generators.
> 
>   - **Imports**:
>     - Remove unused import `TypeIR` from `lib.rs` in the Go language generator.
>     - Remove unused import `base::TypeMeta` from `mod.rs` in the Python, Ruby, and TypeScript language generators.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 1b09f41b291ec7efbc47efc64d761b6548c042f6. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->