### PR TITLE
chore: remove package.json skip steps

### DIFF
--- a/engine/baml-schema-wasm/nodejs/package.json
+++ b/engine/baml-schema-wasm/nodejs/package.json
@@ -10,7 +10,6 @@
     "release": "pnpm run pack --release",
     "pack": "wasm-pack build ../ --target nodejs --out-dir ./nodejs/dist",
     "typecheck": "pnpm run pack --dev",
-    "dev.skip": "cargo watch -C .. -w ./src -s 'cargo build --manifest-path ../Cargo.toml && pnpm run pack --dev'",
     "dev": "pnpm run build"
   },
   "repository": {

--- a/engine/baml-schema-wasm/web/package.json
+++ b/engine/baml-schema-wasm/web/package.json
@@ -8,9 +8,7 @@
     "comment": "don't use 'wasm pack --dev' below or it will be too big of a bundle and playground will be slow to load.",
     "build": "pnpm run release",
     "release": "pnpm run pack --release",
-    "pack": "wasm-pack build ../ --target bundler --out-dir ./web/dist",
-    "dev.skip": "cargo watch -C ../ -w ./src -s 'cargo build --package baml-schema-build && pnpm run pack --dev'",
-    "dev.skip2": "pnpm run build"
+    "pack": "wasm-pack build ../ --target bundler --out-dir ./web/dist"
   },
   "exports": {
     ".": {

--- a/engine/cli/package.json
+++ b/engine/cli/package.json
@@ -8,7 +8,6 @@
   },
   "scripts": {
     "dev": "pnpm build && pnpm run copy:debug",
-    "dev.skip": "cargo watch -x 'build --bin baml-cli' -s 'pnpm run copy:debug'",
     "clean": "git clean -xdf .turbo node_modules target",
     "copy:debug": "mkdir -p dist && cp ../target/debug/baml-cli dist/baml-cli",
     "copy:release": "mkdir -p dist && cp ../target/release/baml-cli dist/baml-cli",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unused `dev.skip` script entries from `package.json` files in `nodejs`, `web`, and `cli` directories.
> 
>   - **Scripts Cleanup**:
>     - Removed `dev.skip` from `nodejs/package.json`.
>     - Removed `dev.skip` and `dev.skip2` from `web/package.json`.
>     - Removed `dev.skip` from `cli/package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 24b8a8cce7e2818201e091125995ff9390cc2eee. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->