### PR TITLE
make api key dialog scrollable

### DIFF
--- a/typescript/packages/playground-common/src/components/api-keys-dialog/dialog-content.tsx
+++ b/typescript/packages/playground-common/src/components/api-keys-dialog/dialog-content.tsx
@@ -16,7 +16,7 @@ export const ApiKeysDialogContent: React.FC = () => {
     syncLocalApiKeys();
   }, [syncLocalApiKeys]);
   return (
-    <div className="space-y-2 h-full overflow-y-auto">
+    <div className="space-y-2 max-h-[70vh] overflow-y-auto">
       {/* Add New Api Key Form */}
       <div className="mb-4 p-4 rounded-md border border-border flex flex-col gap-2">
         <AddApiKeyForm />


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make API key dialog scrollable by setting `max-h-[70vh]` in `dialog-content.tsx`.
> 
>   - **UI Update**:
>     - In `dialog-content.tsx`, set `max-h-[70vh]` on the main `div` to make the API key dialog scrollable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ac6468dc7c4d7cb1ca91781674d011322fb78f76. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->