### PR TITLE
Remove Pdf media type specification

### DIFF
--- a/engine/baml-lib/baml-types/src/media.rs
+++ b/engine/baml-lib/baml-types/src/media.rs
@@ -47,10 +47,19 @@ pub enum BamlMediaContent {
 
 impl BamlMedia {
     pub fn mime_type_as_ok(&self) -> Result<String> {
-        self.mime_type.clone().context(format!(
-            "Please specify a media type for this {}; we could not infer one",
-            self.media_type
-        ))
+        match &self.mime_type {
+            Some(mt) => Ok(mt.clone()),
+            None => {
+                if self.media_type == BamlMediaType::Pdf {
+                    Ok("application/pdf".to_string())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Please specify a media type for this {}; we could not infer one",
+                        self.media_type
+                    ))
+                }
+            }
+        }
     }
     pub fn file(
         media_type: BamlMediaType,

--- a/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/traits/mod.rs
@@ -515,12 +515,7 @@ async fn process_media(
                                 .strip_prefix("file://")
                                 .unwrap_or(media_path.as_str())
                         ),
-                        // necessary due to media type is used in the pdf mime type
-                        Some(if part.media_type == BamlMediaType::Pdf {
-                            "application/pdf".to_string()
-                        } else {
-                            format!("{}/{}", part.media_type, ext)
-                        }),
+                        Some(format!("{}/{}", part.media_type, ext)),
                     ));
                 }
             }
