### PR TITLE
make changes in py, ts, ruby to support baml as an alias to baml-cli

### DIFF
--- a/engine/language_client_python/pyproject.toml
+++ b/engine/language_client_python/pyproject.toml
@@ -21,6 +21,7 @@ features = ["pyo3/extension-module", "pyo3/generate-import-lib"]
 
 [project.scripts]
 baml-cli = "baml_py:invoke_runtime_cli"
+baml = "baml_py:invoke_runtime_cli"
 
 # NOTE: dependencies is _deliberately_ empty so that different flavors of BAML
 # don't have to share dependencies, e.g. we currently generate python/pydantic

--- a/engine/language_client_ruby/baml.gemspec
+++ b/engine/language_client_ruby/baml.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["exe/*", "lib/**/*.rb", "ext/**/*.{rs,toml,lock,rb}"]
   spec.bindir = "exe"
   # TODO: make sure this is invoke-able from an installed gem
-  spec.executables = ["baml-cli"]
+  spec.executables = ["baml-cli", "baml"]
   spec.require_paths = ["lib"]
   spec.extensions = ["ext/ruby_ffi/extconf.rb"]
 

--- a/engine/language_client_typescript/package.json
+++ b/engine/language_client_typescript/package.json
@@ -17,7 +17,8 @@
     "node-addon-api"
   ],
   "bin": {
-    "baml-cli": "cli.js"
+    "baml-cli": "cli.js",
+    "baml": "cli.js"
   },
   "files": [
     "./cli.js",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add 'baml' as an alias to 'baml-cli' in Python, Ruby, and TypeScript configurations for CLI invocation.
> 
>   - **Behavior**:
>     - Add `baml` as an alias to `baml-cli` in `pyproject.toml`, `baml.gemspec`, and `package.json`.
>     - Allows invoking the CLI using `baml` command in Python, Ruby, and TypeScript environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 87e5e7f0c13a4bc55a3cd23af1550127f76d00a3. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->