### PR TITLE
Remove `Walker`s from IR

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/ir_hasher/class.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_hasher/class.rs
@@ -2,7 +2,8 @@ use std::collections::HashSet;
 
 use baml_types::{Constraint, StringOr, TypeIR};
 
-use super::{super::Class, ShallowSignature};
+use super::ShallowSignature;
+use crate::ir::repr::{Class, Node};
 
 /// Find some way to hash the class
 
@@ -62,7 +63,7 @@ impl<'a> std::hash::Hash for ClassImplementationHash<'a> {
     }
 }
 
-impl super::ShallowSignature for Class {
+impl super::ShallowSignature for &Node<Class> {
     fn shallow_hash_prefix(&self) -> &'static str {
         "class"
     }

--- a/engine/baml-lib/baml-core/src/ir/ir_hasher/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_hasher/mod.rs
@@ -291,8 +291,8 @@ impl IRSignature {
     pub fn new_from_ir(ir: &IntermediateRepr) -> Result<Self> {
         let mut shallow_hash = HashMap::new();
 
-        for class in ir.walk_classes() {
-            shallow_hash.insert(class.name(), ShallowHash::from_signature(class));
+        for class in &ir.classes {
+            shallow_hash.insert(class.elem.name.as_str(), ShallowHash::from_signature(class));
         }
         for r#enum in ir.walk_enums() {
             shallow_hash.insert(r#enum.name(), ShallowHash::from_signature(r#enum));
@@ -335,21 +335,25 @@ impl IRSignature {
             .collect::<Result<_>>()?;
 
         let classes_map: HashMap<String, (TypeNodeSignature, ClassSignatureDetails)> = ir
-            .walk_classes()
-            .map(|class_walker| {
+            .classes
+            .iter()
+            .map(|class| {
                 Ok((
-                    class_walker.name().to_string(),
+                    class.elem.name.to_string(),
                     (
                         TypeNodeSignature {
-                            signature: Signature::new_class(class_walker.name(), &shallow_hash)?,
+                            signature: Signature::new_class(
+                                class.elem.name.as_str(),
+                                &shallow_hash,
+                            )?,
                             field_type: Arc::new(baml_types::ir_type::TypeNonStreaming::class(
-                                class_walker.name(),
+                                class.elem.name.as_str(),
                             )),
                         },
                         ClassSignatureDetails {
                             fields: Arc::new(
-                                class_walker
-                                    .elem()
+                                class
+                                    .elem
                                     .static_fields
                                     .iter()
                                     .map(|field_node| {

--- a/engine/baml-lib/baml-core/src/ir/ir_hasher/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_hasher/mod.rs
@@ -297,8 +297,8 @@ impl IRSignature {
         for r#enum in ir.walk_enums() {
             shallow_hash.insert(r#enum.name(), ShallowHash::from_signature(r#enum));
         }
-        for type_alias in ir.walk_type_aliases() {
-            shallow_hash.insert(type_alias.name(), ShallowHash::from_signature(type_alias));
+        for alias in &ir.type_aliases {
+            shallow_hash.insert(&alias.elem.name, ShallowHash::from_signature(alias));
         }
         for func in ir.walk_functions() {
             shallow_hash.insert(func.name(), ShallowHash::from_signature(func));
@@ -402,16 +402,14 @@ impl IRSignature {
             .collect::<Result<_>>()?;
 
         let type_aliases_map: HashMap<String, TypeNodeSignature> = ir
-            .walk_type_aliases()
-            .map(|type_alias_walker| {
-                let resolved_field_type = type_alias_walker.elem().r#type.elem.clone();
+            .type_aliases
+            .iter()
+            .map(|type_alias| {
+                let resolved_field_type = type_alias.elem.r#type.elem.clone();
                 Ok((
-                    type_alias_walker.name().to_string(),
+                    type_alias.elem.name.to_string(),
                     TypeNodeSignature {
-                        signature: Signature::new_type_alias(
-                            type_alias_walker.name(),
-                            &shallow_hash,
-                        )?,
+                        signature: Signature::new_type_alias(&type_alias.elem.name, &shallow_hash)?,
                         field_type: Arc::new(resolved_field_type.to_non_streaming_type(ir)),
                     },
                 ))

--- a/engine/baml-lib/baml-core/src/ir/ir_hasher/type_alias.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_hasher/type_alias.rs
@@ -2,7 +2,8 @@ use std::collections::HashSet;
 
 use baml_types::TypeIR;
 
-use super::{super::TypeAlias, ShallowSignature};
+use super::ShallowSignature;
+use crate::ir::repr::{Node, TypeAlias};
 
 /// Find some way to hash the class
 
@@ -35,7 +36,7 @@ impl<'a> std::hash::Hash for TypeAliasImplementationHash<'a> {
     }
 }
 
-impl super::ShallowSignature for TypeAlias {
+impl super::ShallowSignature for &Node<TypeAlias> {
     fn shallow_hash_prefix(&self) -> &'static str {
         "type_alias"
     }

--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
@@ -22,9 +22,8 @@ use super::{repr, ExprFunctionNode};
 use crate::{
     error_not_found,
     ir::{
-        repr::{IntermediateRepr, Walker},
+        repr::{IntermediateRepr, Node, TypeAlias, Walker},
         Class, Client, Enum, EnumValue, Field, FunctionNode, RetryPolicy, TemplateString, TestCase,
-        TypeAlias,
     },
 };
 
@@ -33,7 +32,6 @@ pub type ExprFunctionWalker<'a> = Walker<'a, &'a ExprFunctionNode>;
 pub type EnumWalker<'a> = Walker<'a, &'a Enum>;
 pub type EnumValueWalker<'a> = Walker<'a, &'a EnumValue>;
 pub type ClassWalker<'a> = Walker<'a, &'a Class>;
-pub type TypeAliasWalker<'a> = Walker<'a, &'a TypeAlias>;
 pub type TemplateStringWalker<'a> = Walker<'a, &'a TemplateString>;
 pub type ClientWalker<'a> = Walker<'a, &'a Client>;
 pub type RetryPolicyWalker<'a> = Walker<'a, &'a RetryPolicy>;
@@ -44,7 +42,7 @@ pub type ClassFieldWalker<'a> = Walker<'a, &'a Field>;
 pub trait IRHelper {
     fn find_enum<'a>(&'a self, enum_name: &str) -> Result<EnumWalker<'a>>;
     fn find_class<'a>(&'a self, class_name: &str) -> Result<ClassWalker<'a>>;
-    fn find_type_alias<'a>(&'a self, alias_name: &str) -> Result<TypeAliasWalker<'a>>;
+    fn find_type_alias(&self, alias_name: &str) -> Result<&Node<TypeAlias>>;
     fn find_expr_fn<'a>(&'a self, function_name: &str) -> Result<ExprFunctionWalker<'a>>;
     fn find_function<'a>(&'a self, function_name: &str) -> Result<FunctionWalker<'a>>;
     fn find_client<'a>(&'a self, client_name: &str) -> Result<ClientWalker<'a>>;
@@ -439,15 +437,22 @@ impl IRHelper for IntermediateRepr {
         }
     }
 
-    fn find_type_alias<'a>(&'a self, alias_name: &str) -> Result<TypeAliasWalker<'a>> {
-        match self.walk_type_aliases().find(|e| e.name() == alias_name) {
+    fn find_type_alias(&self, alias_name: &str) -> Result<&Node<TypeAlias>> {
+        match self
+            .type_aliases
+            .iter()
+            .find(|alias| alias.elem.name == alias_name)
+        {
             Some(e) => Ok(e),
+
             None => {
                 // Get best match.
                 let aliases = self
-                    .walk_type_aliases()
-                    .map(|e| e.name())
+                    .type_aliases
+                    .iter()
+                    .map(|alias| alias.elem.name.clone())
                     .collect::<Vec<_>>();
+
                 error_not_found!("type alias", alias_name, &aliases)
             }
         }
@@ -571,9 +576,9 @@ impl IRHelper for IntermediateRepr {
         }
 
         // Now do the same for type aliases.
-        for alias in self.walk_type_aliases() {
+        for alias in &self.type_aliases {
             alias
-                .elem()
+                .elem
                 .r#type
                 .attributes
                 .symbol_spans
@@ -637,9 +642,9 @@ impl IRHelper for IntermediateRepr {
         }
 
         // Now do the same for type aliases.
-        for alias in self.walk_type_aliases() {
+        for alias in &self.type_aliases {
             alias
-                .elem()
+                .elem
                 .r#type
                 .attributes
                 .symbol_spans
@@ -671,11 +676,10 @@ impl IRHelper for IntermediateRepr {
         let mut locations = vec![];
 
         // First look for the definition of the type alias.
-        for alias in self.walk_type_aliases() {
-            if alias.name() == type_alias_name {
+        for alias in &self.type_aliases {
+            if alias.elem.name == type_alias_name {
                 locations.push(
                     alias
-                        .item
                         .attributes
                         .identifier_span
                         .as_ref()
@@ -704,9 +708,9 @@ impl IRHelper for IntermediateRepr {
         }
 
         // Now do the same for type aliases.
-        for alias in self.walk_type_aliases() {
+        for alias in &self.type_aliases {
             alias
-                .elem()
+                .elem
                 .r#type
                 .attributes
                 .symbol_spans

--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
@@ -22,8 +22,8 @@ use super::{repr, ExprFunctionNode};
 use crate::{
     error_not_found,
     ir::{
-        repr::{IntermediateRepr, Node, TypeAlias, Walker},
-        Class, Client, Enum, EnumValue, Field, FunctionNode, RetryPolicy, TemplateString, TestCase,
+        repr::{Class, IntermediateRepr, Node, TypeAlias, Walker},
+        Client, Enum, EnumValue, Field, FunctionNode, RetryPolicy, TemplateString, TestCase,
     },
 };
 
@@ -31,7 +31,6 @@ pub type FunctionWalker<'a> = Walker<'a, &'a FunctionNode>;
 pub type ExprFunctionWalker<'a> = Walker<'a, &'a ExprFunctionNode>;
 pub type EnumWalker<'a> = Walker<'a, &'a Enum>;
 pub type EnumValueWalker<'a> = Walker<'a, &'a EnumValue>;
-pub type ClassWalker<'a> = Walker<'a, &'a Class>;
 pub type TemplateStringWalker<'a> = Walker<'a, &'a TemplateString>;
 pub type ClientWalker<'a> = Walker<'a, &'a Client>;
 pub type RetryPolicyWalker<'a> = Walker<'a, &'a RetryPolicy>;
@@ -41,7 +40,7 @@ pub type ClassFieldWalker<'a> = Walker<'a, &'a Field>;
 
 pub trait IRHelper {
     fn find_enum<'a>(&'a self, enum_name: &str) -> Result<EnumWalker<'a>>;
-    fn find_class<'a>(&'a self, class_name: &str) -> Result<ClassWalker<'a>>;
+    fn find_class(&self, class_name: &str) -> Result<&Node<Class>>;
     fn find_type_alias(&self, alias_name: &str) -> Result<&Node<TypeAlias>>;
     fn find_expr_fn<'a>(&'a self, function_name: &str) -> Result<ExprFunctionWalker<'a>>;
     fn find_function<'a>(&'a self, function_name: &str) -> Result<FunctionWalker<'a>>;
@@ -426,12 +425,16 @@ impl IRHelper for IntermediateRepr {
         }
     }
 
-    fn find_class<'a>(&'a self, class_name: &str) -> Result<ClassWalker<'a>> {
-        match self.walk_classes().find(|e| e.name() == class_name) {
+    fn find_class(&self, class_name: &str) -> Result<&Node<Class>> {
+        match self.classes.iter().find(|e| e.elem.name == class_name) {
             Some(e) => Ok(e),
             None => {
                 // Get best match.
-                let classes = self.walk_classes().map(|e| e.name()).collect::<Vec<_>>();
+                let classes = self
+                    .classes
+                    .iter()
+                    .map(|c| c.elem.name.clone())
+                    .collect::<Vec<_>>();
                 error_not_found!("class", class_name, &classes)
             }
         }
@@ -545,24 +548,17 @@ impl IRHelper for IntermediateRepr {
     fn find_class_locations(&self, class_name: &str) -> Vec<Span> {
         let mut locations = vec![];
 
-        for cls in self.walk_classes() {
+        for cls in &self.classes {
             // First look for the definition of the class.
-            if cls.name() == class_name {
-                locations.push(
-                    cls.item
-                        .attributes
-                        .identifier_span
-                        .as_ref()
-                        .unwrap()
-                        .to_owned(),
-                );
+            if cls.elem.name == class_name {
+                locations.push(cls.attributes.identifier_span.as_ref().unwrap().to_owned());
             }
 
             // After that we'll find all the references to this class in the
             // fields of other classes.
-            for field in cls.walk_fields() {
+            for field in &cls.elem.static_fields {
                 field
-                    .elem()
+                    .elem
                     .r#type
                     .attributes
                     .symbol_spans
@@ -625,10 +621,10 @@ impl IRHelper for IntermediateRepr {
 
         // Then find all the references to this enum in the fields of other
         // classes.
-        for cls in self.walk_classes() {
-            for field in cls.walk_fields() {
+        for cls in &self.classes {
+            for field in &cls.elem.static_fields {
                 field
-                    .elem()
+                    .elem
                     .r#type
                     .attributes
                     .symbol_spans
@@ -691,10 +687,10 @@ impl IRHelper for IntermediateRepr {
 
         // Then find all the references to this type alias in the fields of other
         // classes.
-        for cls in self.walk_classes() {
-            for field in cls.walk_fields() {
+        for cls in &self.classes {
+            for field in &cls.elem.static_fields {
                 field
-                    .elem()
+                    .elem
                     .r#type
                     .attributes
                     .symbol_spans
@@ -788,12 +784,14 @@ impl IRHelperExtended for IntermediateRepr {
 
 impl IRSemanticStreamingHelper for IntermediateRepr {
     fn class_streaming_needed_fields(&self, class_name: &str) -> Result<HashSet<String>> {
-        let class = self.find_class(class_name)?;
-        Ok(class
-            .walk_fields()
-            .filter_map(|field: Walker<'_, &Field>| {
-                if field.r#type().streaming_behavior().needed {
-                    Some(field.name().to_string())
+        Ok(self
+            .find_class(class_name)?
+            .elem
+            .static_fields
+            .iter()
+            .filter_map(|field| {
+                if field.elem.r#type.elem.streaming_behavior().needed {
+                    Some(field.elem.name.clone())
                 } else {
                     None
                 }
@@ -802,8 +800,9 @@ impl IRSemanticStreamingHelper for IntermediateRepr {
     }
 
     fn class_fields(&self, class_name: &str) -> Result<BamlMap<String, TypeIR>> {
-        let class = self.find_class(class_name)?.elem();
-        Ok(class
+        Ok(self
+            .find_class(class_name)?
+            .elem
             .static_fields
             .iter()
             .map(|field_node| {
@@ -824,10 +823,12 @@ impl IRSemanticStreamingHelper for IntermediateRepr {
             Err(_) => Ok(HashSet::new()),
             Ok(class) => {
                 let missing_fields = class
-                    .walk_fields()
-                    .filter_map(|field: Walker<'_, &Field>| {
-                        if !value_names.contains(field.name()) {
-                            Some(field.name().to_string())
+                    .elem
+                    .static_fields
+                    .iter()
+                    .filter_map(|field| {
+                        if !value_names.contains(&field.elem.name) {
+                            Some(field.elem.name.clone())
                         } else {
                             None
                         }

--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/to_baml_arg.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/to_baml_arg.rs
@@ -230,13 +230,17 @@ impl ArgCoercer {
                 BamlValue::Class(_, obj) | BamlValue::Map(obj) => match ir.find_class(name) {
                     Ok(c) => {
                         let mut fields = BamlMap::new();
-                        let is_dynamic = c.item.attributes.dynamic();
+                        let is_dynamic = c.attributes.dynamic();
 
                         // Process fields in the order they appear in the input object to preserve ordering
                         for (key, value) in obj {
                             // Check if this is a known class field first
-                            if let Some(field) = c.walk_fields().find(|f| f.name() == key) {
-                                if let Ok(v) = self.coerce_arg(ir, field.r#type(), value, scope) {
+                            if let Some(field) =
+                                c.elem.static_fields.iter().find(|f| &f.elem.name == key)
+                            {
+                                if let Ok(v) =
+                                    self.coerce_arg(ir, &field.elem.r#type.elem, value, scope)
+                                {
                                     fields.insert(key.clone(), v);
                                 }
                             } else if is_dynamic {
@@ -253,12 +257,13 @@ impl ArgCoercer {
                         }
 
                         // Check for missing required fields
-                        for f in c.walk_fields() {
-                            if !fields.contains_key(f.name()) && !f.r#type().is_optional() {
+                        for f in c.elem.static_fields.iter() {
+                            if !fields.contains_key(&f.elem.name)
+                                && !f.elem.r#type.elem.is_optional()
+                            {
                                 scope.push_error(format!(
                                     "Missing required field `{}` for class {}",
-                                    f.name(),
-                                    name
+                                    f.elem.name, name
                                 ));
                             }
                         }

--- a/engine/baml-lib/baml-core/src/ir/json_schema.rs
+++ b/engine/baml-lib/baml-core/src/ir/json_schema.rs
@@ -5,8 +5,9 @@ use serde_json::json;
 
 use super::{
     repr::{self},
-    Class, Enum, FunctionArgs, FunctionNode, IntermediateRepr, TypeIR, Walker,
+    Enum, FunctionArgs, FunctionNode, IntermediateRepr, TypeIR, Walker,
 };
+use crate::ir::repr::Class;
 
 pub trait WithJsonSchema {
     fn json_schema(&self) -> serde_json::Value;
@@ -18,8 +19,9 @@ impl WithJsonSchema for IntermediateRepr {
             .walk_enums()
             .map(|e| (e.elem().name.clone(), e.json_schema()));
         let classes = self
-            .walk_classes()
-            .map(|c| (c.elem().name.clone(), c.json_schema()));
+            .classes
+            .iter()
+            .map(|c| (c.elem.name.clone(), c.elem.json_schema()));
         let function_inputs = self
             .walk_functions()
             .map(|f| (format!("{}_input", f.name()), (f.item, true).json_schema()));
@@ -125,18 +127,18 @@ impl WithJsonSchema for Walker<'_, &Enum> {
     }
 }
 
-impl WithJsonSchema for Walker<'_, &Class> {
+impl WithJsonSchema for Class {
     fn json_schema(&self) -> serde_json::Value {
         let mut properties = json!({});
         let mut required_props = vec![];
-        for field in self.elem().static_fields.iter() {
+        for field in self.static_fields.iter() {
             properties[field.elem.name.clone()] = field.elem.r#type.elem.json_schema();
             if !field.elem.r#type.elem.is_optional() {
                 required_props.push(field.elem.name.clone());
             }
         }
         json!({
-                "title": self.elem().name,
+                "title": self.name,
                 "type": "object",
                 "properties": properties,
                 "required": required_props,

--- a/engine/baml-lib/baml-core/src/ir/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/mod.rs
@@ -7,16 +7,15 @@ pub mod repr;
 mod walker;
 
 pub use ir_helpers::{
-    scope_diagnostics, ArgCoercer, ClassFieldWalker, ClassWalker, ClientWalker, EnumValueWalker,
-    EnumWalker, ExprFunctionWalker, FunctionWalker, IRHelper, IRHelperExtended,
-    IRSemanticStreamingHelper, RetryPolicyWalker, TemplateStringWalker, TestCaseWalker,
+    scope_diagnostics, ArgCoercer, ClassFieldWalker, ClientWalker, EnumValueWalker, EnumWalker,
+    ExprFunctionWalker, FunctionWalker, IRHelper, IRHelperExtended, IRSemanticStreamingHelper,
+    RetryPolicyWalker, TemplateStringWalker, TestCaseWalker,
 };
 pub(super) use repr::IntermediateRepr;
 
 // Add aliases for the IR types
 pub type Enum = repr::Node<repr::Enum>;
 pub type EnumValue = repr::Node<repr::EnumValue>;
-pub type Class = repr::Node<repr::Class>;
 pub type Field = repr::Node<repr::Field>;
 pub type TypeIR = baml_types::TypeIR;
 pub type TypeValue = baml_types::TypeValue;

--- a/engine/baml-lib/baml-core/src/ir/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/mod.rs
@@ -10,7 +10,6 @@ pub use ir_helpers::{
     scope_diagnostics, ArgCoercer, ClassFieldWalker, ClassWalker, ClientWalker, EnumValueWalker,
     EnumWalker, ExprFunctionWalker, FunctionWalker, IRHelper, IRHelperExtended,
     IRSemanticStreamingHelper, RetryPolicyWalker, TemplateStringWalker, TestCaseWalker,
-    TypeAliasWalker,
 };
 pub(super) use repr::IntermediateRepr;
 
@@ -18,7 +17,6 @@ pub(super) use repr::IntermediateRepr;
 pub type Enum = repr::Node<repr::Enum>;
 pub type EnumValue = repr::Node<repr::EnumValue>;
 pub type Class = repr::Node<repr::Class>;
-pub type TypeAlias = repr::Node<repr::TypeAlias>;
 pub type Field = repr::Node<repr::Field>;
 pub type TypeIR = baml_types::TypeIR;
 pub type TypeValue = baml_types::TypeValue;

--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -8,8 +8,10 @@ use baml_types::{
     baml_value::TypeLookups,
     expr::{self, Builtin, Expr, ExprMetadata, Name, VarIndex},
     ir_type::{ArrowGeneric, TypeNonStreaming, TypeStreaming, UnionConstructor},
-    type_meta, Arrow, BamlMap, BamlValueWithMeta, Constraint, ConstraintLevel, JinjaExpression,
-    Resolvable, StreamingMode, StringOr, TypeIR, TypeValue, UnionType, UnresolvedValue,
+    type_meta::{self, base::StreamingBehavior},
+    Arrow, BamlMap, BamlValueWithMeta, Constraint, ConstraintLevel, EvaluationContext,
+    JinjaExpression, Resolvable, StreamingMode, StringOr, TypeIR, TypeValue, UnionType,
+    UnresolvedValue,
 };
 use either::Either;
 use indexmap::{IndexMap, IndexSet};
@@ -570,10 +572,6 @@ impl IntermediateRepr {
 
     pub fn walk_enums(&self) -> impl ExactSizeIterator<Item = Walker<'_, &Node<Enum>>> {
         self.enums.iter().map(|e| Walker { ir: self, item: e })
-    }
-
-    pub fn walk_classes(&self) -> impl Iterator<Item = Walker<'_, &Node<Class>>> {
-        self.classes.iter().map(|e| Walker { ir: self, item: e })
     }
 
     // TODO: Exact size Iterator + Node<>?
@@ -1402,6 +1400,21 @@ impl<T> Node<T> {
     pub fn span(&self) -> Option<&ast::Span> {
         self.attributes.span.as_ref()
     }
+
+    pub fn alias(&self, ctx: &EvaluationContext<'_>) -> Result<Option<String>> {
+        self.attributes.alias().map(|v| v.resolve(ctx)).transpose()
+    }
+
+    pub fn description(&self, ctx: &EvaluationContext<'_>) -> Result<Option<String>> {
+        self.attributes
+            .description()
+            .map(|v| v.resolve(ctx))
+            .transpose()
+    }
+
+    pub fn streaming_behavior(&self) -> StreamingBehavior {
+        self.attributes.streaming_behavior()
+    }
 }
 
 /// Implement this for every node in the IR AST, where T is the type of IR node
@@ -1890,6 +1903,10 @@ impl WithRepr<Class> for ClassWalker<'_> {
 impl Class {
     pub fn inputs(&self) -> &Vec<(String, TypeIR)> {
         &self.inputs
+    }
+
+    pub fn find_field(&self, name: &str) -> Option<&Node<Field>> {
+        self.static_fields.iter().find(|f| f.elem.name == name)
     }
 }
 
@@ -2856,7 +2873,7 @@ mod tests {
         .unwrap();
 
         // Test class docstrings
-        let foo = ir.find_class("Foo").as_ref().unwrap().clone().elem();
+        let foo = &ir.find_class("Foo").as_ref().unwrap().clone().elem;
         assert_eq!(foo.docstring.as_ref().unwrap().0.as_str(), "Foo class.");
         match foo.static_fields.as_slice() {
             [field1, field2] => {
@@ -2939,33 +2956,27 @@ mod tests {
         )
         .unwrap();
         let foo = ir.find_class("Foo").unwrap();
-        assert!(!foo.streaming_behavior().done);
-        match foo.walk_fields().collect::<Vec<_>>().as_slice() {
+        assert!(!foo.attributes.streaming_behavior().done);
+        match foo.elem.static_fields.as_slice() {
             [field1, field2, field3] => {
-                let type1 = &field1.item.elem.r#type;
+                let type1 = &field1.elem.r#type;
                 assert!(type1.attributes.streaming_behavior().needed);
-                let type2 = &field2.item.elem.r#type;
-                assert!(!field2.streaming_behavior().state);
+                let type2 = &field2.elem.r#type;
+                assert!(!field2.attributes.streaming_behavior().state);
                 assert!(type2.attributes.get("stream.with_state").is_some());
-                let type3 = &field3.item.elem.r#type;
+                let type3 = &field3.elem.r#type;
                 // the field doesnt have this attribute / behavior -- the type does. But we should document why somewhere better.
-                assert!(!field3.streaming_behavior().done);
+                assert!(!field3.attributes.streaming_behavior().done);
                 assert!(type3.attributes.get("stream.done").is_some());
             }
             _ => panic!("Expected exactly 3 fields"),
         }
         let bar = ir.find_class("Bar").unwrap();
-        assert!(bar.streaming_behavior().done);
-        match bar.walk_fields().collect::<Vec<_>>().as_slice() {
+        assert!(bar.attributes.streaming_behavior().done);
+        match bar.elem.static_fields.as_slice() {
             [field1, field2] => {
-                assert!(!field1.streaming_behavior().done);
-                assert!(field1
-                    .item
-                    .elem
-                    .r#type
-                    .attributes
-                    .get("stream.done")
-                    .is_some());
+                assert!(!field1.attributes.streaming_behavior().done);
+                assert!(field1.elem.r#type.attributes.get("stream.done").is_some());
             }
             _ => panic!("Expected exactly 2 fields"),
         }
@@ -2986,9 +2997,9 @@ mod tests {
         .unwrap();
 
         let class = ir.find_class("Test").unwrap();
-        let alias = class.find_field("field").unwrap();
+        let alias = class.elem.find_field("field").unwrap();
 
-        assert_eq!(*alias.r#type(), TypeIR::int());
+        assert_eq!(alias.elem.r#type.elem, TypeIR::int());
     }
 
     #[test]
@@ -3007,9 +3018,9 @@ mod tests {
         .unwrap();
 
         let class = ir.find_class("Test").unwrap();
-        let alias = class.find_field("field").unwrap();
+        let alias = class.elem.find_field("field").unwrap();
 
-        let type_meta::base::TypeMeta { constraints, .. } = alias.r#type().meta();
+        let type_meta::base::TypeMeta { constraints, .. } = alias.elem.r#type.elem.meta();
 
         assert_eq!(constraints.len(), 3);
 
@@ -3042,11 +3053,11 @@ mod tests {
             .unwrap();
 
             let class = ir.find_class("UseMyUnion").unwrap();
-            let field1 = class.find_field("u").unwrap();
-            let field1_type = &field1.elem().r#type.elem;
+            let field1 = class.elem.find_field("u").unwrap();
+            let field1_type = &field1.elem.r#type.elem;
 
-            let field2 = class.find_field("u2").unwrap();
-            let field2_type = &field2.elem().r#type.elem;
+            let field2 = class.elem.find_field("u2").unwrap();
+            let field2_type = &field2.elem.r#type.elem;
 
             // Both fields should have consistent type resolution for Recursive1
             assert_eq!(
@@ -3081,11 +3092,11 @@ mod tests {
             .unwrap();
 
             let class = ir.find_class("UseMyUnion").unwrap();
-            let field1 = class.find_field("u").unwrap();
-            let field1_type = &field1.elem().r#type.elem;
+            let field1 = class.elem.find_field("u").unwrap();
+            let field1_type = &field1.elem.r#type.elem;
 
-            let field2 = class.find_field("u2").unwrap();
-            let field2_type = &field2.elem().r#type.elem;
+            let field2 = class.elem.find_field("u2").unwrap();
+            let field2_type = &field2.elem.r#type.elem;
 
             // Both fields should have consistent type resolution for Recursive1
             assert_eq!(

--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -576,12 +576,6 @@ impl IntermediateRepr {
         self.classes.iter().map(|e| Walker { ir: self, item: e })
     }
 
-    pub fn walk_type_aliases(&self) -> impl ExactSizeIterator<Item = Walker<'_, &Node<TypeAlias>>> {
-        self.type_aliases
-            .iter()
-            .map(|e| Walker { ir: self, item: e })
-    }
-
     // TODO: Exact size Iterator + Node<>?
     pub fn walk_alias_cycles(&self) -> impl Iterator<Item = Walker<'_, (&String, &TypeIR)>> {
         self.structural_recursive_alias_cycles
@@ -1009,9 +1003,9 @@ impl IntermediateRepr {
         }
 
         // Also check regular type aliases that directly reference themselves
-        for alias in self.walk_type_aliases() {
-            let alias_name = &alias.item.elem.name;
-            let field_type = &alias.item.elem.r#type.elem;
+        for alias in &self.type_aliases {
+            let alias_name = &alias.elem.name;
+            let field_type = &alias.elem.r#type.elem;
 
             // Check if this alias directly references itself (causes immediate circular reference)
             if self.type_directly_references_self(field_type, alias_name) {
@@ -1157,8 +1151,8 @@ impl IntermediateRepr {
         let mut conversion_map = std::collections::HashMap::new();
 
         // All type aliases default to type aliases
-        for alias in self.walk_type_aliases() {
-            conversion_map.insert(alias.item.elem.name.clone(), false);
+        for alias in &self.type_aliases {
+            conversion_map.insert(alias.elem.name.clone(), false);
         }
 
         // All recursive alias cycle types default to type aliases
@@ -1402,6 +1396,12 @@ fn to_ir_attributes(
 pub struct Node<T> {
     pub attributes: NodeAttributes,
     pub elem: T,
+}
+
+impl<T> Node<T> {
+    pub fn span(&self) -> Option<&ast::Span> {
+        self.attributes.span.as_ref()
+    }
 }
 
 /// Implement this for every node in the IR AST, where T is the type of IR node

--- a/engine/baml-lib/baml-core/src/ir/walker.rs
+++ b/engine/baml-lib/baml-core/src/ir/walker.rs
@@ -13,8 +13,8 @@ use internal_llm_client::ClientSpec;
 use crate::ir::{
     jinja_helpers::render_expression,
     repr::{self, ExprFunction, FunctionConfig, Node, TypeBuilderEntry, WithRepr},
-    Class, Client, Enum, EnumValue, ExprFunctionNode, Field, Function, FunctionNode, IRHelper,
-    Impl, IntermediateRepr, RetryPolicy, TemplateString, TestCase, TypeIR, Walker,
+    Client, Enum, EnumValue, ExprFunctionNode, Field, Function, FunctionNode, IRHelper, Impl,
+    IntermediateRepr, RetryPolicy, TemplateString, TestCase, TypeIR, Walker,
 };
 
 impl<'a> Walker<'a, &'a ExprFunctionNode> {
@@ -304,55 +304,6 @@ impl<'a> Walker<'a, (&'a FunctionNode, &'a TestCase)> {
             ir: self.ir,
             item: self.item.0,
         }
-    }
-}
-
-impl<'a> Walker<'a, &'a Class> {
-    pub fn name(&self) -> &'a str {
-        &self.elem().name
-    }
-
-    pub fn alias(&self, ctx: &EvaluationContext<'_>) -> Result<Option<String>> {
-        self.item
-            .attributes
-            .alias()
-            .map(|v| v.resolve(ctx))
-            .transpose()
-    }
-
-    pub fn streaming_behavior(&self) -> StreamingBehavior {
-        self.item.attributes.streaming_behavior()
-    }
-
-    pub fn walk_fields(&'a self) -> impl Iterator<Item = Walker<'a, &'a Field>> {
-        self.item.elem.static_fields.iter().map(|f| Walker {
-            ir: self.ir,
-            item: f,
-        })
-    }
-
-    pub fn find_field(&'a self, name: &str) -> Option<Walker<'a, &'a Field>> {
-        self.item
-            .elem
-            .static_fields
-            .iter()
-            .find(|f| f.elem.name == name)
-            .map(|f| Walker {
-                ir: self.ir,
-                item: f,
-            })
-    }
-
-    pub fn elem(&self) -> &'a repr::Class {
-        &self.item.elem
-    }
-
-    pub fn span(&self) -> Option<&crate::Span> {
-        self.item.attributes.span.as_ref()
-    }
-
-    pub fn inputs(&self) -> &'a Vec<(String, baml_types::TypeIR)> {
-        self.elem().inputs()
     }
 }
 

--- a/engine/baml-lib/baml-core/src/ir/walker.rs
+++ b/engine/baml-lib/baml-core/src/ir/walker.rs
@@ -14,7 +14,7 @@ use crate::ir::{
     jinja_helpers::render_expression,
     repr::{self, ExprFunction, FunctionConfig, Node, TypeBuilderEntry, WithRepr},
     Class, Client, Enum, EnumValue, ExprFunctionNode, Field, Function, FunctionNode, IRHelper,
-    Impl, IntermediateRepr, RetryPolicy, TemplateString, TestCase, TypeAlias, TypeIR, Walker,
+    Impl, IntermediateRepr, RetryPolicy, TemplateString, TestCase, TypeIR, Walker,
 };
 
 impl<'a> Walker<'a, &'a ExprFunctionNode> {
@@ -353,20 +353,6 @@ impl<'a> Walker<'a, &'a Class> {
 
     pub fn inputs(&self) -> &'a Vec<(String, baml_types::TypeIR)> {
         self.elem().inputs()
-    }
-}
-
-impl<'a> Walker<'a, &'a TypeAlias> {
-    pub fn elem(&self) -> &'a repr::TypeAlias {
-        &self.item.elem
-    }
-
-    pub fn name(&self) -> &'a str {
-        &self.elem().name
-    }
-
-    pub fn span(&self) -> Option<&crate::Span> {
-        self.item.attributes.span.as_ref()
     }
 }
 

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/expr_typecheck.rs
@@ -252,26 +252,23 @@ pub fn typecheck_in_context(
             spread,
             meta,
         } => {
-            if let Ok(class_walker) = ir.find_class(name) {
+            if let Ok(class) = ir.find_class(name) {
                 // Typecheck each field in the constructor.
                 for (field_name, field_value) in fields.iter() {
                     let maybe_field_type = field_value.meta().1.clone();
                     if let Some(field_type) = maybe_field_type {
-                        if let Some(field_walker) = class_walker.find_field(field_name) {
+                        if let Some(field_walker) = class.elem.find_field(field_name) {
                             // panic!("SOME FIELD TYPE FOUND: {:?}", field_walker.r#type());
                             if !compatible_as_subtype(
                                 ir,
-                                &Some(field_walker.r#type().clone()),
+                                &Some(field_walker.elem.r#type.elem.clone()),
                                 &Some(field_type.clone()),
                             ) {
                                 // panic!("INCOMPATIBLE");
                                 diagnostics.push_error(DatamodelError::new_validation_error(
                                     &format!(
                                         "{}.{} expected type {}, but found {}",
-                                        name,
-                                        field_name,
-                                        field_walker.r#type(),
-                                        field_type
+                                        name, field_name, field_walker.elem.r#type.elem, field_type
                                     ),
                                     field_value.meta().0.clone(),
                                 ));
@@ -288,11 +285,13 @@ pub fn typecheck_in_context(
 
                 // Check that all fields are present.
                 if spread.is_none() {
-                    let missing_fields = class_walker
-                        .walk_fields()
+                    let missing_fields = class
+                        .elem
+                        .static_fields
+                        .iter()
                         .filter_map(|f| {
-                            if !fields.contains_key(f.name()) {
-                                Some(f.name().to_string())
+                            if !fields.contains_key(&f.elem.name) {
+                                Some(f.elem.name.to_string())
                             } else {
                                 None
                             }

--- a/engine/baml-lib/jinja-runtime/src/baml_value_to_jinja_value.rs
+++ b/engine/baml-lib/jinja-runtime/src/baml_value_to_jinja_value.rs
@@ -65,13 +65,13 @@ impl IntoMiniJinjaValue for BamlValue {
 
                 let mut key_to_alias = IndexMap::new();
                 if let Ok(c) = ir.find_class(name) {
-                    for field in c.walk_fields() {
+                    for field in c.elem.static_fields.iter() {
                         let key = field
                             .alias(eval_ctx)
                             .ok()
                             .and_then(|a| a)
-                            .unwrap_or_else(|| field.name().to_string());
-                        key_to_alias.insert(field.name().to_string(), key);
+                            .unwrap_or_else(|| field.elem.name.clone());
+                        key_to_alias.insert(field.elem.name.clone(), key);
                     }
                 }
 

--- a/engine/baml-lib/jsonish/src/helpers/mod.rs
+++ b/engine/baml-lib/jsonish/src/helpers/mod.rs
@@ -11,8 +11,8 @@ use internal_baml_core::{
     ast::Field,
     internal_baml_diagnostics::SourceFile,
     ir::{
-        repr::IntermediateRepr, ClassWalker, EnumWalker, IRHelper, IRHelperExtended, TypeIR,
-        TypeValue,
+        repr::{self, IntermediateRepr, Node},
+        EnumWalker, IRHelper, IRHelperExtended, TypeIR, TypeValue,
     },
     validate,
 };
@@ -68,21 +68,21 @@ pub fn render_output_format(
 fn find_existing_class_field(
     class_name: &str,
     field_name: &str,
-    class_walker: &Result<ClassWalker<'_>>,
+    class: &Result<&Node<repr::Class>>,
     env_values: &EvaluationContext<'_>,
 ) -> Result<(Name, TypeIR, Option<String>, bool)> {
-    let Ok(class_walker) = class_walker else {
+    let Ok(class_walker) = class else {
         anyhow::bail!("Class {} does not exist", class_name);
     };
 
-    let Some(field_walker) = class_walker.find_field(field_name) else {
+    let Some(field) = class_walker.elem.find_field(field_name) else {
         anyhow::bail!("Class {} does not have a field: {}", class_name, field_name);
     };
 
-    let name = Name::new_with_alias(field_name.to_string(), field_walker.alias(env_values)?);
-    let desc = field_walker.description(env_values)?;
-    let r#type = field_walker.r#type();
-    let streaming_needed = field_walker.item.attributes.streaming_behavior().needed;
+    let name = Name::new_with_alias(field_name.to_string(), field.alias(env_values)?);
+    let desc = field.description(env_values)?;
+    let r#type = &field.elem.r#type.elem;
+    let streaming_needed = field.streaming_behavior().needed;
     Ok((name, r#type.clone(), desc, streaming_needed))
 }
 
@@ -228,7 +228,7 @@ fn relevant_data_models<'a>(
 
                     let real_fields = walker
                         .as_ref()
-                        .map(|e| e.walk_fields().map(|v| v.name().to_string()))
+                        .map(|e| e.elem.static_fields.iter().map(|v| v.elem.name.to_string()))
                         .ok();
 
                     let fields = real_fields

--- a/engine/baml-lib/jsonish/src/tests/mod.rs
+++ b/engine/baml-lib/jsonish/src/tests/mod.rs
@@ -30,7 +30,7 @@ use indexmap::{IndexMap, IndexSet};
 use internal_baml_core::{
     ast::Field,
     internal_baml_diagnostics::SourceFile,
-    ir::{repr::IntermediateRepr, ClassWalker, EnumWalker, IRHelper, TypeValue},
+    ir::{repr::IntermediateRepr, EnumWalker, IRHelper, TypeValue},
     validate,
 };
 use internal_baml_jinja::types::{Class, Enum, Name, OutputFormatContent};
@@ -98,7 +98,7 @@ test_deserializer!(
     r#"Some preview text
 
     JSON Output:
-    
+
     [
       {
         "blah": "blah"
@@ -114,7 +114,7 @@ test_deserializer!(
     r#"Some preview text
 
     JSON Output:
-    
+
     [
       {
         "blah": "blah"
@@ -132,7 +132,7 @@ test_deserializer!(
     test_string_from_string22,
     EMPTY_FILE,
     r#"Hello there.
-    
+
     JSON Output:
     ```json
     [
@@ -150,7 +150,7 @@ test_deserializer!(
     "#,
     TypeIR::Primitive(TypeValue::String, Default::default()),
     r#"Hello there.
-    
+
     JSON Output:
     ```json
     [
@@ -218,24 +218,24 @@ class Score {
       1 to 100
     "#)
   }
-  
+
   class PopularityOverTime {
     bookName string
     scores Score[]
   }
-  
+
   class WordCount {
     bookName string
     count int
   }
-  
+
   class Ranking {
     bookName string
     score int @description(#"
       1 to 100 of your own personal score of this book
     "#)
   }
-   
+
   class BookAnalysis {
     bookNames string[] @description(#"
       The list of book names  provided
@@ -244,10 +244,10 @@ class Score {
       Print the popularity of EACH BOOK over time.
     "#) @alias(popularityData)
     // popularityRankings Ranking[] @description(#"
-    //   A list of the book's popularity rankings over time. 
+    //   A list of the book's popularity rankings over time.
     //   The first element is the top ranking
     // "#)
-   
+
     // wordCounts WordCount[]
   }
 "##;

--- a/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
+++ b/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
@@ -8,7 +8,8 @@ use baml_types::{
 };
 use indexmap::{IndexMap, IndexSet};
 use internal_baml_core::ir::{
-    repr::IntermediateRepr, ClassWalker, EnumWalker, IRHelper, IRHelperExtended,
+    repr::{self, IntermediateRepr},
+    EnumWalker, IRHelper, IRHelperExtended,
 };
 use internal_baml_jinja::types::{Class, Enum, Name, OutputFormatContent};
 
@@ -77,7 +78,7 @@ impl OverridableValue<String> {
 fn find_new_class_field(
     class_name: &str,
     field_name: &str,
-    class_walker: &Result<ClassWalker<'_>>,
+    class_walker: &Result<&repr::Node<repr::Class>>,
     overrides: &RuntimeClassOverride,
     _ctx: &RuntimeContext,
 ) -> Result<(Name, TypeIR, Option<String>, bool)> {
@@ -86,8 +87,8 @@ fn find_new_class_field(
     };
 
     // Ensure the original field does not exist
-    if let Ok(class_walker) = class_walker {
-        if class_walker.find_field(field_name).is_some() {
+    if let Ok(class) = class_walker {
+        if class.elem.find_field(field_name).is_some() {
             anyhow::bail!(
                 "Class {} already has a pre-defined field: {}",
                 class_name,
@@ -108,15 +109,15 @@ fn find_new_class_field(
 fn find_existing_class_field(
     class_name: &str,
     field_name: &str,
-    class_walker: &Result<ClassWalker<'_>>,
+    class_walker: &Result<&repr::Node<repr::Class>>,
     overrides: &Option<&RuntimeClassOverride>,
     ctx: &RuntimeContext,
 ) -> Result<(Name, TypeIR, Option<String>, bool)> {
-    let Ok(class_walker) = class_walker else {
+    let Ok(class) = class_walker else {
         anyhow::bail!("Class {} does not exist", class_name);
     };
 
-    let Some(field_walker) = class_walker.find_field(field_name) else {
+    let Some(field_walker) = class.elem.find_field(field_name) else {
         anyhow::bail!("Class {} does not have a field: {}", class_name, field_name);
     };
 
@@ -148,7 +149,7 @@ fn find_existing_class_field(
 
     let name = Name::new_with_alias(field_name.to_string(), alias.value());
     let desc = desc.value();
-    let r#type = field_walker.r#type();
+    let r#type = &field_walker.elem.r#type.elem;
     let needed = needed.value().unwrap_or(false);
     Ok((name, r#type.clone(), desc, needed))
 }
@@ -348,7 +349,7 @@ fn relevant_data_models<'a>(
 
                     let real_fields = walker
                         .as_ref()
-                        .map(|e| e.walk_fields().map(|v| v.name().to_string()))
+                        .map(|e| e.elem.static_fields.iter().map(|v| v.elem.name.to_string()))
                         .ok();
                     let override_fields = overrides
                         .map(|o| o.update_fields.keys().cloned())

--- a/engine/baml-runtime/src/internal/prompt_renderer/scoped_ir.rs
+++ b/engine/baml-runtime/src/internal/prompt_renderer/scoped_ir.rs
@@ -32,7 +32,12 @@ impl<'ir> ScopedIr<'ir> {
     fn find_class(
         &self,
         class_name: &str,
-    ) -> Result<FindResult<internal_baml_core::ir::ClassWalker<'ir>, &RuntimeClassOverride>> {
+    ) -> Result<
+        FindResult<
+            &internal_baml_core::ir::repr::Node<internal_baml_core::ir::repr::Class>,
+            &RuntimeClassOverride,
+        >,
+    > {
         let class_override = self.ctx.class_override.get(class_name);
         let class = self.ir.find_class(class_name);
 
@@ -68,10 +73,12 @@ impl IRSemanticStreamingHelper for ScopedIr<'_> {
         let class_type = &self.find_class(class_name)?;
         let result = match class_type {
             FindResult::OnlyIr(cls) | FindResult::Overriden(cls, _) => cls
-                .walk_fields()
+                .elem
+                .static_fields
+                .iter()
                 .filter_map(|field| {
                     if field.streaming_behavior().needed {
-                        Some(field.name().to_string())
+                        Some(field.elem.name.to_string())
                     } else {
                         None
                     }
@@ -93,7 +100,7 @@ impl IRSemanticStreamingHelper for ScopedIr<'_> {
                     .iter()
                     .map(|(k, v)| (k.clone(), v.0.clone()));
 
-                cls.elem()
+                cls.elem
                     .static_fields
                     .iter()
                     .map(|field_node| {
@@ -111,7 +118,7 @@ impl IRSemanticStreamingHelper for ScopedIr<'_> {
                 .map(|(k, v)| (k.clone(), v.0.clone()))
                 .collect(),
             FindResult::OnlyIr(cls) => cls
-                .elem()
+                .elem
                 .static_fields
                 .iter()
                 .map(|field_node| {
@@ -135,10 +142,12 @@ impl IRSemanticStreamingHelper for ScopedIr<'_> {
 
         let result = match class_type {
             FindResult::OnlyIr(cls) | FindResult::Overriden(cls, _) => cls
-                .walk_fields()
+                .elem
+                .static_fields
+                .iter()
                 .filter_map(|field| {
-                    if !value_names.contains(field.name()) {
-                        Some(field.name().to_string())
+                    if !value_names.contains(&field.elem.name) {
+                        Some(field.elem.name.to_string())
                     } else {
                         None
                     }

--- a/engine/generators/languages/go/src/ir_to_go/classes.rs
+++ b/engine/generators/languages/go/src/ir_to_go/classes.rs
@@ -1,11 +1,14 @@
-use internal_baml_core::ir::{Class, Field};
+use internal_baml_core::ir::{
+    repr::{Class, Node},
+    Field,
+};
 
 use crate::{
     generated_types::{ClassGo, FieldGo},
     package::CurrentRenderPackage,
 };
 
-pub fn ir_class_to_go<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> ClassGo<'a> {
+pub fn ir_class_to_go<'a>(class: &'a Node<Class>, pkg: &'a CurrentRenderPackage) -> ClassGo<'a> {
     ClassGo {
         name: class.elem.name.clone(),
         docstring: class
@@ -24,7 +27,10 @@ pub fn ir_class_to_go<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> Class
     }
 }
 
-pub fn ir_class_to_go_stream<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> ClassGo<'a> {
+pub fn ir_class_to_go_stream<'a>(
+    class: &'a Node<Class>,
+    pkg: &'a CurrentRenderPackage,
+) -> ClassGo<'a> {
     ClassGo {
         name: class.elem.name.clone(),
         docstring: class
@@ -91,7 +97,7 @@ mod tests {
         )
         .unwrap();
         let ir = std::sync::Arc::new(ir);
-        let class = ir.find_class("SimpleClass").unwrap().item;
+        let class = ir.find_class("SimpleClass").unwrap();
         let pkg = CurrentRenderPackage::new("baml_client", ir.clone());
         let class_go = ir_class_to_go_stream(class, &pkg);
         assert_eq!(class_go.name, "SimpleClass");
@@ -110,7 +116,7 @@ mod tests {
         )
         .unwrap();
         let ir = std::sync::Arc::new(ir);
-        let class = ir.find_class("ChildClass").unwrap().item;
+        let class = ir.find_class("ChildClass").unwrap();
         let pkg = CurrentRenderPackage::new("baml_client", ir.clone());
         let class_go = ir_class_to_go_stream(class, &pkg);
         let digits_field = class_go.fields.iter().find(|f| f.name == "digits").unwrap();
@@ -131,7 +137,7 @@ mod tests {
         )
         .expect("Valid IR");
         let ir = std::sync::Arc::new(ir);
-        let class = ir.find_class("Foo").unwrap().item;
+        let class = ir.find_class("Foo").unwrap();
         let pkg = CurrentRenderPackage::new("baml_client", ir.clone());
         let class_go = ir_class_to_go_stream(class, &pkg);
         assert_eq!(class_go.fields[0].docstring, Some("ds".to_string()));

--- a/engine/generators/languages/go/src/ir_to_go/type_aliases.rs
+++ b/engine/generators/languages/go/src/ir_to_go/type_aliases.rs
@@ -1,5 +1,5 @@
 use baml_types::baml_value::TypeLookups;
-use internal_baml_core::ir::TypeAlias;
+use internal_baml_core::ir::repr::TypeAlias;
 
 use crate::{generated_types::TypeAliasGo, ir_to_go, package::CurrentRenderPackage};
 
@@ -25,19 +25,15 @@ pub fn ir_type_alias_to_go<'a>(
     pkg: &'a CurrentRenderPackage,
     drop_type: Option<&String>,
 ) -> TypeAliasGo<'a> {
-    let non_streaming = alias.elem.r#type.elem.to_non_streaming_type(pkg.lookup());
+    let non_streaming = alias.r#type.elem.to_non_streaming_type(pkg.lookup());
     let lookup = LookupWithDrop {
         lookup: pkg.lookup(),
         drop_type,
     };
     TypeAliasGo {
-        name: alias.elem.name.clone(),
+        name: alias.name.clone(),
         type_: ir_to_go::type_to_go(&non_streaming, &lookup),
-        docstring: alias
-            .elem
-            .docstring
-            .clone()
-            .map(|docstring| docstring.0.clone()),
+        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
         pkg,
     }
 }
@@ -47,20 +43,16 @@ pub fn ir_type_alias_to_go_stream<'a>(
     pkg: &'a CurrentRenderPackage,
     drop_type: Option<&String>,
 ) -> TypeAliasGo<'a> {
-    let partialized = alias.elem.r#type.elem.to_streaming_type(pkg.lookup());
+    let partialized = alias.r#type.elem.to_streaming_type(pkg.lookup());
 
     let lookup = LookupWithDrop {
         lookup: pkg.lookup(),
         drop_type,
     };
     TypeAliasGo {
-        name: alias.elem.name.clone(),
+        name: alias.name.clone(),
         type_: ir_to_go::stream_type_to_go(&partialized, &lookup),
-        docstring: alias
-            .elem
-            .docstring
-            .clone()
-            .map(|docstring| docstring.0.clone()),
+        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
         pkg,
     }
 }

--- a/engine/generators/languages/go/src/lib.rs
+++ b/engine/generators/languages/go/src/lib.rs
@@ -69,8 +69,9 @@ impl LanguageFeatures for GoLanguageFeatures {
         );
 
         let go_classes = ir
-            .walk_classes()
-            .map(|c| ir_to_go::classes::ir_class_to_go(c.item, &pkg))
+            .classes
+            .iter()
+            .map(|c| ir_to_go::classes::ir_class_to_go(c, &pkg))
             .collect::<Vec<_>>();
         let enums = ir
             .walk_enums()
@@ -178,8 +179,9 @@ impl LanguageFeatures for GoLanguageFeatures {
         };
 
         let go_classes = ir
-            .walk_classes()
-            .map(|c| ir_to_go::classes::ir_class_to_go_stream(c.item, &pkg))
+            .classes
+            .iter()
+            .map(|c| ir_to_go::classes::ir_class_to_go_stream(c, &pkg))
             .collect::<Vec<_>>();
 
         pkg.set("baml_client.stream_types");

--- a/engine/generators/languages/go/src/lib.rs
+++ b/engine/generators/languages/go/src/lib.rs
@@ -86,7 +86,6 @@ impl LanguageFeatures for GoLanguageFeatures {
             unions.dedup_by_key(|u| u.name.clone());
             unions
         };
-        let type_aliases = ir.walk_type_aliases().collect::<Vec<_>>();
 
         // key-value pair of what type to drop from the cycle for any given type
         let invalid_cycles = ir
@@ -118,25 +117,27 @@ impl LanguageFeatures for GoLanguageFeatures {
             })
             .collect::<baml_types::BamlMap<_, _>>();
 
-        let mut go_type_aliases = type_aliases
+        let mut go_type_aliases = ir
+            .type_aliases
             .iter()
-            .map(|c| {
+            .map(|alias| {
                 ir_to_go::type_aliases::ir_type_alias_to_go(
-                    c.item,
+                    &alias.elem,
                     &pkg,
-                    invalid_cycles.get(&c.elem().name),
+                    invalid_cycles.get(&alias.elem.name),
                 )
             })
             .collect::<Vec<_>>();
         go_type_aliases.sort_by(|a, b| a.name.cmp(&b.name));
 
-        let mut stream_type_aliases = type_aliases
+        let mut stream_type_aliases = ir
+            .type_aliases
             .iter()
-            .map(|c| {
+            .map(|alias| {
                 ir_to_go::type_aliases::ir_type_alias_to_go_stream(
-                    c.item,
+                    &alias.elem,
                     &pkg,
-                    invalid_cycles.get(&c.elem().name),
+                    invalid_cycles.get(&alias.elem.name),
                 )
             })
             .collect::<Vec<_>>();

--- a/engine/generators/languages/openapi/src/generate_types.rs
+++ b/engine/generators/languages/openapi/src/generate_types.rs
@@ -35,10 +35,10 @@ impl OpenApiUserData {
                     convert_ir_enum(&r#enum.item.elem),
                 )
             })
-            .chain(ir.walk_classes().map(|class| {
+            .chain(ir.classes.iter().map(|class| {
                 (
-                    TypeName(class.name().to_string()),
-                    convert_ir_class(ir, &class.item.elem),
+                    TypeName(class.elem.name.clone()),
+                    convert_ir_class(ir, &class.elem),
                 )
             }))
             .collect();
@@ -141,11 +141,12 @@ impl OpenApiUserData {
 
 mod class {
     use indexmap::IndexSet;
+    use internal_baml_core::ir::repr::Class;
 
     use super::*;
     use crate::r#type::{TypeOpenApi, TypePrimitive};
 
-    pub fn convert_ir_class(ir: &repr::IntermediateRepr, class: &repr::Class) -> TypeOpenApi {
+    pub fn convert_ir_class(ir: &repr::IntermediateRepr, class: &Class) -> TypeOpenApi {
         let mut required = IndexSet::new();
         let mut properties: IndexMap<String, TypeOpenApi> = class
             .static_fields

--- a/engine/generators/languages/python/src/ir_to_py/classes.rs
+++ b/engine/generators/languages/python/src/ir_to_py/classes.rs
@@ -1,11 +1,14 @@
-use internal_baml_core::ir::{Class, Field};
+use internal_baml_core::ir::{
+    repr::{Class, Node},
+    Field,
+};
 
 use crate::{
     generated_types::{ClassPy, FieldPy},
     package::CurrentRenderPackage,
 };
 
-pub fn ir_class_to_py<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> ClassPy<'a> {
+pub fn ir_class_to_py<'a>(class: &'a Node<Class>, pkg: &'a CurrentRenderPackage) -> ClassPy<'a> {
     ClassPy {
         name: class.elem.name.clone(),
         docstring: class
@@ -24,7 +27,10 @@ pub fn ir_class_to_py<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> Class
     }
 }
 
-pub fn ir_class_to_py_stream<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> ClassPy<'a> {
+pub fn ir_class_to_py_stream<'a>(
+    class: &'a Node<Class>,
+    pkg: &'a CurrentRenderPackage,
+) -> ClassPy<'a> {
     ClassPy {
         name: class.elem.name.clone(),
         docstring: class

--- a/engine/generators/languages/python/src/ir_to_py/type_aliases.rs
+++ b/engine/generators/languages/python/src/ir_to_py/type_aliases.rs
@@ -1,4 +1,4 @@
-use internal_baml_core::ir::TypeAlias;
+use internal_baml_core::ir::repr::TypeAlias;
 
 use crate::{generated_types::TypeAliasPy, ir_to_py, package::CurrentRenderPackage};
 
@@ -7,16 +7,12 @@ pub fn ir_type_alias_to_py<'a>(
     pkg: &'a CurrentRenderPackage,
 ) -> TypeAliasPy<'a> {
     TypeAliasPy {
-        name: alias.elem.name.clone(),
+        name: alias.name.clone(),
         type_: ir_to_py::type_to_py(
-            &alias.elem.r#type.elem.to_non_streaming_type(pkg.lookup()),
+            &alias.r#type.elem.to_non_streaming_type(pkg.lookup()),
             pkg.lookup(),
         ),
-        docstring: alias
-            .elem
-            .docstring
-            .clone()
-            .map(|docstring| docstring.0.clone()),
+        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
         pkg,
     }
 }
@@ -25,15 +21,11 @@ pub fn ir_type_alias_to_py_stream<'a>(
     alias: &TypeAlias,
     pkg: &'a CurrentRenderPackage,
 ) -> TypeAliasPy<'a> {
-    let partialized = alias.elem.r#type.elem.to_streaming_type(pkg.lookup());
+    let partialized = alias.r#type.elem.to_streaming_type(pkg.lookup());
     TypeAliasPy {
-        name: alias.elem.name.clone(),
+        name: alias.name.clone(),
         type_: ir_to_py::stream_type_to_py(&partialized, pkg.lookup()),
-        docstring: alias
-            .elem
-            .docstring
-            .clone()
-            .map(|docstring| docstring.0.clone()),
+        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
         pkg,
     }
 }

--- a/engine/generators/languages/python/src/lib.rs
+++ b/engine/generators/languages/python/src/lib.rs
@@ -77,11 +77,11 @@ impl LanguageFeatures for PyLanguageFeatures {
             .walk_enums()
             .map(|e| ir_to_py::enums::ir_enum_to_py(e.item, &pkg))
             .collect::<Vec<_>>();
-        let type_aliases = ir.walk_type_aliases().collect::<Vec<_>>();
 
-        let mut py_type_aliases = type_aliases
+        let mut py_type_aliases = ir
+            .type_aliases
             .iter()
-            .map(|c| ir_to_py::type_aliases::ir_type_alias_to_py(c.item, &pkg))
+            .map(|alias| ir_to_py::type_aliases::ir_type_alias_to_py(&alias.elem, &pkg))
             .collect::<Vec<_>>();
         py_type_aliases.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -101,9 +101,10 @@ impl LanguageFeatures for PyLanguageFeatures {
         collector.append_to_file("types.py", &render_py_types(&py_classes, &pkg)?)?;
         collector.append_to_file("types.py", &render_py_types(&py_type_aliases, &pkg)?)?;
 
-        let mut py_stream_type_aliases = type_aliases
+        let mut py_stream_type_aliases = ir
+            .type_aliases
             .iter()
-            .map(|c| ir_to_py::type_aliases::ir_type_alias_to_py_stream(c.item, &pkg))
+            .map(|alias| ir_to_py::type_aliases::ir_type_alias_to_py_stream(&alias.elem, &pkg))
             .collect::<Vec<_>>();
         py_stream_type_aliases.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/engine/generators/languages/python/src/lib.rs
+++ b/engine/generators/languages/python/src/lib.rs
@@ -70,8 +70,9 @@ impl LanguageFeatures for PyLanguageFeatures {
         collector.add_file("parser.py", render_parser(&functions, &pkg)?)?;
 
         let py_classes = ir
-            .walk_classes()
-            .map(|c| ir_to_py::classes::ir_class_to_py(c.item, &pkg))
+            .classes
+            .iter()
+            .map(|c| ir_to_py::classes::ir_class_to_py(c, &pkg))
             .collect::<Vec<_>>();
         let enums = ir
             .walk_enums()
@@ -109,8 +110,9 @@ impl LanguageFeatures for PyLanguageFeatures {
         py_stream_type_aliases.sort_by(|a, b| a.name.cmp(&b.name));
 
         let py_classes = ir
-            .walk_classes()
-            .map(|c| ir_to_py::classes::ir_class_to_py_stream(c.item, &pkg))
+            .classes
+            .iter()
+            .map(|c| ir_to_py::classes::ir_class_to_py_stream(c, &pkg))
             .collect::<Vec<_>>();
 
         pkg.set("baml_client.stream_types");

--- a/engine/generators/languages/ruby/src/ir_to_rb/classes.rs
+++ b/engine/generators/languages/ruby/src/ir_to_rb/classes.rs
@@ -1,11 +1,14 @@
-use internal_baml_core::ir::{Class, Field};
+use internal_baml_core::ir::{
+    repr::{Class, Node},
+    Field,
+};
 
 use crate::{
     generated_types::{ClassRb, FieldRb},
     package::CurrentRenderPackage,
 };
 
-pub fn ir_class_to_rb<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> ClassRb<'a> {
+pub fn ir_class_to_rb<'a>(class: &'a Node<Class>, pkg: &'a CurrentRenderPackage) -> ClassRb<'a> {
     ClassRb {
         name: class.elem.name.clone(),
         docstring: class
@@ -24,7 +27,10 @@ pub fn ir_class_to_rb<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> Class
     }
 }
 
-pub fn ir_class_to_rb_stream<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> ClassRb<'a> {
+pub fn ir_class_to_rb_stream<'a>(
+    class: &'a Node<Class>,
+    pkg: &'a CurrentRenderPackage,
+) -> ClassRb<'a> {
     ClassRb {
         name: class.elem.name.clone(),
         docstring: class

--- a/engine/generators/languages/ruby/src/ir_to_rb/type_aliases.rs
+++ b/engine/generators/languages/ruby/src/ir_to_rb/type_aliases.rs
@@ -1,4 +1,4 @@
-use internal_baml_core::ir::TypeAlias;
+use internal_baml_core::ir::repr::TypeAlias;
 
 use crate::{generated_types::TypeAliasRb, ir_to_rb, package::CurrentRenderPackage};
 
@@ -7,16 +7,12 @@ pub fn ir_type_alias_to_rb<'a>(
     pkg: &'a CurrentRenderPackage,
 ) -> TypeAliasRb<'a> {
     TypeAliasRb {
-        name: alias.elem.name.clone(),
+        name: alias.name.clone(),
         type_: ir_to_rb::type_to_rb(
-            &alias.elem.r#type.elem.to_non_streaming_type(pkg.lookup()),
+            &alias.r#type.elem.to_non_streaming_type(pkg.lookup()),
             pkg.lookup(),
         ),
-        docstring: alias
-            .elem
-            .docstring
-            .clone()
-            .map(|docstring| docstring.0.clone()),
+        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
         pkg,
     }
 }
@@ -25,15 +21,11 @@ pub fn ir_type_alias_to_rb_stream<'a>(
     alias: &TypeAlias,
     pkg: &'a CurrentRenderPackage,
 ) -> TypeAliasRb<'a> {
-    let partialized = alias.elem.r#type.elem.to_streaming_type(pkg.lookup());
+    let partialized = alias.r#type.elem.to_streaming_type(pkg.lookup());
     TypeAliasRb {
-        name: alias.elem.name.clone(),
+        name: alias.name.clone(),
         type_: ir_to_rb::stream_type_to_rb(&partialized, pkg.lookup()),
-        docstring: alias
-            .elem
-            .docstring
-            .clone()
-            .map(|docstring| docstring.0.clone()),
+        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
         pkg,
     }
 }

--- a/engine/generators/languages/ruby/src/lib.rs
+++ b/engine/generators/languages/ruby/src/lib.rs
@@ -129,10 +129,10 @@ impl LanguageFeatures for RbLanguageFeatures {
             .walk_enums()
             .map(|e| ir_to_rb::enums::ir_enum_to_rb(e.item, &pkg))
             .collect::<Vec<_>>();
-        let type_aliases = ir.walk_type_aliases().collect::<Vec<_>>();
-        let mut rb_type_aliases = type_aliases
+        let mut rb_type_aliases = ir
+            .type_aliases
             .iter()
-            .map(|c| ir_to_rb::type_aliases::ir_type_alias_to_rb(c.item, &pkg))
+            .map(|alias| ir_to_rb::type_aliases::ir_type_alias_to_rb(&alias.elem, &pkg))
             .collect::<Vec<_>>();
         rb_type_aliases.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -153,9 +153,10 @@ impl LanguageFeatures for RbLanguageFeatures {
         collector.append_to_file("types.rb", &render_rb_types(&rb_type_aliases, &pkg)?)?;
         collector.append_to_file("types.rb", "\nend\n")?;
 
-        let mut rb_stream_type_aliases = type_aliases
+        let mut rb_stream_type_aliases = ir
+            .type_aliases
             .iter()
-            .map(|c| ir_to_rb::type_aliases::ir_type_alias_to_rb_stream(c.item, &pkg))
+            .map(|alias| ir_to_rb::type_aliases::ir_type_alias_to_rb_stream(&alias.elem, &pkg))
             .collect::<Vec<_>>();
         rb_stream_type_aliases.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/engine/generators/languages/ruby/src/lib.rs
+++ b/engine/generators/languages/ruby/src/lib.rs
@@ -122,8 +122,9 @@ impl LanguageFeatures for RbLanguageFeatures {
         // collector.add_file("parser.rb", render_parser(&functions, &pkg)?)?;
 
         let rb_classes = ir
-            .walk_classes()
-            .map(|c| ir_to_rb::classes::ir_class_to_rb(c.item, &pkg))
+            .classes
+            .iter()
+            .map(|c| ir_to_rb::classes::ir_class_to_rb(c, &pkg))
             .collect::<Vec<_>>();
         let enums = ir
             .walk_enums()
@@ -161,8 +162,9 @@ impl LanguageFeatures for RbLanguageFeatures {
         rb_stream_type_aliases.sort_by(|a, b| a.name.cmp(&b.name));
 
         let rb_classes = ir
-            .walk_classes()
-            .map(|c| ir_to_rb::classes::ir_class_to_rb_stream(c.item, &pkg))
+            .classes
+            .iter()
+            .map(|c| ir_to_rb::classes::ir_class_to_rb_stream(c, &pkg))
             .collect::<Vec<_>>();
 
         pkg.set("BamlClient.StreamTypes");

--- a/engine/generators/languages/typescript/src/ir_to_ts/classes.rs
+++ b/engine/generators/languages/typescript/src/ir_to_ts/classes.rs
@@ -1,11 +1,14 @@
-use internal_baml_core::ir::{Class, Field};
+use internal_baml_core::ir::{
+    repr::{Class, Node},
+    Field,
+};
 
 use crate::{
     generated_types::{ClassTS, FieldTS},
     package::CurrentRenderPackage,
 };
 
-pub fn ir_class_to_ts<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> ClassTS<'a> {
+pub fn ir_class_to_ts<'a>(class: &'a Node<Class>, pkg: &'a CurrentRenderPackage) -> ClassTS<'a> {
     ClassTS {
         name: class.elem.name.clone(),
         docstring: class
@@ -23,7 +26,10 @@ pub fn ir_class_to_ts<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> Class
     }
 }
 
-pub fn ir_class_to_ts_stream<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> ClassTS<'a> {
+pub fn ir_class_to_ts_stream<'a>(
+    class: &'a Node<Class>,
+    pkg: &'a CurrentRenderPackage,
+) -> ClassTS<'a> {
     ClassTS {
         name: class.elem.name.clone(),
         docstring: class
@@ -89,7 +95,7 @@ mod tests {
         )
         .unwrap();
         let ir = std::sync::Arc::new(ir);
-        let class = ir.find_class("SimpleClass").unwrap().item;
+        let class = ir.find_class("SimpleClass").unwrap();
         let pkg = CurrentRenderPackage::new("baml_client", ir.clone());
         let class_go = ir_class_to_ts_stream(class, &pkg);
         assert_eq!(class_go.name, "SimpleClass");
@@ -109,7 +115,7 @@ mod tests {
         )
         .unwrap();
         let ir = std::sync::Arc::new(ir);
-        let class = ir.find_class("ChildClass").unwrap().item;
+        let class = ir.find_class("ChildClass").unwrap();
         let pkg = CurrentRenderPackage::new("baml_client", ir.clone());
         let class_ts = ir_class_to_ts_stream(class, &pkg);
         let digits_field = class_ts.fields.iter().find(|f| f.name == "digits").unwrap();
@@ -141,7 +147,7 @@ mod tests {
         )
         .expect("Valid IR");
         let ir = std::sync::Arc::new(ir);
-        let class = ir.find_class("Foo").unwrap().item;
+        let class = ir.find_class("Foo").unwrap();
         let pkg = CurrentRenderPackage::new("baml_client", ir.clone());
         let class_ts = ir_class_to_ts_stream(class, &pkg);
         assert_eq!(class_ts.fields[0].docstring, Some("ds".to_string()));

--- a/engine/generators/languages/typescript/src/ir_to_ts/type_aliases.rs
+++ b/engine/generators/languages/typescript/src/ir_to_ts/type_aliases.rs
@@ -1,4 +1,4 @@
-use internal_baml_core::ir::TypeAlias;
+use internal_baml_core::ir::repr::TypeAlias;
 
 use crate::{
     generated_types::{TypeAliasInterfaceTS, TypeAliasTS},
@@ -11,16 +11,12 @@ pub fn ir_type_alias_to_ts<'a>(
     pkg: &'a CurrentRenderPackage,
 ) -> TypeAliasTS<'a> {
     TypeAliasTS {
-        name: alias.elem.name.clone(),
+        name: alias.name.clone(),
         target_type: ir_to_ts::type_to_ts(
-            &alias.elem.r#type.elem.to_non_streaming_type(pkg.lookup()),
+            &alias.r#type.elem.to_non_streaming_type(pkg.lookup()),
             pkg.lookup(),
         ),
-        docstring: alias
-            .elem
-            .docstring
-            .clone()
-            .map(|docstring| docstring.0.clone()),
+        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
         pkg,
     }
 }
@@ -29,15 +25,11 @@ pub fn ir_type_alias_to_ts_stream<'a>(
     alias: &TypeAlias,
     pkg: &'a CurrentRenderPackage,
 ) -> TypeAliasTS<'a> {
-    let partialized = alias.elem.r#type.elem.to_streaming_type(pkg.lookup());
+    let partialized = alias.r#type.elem.to_streaming_type(pkg.lookup());
     TypeAliasTS {
-        name: alias.elem.name.clone(),
+        name: alias.name.clone(),
         target_type: ir_to_ts::stream_type_to_ts(&partialized, pkg.lookup()),
-        docstring: alias
-            .elem
-            .docstring
-            .clone()
-            .map(|docstring| docstring.0.clone()),
+        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
         pkg,
     }
 }
@@ -49,18 +41,14 @@ pub fn ir_type_alias_to_ts_interface<'a>(
 ) -> Option<TypeAliasInterfaceTS<'a>> {
     use baml_types::ir_type::TypeGeneric;
 
-    match &alias.elem.r#type.elem {
+    match &alias.r#type.elem {
         TypeGeneric::Map(_, value_type, _) => Some(TypeAliasInterfaceTS {
-            name: alias.elem.name.clone(),
+            name: alias.name.clone(),
             value_type: ir_to_ts::type_to_ts(
                 &value_type.to_non_streaming_type(pkg.lookup()),
                 pkg.lookup(),
             ),
-            docstring: alias
-                .elem
-                .docstring
-                .clone()
-                .map(|docstring| docstring.0.clone()),
+            docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
             pkg,
         }),
         TypeGeneric::Union(union_type, _) => {
@@ -69,16 +57,12 @@ pub fn ir_type_alias_to_ts_interface<'a>(
                 if let TypeGeneric::Map(_, value_type, _) = variant {
                     // Found a map in the union - create an interface that extends the union but as an index signature
                     return Some(TypeAliasInterfaceTS {
-                        name: alias.elem.name.clone(),
+                        name: alias.name.clone(),
                         value_type: ir_to_ts::type_to_ts(
                             &value_type.to_non_streaming_type(pkg.lookup()),
                             pkg.lookup(),
                         ),
-                        docstring: alias
-                            .elem
-                            .docstring
-                            .clone()
-                            .map(|docstring| docstring.0.clone()),
+                        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
                         pkg,
                     });
                 }
@@ -96,16 +80,12 @@ pub fn ir_type_alias_to_ts_interface_stream<'a>(
 ) -> Option<TypeAliasInterfaceTS<'a>> {
     use baml_types::ir_type::TypeGeneric;
 
-    let partialized = alias.elem.r#type.elem.to_streaming_type(pkg.lookup());
+    let partialized = alias.r#type.elem.to_streaming_type(pkg.lookup());
     match &partialized {
         TypeGeneric::Map(_, value_type, _) => Some(TypeAliasInterfaceTS {
-            name: alias.elem.name.clone(),
+            name: alias.name.clone(),
             value_type: ir_to_ts::stream_type_to_ts(value_type, pkg.lookup()),
-            docstring: alias
-                .elem
-                .docstring
-                .clone()
-                .map(|docstring| docstring.0.clone()),
+            docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
             pkg,
         }),
         TypeGeneric::Union(union_type, _) => {
@@ -114,13 +94,9 @@ pub fn ir_type_alias_to_ts_interface_stream<'a>(
                 if let TypeGeneric::Map(_, value_type, _) = variant {
                     // Found a map in the union - create an interface that extends the union but as an index signature
                     return Some(TypeAliasInterfaceTS {
-                        name: alias.elem.name.clone(),
+                        name: alias.name.clone(),
                         value_type: ir_to_ts::stream_type_to_ts(&partialized, pkg.lookup()),
-                        docstring: alias
-                            .elem
-                            .docstring
-                            .clone()
-                            .map(|docstring| docstring.0.clone()),
+                        docstring: alias.docstring.clone().map(|docstring| docstring.0.clone()),
                         pkg,
                     });
                 }

--- a/engine/generators/languages/typescript/src/lib.rs
+++ b/engine/generators/languages/typescript/src/lib.rs
@@ -105,7 +105,6 @@ $ pnpm add @boundaryml/baml
             .walk_enums()
             .map(|e| ir_to_ts::enums::ir_enum_to_ts(e.item))
             .collect::<Vec<_>>();
-        let type_aliases = ir.walk_type_aliases().collect::<Vec<_>>();
 
         // Get the conversion map to determine which type aliases should become interfaces
         let conversion_map = ir.get_typescript_alias_conversion_map();
@@ -122,8 +121,8 @@ $ pnpm add @boundaryml/baml
             .collect();
 
         // Process regular type aliases (skip those that are part of recursive cycles)
-        for alias_walker in type_aliases.iter() {
-            let alias_name = &alias_walker.item.elem.name;
+        for alias in &ir.type_aliases {
+            let alias_name = &alias.elem.name;
 
             // Skip if this alias is part of a recursive cycle (will be processed separately)
             if recursive_alias_names.contains(alias_name) {
@@ -133,20 +132,20 @@ $ pnpm add @boundaryml/baml
             if conversion_map.get(alias_name) == Some(&true) {
                 // Convert to interface
                 if let Some(interface) =
-                    ir_to_ts::type_aliases::ir_type_alias_to_ts_interface(alias_walker.item, &pkg)
+                    ir_to_ts::type_aliases::ir_type_alias_to_ts_interface(&alias.elem, &pkg)
                 {
                     ts_interface_aliases.push(interface);
                 } else {
                     // Fallback to regular type alias if interface conversion fails
                     ts_type_aliases.push(ir_to_ts::type_aliases::ir_type_alias_to_ts(
-                        alias_walker.item,
+                        &alias.elem,
                         &pkg,
                     ));
                 }
             } else {
                 // Keep as type alias
                 ts_type_aliases.push(ir_to_ts::type_aliases::ir_type_alias_to_ts(
-                    alias_walker.item,
+                    &alias.elem,
                     &pkg,
                 ));
             }
@@ -171,14 +170,14 @@ $ pnpm add @boundaryml/baml
                     };
 
                     if let Some(interface) = ir_to_ts::type_aliases::ir_type_alias_to_ts_interface(
-                        &synthetic_alias,
+                        &synthetic_alias.elem,
                         &pkg,
                     ) {
                         ts_interface_aliases.push(interface);
                     } else {
                         // Fallback to regular type alias
                         ts_type_aliases.push(ir_to_ts::type_aliases::ir_type_alias_to_ts(
-                            &synthetic_alias,
+                            &synthetic_alias.elem,
                             &pkg,
                         ));
                     }
@@ -197,7 +196,7 @@ $ pnpm add @boundaryml/baml
                         },
                     };
                     ts_type_aliases.push(ir_to_ts::type_aliases::ir_type_alias_to_ts(
-                        &synthetic_alias,
+                        &synthetic_alias.elem,
                         &pkg,
                     ));
                 }
@@ -224,8 +223,8 @@ $ pnpm add @boundaryml/baml
         let mut ts_stream_interface_aliases = Vec::new();
 
         // Process regular type aliases (skip those that are part of recursive cycles)
-        for alias_walker in type_aliases.iter() {
-            let alias_name = &alias_walker.item.elem.name;
+        for alias in &ir.type_aliases {
+            let alias_name = &alias.elem.name;
 
             // Skip if this alias is part of a recursive cycle (will be processed separately)
             if recursive_alias_names.contains(alias_name) {
@@ -235,22 +234,19 @@ $ pnpm add @boundaryml/baml
             if conversion_map.get(alias_name) == Some(&true) {
                 // Convert to interface
                 if let Some(interface) =
-                    ir_to_ts::type_aliases::ir_type_alias_to_ts_interface_stream(
-                        alias_walker.item,
-                        &pkg,
-                    )
+                    ir_to_ts::type_aliases::ir_type_alias_to_ts_interface_stream(&alias.elem, &pkg)
                 {
                     ts_stream_interface_aliases.push(interface);
                 } else {
                     // Fallback to regular type alias if interface conversion fails
                     ts_stream_type_aliases.push(
-                        ir_to_ts::type_aliases::ir_type_alias_to_ts_stream(alias_walker.item, &pkg),
+                        ir_to_ts::type_aliases::ir_type_alias_to_ts_stream(&alias.elem, &pkg),
                     );
                 }
             } else {
                 // Keep as type alias
                 ts_stream_type_aliases.push(ir_to_ts::type_aliases::ir_type_alias_to_ts_stream(
-                    alias_walker.item,
+                    &alias.elem,
                     &pkg,
                 ));
             }
@@ -276,7 +272,7 @@ $ pnpm add @boundaryml/baml
 
                     if let Some(interface) =
                         ir_to_ts::type_aliases::ir_type_alias_to_ts_interface_stream(
-                            &synthetic_alias,
+                            &synthetic_alias.elem,
                             &pkg,
                         )
                     {
@@ -285,7 +281,7 @@ $ pnpm add @boundaryml/baml
                         // Fallback to regular type alias
                         ts_stream_type_aliases.push(
                             ir_to_ts::type_aliases::ir_type_alias_to_ts_stream(
-                                &synthetic_alias,
+                                &synthetic_alias.elem,
                                 &pkg,
                             ),
                         );
@@ -305,7 +301,10 @@ $ pnpm add @boundaryml/baml
                         },
                     };
                     ts_stream_type_aliases.push(
-                        ir_to_ts::type_aliases::ir_type_alias_to_ts_stream(&synthetic_alias, &pkg),
+                        ir_to_ts::type_aliases::ir_type_alias_to_ts_stream(
+                            &synthetic_alias.elem,
+                            &pkg,
+                        ),
                     );
                 }
             }

--- a/engine/generators/languages/typescript/src/lib.rs
+++ b/engine/generators/languages/typescript/src/lib.rs
@@ -55,8 +55,9 @@ $ pnpm add @boundaryml/baml
         let pkg = package::CurrentRenderPackage::new("baml_client", ir.clone());
         let file_map = args.file_map_as_json_string()?;
         let mut types: Vec<String> = ir
-            .walk_classes()
-            .map(|c| c.name().to_string())
+            .classes
+            .iter()
+            .map(|c| c.elem.name.clone())
             .chain(ir.walk_enums().map(|e| e.name().to_string()))
             .chain(ir.walk_alias_cycles().map(|a| a.item.0.clone()))
             .collect();
@@ -92,14 +93,15 @@ $ pnpm add @boundaryml/baml
         )?;
 
         // Generate type files
-        let classes = ir.walk_classes().collect::<Vec<_>>();
-        let ts_classes = classes
+        let ts_classes = ir
+            .classes
             .iter()
-            .map(|c| ir_to_ts::classes::ir_class_to_ts(c.item, &pkg))
+            .map(|c| ir_to_ts::classes::ir_class_to_ts(c, &pkg))
             .collect::<Vec<_>>();
-        let ts_classes_stream = classes
+        let ts_classes_stream = ir
+            .classes
             .iter()
-            .map(|c| ir_to_ts::classes::ir_class_to_ts_stream(c.item, &pkg))
+            .map(|c| ir_to_ts::classes::ir_class_to_ts_stream(c, &pkg))
             .collect::<Vec<_>>();
         let ts_enums = ir
             .walk_enums()

--- a/engine/language_client_codegen/src/lib.rs
+++ b/engine/language_client_codegen/src/lib.rs
@@ -229,14 +229,14 @@ impl TypeCheckAttributes {
 /// `Classes_a` and `Classes_a_b`.
 pub fn type_check_attributes(ir: &IntermediateRepr) -> HashSet<TypeCheckAttributes> {
     let mut all_types_in_ir: Vec<&TypeIR> = Vec::new();
-    for class in ir.walk_classes() {
-        for field in class.item.elem.static_fields.iter() {
+    for class in &ir.classes {
+        for field in &class.elem.static_fields {
             let field_type = &field.elem.r#type.elem;
             all_types_in_ir.push(field_type);
         }
     }
     for function in ir.walk_functions() {
-        for (_param_name, parameter) in function.item.elem.inputs.iter() {
+        for (_param_name, parameter) in &function.item.elem.inputs {
             all_types_in_ir.push(parameter);
         }
         let return_type = &function.item.elem.output;

--- a/engine/language_server/src/baml_project/mod.rs
+++ b/engine/language_server/src/baml_project/mod.rs
@@ -698,13 +698,13 @@ impl BamlRuntimeExt for BamlRuntime {
                 end_character: e_character,
             });
         }
-        if let Ok(walker) = runtime.find_type_alias(symbol) {
-            let elem = walker.span().unwrap();
+        if let Ok(type_alias) = runtime.find_type_alias(symbol) {
+            let span = type_alias.span().unwrap();
 
-            let _uri_str = elem.file.path().to_string(); // Store the String in a variable
-            let ((s_line, s_character), (e_line, e_character)) = elem.line_and_column();
+            let _uri_str = span.file.path().to_string(); // Store the String in a variable
+            let ((s_line, s_character), (e_line, e_character)) = span.line_and_column();
             return Some(SymbolLocation {
-                uri: elem.file.path().to_string(), // Use the variable here
+                uri: span.file.path().to_string(), // Use the variable here
                 start_line: s_line,
                 start_character: s_character,
                 end_line: e_line,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Remove `Walker` abstraction from IR, updating class and type alias handling across code generation and validation modules.
> 
>   - **IR Changes**:
>     - Remove `Walker` abstraction from IR, replacing with direct `Node` access in `class.rs`, `type_alias.rs`, and `mod.rs`.
>     - Update `IRHelper` and `IRHelperExtended` to use `Node` directly instead of `Walker`.
>   - **Code Generation**:
>     - Update Go, Python, Ruby, and TypeScript generators to use `Node` for class and type alias handling.
>     - Modify `ir_to_go`, `ir_to_py`, `ir_to_rb`, and `ir_to_ts` modules to reflect `Walker` removal.
>   - **Validation and Helpers**:
>     - Adjust `expr_typecheck.rs` and `json_schema.rs` to work with `Node`.
>     - Update `baml_value_to_jinja_value.rs` and `helpers/mod.rs` for `Node` usage.
>   - **Miscellaneous**:
>     - Remove `Walker` type definitions from `ir_helpers/mod.rs`.
>     - Update tests across various modules to align with `Node` changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 5fb641d495c7eadc36aa5cf082779e55f49fd690. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->