### PR TITLE
[bug] Fix parser during streaming so that we correctly parse string[] from "["foo",

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/array_helper.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/array_helper.rs
@@ -94,13 +94,13 @@ pub(super) fn pick_best(
                         ) = (a_val, b_val)
                         {
                             // Prefer lists with properly parsed content over lists containing raw markdown strings
-                            let a_has_markdown_string = items_a.get(0).map_or(false, |item| {
+                            let a_has_markdown_string = items_a.first().is_some_and(|item| {
                                 item.conditions()
                                     .flags
                                     .iter()
                                     .any(|f| matches!(f, Flag::ObjectFromMarkdown(_)))
                             });
-                            let b_has_markdown_string = items_b.get(0).map_or(false, |item| {
+                            let b_has_markdown_string = items_b.first().is_some_and(|item| {
                                 item.conditions()
                                     .flags
                                     .iter()

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/array_helper.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/array_helper.rs
@@ -93,6 +93,28 @@ pub(super) fn pick_best(
                             BamlValueWithFlags::List(_, _, items_b),
                         ) = (a_val, b_val)
                         {
+                            // Prefer lists with properly parsed content over lists containing raw markdown strings
+                            let a_has_markdown_string = items_a.get(0).map_or(false, |item| {
+                                item.conditions()
+                                    .flags
+                                    .iter()
+                                    .any(|f| matches!(f, Flag::ObjectFromMarkdown(_)))
+                            });
+                            let b_has_markdown_string = items_b.get(0).map_or(false, |item| {
+                                item.conditions()
+                                    .flags
+                                    .iter()
+                                    .any(|f| matches!(f, Flag::ObjectFromMarkdown(_)))
+                            });
+
+                            match (a_has_markdown_string, b_has_markdown_string) {
+                                // If a has markdown string but b doesn't, prefer b
+                                (true, false) => return std::cmp::Ordering::Greater,
+                                // If b has markdown string but a doesn't, prefer a
+                                (false, true) => return std::cmp::Ordering::Less,
+                                _ => {}
+                            }
+
                             let unparseables_a = a_val
                                 .conditions()
                                 .flags

--- a/engine/baml-lib/jsonish/src/tests/test_lists.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_lists.rs
@@ -158,3 +158,15 @@ test_deserializer!(
     ),
     [1234]
 );
+
+test_deserializer!(
+    test_list_streaming_inside_json_block,
+    "",
+    r#"```json
+["a","#,
+    TypeIR::List(
+        TypeIR::Primitive(TypeValue::String, TypeMeta::default()).into(),
+        TypeMeta::default()
+    ),
+    ["a"]
+);


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes list parsing in `array_helper.rs` to prefer lists without markdown strings and adds a test for JSON block streaming.
> 
>   - **Behavior**:
>     - Fixes list parsing in `pick_best()` in `array_helper.rs` to prefer lists without markdown strings over those with.
>     - Adds logic to handle markdown strings in lists, ensuring correct parsing order.
>   - **Tests**:
>     - Adds `test_list_streaming_inside_json_block` in `test_lists.rs` to verify correct parsing of lists within JSON blocks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 067eea7d768da66d63f7241ce4b24a445a969882. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->