### PR TITLE
fix missing computer_call type

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/response_handler.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/response_handler.rs
@@ -297,6 +297,7 @@ pub fn parse_openai_responses_response<C: WithClient + RequestBuilder>(
                 }
                 ResponseOutputType::WebSearchCall
                 | ResponseOutputType::FileSearchCall
+                | ResponseOutputType::ComputerCall
                 | ResponseOutputType::Reasoning => {
                     // Tool calls and reasoning outputs don't have text content, skip them
                     None

--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/types.rs
@@ -28,6 +28,7 @@ pub enum ResponseOutputType {
     FileSearchCall,
     FunctionCall,
     Reasoning,
+    ComputerCall,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `ComputerCall` type to `ResponseOutputType` enum and update handling logic in `response_handler.rs`.
> 
>   - **Behavior**:
>     - Add `ComputerCall` to `ResponseOutputType` enum in `types.rs`.
>     - Update `parse_openai_responses_response()` in `response_handler.rs` to skip `ComputerCall` type, similar to other non-text content types.
>   - **Misc**:
>     - No changes to existing tests or documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 08257ba1b98921c38bf11412b6fd453ca23dd972. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->