### PR TITLE
hellovai/fix union types

### DIFF
--- a/engine/baml-rpc/src/ast/type_reference.rs
+++ b/engine/baml-rpc/src/ast/type_reference.rs
@@ -42,11 +42,7 @@ impl std::fmt::Display for TypeMetadata {
             write!(
                 f,
                 "@assert({})",
-                assert
-                    .name
-                    .as_ref()
-                    .map(|f| f.as_str())
-                    .unwrap_or("unnamed")
+                assert.name.as_deref().unwrap_or("unnamed")
             )?;
         }
         Ok(())
@@ -104,15 +100,15 @@ impl<T: std::fmt::Display> std::fmt::Display for TypeReferenceWithMetadata<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             TypeReferenceWithMetadata::Unknown => write!(f, "unknown"),
-            TypeReferenceWithMetadata::String(meta) => write!(f, "string {}", meta),
-            TypeReferenceWithMetadata::Int(meta) => write!(f, "int {}", meta),
-            TypeReferenceWithMetadata::Float(meta) => write!(f, "float {}", meta),
-            TypeReferenceWithMetadata::Bool(meta) => write!(f, "bool {}", meta),
+            TypeReferenceWithMetadata::String(meta) => write!(f, "string {meta}"),
+            TypeReferenceWithMetadata::Int(meta) => write!(f, "int {meta}"),
+            TypeReferenceWithMetadata::Float(meta) => write!(f, "float {meta}"),
+            TypeReferenceWithMetadata::Bool(meta) => write!(f, "bool {meta}"),
             TypeReferenceWithMetadata::Media(media_type_definition, meta) => {
-                write!(f, "{} {}", media_type_definition, meta)
+                write!(f, "{media_type_definition} {meta}")
             }
             TypeReferenceWithMetadata::Literal(literal_type_definition, _) => {
-                write!(f, "{}", literal_type_definition)
+                write!(f, "{literal_type_definition}")
             }
             TypeReferenceWithMetadata::Class { type_id, metadata }
             | TypeReferenceWithMetadata::Enum { type_id, metadata }
@@ -120,13 +116,13 @@ impl<T: std::fmt::Display> std::fmt::Display for TypeReferenceWithMetadata<T> {
                 write!(f, "{} {}", type_id.0, metadata)
             }
             TypeReferenceWithMetadata::List(type_reference_with_metadata, metadata) => {
-                write!(f, "{}[] {}", type_reference_with_metadata, metadata)
+                write!(f, "{type_reference_with_metadata}[] {metadata}")
             }
             TypeReferenceWithMetadata::Map {
                 key,
                 value,
                 metadata,
-            } => write!(f, "map<{}, {}> {}", key, value, metadata),
+            } => write!(f, "map<{key}, {value}> {metadata}"),
             TypeReferenceWithMetadata::Union {
                 union_type,
                 metadata,
@@ -171,8 +167,8 @@ impl std::fmt::Display for MediaTypeDefinition {
 impl std::fmt::Display for LiteralTypeDefinition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            LiteralTypeDefinition::String(s) => write!(f, "'{}'", s),
-            LiteralTypeDefinition::Int(i) => write!(f, "{}", i),
+            LiteralTypeDefinition::String(s) => write!(f, "'{s}'"),
+            LiteralTypeDefinition::Int(i) => write!(f, "{i}"),
             LiteralTypeDefinition::Bool(b) => write!(f, "{}", if *b { "true" } else { "false" }),
         }
     }

--- a/engine/baml-rpc/src/ast/type_reference.rs
+++ b/engine/baml-rpc/src/ast/type_reference.rs
@@ -33,6 +33,26 @@ impl TypeMetadata {
     }
 }
 
