### PR TITLE
ci: Faster `typecheck` and `test-generators`

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -60,5 +60,5 @@ runs:
 
     - name: Install Node dependencies
       if: inputs.install-dependencies == 'true'
-      run: pnpm install ${{ inputs.frozen-lockfile == 'true' && '--frozen-lockfile' || '' }}
+      run: pnpm install ${{ inputs.frozen-lockfile == 'true' && '--frozen-lockfile' || '--no-frozen-lockfile' }}
       shell: bash

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -160,13 +160,9 @@ jobs:
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
         with:
-          enable-wasm: true
-
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-
-      - name: Setup Python
-        uses: ./.github/actions/setup-python
+          enable-wasm: false
+          enable-cross: false
+          cache-on-failure: true
 
       - name: Test Generators
         run: |

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -166,11 +166,28 @@ jobs:
           enable-cross: false
           cache-on-failure: true
 
-      - name: Test Generators
+      - name: Test Generators (1 of 3)
         run: |
-          pnpm generate --force --filter=@boundaryml/baml
+          pnpm generate --force --filter=@boundaryml/baml || (echo "::error:: merge canary and run codegen again" && exit 1)
 
-      - name: Ensure No Changes
+      - name: Ensure No Changes (1 of 3)
+        run: |
+          git diff --exit-code || (echo "::error:: merge canary and run codegen again" && exit 1)
+
+
+      - name: Test Generators (2 of 3)
+        run: |
+          pnpm generate --force --filter=@boundaryml/baml || (echo "::error:: merge canary and run codegen again" && exit 1)
+
+      - name: Ensure No Changes (2 of 3)
+        run: |
+          git diff --exit-code || (echo "::error:: merge canary and run codegen again" && exit 1)
+
+      - name: Test Generators (3 of 3)
+        run: |
+          pnpm generate --force --filter=@boundaryml/baml || (echo "::error:: merge canary and run codegen again" && exit 1)
+
+      - name: Ensure No Changes (3 of 3)
         run: |
           git diff --exit-code || (echo "::error:: merge canary and run codegen again" && exit 1)
 

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -121,6 +121,8 @@ jobs:
       # Install protoc-gen-go
       - name: Setup Go
         uses: ./.github/actions/setup-go
+        with:
+          install-goimports: false
 
       - name: Run typecheck for typescript and rust
         run: pnpm typecheck --force

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -158,6 +158,10 @@ jobs:
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
+        with:
+          # TODO: re-enable it once I can solve the problem with baml-cli.
+          frozen-lockfile: false
+
 
       - name: Setup Rust
         uses: ./.github/actions/setup-rust
@@ -168,7 +172,7 @@ jobs:
 
       - name: Test Generators (1 of 3)
         run: |
-          pnpm generate --force --filter=@boundaryml/baml || (echo "::error:: merge canary and run codegen again" && exit 1)
+          pnpm generate --force --filter=@baml/integ-tests || (echo "::error:: merge canary and run codegen again" && exit 1)
 
       - name: Ensure No Changes (1 of 3)
         run: |
@@ -177,7 +181,7 @@ jobs:
 
       - name: Test Generators (2 of 3)
         run: |
-          pnpm generate --force --filter=@boundaryml/baml || (echo "::error:: merge canary and run codegen again" && exit 1)
+          pnpm generate --force --filter=@baml/integ-tests || (echo "::error:: merge canary and run codegen again" && exit 1)
 
       - name: Ensure No Changes (2 of 3)
         run: |
@@ -185,7 +189,7 @@ jobs:
 
       - name: Test Generators (3 of 3)
         run: |
-          pnpm generate --force --filter=@boundaryml/baml || (echo "::error:: merge canary and run codegen again" && exit 1)
+          pnpm generate --force --filter=@baml/integ-tests || (echo "::error:: merge canary and run codegen again" && exit 1)
 
       - name: Ensure No Changes (3 of 3)
         run: |

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -170,7 +170,7 @@ jobs:
 
       - name: Test Generators
         run: |
-          pnpm generate --force || (echo "::error:: merge canary and run codegen again" && exit 1)
+          pnpm generate --force --filter=@boundaryml/baml
 
       - name: Ensure No Changes
         run: |

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -168,10 +168,6 @@ jobs:
       - name: Setup Python
         uses: ./.github/actions/setup-python
 
-      - name: Build Node
-        run: pnpm build:debug
-        working-directory: engine/language_client_typescript
-
       - name: Test Generators
         run: |
           pnpm generate --force || (echo "::error:: merge canary and run codegen again" && exit 1)

