### PR TITLE
Fix typo in docs (openai-responses.mdx)

### DIFF
--- a/fern/03-reference/baml/clients/providers/openai-responses.mdx
+++ b/fern/03-reference/baml/clients/providers/openai-responses.mdx
@@ -92,7 +92,7 @@ client<llm> StandardOpenAIWithResponses {
 These are parameters specific to the OpenAI Responses API that are passed through to the provider.
 
 <ParamField
-  path="reasnoning.effort"
+  path="reasoning.effort"
   type="string"
 >
   Controls the amount of reasoning effort the model should use.


### PR DESCRIPTION
Spelling typo fix
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `openai-responses.mdx`, correcting `reasnoning.effort` to `reasoning.effort`.
> 
>   - Fix typo in `openai-responses.mdx`, changing `reasnoning.effort` to `reasoning.effort`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 553480f0ba40573f89a9c67de25926cdd7abfed1. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->