+impl std::fmt::Display for TypeMetadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for check in &self.checks {
+            write!(f, "@check({})", check.name)?;
+        }
+        for assert in &self.asserts {
+            write!(
+                f,
+                "@assert({})",
+                assert
+                    .name
+                    .as_ref()
+                    .map(|f| f.as_str())
+                    .unwrap_or("unnamed")
+            )?;
+        }
+        Ok(())
+    }
+}
+
 /// FieldType represents the type of either a class field or a function arg.
 /// THIS IS ONLY FOR NON_STREAMING TYPES.
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Hash, TS)]
@@ -78,6 +98,84 @@ pub enum TypeReferenceWithMetadata<Metadata> {
         items: Vec<Self>,
         metadata: Metadata,
     },
+}
+
+impl<T: std::fmt::Display> std::fmt::Display for TypeReferenceWithMetadata<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TypeReferenceWithMetadata::Unknown => write!(f, "unknown"),
+            TypeReferenceWithMetadata::String(meta) => write!(f, "string {}", meta),
+            TypeReferenceWithMetadata::Int(meta) => write!(f, "int {}", meta),
+            TypeReferenceWithMetadata::Float(meta) => write!(f, "float {}", meta),
+            TypeReferenceWithMetadata::Bool(meta) => write!(f, "bool {}", meta),
+            TypeReferenceWithMetadata::Media(media_type_definition, meta) => {
+                write!(f, "{} {}", media_type_definition, meta)
+            }
+            TypeReferenceWithMetadata::Literal(literal_type_definition, _) => {
+                write!(f, "{}", literal_type_definition)
+            }
+            TypeReferenceWithMetadata::Class { type_id, metadata }
+            | TypeReferenceWithMetadata::Enum { type_id, metadata }
+            | TypeReferenceWithMetadata::RecursiveTypeAlias { type_id, metadata } => {
+                write!(f, "{} {}", type_id.0, metadata)
+            }
+            TypeReferenceWithMetadata::List(type_reference_with_metadata, metadata) => {
+                write!(f, "{}[] {}", type_reference_with_metadata, metadata)
+            }
+            TypeReferenceWithMetadata::Map {
+                key,
+                value,
+                metadata,
+            } => write!(f, "map<{}, {}> {}", key, value, metadata),
+            TypeReferenceWithMetadata::Union {
+                union_type,
+                metadata,
+            } => write!(
+                f,
+                "({}) {}",
+                union_type
+                    .types
+                    .iter()
+                    .map(|t| t.to_string())
+                    .collect::<Vec<_>>()
+                    .join(" | "),
+                metadata
+            ),
+            TypeReferenceWithMetadata::Tuple { items, metadata } => {
+                write!(
+                    f,
+                    "({}) {}",
+                    items
+                        .iter()
+                        .map(|t| t.to_string())
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    metadata
+                )
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for MediaTypeDefinition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            MediaTypeDefinition::Image => write!(f, "image"),
+            MediaTypeDefinition::Audio => write!(f, "audio"),
+            MediaTypeDefinition::Pdf => write!(f, "pdf"),
+            MediaTypeDefinition::Video => write!(f, "video"),
+        }
+    }
+}
+
+impl std::fmt::Display for LiteralTypeDefinition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LiteralTypeDefinition::String(s) => write!(f, "'{}'", s),
+            LiteralTypeDefinition::Int(i) => write!(f, "{}", i),
+            LiteralTypeDefinition::Bool(b) => write!(f, "{}", if *b { "true" } else { "false" }),
+        }
+    }
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Hash, TS)]

--- a/engine/baml-rpc/src/runtime_api/baml_value.rs
+++ b/engine/baml-rpc/src/runtime_api/baml_value.rs
@@ -25,6 +25,46 @@ pub struct BamlValue<'a> {
     pub value: ValueContent<'a>,
 }
 
