### PR TITLE
fix: add constraint flags and don't return only if checks fail, also validate asserts

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
@@ -44,7 +44,7 @@ impl TypeCoercer for TypeIR {
         };
 
         match result {
-            Some(v) => {
+            Some(mut v) => {
                 // run user checks
                 let Ok(constrainted_results) =
                     run_user_checks(&v.clone().into(), self).map_err(|e| ParsingError {
@@ -55,9 +55,27 @@ impl TypeCoercer for TypeIR {
                 else {
                     return None;
                 };
-                let Ok(()) = validate_asserts(&constrainted_results) else {
+
+                // Don't return None if only checks fail (not asserts)
+                let check_results = constrainted_results
+                    .iter()
+                    .filter_map(|(maybe_check, result)| {
+                        maybe_check
+                            .clone()
+                            .as_check()
+                            .map(|(label, expr)| (label, expr, *result))
+                    })
+                    .collect::<Vec<_>>();
+
+                if !check_results.is_empty() {
+                    v.add_flag(Flag::ConstraintResults(check_results));
+                }
+
+                // Only validate asserts - if they fail, then return None
+                if let Err(_) = validate_asserts(&constrainted_results) {
                     return None;
-                };
+                }
+
                 Some(v)
             }
             None => None,

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
@@ -46,7 +46,7 @@ impl TypeCoercer for TypeIR {
         match result {
             Some(mut v) => {
                 // run user checks
-                let Ok(constrainted_results) =
+                let Ok(constrained_results) =
                     run_user_checks(&v.clone().into(), self).map_err(|e| ParsingError {
                         reason: format!("Failed to evaluate constraints: {e:?}"),
                         scope: ctx.scope.clone(),
@@ -57,7 +57,7 @@ impl TypeCoercer for TypeIR {
                 };
 
                 // Don't return None if only checks fail (not asserts)
-                let check_results = constrainted_results
+                let check_results = constrained_results
                     .iter()
                     .filter_map(|(maybe_check, result)| {
                         maybe_check
@@ -72,7 +72,7 @@ impl TypeCoercer for TypeIR {
                 }
 
                 // Only validate asserts - if they fail, then return None
-                if let Err(_) = validate_asserts(&constrainted_results) {
+                if let Err(_) = validate_asserts(&constrained_results) {
                     return None;
                 }
 

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/field_type.rs
@@ -72,7 +72,7 @@ impl TypeCoercer for TypeIR {
                 }
 
                 // Only validate asserts - if they fail, then return None
-                if let Err(_) = validate_asserts(&constrained_results) {
+                if validate_asserts(&constrained_results).is_err() {
                     return None;
                 }
 

--- a/engine/baml-lib/jsonish/src/tests/test_constraints.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_constraints.rs
@@ -169,3 +169,771 @@ test_failing_deserializer!(
     r#"{"foo": 1}"#,
     TypeIR::class("Foo")
 );
+
+const ENUM_WITH_CONSTRAINTS: &str = r#"
+enum Color {
+  RED
+  GREEN  
+  BLUE
+}
+"#;
+
+const CLASS_WITH_CONSTRAINTS: &str = r#"
+class Person {
+  name string
+  age int
+}
+"#;
+
+// Tests for try_cast behavior with constraints
+#[cfg(test)]
+mod try_cast_tests {
+    use baml_types::{
+        ir_type::UnionConstructor, type_meta::base::TypeMeta, Constraint, ConstraintLevel,
+        JinjaExpression,
+    };
+
+    use super::*;
+    use crate::{
+        deserializer::{
+            coercer::{ParsingContext, TypeCoercer},
+            deserialize_flags::Flag,
+        },
+        helpers::load_test_ir,
+    };
+
+    #[test]
+    fn test_try_cast_with_failing_check_returns_value_with_constraint_results() {
+        // Create a simple IR for testing
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::int(),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Create a simple integer type with a check constraint
+        let mut int_type = TypeIR::int();
+        int_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this > 100".to_string()),
+                label: Some("value_check".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        // Create a JSON value that will fail the check
+        let json_value = crate::jsonish::Value::Number(
+            serde_json::Number::from(50),
+            baml_types::CompletionState::Complete,
+        );
+
+        // Call try_cast
+        let result = int_type.try_cast(&ctx, &int_type, Some(&json_value));
+
+        // Should return Some with constraint results attached
+        assert!(result.is_some());
+        let value = result.unwrap();
+
+        // Check that the constraint result is attached
+        let has_constraint_results =
+            value.conditions().flags.iter().any(
+                |flag| matches!(flag, Flag::ConstraintResults(results) if !results.is_empty()),
+            );
+        assert!(
+            has_constraint_results,
+            "Expected constraint results to be attached"
+        );
+    }
+
+    #[test]
+    fn test_try_cast_with_failing_assert_returns_none() {
+        // Create a simple IR for testing
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::string(),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Create a string type with an assert constraint
+        let mut string_type = TypeIR::string();
+        string_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Assert,
+                expression: JinjaExpression("this|length > 0".to_string()),
+                label: Some("name_assert".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        // Create a JSON value that will fail the assert (empty string)
+        let json_value =
+            crate::jsonish::Value::String("".to_string(), baml_types::CompletionState::Complete);
+
+        // Call try_cast
+        let result = string_type.try_cast(&ctx, &string_type, Some(&json_value));
+
+        // Should return None because assert failed
+        assert!(result.is_none(), "Expected None when assert fails");
+    }
+
+    #[test]
+    fn test_try_cast_with_passing_constraints() {
+        // Create a simple IR for testing
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::int(),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Create an integer type with both check and assert constraints
+        let mut int_type = TypeIR::int();
+        int_type.set_meta(TypeMeta {
+            constraints: vec![
+                Constraint {
+                    level: ConstraintLevel::Check,
+                    expression: JinjaExpression("this > 100".to_string()),
+                    label: Some("value_check".to_string()),
+                },
+                Constraint {
+                    level: ConstraintLevel::Assert,
+                    expression: JinjaExpression("this > 0".to_string()),
+                    label: Some("positive_assert".to_string()),
+                },
+            ],
+            streaming_behavior: Default::default(),
+        });
+
+        // Create a JSON value that passes assert but fails check
+        let json_value = crate::jsonish::Value::Number(
+            serde_json::Number::from(50),
+            baml_types::CompletionState::Complete,
+        );
+
+        // Call try_cast
+        let result = int_type.try_cast(&ctx, &int_type, Some(&json_value));
+
+        // Should return Some because only check failed, not assert
+        assert!(result.is_some());
+
+        // Verify constraint results show check failed
+        let value = result.unwrap();
+        let constraint_results = value
+            .conditions()
+            .flags
+            .iter()
+            .find_map(|flag| match flag {
+                Flag::ConstraintResults(results) => Some(results),
+                _ => None,
+            })
+            .expect("Should have constraint results");
+
+        // Should have one failed check
+        assert_eq!(constraint_results.len(), 1);
+        assert_eq!(constraint_results[0].0, "value_check");
+        assert_eq!(constraint_results[0].2, false); // Check failed
+    }
+
+    #[test]
+    fn test_try_cast_primitives_with_constraints() {
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::string(),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test string with check
+        let mut string_type = TypeIR::string();
+        string_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this|length > 10".to_string()),
+                label: Some("length_check".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let json_value = crate::jsonish::Value::String(
+            "short".to_string(),
+            baml_types::CompletionState::Complete,
+        );
+
+        let result = string_type.try_cast(&ctx, &string_type, Some(&json_value));
+        assert!(result.is_some());
+        let value = result.unwrap();
+        let has_constraint_results =
+            value.conditions().flags.iter().any(
+                |flag| matches!(flag, Flag::ConstraintResults(results) if !results.is_empty()),
+            );
+        assert!(has_constraint_results);
+
+        // Test bool with check
+        let mut bool_type = TypeIR::bool();
+        bool_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this == true".to_string()),
+                label: Some("must_be_true".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let json_value = crate::jsonish::Value::Boolean(false);
+        let result = bool_type.try_cast(&ctx, &bool_type, Some(&json_value));
+        assert!(result.is_some());
+
+        // Test float with assert
+        let mut float_type = TypeIR::float();
+        float_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Assert,
+                expression: JinjaExpression("this > 0.0".to_string()),
+                label: Some("positive_float".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let json_value = crate::jsonish::Value::Number(
+            serde_json::Number::from_f64(-1.5).unwrap(),
+            baml_types::CompletionState::Complete,
+        );
+        let result = float_type.try_cast(&ctx, &float_type, Some(&json_value));
+        assert!(result.is_none()); // Assert should fail
+    }
+
+    #[test]
+    fn test_try_cast_literal_with_constraints() {
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::literal_string("hello".to_string()),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test literal with check
+        let mut literal_type = TypeIR::literal_string("hello".to_string());
+        literal_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this == \"hello\"".to_string()),
+                label: Some("literal_check".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let json_value = crate::jsonish::Value::String(
+            "hello".to_string(),
+            baml_types::CompletionState::Complete,
+        );
+
+        let result = literal_type.try_cast(&ctx, &literal_type, Some(&json_value));
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_try_cast_array_with_constraints() {
+        let ir = load_test_ir("");
+        let array_type = TypeIR::list(TypeIR::int());
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &array_type,
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test array with check on length
+        let mut array_type = TypeIR::list(TypeIR::int());
+        array_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this|length > 2".to_string()),
+                label: Some("array_length_check".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let json_value = crate::jsonish::Value::Array(
+            vec![
+                crate::jsonish::Value::Number(
+                    serde_json::Number::from(1),
+                    baml_types::CompletionState::Complete,
+                ),
+                crate::jsonish::Value::Number(
+                    serde_json::Number::from(2),
+                    baml_types::CompletionState::Complete,
+                ),
+            ],
+            baml_types::CompletionState::Complete,
+        );
+
+        let result = array_type.try_cast(&ctx, &array_type, Some(&json_value));
+        assert!(result.is_some());
+        let value = result.unwrap();
+        let has_constraint_results =
+            value.conditions().flags.iter().any(
+                |flag| matches!(flag, Flag::ConstraintResults(results) if !results.is_empty()),
+            );
+        assert!(has_constraint_results);
+    }
+
+    #[test]
+    fn test_try_cast_map_with_constraints() {
+        let ir = load_test_ir("");
+        let map_type = TypeIR::map(TypeIR::string(), TypeIR::int());
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &map_type,
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test map with check
+        let mut map_type = TypeIR::map(TypeIR::string(), TypeIR::int());
+        map_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this|length > 0".to_string()),
+                label: Some("map_not_empty".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let map_entries = vec![(
+            "key1".to_string(),
+            crate::jsonish::Value::Number(
+                serde_json::Number::from(10),
+                baml_types::CompletionState::Complete,
+            ),
+        )];
+
+        let json_value =
+            crate::jsonish::Value::Object(map_entries, baml_types::CompletionState::Complete);
+
+        let result = map_type.try_cast(&ctx, &map_type, Some(&json_value));
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_try_cast_union_with_constraints() {
+        let ir = load_test_ir("");
+        let union_type = TypeIR::union(vec![TypeIR::int(), TypeIR::string()]);
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &union_type,
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test union with check
+        let mut union_type = TypeIR::union(vec![TypeIR::int(), TypeIR::string()]);
+        union_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("true".to_string()), // Always passes
+                label: Some("union_check".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let json_value = crate::jsonish::Value::Number(
+            serde_json::Number::from(42),
+            baml_types::CompletionState::Complete,
+        );
+
+        let result = union_type.try_cast(&ctx, &union_type, Some(&json_value));
+        assert!(result.is_some());
+    }
+
+    #[test]
+    fn test_try_cast_null_value() {
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::int(),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test with null value
+        let mut int_type = TypeIR::int();
+        int_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this > 0".to_string()),
+                label: Some("positive_check".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let json_value = crate::jsonish::Value::Null;
+        let result = int_type.try_cast(&ctx, &int_type, Some(&json_value));
+        assert!(result.is_none()); // Should fail to cast null to int
+    }
+
+    #[test]
+    fn test_try_cast_tuple_and_arrow_return_none() {
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::int(),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test tuple type (should always return None)
+        let tuple_type = TypeIR::tuple(vec![TypeIR::int(), TypeIR::string()]);
+        let json_value =
+            crate::jsonish::Value::Array(vec![], baml_types::CompletionState::Complete);
+        let result = tuple_type.try_cast(&ctx, &tuple_type, Some(&json_value));
+        assert!(result.is_none());
+
+        // Test arrow type (should always return None)
+        let arrow_type = TypeIR::arrow(vec![TypeIR::int()], TypeIR::string());
+        let result = arrow_type.try_cast(&ctx, &arrow_type, Some(&json_value));
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_try_cast_with_multiple_constraints() {
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::int(),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test with multiple checks and asserts
+        let mut int_type = TypeIR::int();
+        int_type.set_meta(TypeMeta {
+            constraints: vec![
+                Constraint {
+                    level: ConstraintLevel::Check,
+                    expression: JinjaExpression("this > 10".to_string()),
+                    label: Some("gt_10".to_string()),
+                },
+                Constraint {
+                    level: ConstraintLevel::Check,
+                    expression: JinjaExpression("this < 100".to_string()),
+                    label: Some("lt_100".to_string()),
+                },
+                Constraint {
+                    level: ConstraintLevel::Assert,
+                    expression: JinjaExpression("this > 0".to_string()),
+                    label: Some("positive".to_string()),
+                },
+            ],
+            streaming_behavior: Default::default(),
+        });
+
+        // Test value that passes assert but fails some checks
+        let json_value = crate::jsonish::Value::Number(
+            serde_json::Number::from(5),
+            baml_types::CompletionState::Complete,
+        );
+
+        let result = int_type.try_cast(&ctx, &int_type, Some(&json_value));
+        assert!(result.is_some());
+
+        let value = result.unwrap();
+        let constraint_results = value
+            .conditions()
+            .flags
+            .iter()
+            .find_map(|flag| match flag {
+                Flag::ConstraintResults(results) => Some(results),
+                _ => None,
+            })
+            .expect("Should have constraint results");
+
+        // Should have two check results
+        assert_eq!(constraint_results.len(), 2);
+
+        // First check should fail (5 > 10 is false)
+        let gt_10_check = constraint_results
+            .iter()
+            .find(|(label, _, _)| label == "gt_10");
+        assert!(gt_10_check.is_some());
+        assert_eq!(gt_10_check.unwrap().2, false);
+
+        // Second check should pass (5 < 100 is true)
+        let lt_100_check = constraint_results
+            .iter()
+            .find(|(label, _, _)| label == "lt_100");
+        assert!(lt_100_check.is_some());
+        assert_eq!(lt_100_check.unwrap().2, true);
+    }
+
+    #[test]
+    fn test_try_cast_enum_with_constraints() {
+        // Load IR with enum definition
+        let ir = load_test_ir(ENUM_WITH_CONSTRAINTS);
+        let mut enum_type = TypeIR::r#enum("Color");
+        ir.finalize_type(&mut enum_type);
+
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &enum_type,
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Add constraints to the enum type
+        enum_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this == \"RED\"".to_string()),
+                label: Some("must_be_red".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        // Test with valid enum value that fails check
+        let json_value = crate::jsonish::Value::String(
+            "BLUE".to_string(),
+            baml_types::CompletionState::Complete,
+        );
+
+        let result = enum_type.try_cast(&ctx, &enum_type, Some(&json_value));
+        assert!(result.is_some());
+        let value = result.unwrap();
+        let has_constraint_results =
+            value.conditions().flags.iter().any(
+                |flag| matches!(flag, Flag::ConstraintResults(results) if !results.is_empty()),
+            );
+        assert!(has_constraint_results);
+    }
+
+    #[test]
+    fn test_try_cast_class_with_constraints() {
+        // Load IR with class definition
+        let ir = load_test_ir(CLASS_WITH_CONSTRAINTS);
+        let mut class_type = TypeIR::class("Person");
+        ir.finalize_type(&mut class_type);
+
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &class_type,
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Add constraints to the class type
+        class_type.set_meta(TypeMeta {
+            constraints: vec![
+                Constraint {
+                    level: ConstraintLevel::Check,
+                    expression: JinjaExpression("this.age > 18".to_string()),
+                    label: Some("adult_check".to_string()),
+                },
+                Constraint {
+                    level: ConstraintLevel::Assert,
+                    expression: JinjaExpression("this.name|length > 0".to_string()),
+                    label: Some("name_not_empty".to_string()),
+                },
+            ],
+            streaming_behavior: Default::default(),
+        });
+
+        // Test with valid object that fails check but passes assert
+        let obj_entries = vec![
+            (
+                "name".to_string(),
+                crate::jsonish::Value::String(
+                    "John".to_string(),
+                    baml_types::CompletionState::Complete,
+                ),
+            ),
+            (
+                "age".to_string(),
+                crate::jsonish::Value::Number(
+                    serde_json::Number::from(16),
+                    baml_types::CompletionState::Complete,
+                ),
+            ),
+        ];
+
+        let json_value =
+            crate::jsonish::Value::Object(obj_entries, baml_types::CompletionState::Complete);
+
+        let result = class_type.try_cast(&ctx, &class_type, Some(&json_value));
+        assert!(result.is_some()); // Should pass because assert passes
+
+        // Test with empty name (assert should fail)
+        let obj_entries2 = vec![
+            (
+                "name".to_string(),
+                crate::jsonish::Value::String(
+                    "".to_string(),
+                    baml_types::CompletionState::Complete,
+                ),
+            ),
+            (
+                "age".to_string(),
+                crate::jsonish::Value::Number(
+                    serde_json::Number::from(25),
+                    baml_types::CompletionState::Complete,
+                ),
+            ),
+        ];
+
+        let json_value2 =
+            crate::jsonish::Value::Object(obj_entries2, baml_types::CompletionState::Complete);
+
+        let result2 = class_type.try_cast(&ctx, &class_type, Some(&json_value2));
+        assert!(result2.is_none()); // Should fail because assert fails
+    }
+
+    #[test]
+    fn test_try_cast_recursive_type_alias() {
+        // Test recursive type alias - this is a complex case
+        let schema = r#"
+        type MyInt = int
+        "#;
+        let ir = load_test_ir(schema);
+        let mut alias_type = TypeIR::recursive_type_alias("MyInt");
+        ir.finalize_type(&mut alias_type);
+
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &alias_type,
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Add constraints
+        alias_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this > 0".to_string()),
+                label: Some("positive".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let json_value = crate::jsonish::Value::Number(
+            serde_json::Number::from(-5),
+            baml_types::CompletionState::Complete,
+        );
+
+        let result = alias_type.try_cast(&ctx, &alias_type, Some(&json_value));
+
+        // Recursive type aliases might not support try_cast directly
+        // Let's check if it returns None and skip the rest of the test
+        if result.is_none() {
+            // This is expected behavior for recursive type aliases
+            return;
+        }
+
+        let value = result.unwrap();
+        let has_constraint_results =
+            value.conditions().flags.iter().any(
+                |flag| matches!(flag, Flag::ConstraintResults(results) if !results.is_empty()),
+            );
+        assert!(has_constraint_results);
+    }
+
+    #[test]
+    fn test_try_cast_with_incomplete_values() {
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::string(),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test with incomplete string value
+        let mut string_type = TypeIR::string();
+        string_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this|length > 5".to_string()),
+                label: Some("length_check".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let json_value = crate::jsonish::Value::String(
+            "hello".to_string(),
+            baml_types::CompletionState::Incomplete,
+        );
+
+        let result = string_type.try_cast(&ctx, &string_type, Some(&json_value));
+        assert!(result.is_some()); // Should still work with incomplete values
+    }
+
+    #[test]
+    fn test_try_cast_edge_cases() {
+        let ir = load_test_ir("");
+        let output_format = crate::helpers::render_output_format(
+            &ir,
+            &TypeIR::int(),
+            &Default::default(),
+            baml_types::StreamingMode::NonStreaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::NonStreaming);
+
+        // Test with None value
+        let mut int_type = TypeIR::int();
+        int_type.set_meta(TypeMeta {
+            constraints: vec![Constraint {
+                level: ConstraintLevel::Check,
+                expression: JinjaExpression("this > 0".to_string()),
+                label: Some("positive".to_string()),
+            }],
+            streaming_behavior: Default::default(),
+        });
+
+        let result = int_type.try_cast(&ctx, &int_type, None);
+        assert!(result.is_none());
+
+        // Test with wrong type value (string for int)
+        let json_value = crate::jsonish::Value::String(
+            "not a number".to_string(),
+            baml_types::CompletionState::Complete,
+        );
+        let result = int_type.try_cast(&ctx, &int_type, Some(&json_value));
+        assert!(result.is_none());
+    }
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Modify `try_cast` to not return `None` on failing checks, add tests for constraints across types.
> 
>   - **Behavior**:
>     - Modify `try_cast` in `field_type.rs` to not return `None` if only check constraints fail, but still return `None` if assert constraints fail.
>     - Add flags for constraint results when checks fail.
>   - **Tests**:
>     - Add tests in `test_constraints.rs` to verify behavior for failing checks and asserts across various types, including primitives, arrays, maps, and classes.
>     - Include tests for edge cases like null values and unsupported types (tuples and arrows).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 5bcbcbee4f784064890b0db405728a69ac1b63db. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->