### PR TITLE
Allow optional cache_control arg in jinja role fn

### DIFF
--- a/engine/baml-lib/baml/tests/validation_files/functions_v2/prompt_errors/role.baml
+++ b/engine/baml-lib/baml/tests/validation_files/functions_v2/prompt_errors/role.baml
@@ -1,0 +1,10 @@
+function Foo() -> string {
+    client "openai/gpt-4o"
+    prompt #"
+        You are a helpful assistant.
+        {{ ctx.output_format }}
+
+        {{ _.role("assistant", cache_control={"type": "ephemeral"}) }}
+        Hi
+    "#
+}

--- a/engine/baml-lib/jinja/src/evaluate_type/types.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/types.rs
@@ -280,7 +280,10 @@ impl PredefinedTypes {
             functions: IndexMap::from([
                 (
                     "baml::Chat".into(),
-                    (Type::String, vec![("role".into(), Type::String)]),
+                    (Type::String, vec![
+                        ("role".into(), Type::String),
+                        ("cache_control".into(), Type::merge(vec![Type::Map(Box::new(Type::String), Box::new(Type::Unknown)), Type::None])),
+                        ]),
                 ),
                 (
                     "baml::OutputFormat".into(),

--- a/engine/baml-lib/jinja/src/evaluate_type/types.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/types.rs
@@ -280,10 +280,19 @@ impl PredefinedTypes {
             functions: IndexMap::from([
                 (
                     "baml::Chat".into(),
-                    (Type::String, vec![
-                        ("role".into(), Type::String),
-                        ("cache_control".into(), Type::merge(vec![Type::Map(Box::new(Type::String), Box::new(Type::Unknown)), Type::None])),
-                        ]),
+                    (
+                        Type::String,
+                        vec![
+                            ("role".into(), Type::String),
+                            (
+                                "cache_control".into(),
+                                Type::merge(vec![
+                                    Type::Map(Box::new(Type::String), Box::new(Type::Unknown)),
+                                    Type::None,
+                                ]),
+                            ),
+                        ],
+                    ),
                 ),
                 (
                     "baml::OutputFormat".into(),


### PR DESCRIPTION
 - Closes https://discord.com/channels/1119368998161752075/1253172277449855029/1399068983184855100
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allow optional `cache_control` argument in `role` function within `baml::Chat` and add test case in `role.baml`.
> 
>   - **Behavior**:
>     - Allow optional `cache_control` argument in `role` function within `baml::Chat` in `types.rs`.
>     - `cache_control` can be a `Map` of `String` to `Unknown` or `None`.
>   - **Tests**:
>     - Add test case in `role.baml` to validate `cache_control` usage in `role` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for e01ec44b8872cec8ed56398208748c4986a06f0e. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->