### PR TITLE
Make sure to update cli version of generator

### DIFF
--- a/engine/language_client_python/uv.lock
+++ b/engine/language_client_python/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "baml-py"
-version = "0.202.1"
+version = "0.203.1"
 source = { editable = "." }

--- a/typescript/apps/vscode-ext/src/plugins/language-server-client/cli-downloader/index.ts
+++ b/typescript/apps/vscode-ext/src/plugins/language-server-client/cli-downloader/index.ts
@@ -173,6 +173,19 @@ export async function resolveCliPath(
   if (
     !backoffManager.shouldAttemptDownload(requestedVersion, bamlOutputChannel)
   ) {
+    console.log(`Download blocked by backoff for version ${requestedVersion}. Falling back to bundled CLI.`);
+    bamlOutputChannel.appendLine(
+      `Download blocked by backoff for version ${requestedVersion}. Falling back to bundled CLI.`,
+    );
+    
+    const bundledCliActualPath = getBundledCliPath(context);
+    if (bundledCliActualPath) {
+      bamlOutputChannel.appendLine(
+        `Using bundled CLI as fallback: ${bundledCliActualPath}`,
+      );
+      return bundledCliActualPath;
+    }
+    
     return null;
   }
 
@@ -216,8 +229,22 @@ export async function resolveCliPath(
     return downloadedPath;
   }
 
+  // Download failed - fallback to bundled CLI
+  console.log(`Download failed for version ${requestedVersion}. Falling back to bundled CLI.`);
   bamlOutputChannel.appendLine(
-    `ERROR: Failed to resolve CLI path for version ${requestedVersion} after download attempt.`,
+    `ERROR: Failed to resolve CLI path for version ${requestedVersion} after download attempt. Falling back to bundled CLI.`,
+  );
+  
+  const bundledCliActualPath = getBundledCliPath(context);
+  if (bundledCliActualPath) {
+    bamlOutputChannel.appendLine(
+      `Using bundled CLI as fallback: ${bundledCliActualPath}`,
+    );
+    return bundledCliActualPath;
+  }
+
+  bamlOutputChannel.appendLine(
+    `ERROR: No bundled CLI available as fallback for version ${requestedVersion}.`,
   );
   return null;
 }

