### PR TITLE
[chore] wasm should build with release mode always

### DIFF
--- a/engine/baml-schema-wasm/web/package.json
+++ b/engine/baml-schema-wasm/web/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "clean": "git clean -xdf ./dist .turbo node_modules",
     "comment": "don't use 'wasm pack --dev' below or it will be too big of a bundle and playground will be slow to load.",
-    "build": "pnpm run pack --dev",
+    "build": "pnpm run release",
     "release": "pnpm run pack --release",
     "pack": "wasm-pack build ../ --target bundler --out-dir ./web/dist",
-    "dev.skip": "cargo watch -C .. -w ./src -s 'cargo build --manifest-path ../Cargo.toml && pnpm run pack --dev'",
+    "dev.skip": "cargo watch -C .. -w ./src -s 'cargo build --manifest-path ../Cargo.toml && pnpm run release'",
     "dev": "pnpm run build"
   },
   "exports": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Ensure WebAssembly builds in release mode by updating `build` and `dev.skip` scripts in `package.json`.
> 
>   - **Build Scripts**:
>     - Change `build` script in `package.json` from `pnpm run pack --dev` to `pnpm run release`.
>     - Change `dev.skip` script in `package.json` from `pnpm run pack --dev` to `pnpm run release`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for efb9e04425d2f38fd3e270a6c491d447eb669d56. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->