--- a/engine/baml-rpc/package.json
+++ b/engine/baml-rpc/package.json
@@ -7,11 +7,11 @@
     "./*": "./bindings/*.ts"
   },
   "scripts": {
-    "build": "cargo test export_bindings && tsc",
-    "release": "cargo test export_bindings && tsc",
-    "typecheck": "cargo test export_bindings && tsc --noEmit --emitDeclarationOnly false",
+    "build": "cargo test export_bindings --package baml-rpc && tsc",
+    "release": "cargo test export_bindings --package baml-rpc && tsc",
+    "typecheck": "cargo test export_bindings --package baml-rpc && tsc --noEmit --emitDeclarationOnly false",
     "clean": "git clean -xdf .turbo node_modules target",
-    "dev.skip": "cargo watch -x 'test export_bindings' -s 'tsc'",
+    "dev.skip": "cargo watch -x 'test export_bindings --package baml-rpc' -s 'tsc'",
     "dev": "pnpm run build"
   },
   "devDependencies": {

--- a/engine/baml-schema-wasm/web/package.json
+++ b/engine/baml-schema-wasm/web/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "clean": "git clean -xdf ./dist .turbo node_modules",
     "comment": "don't use 'wasm pack --dev' below or it will be too big of a bundle and playground will be slow to load.",
-    "build": "pnpm run release",
+    "build": "pnpm run pack --dev",
     "release": "pnpm run pack --release",
     "pack": "wasm-pack build ../ --target bundler --out-dir ./web/dist",
-    "dev.skip": "cargo watch -C .. -w ./src -s 'cargo build --manifest-path ../Cargo.toml && pnpm run pack --release'",
+    "dev.skip": "cargo watch -C .. -w ./src -s 'cargo build --manifest-path ../Cargo.toml && pnpm run pack --dev'",
     "dev": "pnpm run build"
   },
   "exports": {

--- a/engine/cli/package.json
+++ b/engine/cli/package.json
@@ -12,7 +12,7 @@
     "clean": "git clean -xdf .turbo node_modules target",
     "copy:debug": "mkdir -p dist && cp ../target/debug/baml-cli dist/baml-cli",
     "copy:release": "mkdir -p dist && cp ../target/release/baml-cli dist/baml-cli",
-    "build": "cargo build && pnpm run copy:debug",
-    "release": "cargo build --release && pnpm run copy:release"
+    "build": "cargo build --bin baml-cli && pnpm run copy:debug",
+    "release": "cargo build --release --bin baml-cli && pnpm run copy:release"
   }
 }

--- a/integ-tests/go/package.json
+++ b/integ-tests/go/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@baml/integ-tests-go",
   "version": "1.0.0",
-  "scripts": {
-    "generate": "baml-cli generate --from ../baml_src"
-  },
   "dependencies": {
     "@boundaryml/baml": "workspace:*"
   }

--- a/integ-tests/package.json
+++ b/integ-tests/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@baml/integ-tests",
+  "version": "1.0.0",
+  "scripts": {
+    "generate": "baml-cli generate --from ../baml_src"
+  },
+  "dependencies": {
+    "@boundaryml/baml": "workspace:*"
+  }
+}

--- a/integ-tests/package.json
+++ b/integ-tests/package.json
@@ -2,9 +2,9 @@
   "name": "@baml/integ-tests",
   "version": "1.0.0",
   "scripts": {
-    "generate": "baml-cli generate --from ../baml_src"
+    "generate": "cd typescript && pnpm run integ-tests"
   },
   "dependencies": {
-    "@boundaryml/baml": "workspace:*"
-  }
+    "@baml/cli": "workspace:*"
+   }
 }

--- a/integ-tests/python-v1/package.json
+++ b/integ-tests/python-v1/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@baml/integ-tests-python-v1",
   "version": "1.0.0",
-  "scripts": {
-    "generate": "baml-cli generate --from ../baml_src"
-  },
   "dependencies": {
     "@boundaryml/baml": "workspace:*"
   }

--- a/integ-tests/python/package.json
+++ b/integ-tests/python/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "generate": "baml-cli generate --from ../baml_src",
     "format": "ruff format .",
     "integ-tests": "./run_tests.sh"
   },

--- a/integ-tests/react/package.json
+++ b/integ-tests/react/package.json
@@ -14,7 +14,6 @@
     "integ-tests": "infisical run --env=test -- pnpm test -- --silent false --testTimeout 30000 --bail --reporters=default --reporters=jest-html-reporter --reporters=jest-summary-reporter",
     "integ-tests:dotenv": "dotenv -e ../.env -- pnpm test -- --silent false --testTimeout 30000",
     "test": "echo 'test'",
