### PR TITLE
change jetbrains extension to use stable release

### DIFF
--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -5,7 +5,7 @@ pluginName = BoundaryML
 pluginId = baml
 pluginRepositoryUrl = https://github.com/boundaryml/baml
 # SemVer format -> https://semver.org
-pluginVersion = 0.203.1-beta
+pluginVersion = 0.203.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # To depend on the TextMate bundle API, the plugin must start build from 241

--- a/tools/versions/jetbrains.cfg
+++ b/tools/versions/jetbrains.cfg
@@ -7,5 +7,5 @@ serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:../jetbrains/gradle.properties]
-search = pluginVersion = {current_version}-beta
-replace = pluginVersion = {new_version}-beta
+search = pluginVersion = {current_version}
+replace = pluginVersion = {new_version}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change JetBrains plugin version from beta to stable by removing '-beta' suffix in versioning files.
> 
>   - **Versioning**:
>     - Change `pluginVersion` from `0.203.1-beta` to `0.203.1` in `jetbrains/gradle.properties`.
>     - Update `bumpversion` configuration in `tools/versions/jetbrains.cfg` to remove `-beta` suffix from version search and replace patterns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 60a4e28631e7cbace9608d3637706279dcfb2510. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->