### PR TITLE
fix union type warning

### DIFF
--- a/engine/baml-rpc/src/runtime_api/baml_value.rs
+++ b/engine/baml-rpc/src/runtime_api/baml_value.rs
@@ -13,6 +13,7 @@ pub enum TypeIndex {
     NotUnion,
     Null,         // the type is a union but the value is null
     Index(usize), // the type is a union and this index points to the actual type
+    NotFound,
 }
 
 // Export this to TS since we don't yet decouple this into a DB specific type or anything. What the runtime exports is what the frontend reads as far as BamlValue is concerned. If you want to decouple it, create a UIBamlValue type and do a conversion from this to the UI type.

--- a/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use baml_rpc::{runtime_api, NarrowingType};
-use baml_types::{ir_type::TypeGeneric, type_meta, BamlValueWithMeta, Constraint, HasType};
+use baml_types::{ir_type::TypeGeneric, type_meta, BamlValueWithMeta, Constraint, HasType, TypeValue, baml_value::TypeQuery, StreamingMode};
 
 use super::{IntoRpcEvent, TypeLookup};
 
@@ -54,8 +54,18 @@ impl<'a, T: HasType<type_meta::NonStreaming>> IntoRpcEvent<'a, runtime_api::Baml
                     baml_rpc::TypeReferenceWithMetadata::Union { union_type, .. } => match value {
                         baml_rpc::runtime_api::ValueContent::Null => runtime_api::TypeIndex::Null,
                         _ => {
-                            baml_log::warn!("Union type index is not set! Please talk to vbv about how to fix this.");
-                            runtime_api::TypeIndex::Index(0)
+                            // Find which type in the union matches the actual value type
+                            let type_index = union_type.types
+                                .iter()
+                                .position(|union_variant_type| {
+                                    matches_value_with_rpc_type(self, union_variant_type, lookup)
+                                })
+                                .unwrap_or_else(|| {
+                                    baml_log::warn!("Could not determine union variant index for value type. Using index 0 as fallback.");
+                                    0
+                                });
+                            
+                            runtime_api::TypeIndex::Index(type_index)
                         }
                     },
                     _ => runtime_api::TypeIndex::NotUnion,
@@ -65,6 +75,54 @@ impl<'a, T: HasType<type_meta::NonStreaming>> IntoRpcEvent<'a, runtime_api::Baml
             },
             value,
         }
+    }
+}
+
+// Helper function to check if a BamlValueWithMeta matches a specific RPC type reference
+fn matches_value_with_rpc_type<T: HasType<type_meta::NonStreaming>>(
+    value: &BamlValueWithMeta<T>, 
+    rpc_type_ref: &baml_rpc::TypeReferenceWithMetadata<baml_rpc::TypeMetadata>, 
+    lookup: &(impl TypeLookup + ?Sized)
+) -> bool {
+    use baml_rpc::TypeReferenceWithMetadata;
+    match (value, rpc_type_ref) {
+        (BamlValueWithMeta::String(_, _), TypeReferenceWithMetadata::String(_)) => true,
+        (BamlValueWithMeta::Int(_, _), TypeReferenceWithMetadata::Int(_)) => true,
+        (BamlValueWithMeta::Float(_, _), TypeReferenceWithMetadata::Float(_)) => true,
+        (BamlValueWithMeta::Bool(_, _), TypeReferenceWithMetadata::Bool(_)) => true,
+        (BamlValueWithMeta::Null(_), _) => true, // Null can match any type in a union
+        (BamlValueWithMeta::Enum(enum_name, _, _), TypeReferenceWithMetadata::Enum { type_id, .. }) => {
+            // Compare the enum name with the type_id name 
+            let type_id_name = type_id.0.to_string();
+            enum_name == &type_id_name
+        }
+        (BamlValueWithMeta::Class(class_name, _, _), TypeReferenceWithMetadata::Class { type_id, .. }) => {
+            // Compare the class name with the type_id name
+            let type_id_name = type_id.0.to_string();
+            class_name == &type_id_name
+        }
+        (BamlValueWithMeta::List(_, _), TypeReferenceWithMetadata::List(_, _)) => true,
+        (BamlValueWithMeta::Map(_, _), TypeReferenceWithMetadata::Map { .. }) => true,
+        (BamlValueWithMeta::Media(media, _), TypeReferenceWithMetadata::Media(media_type, _)) => {
+            match (&media.media_type, media_type) {
+                (baml_types::BamlMediaType::Image, baml_rpc::MediaTypeDefinition::Image) => true,
+                (baml_types::BamlMediaType::Audio, baml_rpc::MediaTypeDefinition::Audio) => true,
+                (baml_types::BamlMediaType::Pdf, baml_rpc::MediaTypeDefinition::Pdf) => true,
+                (baml_types::BamlMediaType::Video, baml_rpc::MediaTypeDefinition::Video) => true,
+                _ => false,
+            }
+        }
+        // Also handle literal values
+        (BamlValueWithMeta::String(s, _), TypeReferenceWithMetadata::Literal(baml_rpc::LiteralTypeDefinition::String(lit_s), _)) => {
+            s == lit_s
+        }
+        (BamlValueWithMeta::Int(i, _), TypeReferenceWithMetadata::Literal(baml_rpc::LiteralTypeDefinition::Int(lit_i), _)) => {
+            i == lit_i
+        }
+        (BamlValueWithMeta::Bool(b, _), TypeReferenceWithMetadata::Literal(baml_rpc::LiteralTypeDefinition::Bool(lit_b), _)) => {
+            b == lit_b
+        }
+        _ => false,
     }
 }
 

