### PR TITLE
dont publish baml src on generate

### DIFF
--- a/engine/baml-runtime/src/cli/generate.rs
+++ b/engine/baml-runtime/src/cli/generate.rs
@@ -30,7 +30,11 @@ impl GenerateArgs {
     }
 
     fn generate_clients(&self, defaults: super::RuntimeCliDefaults) -> Result<()> {
-        let runtime = BamlRuntime::from_directory(&self.from, std::env::vars().collect())
+        // Set BAML_GENERATE to prevent starting the tracing publisher
+        let mut env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
+        env_vars.insert("BAML_GENERATE".to_string(), "1".to_string());
+        
+        let runtime = BamlRuntime::from_directory(&self.from, env_vars)
             .context("Failed to build BAML runtime")?;
         let src_files = baml_src_files(&self.from)
             .context("Failed while searching for .baml files in baml_src/")?;

--- a/engine/baml-runtime/src/cli/generate.rs
+++ b/engine/baml-runtime/src/cli/generate.rs
@@ -33,7 +33,7 @@ impl GenerateArgs {
         // Set BAML_GENERATE to prevent starting the tracing publisher
         let mut env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
         env_vars.insert("BAML_GENERATE".to_string(), "1".to_string());
-        
+
         let runtime = BamlRuntime::from_directory(&self.from, env_vars)
             .context("Failed to build BAML runtime")?;
         let src_files = baml_src_files(&self.from)

--- a/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
@@ -183,6 +183,10 @@ pub fn start_publisher(
     lookup: Arc<AstSignatureWrapper>,
     #[cfg(not(target_arch = "wasm32"))] rt: Arc<tokio::runtime::Runtime>,
 ) {
+    if lookup.env_var("BAML_GENERATE").is_some() {
+        log::debug!("Skipping publisher because BAML_GENERATE is set");
+        return;
+    }
     if lookup.env_var("BOUNDARY_API_KEY").is_none() {
         log::debug!("Skipping publisher because BOUNDARY_API_KEY is not set");
         return;

--- a/integ-tests/typescript/package.json
+++ b/integ-tests/typescript/package.json
@@ -11,7 +11,8 @@
     "integ-tests:dotenv": "tsc && pnpm test -- --silent false --testTimeout 30000",
     "generate": "baml-cli generate --from ../baml_src",
     "memory-test": "BAML_LOG=info infisical run --env=test -- pnpm test -- --silent false --testTimeout 60000 -t 'memory'",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "build:debug": "cd ../../engine/language_client_typescript && pnpm build:debug"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "format:fix": "biome check --write",
     "docker-build": "bash build-docker.sh",
     "test": "turbo run test",
-    "integ-tests": "pnpm run generate && turbo run integ-tests"
+    "integ-tests:ts": "turbo run build:debug --filter=@boundaryml/baml && cd integ-tests/typescript && pnpm generate && pnpm integ-tests"
   },
   "devDependencies": {
     "@infisical/cli": "0.41.89",

--- a/turbo.json
+++ b/turbo.json
@@ -191,6 +191,27 @@
       ],
       "cache": false
     },
+    "@boundaryml/baml#build:debug": {
+      "outputs": ["dist/**", "build/**", "artifacts/**"],
+      "cache": false
+    },
+    "integ-tests:ts": {
+      "dependsOn": ["build:debug"],
+      "outputs": [
+        "coverage/**",
+        ".coverage/**",
+        "junit.xml",
+        "test-results/**"
+      ],
+      "cache": false,
+      "env": [
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GOOGLE_API_KEY",
+        "AWS_*",
+        "INTEG_TESTS_*"
+      ]
+    },
     "integ-tests": {
       "dependsOn": ["build"],
       "outputs": [


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Prevent tracing publisher from starting during BAML generation by setting `BAML_GENERATE` environment variable and update integration test scripts and configurations.
> 
>   - **Behavior**:
>     - Set `BAML_GENERATE` environment variable in `generate_clients()` in `generate.rs` to prevent tracing publisher from starting.
>     - `start_publisher()` in `publisher.rs` checks for `BAML_GENERATE` and skips publisher if set.
>   - **Scripts**:
>     - Add `build:debug` script to `package.json` and `integ-tests/typescript/package.json`.
>     - Update `integ-tests:ts` script in `package.json` to include `build:debug`.
>   - **Configuration**:
>     - Add `build:debug` and `integ-tests:ts` tasks to `turbo.json` with specific outputs and environment variables.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f784452c776c3c4d14ebf7fd66c1f29ccaec1789. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->