### PR TITLE
add parser failures

### DIFF
--- a/engine/baml-lib/jsonish/src/tests/test_class.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_class.rs
@@ -351,6 +351,27 @@ test_deserializer!(
     }
 );
 
+test_deserializer!(
+  test_aliases_with_capitalized_key,
+  CLASS_WITH_ALIASES,
+  // Key21 is now capitalized, but we should still be able to parse it.
+  r#"{
+      "key-dash": "This is a value with a dash",
+      "Key21": "This is a value for key21",
+      "key with space": "This is a value with space",
+      "key4": "This is a value for key4",
+      "key.with.punctuation/123": "This is a value with punctuation and numbers"
+    }"#,
+  TypeIR::class("TestClassAlias"),
+  {
+      "key": "This is a value with a dash",
+      "key2": "This is a value for key21",
+      "key3": "This is a value with space",
+      "key4": "This is a value for key4",
+      "key5": "This is a value with punctuation and numbers"
+  }
+);
+
 const CLASS_SIMPLE: &str = r#"
 class SimpleTest {
     answer Answer
@@ -371,6 +392,18 @@ test_deserializer!(
             "content": 78.54
         }
     }
+);
+
+test_deserializer!(
+  test_class_with_capitalization,
+  CLASS_SIMPLE,
+  r#"{"Answer": {" content ": 78.54}}"#,
+  TypeIR::class("SimpleTest"),
+  {
+      "answer": {
+          "content": 78.54
+      }
+  }
 );
 
 const CLASS_WITH_NESTED_CLASS_LIST: &str = r#"

--- a/engine/baml-lib/jsonish/src/tests/test_lists.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_lists.rs
@@ -14,6 +14,18 @@ test_deserializer!(
 );
 
 test_deserializer!(
+    test_list_streaming_inside_json_block,
+    "",
+    r#"```json
+  ["a","#,
+    TypeIR::List(
+        TypeIR::Primitive(TypeValue::String, TypeMeta::default()).into(),
+        TypeMeta::default()
+    ),
+    ["a"]
+);
+
+test_deserializer!(
     test_list_with_quotes,
     "",
     r#"["\"a\"", "\"b\""]"#,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add test cases for handling capitalized keys and streaming JSON blocks in deserialization.
> 
>   - **Tests**:
>     - Add `test_aliases_with_capitalized_key` and `test_class_with_capitalization` in `test_class.rs` to handle capitalized keys.
>     - Add `test_list_streaming_inside_json_block` in `test_lists.rs` to handle streaming JSON blocks.
>   - **Behavior**:
>     - Ensure deserialization handles capitalized keys and whitespace correctly.
>     - Support for streaming JSON blocks in list deserialization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for a5b3e82f0f91a56b3bd2343c450f82f2d2dfe4b8. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->