--- a/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
@@ -113,13 +113,22 @@ fn matches_value_with_rpc_type<T: HasType<type_meta::NonStreaming>>(
         (BamlValueWithMeta::List(_, _), TypeReferenceWithMetadata::List(_, _)) => true,
         (BamlValueWithMeta::Map(_, _), TypeReferenceWithMetadata::Map { .. }) => true,
         (BamlValueWithMeta::Media(media, _), TypeReferenceWithMetadata::Media(media_type, _)) => {
-            match (&media.media_type, media_type) {
-                (baml_types::BamlMediaType::Image, baml_rpc::MediaTypeDefinition::Image) => true,
-                (baml_types::BamlMediaType::Audio, baml_rpc::MediaTypeDefinition::Audio) => true,
-                (baml_types::BamlMediaType::Pdf, baml_rpc::MediaTypeDefinition::Pdf) => true,
-                (baml_types::BamlMediaType::Video, baml_rpc::MediaTypeDefinition::Video) => true,
-                _ => false,
-            }
+            matches!(
+                (&media.media_type, media_type),
+                (
+                    baml_types::BamlMediaType::Image,
+                    baml_rpc::MediaTypeDefinition::Image
+                ) | (
+                    baml_types::BamlMediaType::Audio,
+                    baml_rpc::MediaTypeDefinition::Audio
+                ) | (
+                    baml_types::BamlMediaType::Pdf,
+                    baml_rpc::MediaTypeDefinition::Pdf
+                ) | (
+                    baml_types::BamlMediaType::Video,
+                    baml_rpc::MediaTypeDefinition::Video
+                )
+            )
         }
         // Also handle literal values
         (

--- a/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
@@ -58,17 +58,17 @@ impl<'a, T: HasType<type_meta::NonStreaming>> IntoRpcEvent<'a, runtime_api::Baml
                         baml_rpc::runtime_api::ValueContent::Null => runtime_api::TypeIndex::Null,
                         _ => {
                             // Find which type in the union matches the actual value type
-                            let type_index = union_type.types
-                                .iter()
-                                .position(|union_variant_type| {
-                                    matches_value_with_rpc_type(self, union_variant_type, lookup)
-                                })
-                                .unwrap_or_else(|| {
-                                    baml_log::warn!("Could not determine union variant index for value type. Using index 0 as fallback.");
-                                    0
-                                });
-
-                            runtime_api::TypeIndex::Index(type_index)
+                            match union_type.types.iter().position(|union_variant_type| {
+                                matches_value_with_rpc_type(self, union_variant_type, lookup)
+                            }) {
+                                Some(idx) => runtime_api::TypeIndex::Index(idx),
+                                None => {
+                                    baml_log::warn!(
+                                        "Could not determine union variant index for value type."
+                                    );
+                                    runtime_api::TypeIndex::NotFound
+                                }
+                            }
                         }
                     },
                     _ => runtime_api::TypeIndex::NotUnion,

--- a/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
@@ -1,7 +1,10 @@
 use std::borrow::Cow;
 
 use baml_rpc::{runtime_api, NarrowingType};
-use baml_types::{ir_type::TypeGeneric, type_meta, BamlValueWithMeta, Constraint, HasType, TypeValue, baml_value::TypeQuery, StreamingMode};
+use baml_types::{
+    baml_value::TypeQuery, ir_type::TypeGeneric, type_meta, BamlValueWithMeta, Constraint, HasType,
+    StreamingMode, TypeValue,
+};
 
 use super::{IntoRpcEvent, TypeLookup};
 
@@ -64,7 +67,7 @@ impl<'a, T: HasType<type_meta::NonStreaming>> IntoRpcEvent<'a, runtime_api::Baml
                                     baml_log::warn!("Could not determine union variant index for value type. Using index 0 as fallback.");
                                     0
                                 });
