### PR TITLE
fix(ask-baml): use correct env var names, hopefully

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           pnpm baml-cli generate
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/canary" ]; then
-            echo TARGET_ENV=prod >>$GITHUB_ENV
+            echo TARGET_ENV=production >>$GITHUB_ENV
           else
             echo TARGET_ENV=preview >>$GITHUB_ENV
           fi
@@ -151,9 +151,9 @@ jobs:
       - name: Set environment variables
         run: |
           if [ "${{ github.event_name }}" = "push" ] && [ "${{ github.ref }}" = "refs/heads/canary" ]; then
-            echo NODE_ENV=production >>$GITHUB_ENV
+            echo PINECONE_ENV=prod >>$GITHUB_ENV
           else
-            echo NODE_ENV=development >>$GITHUB_ENV
+            echo PINECONE_ENV=dev >>$GITHUB_ENV
           fi
 
       - name: Update pinecone

--- a/typescript/apps/sage-backend/lib/pinecone-api.ts
+++ b/typescript/apps/sage-backend/lib/pinecone-api.ts
@@ -10,7 +10,9 @@ import { type SitemapEntry, SitemapGenerator } from './sitemap';
 
 const EMBEDDING_MODEL = 'text-embedding-3-large';
 const PINECONE_INDEX_NAME =
-  process.env.NODE_ENV === 'production' ? 'ask-baml-prod' : 'ask-baml-dev';
+  process.env.PINECONE_ENV === 'prod' || process.env.PINECONE_ENV === 'production'
+    ? 'ask-baml-prod'
+    : 'ask-baml-dev';
 console.log('Using pinecone index:', PINECONE_INDEX_NAME);
 
 const openaiClient = new OpenAI({


### PR DESCRIPTION
Docs assistant is 405'ing right now
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix environment variable names in GitHub Actions and Pinecone API to ensure correct environment settings for production and development.
> 
>   - **Environment Variables**:
>     - In `publish-docs.yml`, change `TARGET_ENV` from `prod` to `production` and `NODE_ENV` to `PINECONE_ENV` with values `prod`/`dev`.
>   - **Pinecone API**:
>     - In `pinecone-api.ts`, update `PINECONE_INDEX_NAME` to use `PINECONE_ENV` for determining index name (`ask-baml-prod` or `ask-baml-dev`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for fff9a6ce1e8432c618e8f1a36df234c5a37ba9d8. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->