### PR TITLE
add integration tests to check for BAML_LOG env var specifically

### DIFF
--- a/integ-tests/python/tests/test_env_var_lazy_load.py
+++ b/integ-tests/python/tests/test_env_var_lazy_load.py
@@ -1,5 +1,7 @@
 import pytest
 from ..baml_client.sync_client import b as sync_b
+from ..baml_client.async_client import b as async_b
+from baml_py.baml_py import get_log_level
 
 
 @pytest.mark.parametrize("test_input,expected_key", [
@@ -40,3 +42,10 @@ def test_env_var_changes_are_reflected(monkeypatch):
     
     # Verify headers are different
     assert request1.headers != request2.headers, "Headers should be different after API key change"
+
+@pytest.mark.asyncio
+async def test_env_var_changes_are_reflected_in_log_level(monkeypatch):
+    """Test that changing environment variables between requests updates the log level."""
+    monkeypatch.setenv("BAML_LOG", "WARN")
+    await async_b.request.ExtractReceiptInfo("test@email.com", "curiosity")
+    assert get_log_level() == "WARN"

--- a/integ-tests/typescript/tests/env_vars.test.ts
+++ b/integ-tests/typescript/tests/env_vars.test.ts
@@ -1,3 +1,4 @@
+import { getLogLevel } from "@boundaryml/baml";
 import { resetBamlEnvVars, traceAsync, traceSync } from "../baml_client";
 import { b } from "./test-setup";
 
@@ -51,5 +52,11 @@ describe("Env Vars Tests", () => {
     );
     const secondHeaders = secondResult.headers as Record<string, string>;
     expect(secondHeaders["authorization"]).toBe("Bearer sk-new-key");
+  });
+
+  it("should reflect BAML_LOG changes in log level", async () => {
+    process.env.BAML_LOG = "WARN";
+    const result = await b.request.ExtractPeople("My name is John. I am 30 years old.");
+    expect(getLogLevel()).toBe("WARN");
   });
 });


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add integration tests to verify `BAML_LOG` environment variable changes update log level in Python and TypeScript.
> 
>   - **Python Tests**:
>     - Added `test_env_var_changes_are_reflected_in_log_level` in `test_env_var_lazy_load.py` to check `BAML_LOG` changes update log level using `async_b` and `get_log_level()`.
>   - **TypeScript Tests**:
>     - Added test case in `env_vars.test.ts` to verify `BAML_LOG` changes update log level using `getLogLevel()`.
>   - **Misc**:
>     - Import `getLogLevel` in `env_vars.test.ts` and `get_log_level` in `test_env_var_lazy_load.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 7914e823bf45c438987d3af257f92be695844208. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->