-    "generate": "baml-cli generate --from ../baml_src",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/integ-tests/ruby/package.json
+++ b/integ-tests/ruby/package.json
@@ -1,9 +1,6 @@
 {
   "name": "@baml/integ-tests-ruby",
   "version": "1.0.0",
-  "scripts": {
-    "generate": "baml-cli generate --from ../baml_src"
-  },
   "dependencies": {
     "@boundaryml/baml": "workspace:*"
   }

--- a/integ-tests/turbo.json
+++ b/integ-tests/turbo.json
@@ -2,9 +2,8 @@
   "$schema": "https://turbo.build/schema.json",
   "extends": ["//"],
   "tasks": {
-    "dev": {
-      "persistent": true,
-      "interruptible": true
+    "generate": {
+        "dependsOn": [ "@baml/cli#build" ]
     }
   }
 }

--- a/integ-tests/typescript-esm/package.json
+++ b/integ-tests/typescript-esm/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "build": "tsc",
     "start": "node ./dist/main.js",
-    "generate": "baml-cli generate --from ../baml_src",
     "typecheck": "tsc --noEmit"
   },
   "engines": {

--- a/integ-tests/typescript/package.json
+++ b/integ-tests/typescript/package.json
@@ -9,7 +9,6 @@
     "integ-tests:ci": "tsc && infisical run --env=test -- pnpm test -- --ci --silent false --testTimeout 30000 --verbose=false --reporters=jest-junit",
     "integ-tests": "tsc && infisical run --env=test -- pnpm test -- --silent false --testTimeout 60000",
     "integ-tests:dotenv": "tsc && pnpm test -- --silent false --testTimeout 30000",
-    "generate": "baml-cli generate --from ../baml_src",
     "memory-test": "BAML_LOG=info infisical run --env=test -- pnpm test -- --silent false --testTimeout 60000 -t 'memory'",
     "typecheck": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dev:vscode": "turbo run dev --filter=baml-extension...",
     "dev:language-server": "turbo run dev --filter=@baml/language-server",
     "dev:playground": "turbo run dev --filter=@baml/playground",
-    "generate": "turbo run generate --concurrency=1",
+    "generate": "turbo run generate",
     "typecheck": "turbo run typecheck",
     "lint:ws": "pnpm dlx sherif@latest",
     "postinstall.skip": "pnpm lint:ws",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - typescript/apps/*
   - typescript/packages/*
   - typescript/workspace-tools/*
-  - integ-tests/*
+  - integ-tests/**
   - engine
   - engine/*
   - engine/baml-schema-wasm/*

--- a/turbo.json
+++ b/turbo.json
@@ -67,7 +67,7 @@
       ]
     },
     "generate": {
-      "dependsOn": ["@boundaryml/baml#build"],
+      "dependsOn": ["@baml/integ-tests#generate"],
       "inputs": ["**/*.baml", "**/*.j2", "**/*.hbs", "**/generators.baml"],
       "outputs": ["baml_client/**"],
       "env": ["SKIP_BAML_SRC_CHECK"]


### PR DESCRIPTION
Brings `primary.yml` CI down to 5 minutes instead of the previously 20 minutes. 

Improvement mainly driven by @aaronvg's idea of ditching most of the generator processes in favor of only calling `generate` once with the TypeScript SDK, which will generate SDKs for all the supported languages in one call.

Improvements remain available:
- Now most of the time is blocked by `rust-unit` and `python-integration`.
- Turborepo cache is still turned off, we didn't turn it on here.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimized CI by reducing generator calls, updated package scripts for efficiency, and improved integration test setup.
> 
>   - **CI Optimization**:
>     - Reduced `primary.yml` CI runtime from 20 to 5 minutes by calling `generate` once for all SDKs.
>     - Disabled `enable-wasm` and `enable-cross` in `setup-rust` for `test-generators`.
>   - **Package Scripts**:
>     - Updated `build`, `release`, and `typecheck` scripts in `engine/baml-rpc/package.json` to specify `--package baml-rpc`.
>     - Changed `build` and `dev.skip` scripts in `engine/baml-schema-wasm/web/package.json` to use `pack --dev`.
>     - Modified `build` and `release` scripts in `engine/cli/package.json` to specify `--bin baml-cli`.
>   - **Miscellaneous**:
>     - Removed redundant `generate` scripts from several `integ-tests/*/package.json` files.
>     - Added `integ-tests/package.json` and `integ-tests/turbo.json` for integration test setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7f67408370bb834615278c58e27fc6dd638da0df. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->