+impl<'a> std::fmt::Display for BamlValue<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.value {
+            ValueContent::Null => write!(f, "null"),
+            ValueContent::String(s) => write!(f, "{}", s),
+            ValueContent::Float(flt) => write!(f, "{}", flt),
+            ValueContent::Int(i) => write!(f, "{}", i),
+            ValueContent::Boolean(b) => write!(f, "{}", b),
+            ValueContent::List(l) => write!(
+                f,
+                "[{}]",
+                l.iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            ValueContent::Map(m) => write!(
+                f,
+                "{{{}}}",
+                m.iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            ValueContent::Class { fields } => write!(
+                f,
+                "{} {{{}}}",
+                self.metadata.type_ref,
+                fields
+                    .iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            ValueContent::Enum { value } => write!(f, "{} {}", value, self.metadata.type_ref),
+            ValueContent::Media(_) => write!(f, "<media placeholder>"),
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckValue {
@@ -67,6 +107,45 @@ pub enum ValueContent<'a> {
         value: String,
     },
     Media(Media<'a>),
+}
+
+impl<'a> std::fmt::Display for ValueContent<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ValueContent::Null => write!(f, "null"),
+            ValueContent::String(s) => write!(f, "{}", s),
+            ValueContent::Float(flt) => write!(f, "{}", flt),
+            ValueContent::Int(i) => write!(f, "{}", i),
+            ValueContent::Boolean(b) => write!(f, "{}", b),
+            ValueContent::List(l) => write!(
+                f,
+                "[{}]",
+                l.iter()
+                    .map(|v| v.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            ValueContent::Map(m) => write!(
+                f,
+                "{{{}}}",
+                m.iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            ValueContent::Class { fields } => write!(
+                f,
+                "class {{{}}}",
+                fields
+                    .iter()
+                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+            ValueContent::Enum { value } => write!(f, "enum {}", value),
+            ValueContent::Media(_) => write!(f, "<media placeholder>"),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]

--- a/engine/baml-rpc/src/runtime_api/baml_value.rs
+++ b/engine/baml-rpc/src/runtime_api/baml_value.rs
@@ -29,10 +29,10 @@ impl<'a> std::fmt::Display for BamlValue<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.value {
             ValueContent::Null => write!(f, "null"),
-            ValueContent::String(s) => write!(f, "{}", s),
-            ValueContent::Float(flt) => write!(f, "{}", flt),
-            ValueContent::Int(i) => write!(f, "{}", i),
-            ValueContent::Boolean(b) => write!(f, "{}", b),
+            ValueContent::String(s) => write!(f, "{s}"),
+            ValueContent::Float(flt) => write!(f, "{flt}"),
+            ValueContent::Int(i) => write!(f, "{i}"),
+            ValueContent::Boolean(b) => write!(f, "{b}"),
             ValueContent::List(l) => write!(
                 f,
                 "[{}]",
@@ -45,7 +45,7 @@ impl<'a> std::fmt::Display for BamlValue<'a> {
                 f,
                 "{{{}}}",
                 m.iter()
-                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .map(|(k, v)| format!("{k}: {v}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
@@ -55,7 +55,7 @@ impl<'a> std::fmt::Display for BamlValue<'a> {
                 self.metadata.type_ref,
                 fields
                     .iter()
-                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .map(|(k, v)| format!("{k}: {v}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
@@ -113,10 +113,10 @@ impl<'a> std::fmt::Display for ValueContent<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ValueContent::Null => write!(f, "null"),
-            ValueContent::String(s) => write!(f, "{}", s),
-            ValueContent::Float(flt) => write!(f, "{}", flt),
-            ValueContent::Int(i) => write!(f, "{}", i),
-            ValueContent::Boolean(b) => write!(f, "{}", b),
+            ValueContent::String(s) => write!(f, "{s}"),
+            ValueContent::Float(flt) => write!(f, "{flt}"),
+            ValueContent::Int(i) => write!(f, "{i}"),
+            ValueContent::Boolean(b) => write!(f, "{b}"),
             ValueContent::List(l) => write!(
                 f,
                 "[{}]",
@@ -129,7 +129,7 @@ impl<'a> std::fmt::Display for ValueContent<'a> {
                 f,
                 "{{{}}}",
                 m.iter()
-                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .map(|(k, v)| format!("{k}: {v}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
@@ -138,11 +138,11 @@ impl<'a> std::fmt::Display for ValueContent<'a> {
                 "class {{{}}}",
                 fields
                     .iter()
-                    .map(|(k, v)| format!("{}: {}", k, v))
+                    .map(|(k, v)| format!("{k}: {v}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ),
-            ValueContent::Enum { value } => write!(f, "enum {}", value),
+            ValueContent::Enum { value } => write!(f, "enum {value}"),
             ValueContent::Media(_) => write!(f, "<media placeholder>"),
         }
     }

--- a/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/types.rs
@@ -64,7 +64,8 @@ impl<'a, T: HasType<type_meta::NonStreaming>> IntoRpcEvent<'a, runtime_api::Baml
                                 Some(idx) => runtime_api::TypeIndex::Index(idx),
                                 None => {
                                     baml_log::warn!(
-                                        "Could not determine union variant index for value type."
+                                        "Unexpected Error. Please report this error on https://github.com/boundaryml/baml/issues.\nCould not determine union variant index for value type: {} for value {}",
+                                        type_ref, value
                                     );
                                     runtime_api::TypeIndex::NotFound
                                 }
@@ -99,19 +100,29 @@ fn matches_value_with_rpc_type<T: HasType<type_meta::NonStreaming>>(
             TypeReferenceWithMetadata::Enum { type_id, .. },
         ) => {
             // Compare the enum name with the type_id name
-            let type_id_name = type_id.0.to_string();
-            enum_name == &type_id_name
+            enum_name == type_id.0.name()
         }
         (
             BamlValueWithMeta::Class(class_name, _, _),
             TypeReferenceWithMetadata::Class { type_id, .. },
         ) => {
             // Compare the class name with the type_id name
-            let type_id_name = type_id.0.to_string();
-            class_name == &type_id_name
+            class_name == type_id.0.name()
         }
-        (BamlValueWithMeta::List(_, _), TypeReferenceWithMetadata::List(_, _)) => true,
-        (BamlValueWithMeta::Map(_, _), TypeReferenceWithMetadata::Map { .. }) => true,
+        (
+            BamlValueWithMeta::List(list_values, _),
+            TypeReferenceWithMetadata::List(inner_type, _),
+        ) => list_values
+            .iter()
+            .all(|value| matches_value_with_rpc_type(value, inner_type, lookup)),
+        (
+            BamlValueWithMeta::Map(map_values, _),
+            TypeReferenceWithMetadata::Map { key, value, .. },
+        ) => map_values.iter().all(|(map_key, map_value)| {
+            // TODO: Validate key type
+            // matches_value_with_rpc_type(map_key, key, lookup)
+            matches_value_with_rpc_type(map_value, value, lookup)
+        }),
         (BamlValueWithMeta::Media(media, _), TypeReferenceWithMetadata::Media(media_type, _)) => {
             matches!(
                 (&media.media_type, media_type),


### PR DESCRIPTION
- **type tweaks**
- *** Add fix for correctly finding the right rpc event. * Added display trait for rpc types and values**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `Display` trait implementations for various types and fixes union type handling in RPC event conversion.
> 
>   - **Display Trait Implementations**:
>     - Added `Display` trait for `TypeMetadata`, `TypeReferenceWithMetadata`, `MediaTypeDefinition`, and `LiteralTypeDefinition` in `type_reference.rs`.
>     - Added `Display` trait for `BamlValue` and `ValueContent` in `baml_value.rs`.
>   - **Union Type Handling**:
>     - Fixed logic in `matches_value_with_rpc_type()` in `types.rs` to correctly determine union variant index.
>     - Improved error logging for union type mismatches in `to_rpc_event()` in `types.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for facd69ec6e00d2054600a2c0602ef2170a453aae. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->