### PR TITLE
Add nix env vars to turbo passthrough

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,15 @@
     "STAGE",
     "VERCEL",
     "VERCEL_ENV",
-    "TARGET"
+    "TARGET",
+    "CMAKE_FRAMEWORK_PATH",
+    "NIX_CC",
+    "NIX_CC_WRAPPER_TARGET_HOST_aarch64_apple_darwin",
+    "NIX_BINTOOLS",
+    "NIX_BINTOOLS_WRAPPER_TARGET_HOST_aarch64_apple_darwin",
+    "CC",
+    "LD",
+    "MACOSX_DEPLOYMENT_TARGET"
   ],
   "globalEnv": ["VSCODE_DEBUG_MODE"],
   "globalDependencies": [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Nix and macOS-related environment variables to `globalPassThroughEnv` in `turbo.json`.
> 
>   - **Environment Variables**:
>     - Added `CMAKE_FRAMEWORK_PATH`, `NIX_CC`, `NIX_CC_WRAPPER_TARGET_HOST_aarch64_apple_darwin`, `NIX_BINTOOLS`, `NIX_BINTOOLS_WRAPPER_TARGET_HOST_aarch64_apple_darwin`, `CC`, `LD`, `MACOSX_DEPLOYMENT_TARGET` to `globalPassThroughEnv` in `turbo.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7072f13ca44738083e93f09d2a00caf3ba1bb538. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->