### PR TITLE
Fix: Validate @assert/@check syntax in test blocks to prevent silent failures

### DIFF
--- a/engine/baml-lib/baml/tests/validation_files/tests/field_level_assert.baml
+++ b/engine/baml-lib/baml/tests/validation_files/tests/field_level_assert.baml
@@ -1,0 +1,24 @@
+function SimpleFunction(input: string) -> string {
+  client "openai/gpt-3.5-turbo"
+  prompt #"Return hello {{input}}"#
+}
+
+test TestFieldLevelAssert {
+  functions [SimpleFunction]
+  args {
+    input "test"
+  }
+  @assert(this == "Hello, test!")  // This should error
+}
+
+// error: Error parsing attribute "assert": Test assertions must use block-level syntax '@@assert' instead of '@assert'. Example:
+//   test MyTest {
+//     functions [MyFunc]
+//     args {}
+//     @@assert(label, {{ this == "expected" }})
+//   }
+//   -->  tests/field_level_assert.baml:11
+//    | 
+// 10 |   }
+// 11 |   @assert(this == "Hello, test!")  // This should error
+//    | 

--- a/engine/baml-lib/baml/tests/validation_files/tests/field_level_check.baml
+++ b/engine/baml-lib/baml/tests/validation_files/tests/field_level_check.baml
@@ -1,0 +1,19 @@
+function ComplexFunction(data: string) -> string {
+  client "openai/gpt-3.5-turbo"
+  prompt #"Process {{data}}"#
+}
+
+test TestFieldLevelCheck {
+  functions [ComplexFunction]
+  args {
+    data "value"
+  }
+  @check(this != null)  // Should error - use @@check instead
+}
+
+// error: Error parsing attribute "check": Test checks must use block-level syntax '@@check' instead of '@check'. Block-level attributes apply to the entire test result.
+//   -->  tests/field_level_check.baml:11
+//    | 
+// 10 |   }
+// 11 |   @check(this != null)  // Should error - use @@check instead
+//    | 

--- a/engine/baml-lib/parser-database/src/types/configurations.rs
+++ b/engine/baml-lib/parser-database/src/types/configurations.rs
@@ -262,6 +262,44 @@ pub(crate) fn visit_test_case<'db>(
             )),
         });
 
+    // Add validation for field-level attributes that shouldn't be in test blocks
+    for field in &config.fields {
+        // Check if the field has any attributes
+        for attribute in &field.attributes {
+            let attr_name = attribute.name.name();
+
+            // Check for constraint attributes that should be block-level
+            if matches!(attr_name, "assert" | "check") {
+                let error_msg = match attr_name {
+                    "assert" => format!(
+                        "Test assertions must use block-level syntax '@@assert' instead of '@assert'. \
+                         Example:\n  test MyTest {{\n    functions [MyFunc]\n    args {{}}\n    \
+                         @@assert(label, {{{{ this == \"expected\" }}}})\n  }}"
+                    ),
+                    "check" => format!(
+                        "Test checks must use block-level syntax '@@check' instead of '@check'. \
+                         Block-level attributes apply to the entire test result."
+                    ),
+                    _ => unreachable!(),
+                };
+                
+                ctx.push_error(DatamodelError::new_attribute_validation_error(
+                    &error_msg,
+                    attr_name,
+                    attribute.span.clone(),
+                ));
+            }
+
+            // Also check for other field-only attributes that don't make sense in tests
+            if matches!(attr_name, "description" | "alias" | "skip") {
+                ctx.push_error(DatamodelError::new_attribute_not_known_error(
+                    attr_name,
+                    attribute.span.clone(),
+                ));
+            }
+        }
+    }
+
     let constraints: Vec<(Constraint, Span, Span)> = config
         .attributes
         .iter()


### PR DESCRIPTION
## Summary

This PR fixes a critical validation gap where `@assert` (single @) is incorrectly accepted in test blocks by the linter/LSP but is silently ignored at runtime. Only `@@assert` (double @@) actually evaluates assertions, leading to false-positive test results.

## Problem

When users write tests with `@assert` instead of `@@assert`, the BAML tooling:
- ✅ Parses the syntax without errors
- ✅ Shows no warnings in the IDE
- ❌ **Silently ignores the assertion at runtime**

This creates a dangerous situation where tests appear to pass but aren't actually validating anything.

## Solution

Added validation in the parser to detect and reject field-level constraint attributes (`@assert`, `@check`) within test blocks, with clear error messages guiding users to the correct block-level syntax (`@@assert`, `@@check`).

## Changes

- **Parser validation**: Modified `visit_test_case` in `configurations.rs` to validate field attributes
- **Error messages**: Added helpful examples showing the correct `@@assert` syntax
- **Test coverage**: Added comprehensive tests for both `@assert` and `@check` validation
- **Additional validation**: Also validates other misplaced field attributes (description, alias, skip)

## Example Error Message

When users incorrectly use `@assert`:
```
error: Error parsing attribute "assert": Test assertions must use block-level syntax '@@assert' instead of '@assert'. Example:
  test MyTest {
    functions [MyFunc]
    args {}
    @@assert(label, {{ this == "expected" }})
  }
```

## Testing

- ✅ All existing tests pass
- ✅ New validation tests added for `@assert` and `@check`
- ✅ Error messages are clear and actionable
- ✅ No breaking changes to existing valid code

## Impact

This change prevents a category of subtle bugs where tests silently fail to validate their assertions, improving the reliability of BAML test suites.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds parser validation to reject incorrect `@assert` and `@check` syntax in test blocks, preventing silent test failures.
> 
>   - **Parser Validation**:
>     - Modified `visit_test_case` in `configurations.rs` to validate field attributes in test blocks.
>     - Detects and rejects `@assert` and `@check` in test blocks, requiring `@@assert` and `@@check` instead.
>     - Validates other misplaced field attributes (`description`, `alias`, `skip`).
>   - **Error Messages**:
>     - Added detailed error messages with examples for incorrect `@assert` and `@check` usage.
>   - **Test Coverage**:
>     - Added tests in `field_level_assert.baml` and `field_level_check.baml` to verify validation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 2c36444bc62115594f65c7fb0350eb6b8e1810cb. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->