### PR TITLE
fix: build issue with fiddle

### DIFF
--- a/typescript/apps/fiddle-web-app/app/[project_id]/_components/EmbedDialog.tsx
+++ b/typescript/apps/fiddle-web-app/app/[project_id]/_components/EmbedDialog.tsx
@@ -13,7 +13,7 @@ import { Label } from '@baml/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@baml/ui/tabs';
 import { Code, Info, Link as LinkIcon } from 'lucide-react';
 import dynamic from 'next/dynamic';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { SiReact } from 'react-icons/si';
 
 const ProjectView = dynamic(() => import('./ProjectView'), { ssr: false });
@@ -26,8 +26,15 @@ interface EmbedDialogProps {
 
 export function EmbedDialog({ open, onOpenChange, shareId }: EmbedDialogProps) {
   const [activeTab, setActiveTab] = useState('link');
+  const [generatedUrl, setGeneratedUrl] = useState('');
 
-  const generatedUrl = shareId ? `${window?.location.origin}/${shareId}` : '';
+  useEffect(() => {
+    if (shareId && typeof window !== 'undefined') {
+      setGeneratedUrl(`${window.location.origin}/${shareId}`);
+    } else {
+      setGeneratedUrl('');
+    }
+  }, [shareId]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/index.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/index.tsx
@@ -5,6 +5,7 @@ import { useAtomValue } from 'jotai';
 import { ApiKeysDialog } from '../../../../components/api-keys-dialog/dialog';
 import { StatusBar } from '../../../../components/status-bar';
 import { wasmAtom } from '../../atoms';
+import { vscode } from '../../vscode';
 import { functionTestSnippetAtom, selectionAtom } from '../atoms';
 import { PreviewToolbar } from '../preview-toolbar';
 import { TestingSidebar } from '../side-bar';
@@ -73,7 +74,7 @@ export const PromptPreview = () => {
 
   return (
     <>
-      <SidebarProvider defaultOpen={true}>
+      <SidebarProvider defaultOpen={vscode.isVscode()}>
         <SidebarInset>
           {wasm ? (
             <div className="h-full flex flex-col overflow-hidden relative">


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix build issue by updating `EmbedDialog` to use `useEffect` for URL state management and conditionally opening sidebar in `PromptPreview`.
> 
>   - **EmbedDialog.tsx**:
>     - Added `useEffect` to manage `generatedUrl` state based on `shareId` and window availability.
>     - Replaced direct URL generation with state management for better reactivity.
>   - **index.tsx**:
>     - Updated `SidebarProvider` to open by default if `vscode.isVscode()` returns true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 049271949f98aec1d729ebead52644fce27a7451. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->