-                            
+
                             runtime_api::TypeIndex::Index(type_index)
                         }
                     },
@@ -80,9 +83,9 @@ impl<'a, T: HasType<type_meta::NonStreaming>> IntoRpcEvent<'a, runtime_api::Baml
 
 // Helper function to check if a BamlValueWithMeta matches a specific RPC type reference
 fn matches_value_with_rpc_type<T: HasType<type_meta::NonStreaming>>(
-    value: &BamlValueWithMeta<T>, 
-    rpc_type_ref: &baml_rpc::TypeReferenceWithMetadata<baml_rpc::TypeMetadata>, 
-    lookup: &(impl TypeLookup + ?Sized)
+    value: &BamlValueWithMeta<T>,
+    rpc_type_ref: &baml_rpc::TypeReferenceWithMetadata<baml_rpc::TypeMetadata>,
+    lookup: &(impl TypeLookup + ?Sized),
 ) -> bool {
     use baml_rpc::TypeReferenceWithMetadata;
     match (value, rpc_type_ref) {
@@ -91,12 +94,18 @@ fn matches_value_with_rpc_type<T: HasType<type_meta::NonStreaming>>(
         (BamlValueWithMeta::Float(_, _), TypeReferenceWithMetadata::Float(_)) => true,
         (BamlValueWithMeta::Bool(_, _), TypeReferenceWithMetadata::Bool(_)) => true,
         (BamlValueWithMeta::Null(_), _) => true, // Null can match any type in a union
-        (BamlValueWithMeta::Enum(enum_name, _, _), TypeReferenceWithMetadata::Enum { type_id, .. }) => {
-            // Compare the enum name with the type_id name 
+        (
+            BamlValueWithMeta::Enum(enum_name, _, _),
+            TypeReferenceWithMetadata::Enum { type_id, .. },
+        ) => {
+            // Compare the enum name with the type_id name
             let type_id_name = type_id.0.to_string();
             enum_name == &type_id_name
         }
-        (BamlValueWithMeta::Class(class_name, _, _), TypeReferenceWithMetadata::Class { type_id, .. }) => {
+        (
+            BamlValueWithMeta::Class(class_name, _, _),
+            TypeReferenceWithMetadata::Class { type_id, .. },
+        ) => {
             // Compare the class name with the type_id name
             let type_id_name = type_id.0.to_string();
             class_name == &type_id_name
@@ -113,15 +122,18 @@ fn matches_value_with_rpc_type<T: HasType<type_meta::NonStreaming>>(
             }
         }
         // Also handle literal values
-        (BamlValueWithMeta::String(s, _), TypeReferenceWithMetadata::Literal(baml_rpc::LiteralTypeDefinition::String(lit_s), _)) => {
-            s == lit_s
-        }
-        (BamlValueWithMeta::Int(i, _), TypeReferenceWithMetadata::Literal(baml_rpc::LiteralTypeDefinition::Int(lit_i), _)) => {
-            i == lit_i
-        }
-        (BamlValueWithMeta::Bool(b, _), TypeReferenceWithMetadata::Literal(baml_rpc::LiteralTypeDefinition::Bool(lit_b), _)) => {
-            b == lit_b
-        }
+        (
+            BamlValueWithMeta::String(s, _),
+            TypeReferenceWithMetadata::Literal(baml_rpc::LiteralTypeDefinition::String(lit_s), _),
+        ) => s == lit_s,
+        (
+            BamlValueWithMeta::Int(i, _),
+            TypeReferenceWithMetadata::Literal(baml_rpc::LiteralTypeDefinition::Int(lit_i), _),
+        ) => i == lit_i,
+        (
+            BamlValueWithMeta::Bool(b, _),
+            TypeReferenceWithMetadata::Literal(baml_rpc::LiteralTypeDefinition::Bool(lit_b), _),
+        ) => b == lit_b,
         _ => false,
     }
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `NotFound` to `TypeIndex` and improves union type handling in `to_rpc_event()` with a new helper function in `types.rs`.
> 
>   - **Behavior**:
>     - Adds `NotFound` variant to `TypeIndex` in `baml_value.rs` to handle cases where union type index cannot be determined.
>     - Updates `to_rpc_event()` in `types.rs` to use `NotFound` when union type index is not found.
>   - **Functions**:
>     - Adds `matches_value_with_rpc_type()` in `types.rs` to check if `BamlValueWithMeta` matches a specific RPC type reference.
>   - **Logging**:
>     - Logs a warning when union variant index cannot be determined in `to_rpc_event()` in `types.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 096862553270ae637b0d3da3bd2807d6d0ec983b. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->