--- a/typescript/apps/vscode-ext/src/plugins/language-server-client/cli-downloader/index.ts
+++ b/typescript/apps/vscode-ext/src/plugins/language-server-client/cli-downloader/index.ts
@@ -109,21 +109,6 @@ export async function resolveCliPath(
   const packageJson = await import('../../../../package.json');
   const bundledVersion = packageJson.version as string;
 
-  // Always use CLI from node_modules/@baml/cli/dist if present
-  const bundledCliActualPath = getBundledCliPath(context);
-  if (bundledCliActualPath) {
-    await cacheBundledCli(
-      context,
-      bundledCliActualPath,
-      bundledVersion,
-      bamlOutputChannel,
-    );
-    bamlOutputChannel.appendLine(
-      `Using CLI from node_modules: ${bundledCliActualPath}`,
-    );
-    return bundledCliActualPath;
-  }
-
   // Check if requested version matches bundled version
   if (
     semver.valid(requestedVersion) &&
@@ -133,10 +118,21 @@ export async function resolveCliPath(
     console.log(
       `Requested version (${requestedVersion}) matches bundled version (${bundledVersion}).`,
     );
+    bamlOutputChannel.appendLine(
+      `Requested version (${requestedVersion}) matches bundled version (${bundledVersion}).`,
+    );
 
+    // Use CLI from node_modules/@baml/cli/dist if present
+    const bundledCliActualPath = getBundledCliPath(context);
     if (bundledCliActualPath) {
+      await cacheBundledCli(
+        context,
+        bundledCliActualPath,
+        bundledVersion,
+        bamlOutputChannel,
+      );
       bamlOutputChannel.appendLine(
-        `Using bundled CLI path: ${bundledCliActualPath}`,
+        `Using CLI from node_modules: ${bundledCliActualPath}`,
       );
       return bundledCliActualPath;
     }
@@ -146,7 +142,7 @@ export async function resolveCliPath(
     );
   } else {
     bamlOutputChannel.appendLine(
-      `Requested version (${requestedVersion}) does not match bundled version (${bundledVersion}).`,
+      `Requested version (${requestedVersion}) does not match bundled version (${bundledVersion}). Will download specific version.`,
     );
   }
 

--- a/typescript/apps/vscode-ext/src/plugins/language-server-client/index.ts
+++ b/typescript/apps/vscode-ext/src/plugins/language-server-client/index.ts
@@ -44,6 +44,8 @@ const intervalTimers: NodeJS.Timeout[] = [];
 let bamlOutputChannel: OutputChannel;
 // Variable to store the path of the currently executing CLI
 let currentExecutingCliPath: string | null = null;
+// Flag to prevent concurrent LSP restarts
+let isRestarting = false;
 
 const isDebugMode = () => process.env.VSCODE_DEBUG_MODE === 'true';
 const isE2ETestOnPullRequest = () => process.env.PRISMA_USE_LOCAL_LS === 'true';
@@ -325,6 +327,41 @@ export const registerClientEventHandlers = (client: LanguageClient, context: Ext
           `============ baml_src_generator_version notification: ${payload.version} ${payload.root_path}`,
         );
 
+        // Check if this version update is for the currently active baml_src directory
+        const activeEditor =
+          window.activeTextEditor || (window.visibleTextEditors.length > 0 ? window.visibleTextEditors[0] : null);
+        if (activeEditor) {
+          try {
+            const currentFilePath = URI.parse(activeEditor.document.uri.toString()).fsPath;
+            const rootPathUri = URI.file(payload.root_path).fsPath;
+            if (!currentFilePath.startsWith(rootPathUri)) {
+              bamlOutputChannel.appendLine(
+                `baml_src_generator_version ignored: root path does not match active editor ${currentFilePath} ${rootPathUri}`,
+              );
+              return;
+            }
+          } catch (e) {
+            console.error('Error checking if root path matches active editor:', e);
+            bamlOutputChannel.appendLine(
+              `ERROR: Error checking if root path matches active editor: ${e}`,
+            );
+            return;
+          }
+        } else {
+          bamlOutputChannel.appendLine(
+            'baml_src_generator_version ignored: no active editor',
+          );
+          return;
+        }
+
+        // Prevent concurrent restarts
+        if (isRestarting) {
+          bamlOutputChannel.appendLine(
+            `baml_src_generator_version ignored: LSP restart already in progress for version ${payload.version}`,
+          );
+          return;
+        }
+
         const syncExtensionToGeneratorVersion =
           BAML_CONFIG_SINGLETON.config?.syncExtensionToGeneratorVersion;
         if (syncExtensionToGeneratorVersion === 'never') {
@@ -399,6 +436,9 @@ export const registerClientEventHandlers = (client: LanguageClient, context: Ext
             `Target path (${targetCliPath}) differs from current (${currentExecutingCliPath}). Restarting LSP...`,
           );
 
+          // Set the restarting flag
+          isRestarting = true;
+
           const serverOptionsForRestart: ServerOptions = {
             run: {
               command: targetCliPath,
@@ -449,6 +489,9 @@ export const registerClientEventHandlers = (client: LanguageClient, context: Ext
                 window.showErrorMessage(
                   `Failed to restart BAML Language Server to version ${version}.`,
                 );
+              } finally {
+                // Clear the restarting flag regardless of success or failure
+                isRestarting = false;
               }
             },
           );
@@ -497,6 +540,8 @@ const activateClient = (
     .then(() => {
       console.log('Language client is ready.');
       clientReady = true;
+      // Clear the restarting flag when client is ready
+      isRestarting = false;
 
       registerClientEventHandlers(client, context);
       console.log('Client event handlers registered.');
@@ -528,6 +573,8 @@ const activateClient = (
     .catch((error) => {
       console.error('Language client failed to become ready:', error);
       clientReady = false;
+      // Clear the restarting flag on failure as well
+      isRestarting = false;
       window.showErrorMessage('BAML Language Server failed to initialize.');
     });
 
@@ -618,7 +665,19 @@ const plugin: BamlVSCodePlugin = {
     context.subscriptions.push(
       commands.registerCommand('baml.restartLanguageServer', async () => {
         console.log("Manual 'baml.restartLanguageServer' command triggered.");
+        
+        // Prevent concurrent restarts
+        if (isRestarting) {
+          window.showWarningMessage('BAML Language Server restart already in progress. Please wait...');
+          bamlOutputChannel.appendLine(
+            'Manual restart ignored: LSP restart already in progress',
+          );
+          return;
+        }
+        
         window.showInformationMessage('Restarting BAML Language Server...');
+        isRestarting = true;
+        
         try {
           const currentVersion =
             BAML_CONFIG_SINGLETON.cliVersion || packageJson.version;
@@ -677,6 +736,9 @@ const plugin: BamlVSCodePlugin = {
           window.showErrorMessage(
             'Failed to manually restart Baml language server.',
           );
+        } finally {
+          // Clear the restarting flag regardless of success or failure
+          isRestarting = false;
         }
       }),
 

--- a/typescript/apps/vscode-ext/src/plugins/language-server-client/index.ts
+++ b/typescript/apps/vscode-ext/src/plugins/language-server-client/index.ts
@@ -1,4 +1,5 @@
 import * as os from 'node:os';
+import * as path from 'node:path';
 
 import type {} from '@baml/common';
 import semver from 'semver';
@@ -36,6 +37,134 @@ import {
 import { resolveCliPath } from './cliDownloader';
 
 export { BAML_CONFIG_SINGLETON as bamlConfig };
+
+/**
+ * Path comparison that handles Windows case insensitivity.
+ * @param childPath The path that should be inside the parent
+ * @param parentPath The parent/root path
+ * @returns true if childPath is within parentPath
+ */
+const isPathWithinParent = (childPath: string, parentPath: string): boolean => {
+  try {
+    // Normalize both paths to handle case sensitivity and path separators
+    const normalizedChild = path.resolve(childPath);
+    const normalizedParent = path.resolve(parentPath);
+    
+    // Use path.relative to check containment
+    const relativePath = path.relative(normalizedParent, normalizedChild);
+    
+    // If the relative path doesn't start with ".." and isn't an absolute path,
+    // then the child is within the parent
+    return !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
+  } catch (e) {
+    console.error('Error comparing paths:', e);
+    return false;
+  }
+};
+
+/**
+ * Shared helper for LSP restart logic.
+ * @param options Configuration for the restart operation
+ * @returns Promise that resolves when restart is complete or fails
+ */
+const executeLanguageServerRestart = async (options: {
+  context: ExtensionContext;
+  version: string;
+  targetCliPath: string;
+  isManualRestart?: boolean;
+  reason?: string;
+}): Promise<void> => {
+  const { context, version, targetCliPath, isManualRestart = false, reason } = options;
+  
+  // Prevent concurrent restarts
+  if (isRestarting) {
+    const message = isManualRestart 
+      ? 'BAML Language Server restart already in progress. Please wait...'
+      : `baml_src_generator_version ignored: LSP restart already in progress for version ${version}`;
+    
+    if (isManualRestart) {
+      window.showWarningMessage(message);
+    }
+    bamlOutputChannel.appendLine(message);
+    return;
+  }
+
+  // Set the restarting flag
+  isRestarting = true;
+
+  try {
+    const serverOptionsForRestart: ServerOptions = {
+      run: {
+        command: targetCliPath,
+        args: ['lsp'],
+        options: { env: process.env },
+      },
+      debug: {
+        command: targetCliPath,
+        args: ['lsp'],
+        options: debugOptions,
+      },
+    };
+
+    const clientOptionsForRestart = getClientOptions();
+
+    const progressTitle = isManualRestart
+      ? `Restarting BAML Language Server (v${version})...`
+      : `Restarting BAML Language Server (v${version})...`;
+
+    const operation = async () => {
+      console.log(`Calling activateClient for ${isManualRestart ? 'manual' : 'automatic'} restart...`);
+      // clientReady will be managed by activateClient's onReady handlers.
+      // activateClient also handles stopping the previous client.
+      activateClient(context, serverOptionsForRestart, clientOptionsForRestart);
+      console.log(`activateClient called for version ${version}.`);
+      currentExecutingCliPath = targetCliPath;
+      BAML_CONFIG_SINGLETON.cliVersion = version; // This might be better set after onReady, or via a message from the client
+
+      const successMessage = isManualRestart
+        ? `BAML Language Server (v${version}) restarted manually.`
+        : `BAML Language Server reload initiated for version ${version}.`;
+      
+      bamlOutputChannel?.appendLine(successMessage);
+      
+      if (isManualRestart) {
+        window.showInformationMessage(successMessage);
+      }
+    };
+
+    if (isManualRestart) {
+      await operation();
+    } else {
+      await window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          cancellable: false,
+          title: progressTitle,
+        },
+        async () => {
+          await operation();
+        },
+      );
+    }
+  } catch (e) {
+    clientReady = false; // Ensure clientReady is false if restart fails
+    console.error(`Error during ${isManualRestart ? 'manual' : 'automatic'} restart:`, e);
+    // Ensure error message is a string
+    const errorMessage = e instanceof Error ? e.message : String(e);
+    const logMessage = `ERROR: Error during ${isManualRestart ? 'manual' : 'automatic'} restart for version ${version}: ${errorMessage}`;
+    bamlOutputChannel?.appendLine(logMessage);
+    
+    const userMessage = isManualRestart
+      ? 'Failed to manually restart Baml language server.'
+      : `Failed to restart BAML Language Server to version ${version}.`;
+    
+    window.showErrorMessage(userMessage);
+  } finally {
+    // Clear the restarting flag regardless of success or failure
+    isRestarting = false;
+  }
+};
+
 let clientReady = false;
 
 let client: LanguageClient;
@@ -298,7 +427,7 @@ export const registerClientEventHandlers = (client: LanguageClient, context: Ext
       try {
         const currentFilePath = URI.parse(activeEditor.document.uri.toString()).fsPath
         const rootPathUri = URI.file(params.root_path).fsPath
-        if (currentFilePath.startsWith(rootPathUri)) {
+        if (isPathWithinParent(currentFilePath, rootPathUri)) {
           console.log('Forwarding runtime_updated to WebviewPanelHost')
           WebviewPanelHost.currentPanel?.postMessage('add_project', {
             ...params,
@@ -334,7 +463,7 @@ export const registerClientEventHandlers = (client: LanguageClient, context: Ext
           try {
             const currentFilePath = URI.parse(activeEditor.document.uri.toString()).fsPath;
             const rootPathUri = URI.file(payload.root_path).fsPath;
-            if (!currentFilePath.startsWith(rootPathUri)) {
+            if (!isPathWithinParent(currentFilePath, rootPathUri)) {
               bamlOutputChannel.appendLine(
                 `baml_src_generator_version ignored: root path does not match active editor ${currentFilePath} ${rootPathUri}`,
               );
@@ -350,14 +479,6 @@ export const registerClientEventHandlers = (client: LanguageClient, context: Ext
         } else {
           bamlOutputChannel.appendLine(
             'baml_src_generator_version ignored: no active editor',
-          );
-          return;
-        }
-
-        // Prevent concurrent restarts
-        if (isRestarting) {
-          bamlOutputChannel.appendLine(
-            `baml_src_generator_version ignored: LSP restart already in progress for version ${payload.version}`,
           );
           return;
         }
@@ -436,65 +557,13 @@ export const registerClientEventHandlers = (client: LanguageClient, context: Ext
             `Target path (${targetCliPath}) differs from current (${currentExecutingCliPath}). Restarting LSP...`,
           );
 
-          // Set the restarting flag
-          isRestarting = true;
-
-          const serverOptionsForRestart: ServerOptions = {
-            run: {
-              command: targetCliPath,
-              args: ['lsp'],
-              options: { env: process.env },
-            },
-            debug: {
-              command: targetCliPath,
-              args: ['lsp'],
-              options: debugOptions,
-            },
-          };
-
-          const clientOptionsForRestart = getClientOptions();
-
-          window.withProgress(
-            {
-              location: vscode.ProgressLocation.Notification,
-              cancellable: false,
-              title: `Restarting BAML Language Server (v${version})...`,
-            },
-            // eslint-disable-next-line @typescript-eslint/require-await
-            async () => {
-              try {
-                console.log('Calling restartClient utility...');
-                // clientReady will be managed by activateClient's onReady handlers.
-                // activateClient also handles stopping the previous client.
-                activateClient(
-                  context,
-                  serverOptionsForRestart,
-                  clientOptionsForRestart,
-                );
-                console.log(`activateClient called for version ${version}.`);
-                currentExecutingCliPath = targetCliPath;
-                BAML_CONFIG_SINGLETON.cliVersion = version; // This might be better set after onReady, or via a message from the client
-
-                bamlOutputChannel?.appendLine(
-                  `BAML Language Server reload initiated for version ${version}.`,
-                );
-              } catch (e) {
-                clientReady = false; // Ensure clientReady is false if restart fails
-                console.error('Error restarting client:', e);
-                // Ensure error message is a string
-                const errorMessage = e instanceof Error ? e.message : String(e);
-                bamlOutputChannel?.appendLine(
-                  `ERROR: Error restarting client for version ${version}: ${errorMessage}`,
-                );
-                window.showErrorMessage(
-                  `Failed to restart BAML Language Server to version ${version}.`,
-                );
-              } finally {
-                // Clear the restarting flag regardless of success or failure
-                isRestarting = false;
-              }
-            },
-          );
+          await executeLanguageServerRestart({
+            context,
+            version,
+            targetCliPath,
+            isManualRestart: false,
+            reason: 'generator version update',
+          });
         } else {
           // bamlOutputChannel?.appendLine(
           //   `Resolved path is the same as current. No LSP restart needed for version ${version}.`,
@@ -666,27 +735,18 @@ const plugin: BamlVSCodePlugin = {
       commands.registerCommand('baml.restartLanguageServer', async () => {
         console.log("Manual 'baml.restartLanguageServer' command triggered.");
         
-        // Prevent concurrent restarts
-        if (isRestarting) {
-          window.showWarningMessage('BAML Language Server restart already in progress. Please wait...');
-          bamlOutputChannel.appendLine(
-            'Manual restart ignored: LSP restart already in progress',
-          );
-          return;
-        }
-        
         window.showInformationMessage('Restarting BAML Language Server...');
-        isRestarting = true;
+        
+        const currentVersion =
+          BAML_CONFIG_SINGLETON.cliVersion || packageJson.version;
+        console.log(
+          `Manual restart: Resolving CLI path for version ${currentVersion}`,
+        );
+        bamlOutputChannel.appendLine(
+          `Manual restart: Resolving CLI path for version ${currentVersion}`,
+        );
         
         try {
-          const currentVersion =
-            BAML_CONFIG_SINGLETON.cliVersion || packageJson.version;
-          console.log(
-            `Manual restart: Resolving CLI path for version ${currentVersion}`,
-          );
-          bamlOutputChannel.appendLine(
-            `Manual restart: Resolving CLI path for version ${currentVersion}`,
-          );
           const resolvedPath = await resolveCliPath(
             context,
             currentVersion,
@@ -694,29 +754,13 @@ const plugin: BamlVSCodePlugin = {
           );
 
           if (resolvedPath) {
-            const restartServerOptions: ServerOptions = {
-              run: {
-                command: resolvedPath,
-                args: ['lsp'],
-                options: { env: process.env },
-              },
-              debug: {
-                command: resolvedPath,
-                args: ['lsp'],
-                options: debugOptions,
-              },
-            };
-            const restartClientOptions = getClientOptions();
-            // activateClient will handle stopping the old client, creating/starting the new one,
-            // and managing clientReady, event handlers, and diagnostics via its onReady handlers.
-            activateClient(context, restartServerOptions, restartClientOptions);
-            currentExecutingCliPath = resolvedPath;
-            window.showInformationMessage(
-              `BAML Language Server (v${currentVersion}) restarted manually.`,
-            );
-            bamlOutputChannel.appendLine(
-              `BAML Language Server (v${currentVersion}) restarted manually.`,
-            );
+            await executeLanguageServerRestart({
+              context,
+              version: currentVersion,
+              targetCliPath: resolvedPath,
+              isManualRestart: true,
+              reason: 'manual restart command',
+            });
           } else {
             window.showErrorMessage(
               `Manual restart failed: Could not resolve executable path for version ${currentVersion}.`,
@@ -736,9 +780,6 @@ const plugin: BamlVSCodePlugin = {
           window.showErrorMessage(
             'Failed to manually restart Baml language server.',
           );
-        } finally {
-          // Clear the restarting flag regardless of success or failure
-          isRestarting = false;
         }
       }),
 


### PR DESCRIPTION
Note: This still does not fix a bug with the generate triggering before the ls restart causing the first save after changing the version to generate using the old ls with the previous version.

This fixes:
- The language server restarting in a loop when two or more `baml_src` are present in the same repo
- The language server not updating to the correct cli version when the generate version is changed


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes language server restart loop and ensures correct CLI version update, adding `executeLanguageServerRestart` for better restart management.
> 
>   - **Behavior**:
>     - Fixes language server restart loop when multiple `baml_src` are present.
>     - Ensures language server updates to correct CLI version when `baml_src_generator_version` changes.
>   - **Functions**:
>     - Adds `executeLanguageServerRestart` in `index.ts` to manage language server restarts, preventing concurrent restarts.
>     - Updates `resolveCliPath` in `cli-downloader/index.ts` to handle CLI version resolution and fallback logic.
>   - **Misc**:
>     - Updates `baml-py` version to `0.203.1` in `uv.lock`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for debf1697929fd44bb76904f37ac10e334f535f56. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->