@@ -537,17 +532,31 @@ async fn process_media(
 
             if mime_type.is_none() {
                 if let Some(ext) = media_file.extension() {
-                    mime_type = Some(if part.media_type == BamlMediaType::Pdf {
-                        "application/pdf".to_string()
-                    } else {
-                        format!("{}/{}", part.media_type, ext)
-                    });
+                    mime_type = Some(format!("{}/{}", part.media_type, ext));
                 }
             }
 
             if mime_type.is_none() {
                 if let Some(t) = infer::get(&bytes) {
                     mime_type = Some(t.mime_type().to_string());
+                }
+            }
+
+            // ENFORCEMENT: For PDF, the mime type must be application/pdf
+            if part.media_type == BamlMediaType::Pdf {
+                match &mime_type {
+                    Some(mt) if mt != "application/pdf" => {
+                        anyhow::bail!(
+                            "File provided for PDF input is not a PDF. Detected mime type: '{}'. Only application/pdf is allowed.",
+                            mt
+                        );
+                    }
+                    None => {
+                        anyhow::bail!(
+                            "Could not determine mime type for PDF input. Only application/pdf is allowed."
+                        );
+                    }
+                    _ => {}
                 }
             }
 

--- a/engine/language_client_python/src/types/pdf.rs
+++ b/engine/language_client_python/src/types/pdf.rs
@@ -12,20 +12,23 @@ crate::lang_wrapper!(BamlPdfPy, baml_types::BamlMedia);
 #[pymethods]
 impl BamlPdfPy {
     #[staticmethod]
-    #[pyo3(signature = (url, media_type = None))]
-    fn from_url(url: String, media_type: Option<String>) -> Self {
+    fn from_url(url: String) -> Self {
         BamlPdfPy {
-            inner: baml_types::BamlMedia::url(baml_types::BamlMediaType::Pdf, url, media_type),
+            inner: baml_types::BamlMedia::url(
+                baml_types::BamlMediaType::Pdf,
+                url,
+                Some("application/pdf".to_string()),
+            ),
         }
     }
 
     #[staticmethod]
-    fn from_base64(media_type: String, base64: String) -> Self {
+    fn from_base64(base64: String) -> Self {
         BamlPdfPy {
             inner: baml_types::BamlMedia::base64(
                 baml_types::BamlMediaType::Pdf,
                 base64,
-                Some(media_type),
+                Some("application/pdf".to_string()),
             ),
         }
     }

--- a/engine/language_client_ruby/ext/ruby_ffi/src/types/media.rs
+++ b/engine/language_client_ruby/ext/ruby_ffi/src/types/media.rs
@@ -78,21 +78,25 @@ pub(crate) struct Pdf {
 }
 
 impl Pdf {
-    pub fn from_url(url: String, media_type: Option<String>) -> Self {
+    pub fn from_url(url: String) -> Self {
         Self {
-            inner: BamlMedia::url(BamlMediaType::Pdf, url, media_type),
+            inner: BamlMedia::url(BamlMediaType::Pdf, url, Some("application/pdf".to_string())),
         }
     }
-    pub fn from_base64(media_type: String, base64: String) -> Self {
+    pub fn from_base64(base64: String) -> Self {
         Self {
-            inner: BamlMedia::base64(BamlMediaType::Pdf, base64, Some(media_type)),
+            inner: BamlMedia::base64(
+                BamlMediaType::Pdf,
+                base64,
+                Some("application/pdf".to_string()),
+            ),
         }
     }
 
     pub fn define_in_ruby(module: &RModule) -> Result<()> {
         let cls = module.define_class("Pdf", class::object())?;
-        cls.define_singleton_method("from_url", function!(Pdf::from_url, 2))?;
-        cls.define_singleton_method("from_base64", function!(Pdf::from_base64, 2))?;
+        cls.define_singleton_method("from_url", function!(Pdf::from_url, 1))?;
+        cls.define_singleton_method("from_base64", function!(Pdf::from_base64, 1))?;
 
         Ok(())
     }

--- a/engine/language_client_typescript/native.d.ts
+++ b/engine/language_client_typescript/native.d.ts
@@ -19,8 +19,8 @@ export declare class BamlImage {
 }
 
 export declare class BamlPdf {
-  static fromUrl(url: string, mediaType?: string | undefined | null): BamlPdf
-  static fromBase64(mediaType: string, base64: string): BamlPdf
+  static fromUrl(url: string): BamlPdf
+  static fromBase64(base64: string): BamlPdf
   get url(): string | null
   asUrl(): string
   isUrl(): boolean

--- a/engine/language_client_typescript/src/types/pdf.rs
+++ b/engine/language_client_typescript/src/types/pdf.rs
@@ -9,20 +9,24 @@ crate::lang_wrapper!(BamlPdf, baml_types::BamlMedia);
 #[napi]
 impl BamlPdf {
     #[napi(ts_return_type = "BamlPdf")]
-    pub fn from_url(url: String, media_type: Option<String>) -> External<BamlPdf> {
+    pub fn from_url(url: String) -> External<BamlPdf> {
         let pdf = BamlPdf {
-            inner: baml_types::BamlMedia::url(baml_types::BamlMediaType::Pdf, url, media_type),
+            inner: baml_types::BamlMedia::url(
+                baml_types::BamlMediaType::Pdf,
+                url,
+                Some("application/pdf".to_string()),
+            ),
         };
         External::new(pdf)
     }
 
     #[napi(ts_return_type = "BamlPdf")]
-    pub fn from_base64(media_type: String, base64: String) -> External<BamlPdf> {
+    pub fn from_base64(base64: String) -> External<BamlPdf> {
         let pdf = BamlPdf {
             inner: baml_types::BamlMedia::base64(
                 baml_types::BamlMediaType::Pdf,
                 base64,
-                Some(media_type),
+                Some("application/pdf".to_string()),
             ),
         };
         External::new(pdf)
@@ -54,7 +58,10 @@ impl BamlPdf {
         match &self.inner.content {
             baml_types::BamlMediaContent::Base64(base64) => Ok(vec![
                 base64.base64.clone(),
-                self.inner.mime_type.clone().unwrap_or("".to_string()),
+                self.inner
+                    .mime_type
+                    .clone()
+                    .unwrap_or("application/pdf".to_string()),
             ]),
             _ => Err(invalid_argument_error("Pdf is not base64")),
         }

--- a/engine/language_server/src/playground/playground_server.rs
+++ b/engine/language_server/src/playground/playground_server.rs
@@ -7,8 +7,10 @@ use tokio::sync::RwLock;
 /// On the input port
 use crate::playground::definitions::PlaygroundState;
 use crate::{
-    playground::playground_server_helpers::{create_server_routes, get_playground_dist},
-    playground::proxy::ProxyServer,
+    playground::{
+        playground_server_helpers::{create_server_routes, get_playground_dist},
+        proxy::ProxyServer,
+    },
     session::Session,
 };
 

--- a/engine/language_server/src/playground/playground_server_helpers.rs
+++ b/engine/language_server/src/playground/playground_server_helpers.rs
@@ -21,8 +21,10 @@ use tokio::{fs as async_fs, sync::RwLock};
 use warp::{http, http::Response, ws::Message, Filter, Rejection, Reply};
 
 use crate::{
-    playground::definitions::{FrontendMessage, PlaygroundState},
-    playground::playground_server_rpc::handle_rpc_websocket,
+    playground::{
+        definitions::{FrontendMessage, PlaygroundState},
+        playground_server_rpc::handle_rpc_websocket,
+    },
     session::Session,
 };
 

--- a/engine/language_server/src/playground/proxy.rs
+++ b/engine/language_server/src/playground/proxy.rs
@@ -1,5 +1,6 @@
-use anyhow::Result;
 use std::sync::Arc;
+
+use anyhow::Result;
 use warp::{http, Filter, Rejection, Reply};
 
 /// Custom response type for binary data with CORS headers

--- a/fern/03-reference/baml_client/pdf.mdx
+++ b/fern/03-reference/baml_client/pdf.mdx
@@ -23,12 +23,12 @@ from baml_client import b
 
 async def test_pdf_input():
     # Create a Pdf object from URL
-    pdf_url = Pdf.from_url("https://example.com/document.pdf", "application/pdf")
+    pdf_url = Pdf.from_url("https://example.com/document.pdf")
     res1 = await b.TestPdfInput(pdf=pdf_url)
     
     # Create a Pdf object from Base64 data
     pdf_b64 = "JVBERi0K..."
-    pdf = Pdf.from_base64("application/pdf", pdf_b64)
+    pdf = Pdf.from_base64(pdf_b64)
     res2 = await b.TestPdfInput(pdf=pdf)
 ```
 
@@ -37,18 +37,18 @@ import { b } from '../baml_client'
 import { Pdf } from "@boundaryml/baml"
 
 // Create a Pdf object from URL
-const pdfUrl = Pdf.fromUrl('https://example.com/document.pdf', 'application/pdf')
+const pdfUrl = Pdf.fromUrl('https://example.com/document.pdf')
 const res1 = await b.TestPdfInput(pdfUrl)
 
 // Create a Pdf object from Base64 data
 const pdf_b64 = "JVBERi0K..."
 const res2 = await b.TestPdfInput(
-  Pdf.fromBase64('application/pdf', pdf_b64)
+  Pdf.fromBase64(pdf_b64)
 )
 
 // Browser-specific helpers
 const filePdf = await Pdf.fromFile(file)
-const blobPdf = await Pdf.fromBlob(blob, 'application/pdf')
+const blobPdf = await Pdf.fromBlob(blob)
 ```
 
 ```tsx
@@ -60,12 +60,12 @@ export function TestPdfInput() {
 
     const handleClick = async () => {
         // Using URL
-        const pdfUrl = Pdf.fromUrl('https://example.com/document.pdf', 'application/pdf')
+        const pdfUrl = Pdf.fromUrl('https://example.com/document.pdf')
         mutate(pdfUrl)
         
         // Or using Base64
         const pdf_b64 = "JVBERi0K..."
-        const pdf = Pdf.fromBase64('application/pdf', pdf_b64)
+        const pdf = Pdf.fromBase64(pdf_b64)
         mutate(pdf)
     }
 

--- a/integ-tests/python/tests/test_media_inputs.py
+++ b/integ-tests/python/tests/test_media_inputs.py
@@ -31,7 +31,10 @@ def test_media_url_roundtrip(cls, url, mime):
 )
 def test_media_base64_roundtrip(cls, mime, base64_stub):
     """Ensure `from_base64` stores mime-type and base64 string, and `as_base64` returns them."""
-    obj = cls.from_base64(mime, base64_stub)
+    if cls is Pdf:
+        obj = cls.from_base64(base64_stub)
+    else:
+        obj = cls.from_base64(mime, base64_stub)
     assert not obj.is_url()
     base64_out, mime_out = obj.as_base64()
     assert base64_out == base64_stub

--- a/integ-tests/typescript/tests/media.test.ts
+++ b/integ-tests/typescript/tests/media.test.ts
@@ -35,15 +35,14 @@ describe("Media Tests", () => {
   it("should work with pdf from url", async () => {
     let res = await b.PdfInput(
       Pdf.fromUrl(
-        "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf",
-        "application/pdf"
+        "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
       ),
     );
     expect(res.toLowerCase()).toMatch(/(dummy|pdf|document)/);
   });
 
   it("should work with pdf from base 64", async () => {
-    let res = await b.PdfInput(Pdf.fromBase64("application/pdf", pdf_b64));
+    let res = await b.PdfInput(Pdf.fromBase64(pdf_b64));
     expect(res.toLowerCase()).toMatch(/(bookmarks|pdf|sample|usage)/);
   });
 
@@ -53,7 +52,7 @@ describe("Media Tests", () => {
     let res = await b.VideoInputGemini(
       Video.fromUrl("https://youtu.be/dQw4w9WgXcQ?si=aQdfsK0DdcDtCCud")
     );
-    expect(res.toLowerCase()).toMatch(/(singing|rickroll|dancing)/);
+    expect(res.toLowerCase()).toMatch(/(singing|rickroll|dancing|80s|pop|music)/);
   });
 
   it("should work with video from base 64", async () => {

--- a/typescript/apps/vscode-ext/src/panels/WebviewPanelHost.ts
+++ b/typescript/apps/vscode-ext/src/panels/WebviewPanelHost.ts
@@ -260,9 +260,70 @@ export class WebviewPanelHost {
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="stylesheet" type="text/css" href="${stylesUri}">
         <title>BAML Playground</title>
+        <style>
+          /* Match playground loading spinner style */
+          .baml-loading-container {
+            width: 100vw;
+            height: 100vh;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: var(--vscode-sideBar-background, #18181b);
+          }
+          .baml-loading-box {
+            max-width: 24rem;
+            width: 100%;
+            border: 1px solid var(--vscode-panel-border, #333);
+            border-radius: 0.5rem;
+            background: var(--vscode-editor-background, #23272e);
+            padding: 2rem;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+          }
+          .baml-spinner {
+            width: 2rem;
+            height: 2rem;
+            border: 2px solid var(--vscode-panel-border, #333);
+            border-top: 2px solid var(--vscode-foreground, #fff);
+            border-radius: 50%;
+            animation: baml-spin 1s linear infinite;
+            margin-bottom: 1.5rem;
+            box-sizing: border-box;
+            transform-origin: center;
+            will-change: transform;
+            flex-shrink: 0;
+          }
+          @keyframes baml-spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+          }
+          .baml-loading-title {
+            font-size: 1.125rem;
+            font-weight: 500;
+            color: var(--vscode-foreground, #fff);
+            margin-bottom: 0.5rem;
+            text-align: center;
+          }
+          .baml-loading-desc {
+            font-size: 0.95rem;
+            color: var(--vscode-description-foreground, #aaa);
+            text-align: center;
+          }
+        </style>
       </head>
       <body>
-        <div id="root">Loading BAML Playground...</div>
+        <div id="root">
+          <div class="baml-loading-container">
+            <div class="baml-loading-box">
+              <div class="baml-spinner"></div>
+              <div class="baml-loading-title">Loading BAML Playground...</div>
+              <div class="baml-loading-desc">Please wait while the playground loads.</div>
+            </div>
+          </div>
+        </div>
         ${isDevelopment ? reactRefresh : ''}
         <script type="module" ${isDevelopment ? '' : `nonce=\"${nonce}\"`} src="${scriptUri}"></script>
       </body>

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/media-collapsed-atom.ts
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/media-collapsed-atom.ts
@@ -1,0 +1,4 @@
+import { atom } from 'jotai';
+
+// Map of media content (as unique key) to its collapsed state
+export const mediaCollapsedMapAtom = atom<Map<string, boolean>>(new Map()); 

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/webview-media.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/webview-media.tsx
@@ -1,7 +1,7 @@
 // import Link from "next/link";
 import type { WasmChatMessagePartMedia } from '@gloo-ai/baml-schema-wasm-web';
 /* eslint-disable @typescript-eslint/require-await */
-import { useAtomValue, useSetAtom } from 'jotai';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
 import { ExternalLinkIcon, ImageIcon, Music, FileText, Video, Copy, Check, X, ChevronDown, ChevronUp } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';
 import useSWR from 'swr';
@@ -9,6 +9,7 @@ import { Button } from '@baml/ui/button';
 import { wasmAtom } from '../../atoms';
 import { showTokensAtom } from './render-text';
 import { imageStatsMapAtom } from './image-stats-atom';
+import { mediaCollapsedMapAtom } from './media-collapsed-atom';
 import { PdfViewer } from './pdf-viewer';
 
 interface WebviewMediaProps {
@@ -110,6 +111,7 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
   const wasm = useAtomValue(wasmAtom);
   const isDebugMode = useAtomValue(showTokensAtom);
   const setImageStatsMap = useSetAtom(imageStatsMapAtom);
+  const [mediaCollapsedMap, setMediaCollapsedMap] = useAtom(mediaCollapsedMapAtom);
   const [imageStats, setImageStats] = useState<{
     width: number;
     height: number;
@@ -119,7 +121,17 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
   // Track blob URLs for cleanup
   const blobUrlRef = useRef<string | null>(null);
   const [optimizedMediaUrl, setOptimizedMediaUrl] = useState<string | null>(null);
-  const [collapsed, setCollapsed] = useState(false);
+  
+  // Create unique key for this media item and get its collapsed state
+  const mediaKey = media.content;
+  const collapsed = mediaCollapsedMap.get(mediaKey) ?? false;
+  const setCollapsed = (newCollapsed: boolean) => {
+    setMediaCollapsedMap((prev) => {
+      const newMap = new Map(prev);
+      newMap.set(mediaKey, newCollapsed);
+      return newMap;
+    });
+  };
   
 
   
@@ -265,13 +277,14 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
     switch (bamlMediaType) {
       case 'image':
         return (
-          <div className="relative w-full min-h-[200px] max-h-[60vh] flex items-center justify-center overflow-hidden">
+          <div className="relative w-full flex items-center justify-center">
             <img
               src={optimizedMediaUrl || ''}
               // biome-ignore lint/a11y/noRedundantAlt: not correct
               alt={'Image Not Found'}
-              className="max-w-full max-h-full rounded object-contain border border-[var(--vscode-panel-border)]"
+              className="max-w-full h-auto rounded object-contain border border-[var(--vscode-panel-border)]"
               onLoad={onImageLoad}
+              style={{ maxHeight: '70vh' }}
             />
             {imageStats && isDebugMode && (
               <div className="max-h-sm absolute bottom-2 left-2 bg-[var(--vscode-editor-background)] text-[var(--vscode-foreground)] text-xs px-2 py-1 rounded border border-[var(--vscode-panel-border)]">
@@ -458,13 +471,15 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
 
   return (
     <div className="w-full flex justify-center p-4 bg-[var(--vscode-sideBar-background)]">
-      <div className="max-w-lg w-full border border-[var(--vscode-panel-border)] rounded bg-[var(--vscode-editor-background)] space-y-3">
+      <div className={`border border-[var(--vscode-panel-border)] rounded bg-[var(--vscode-editor-background)] space-y-3 ${
+        bamlMediaType === 'image' ? 'w-fit max-w-[90vw] min-w-80' : 'max-w-lg w-full'
+      }`}>
         {/* Header with file type icon and link/copy */}
         {mediaUrl && (
           <div
             className="flex items-center justify-between px-3 py-2 border-b border-[var(--vscode-panel-border)] bg-[var(--vscode-sideBar-background)] cursor-pointer select-none overflow-hidden"
             onClick={e => {
-              setCollapsed((c) => !c);
+              setCollapsed(!collapsed);
             }}
             tabIndex={0}
             role="button"
@@ -486,7 +501,7 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
                    bamlMediaType === 'audio' ? 
                     `${fileFormat || 'Unknown format'}${fileSize ? ` • ${fileSize}` : ''}` :
                    bamlMediaType === 'pdf' ? 
-                    `${fileSize || 'PDF url'}` :
+                    `${fileSize || 'Url'}` :
                    bamlMediaType === 'video' ? 
                     `${fileFormat || 'Video url'}${fileSize ? ` • ${fileSize}` : ''}` :
                    'Media file'}
@@ -557,7 +572,7 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
             )}
             {/* Collapse/Expand Button (rightmost) */}
             <Button
-              onClick={e => { e.stopPropagation(); setCollapsed((c) => !c); }}
+              onClick={e => { e.stopPropagation(); setCollapsed(!collapsed); }}
               aria-label={collapsed ? 'Expand media' : 'Collapse media'}
               variant="outline"
               size="xs"

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/webview-media.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/webview-media.tsx
@@ -2,7 +2,7 @@
 import type { WasmChatMessagePartMedia } from '@gloo-ai/baml-schema-wasm-web';
 /* eslint-disable @typescript-eslint/require-await */
 import { useAtomValue, useSetAtom } from 'jotai';
-import { ExternalLinkIcon, ImageIcon, Music, FileText, Video, Copy, Check, X } from 'lucide-react';
+import { ExternalLinkIcon, ImageIcon, Music, FileText, Video, Copy, Check, X, ChevronDown, ChevronUp } from 'lucide-react';
 import { useState, useEffect, useRef } from 'react';
 import useSWR from 'swr';
 import { Button } from '@baml/ui/button';
@@ -119,6 +119,7 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
   // Track blob URLs for cleanup
   const blobUrlRef = useRef<string | null>(null);
   const [optimizedMediaUrl, setOptimizedMediaUrl] = useState<string | null>(null);
+  const [collapsed, setCollapsed] = useState(false);
   
 
   
@@ -460,17 +461,25 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
       <div className="max-w-lg w-full border border-[var(--vscode-panel-border)] rounded bg-[var(--vscode-editor-background)] space-y-3">
         {/* Header with file type icon and link/copy */}
         {mediaUrl && (
-          <div className="flex items-center justify-between px-3 py-2 border-b border-[var(--vscode-panel-border)] bg-[var(--vscode-sideBar-background)]">
-            <div className="flex items-center gap-2 min-w-0 flex-1">
+          <div
+            className="flex items-center justify-between px-3 py-2 border-b border-[var(--vscode-panel-border)] bg-[var(--vscode-sideBar-background)] cursor-pointer select-none overflow-hidden"
+            onClick={e => {
+              setCollapsed((c) => !c);
+            }}
+            tabIndex={0}
+            role="button"
+            aria-expanded={!collapsed}
+            style={{ userSelect: 'none' }}
+          >
+            <div className="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
               {bamlMediaType === 'image' && <ImageIcon className="w-6 h-6 text-blue-400 flex-shrink-0" />}
               {bamlMediaType === 'audio' && <Music className="w-6 h-6 text-purple-400 flex-shrink-0" />}
               {bamlMediaType === 'pdf' && <FileText className="w-6 h-6 text-red-400 flex-shrink-0" />}
               {bamlMediaType === 'video' && <Video className="w-6 h-6 text-green-400 flex-shrink-0" />}
-              <div className="flex flex-col min-w-0">
-                <span className="text-xs font-medium text-[var(--vscode-foreground)] capitalize leading-tight">
+              <div className="flex flex-col min-w-0 overflow-hidden">
+                <span className="text-xs font-medium text-[var(--vscode-foreground)] capitalize leading-tight truncate">
                   {bamlMediaType}
                 </span>
-                {/* File statistics */}
                 <span className="text-xs text-[var(--vscode-description-foreground)] leading-tight truncate">
                   {bamlMediaType === 'image' && imageStats ? 
                     `${fileFormat ? `${fileFormat} • ` : ''}${imageStats.width}×${imageStats.height}${fileSize ? ` • ${fileSize}` : imageStats.size ? ` • ${imageStats.size}` : ''}` :
@@ -485,21 +494,22 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
                 </span>
               </div>
             </div>
-            {/* Button area, right-aligned, same size for both buttons */}
-            <div className="flex items-center ml-2">
+            {/* Button area, right-aligned, compact, no overflow */}
+            <div className="flex items-center ml-2 flex-nowrap gap-1 h-7" onClick={e => e.stopPropagation()} style={{maxWidth: 'calc(100% - 2rem)'}}>
             {isBase64 ? (
               <Button
                 onClick={handleCopyToClipboard}
                 disabled={copyStatus === 'copying'}
                 variant="outline"
                 size="xs"
-                className={`flex gap-1.5 items-center text-xs px-2 py-1 rounded flex-shrink-0 min-w-[110px] transition-all duration-200
+                className={`flex gap-1 items-center text-xs px-2 py-0 rounded flex-shrink-0 h-7 transition-all duration-200
                   ${copyStatus === 'success'
                     ? 'border-[var(--vscode-charts-green)] text-[var(--vscode-charts-green)] bg-[var(--vscode-editor-background)]'
                     : copyStatus === 'error'
                     ? 'border-[var(--vscode-charts-red)] text-[var(--vscode-charts-red)] bg-[var(--vscode-editor-background)]'
                     : ''
                   }`}
+                style={{minWidth: 0, maxWidth: 140}}
               >
                 {copyStatus === 'copying' && (
                   <div className="w-3 h-3 border border-[var(--vscode-button-foreground)] border-t-transparent rounded-full animate-spin" />
@@ -507,7 +517,7 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
                 {copyStatus === 'success' && <Check className="w-3 h-3" />}
                 {copyStatus === 'error' && <X className="w-3 h-3" />}
                 {copyStatus === 'idle' && <Copy className="w-3 h-3" />}
-                <span>
+                <span className="truncate">
                   {copyStatus === 'copying' && `Copying...`}
                   {copyStatus === 'success' && `Copied!`}
                   {copyStatus === 'error' && `Failed`}
@@ -519,19 +529,20 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
                 asChild
                 variant="outline"
                 size="xs"
-                className="flex gap-1.5 items-center text-xs px-2 py-1 rounded border flex-shrink-0 min-w-[110px] transition-all duration-200"
+                className="flex gap-1 items-center text-xs px-2 py-0 rounded border flex-shrink-0 h-7 transition-all duration-200"
+                style={{minWidth: 0, maxWidth: 140}}
               >
                 <a
                   href={mediaUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="flex gap-1.5 items-center w-full h-full"
+                  className="flex gap-1 items-center w-full h-full truncate"
+                  style={{maxWidth: 120}}
                 >
                   <ExternalLinkIcon className="w-3 h-3" />
-                  <span>
+                  <span className="truncate">
                     {(() => {
                       const url = mediaUrl || '';
-                      // Extract filename from URL
                       const urlParts = url.split('/');
                       const filename = urlParts[urlParts.length - 1];
                       const cleanFilename = filename?.split('?')[0]?.split('#')[0];
@@ -544,14 +555,32 @@ export const WebviewMedia: React.FC<WebviewMediaProps> = ({
                 </a>
               </Button>
             )}
+            {/* Collapse/Expand Button (rightmost) */}
+            <Button
+              onClick={e => { e.stopPropagation(); setCollapsed((c) => !c); }}
+              aria-label={collapsed ? 'Expand media' : 'Collapse media'}
+              variant="outline"
+              size="xs"
+              className="ml-1 flex items-center justify-center px-1.5 py-0 h-7 transition-colors duration-150 flex-shrink-0"
+              style={{ outline: 'none', minWidth: 0 }}
+              tabIndex={0}
+            >
+              {collapsed ? (
+                <ChevronDown className="w-4 h-4" />
+              ) : (
+                <ChevronUp className="w-4 h-4" />
+              )}
+            </Button>
             </div>
           </div>
         )}
 
-        {/* Media content */}
-        <div className="p-4">
-          {renderMediaContent()}
-        </div>
+        {/* Media content (collapsible) */}
+        {!collapsed && (
+          <div className="p-4">
+            {renderMediaContent()}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/typescript/packages/ui/src/custom/loader.tsx
+++ b/typescript/packages/ui/src/custom/loader.tsx
@@ -8,12 +8,13 @@ export const Loader: React.FC<{ message?: string; className?: string }> = ({
   return (
     <div
       className={cn(
-        'flex gap-2 justify-center items-center text-muted-foreground',
+        // VSCode webview: prevent flexbox/scrollbar glitches
+        'flex justify-center items-center text-muted-foreground min-w-[80px] min-h-[32px] overflow-hidden',
         className,
       )}
     >
-      <Loader2 className="animate-spin" />
-      {message}
+      <Loader2 className="animate-spin w-5 h-5 flex-shrink-0 mr-2" />
+      {message && <span className="whitespace-nowrap">{message}</span>}
     </div>
   );
 };


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove explicit PDF media type specification, defaulting to 'application/pdf' across the codebase, and update related tests and documentation.
> 
>   - **Behavior**:
>     - `BamlMedia::mime_type_as_ok()` in `media.rs` now defaults to `application/pdf` for `Pdf` type if `mime_type` is `None`.
>     - Enforces `application/pdf` mime type for `Pdf` in `process_media()` in `mod.rs`.
>     - Removes `media_type` parameter from `Pdf.from_url()` and `Pdf.from_base64()` in `pdf.rs` and `media.rs`.
>   - **Tests**:
>     - Update `test_media_base64_roundtrip()` in `test_media_inputs.py` to remove `media_type` for `Pdf`.
>     - Update `media.test.ts` to remove `media_type` for `Pdf`.
>   - **Documentation**:
>     - Update `pdf.mdx` to reflect removal of `mediaType` parameter for `Pdf` methods.
>   - **Misc**:
>     - Add loading spinner styles in `WebviewPanelHost.ts`.
>     - Add `mediaCollapsedMapAtom` in `media-collapsed-atom.ts` for media state management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7916aa5040b99db5e4a676123057c8aa5358fc9e. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->