### PR TITLE
Fix clippy lints in `canary`

### DIFF
--- a/engine/baml-lib/baml-types/src/baml_value.rs
+++ b/engine/baml-lib/baml-types/src/baml_value.rs
@@ -828,7 +828,7 @@ impl<T> BamlValueWithMeta<T> {
 
     /// Iterating over a `BamlValueWithMeta` produces a depth-first traversal
     /// of the value and all its children.
-    pub fn iter(&self) -> BamlValueWithMetaIterator<T> {
+    pub fn iter(&self) -> BamlValueWithMetaIterator<'_, T> {
         BamlValueWithMetaIterator::new(self)
     }
 

--- a/engine/baml-lib/baml-types/src/media.rs
+++ b/engine/baml-lib/baml-types/src/media.rs
@@ -120,7 +120,7 @@ impl MediaFile {
             .context("Internal error: no path to resolve against")?
             .join(&self.relpath))
     }
-    pub fn extension(&self) -> Option<Cow<str>> {
+    pub fn extension(&self) -> Option<Cow<'_, str>> {
         self.relpath.extension().map(|ext| ext.to_string_lossy())
     }
 }

--- a/engine/baml-lib/baml/build.rs
+++ b/engine/baml-lib/baml/build.rs
@@ -2,9 +2,9 @@ use std::{env, fs, io::Write as _, path};
 
 const VALIDATIONS_ROOT_DIR: &str = "tests/validation_files";
 const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
-const BAML_CLI_INIT_DIR: &str = concat!("/../../baml-runtime/src/cli/initial_project/baml_src");
+const BAML_CLI_INIT_DIR: &str = "/../../baml-runtime/src/cli/initial_project/baml_src";
 const PROMPT_FIDDLE_EXAMPLE_DIR: &str =
-    concat!("/../../../typescript/apps/fiddle-web-app/public/_examples/all-projects/baml_src");
+    "/../../../typescript/apps/fiddle-web-app/public/_examples/all-projects/baml_src";
 
 fn main() {
     if std::env::var("SKIP_BAML_VALIDATION").unwrap_or_default() == "1" {

--- a/engine/baml-lib/jinja/src/evaluate_type/stmt.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/stmt.rs
@@ -19,15 +19,15 @@ fn track_walk(node: &ast::Stmt<'_>, state: &mut PredefinedTypes) {
         ast::Stmt::EmitRaw(_) => {}
         ast::Stmt::ForLoop(stmt) => {
             let iter_type = evaluate_type(&stmt.iter, state);
-            let iter_type = if iter_type.is_err() {
-                state.errors_mut().extend(iter_type.err().unwrap());
-                Type::Unknown
-            } else {
-                match iter_type.unwrap() {
+            let iter_type = if let Ok(t) = iter_type {
+                match t {
                     Type::List(t) => *t,
                     Type::Map(k, _) => *k,
                     _ => Type::Unknown,
                 }
+            } else {
+                state.errors_mut().extend(iter_type.err().unwrap());
+                Type::Unknown
             };
 
             let _filter_type = stmt.filter_expr.as_ref().map(|x| evaluate_type(x, state));

--- a/engine/baml-lib/jinja/src/evaluate_type/stmt.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/stmt.rs
@@ -18,16 +18,16 @@ fn track_walk(node: &ast::Stmt<'_>, state: &mut PredefinedTypes) {
         }
         ast::Stmt::EmitRaw(_) => {}
         ast::Stmt::ForLoop(stmt) => {
-            let iter_type = evaluate_type(&stmt.iter, state);
-            let iter_type = if let Ok(t) = iter_type {
-                match t {
+            let iter_type = match evaluate_type(&stmt.iter, state) {
+                Ok(t) => match t {
                     Type::List(t) => *t,
                     Type::Map(k, _) => *k,
                     _ => Type::Unknown,
+                },
+                Err(e) => {
+                    state.errors_mut().extend(e);
+                    Type::Unknown
                 }
-            } else {
-                state.errors_mut().extend(iter_type.err().unwrap());
-                Type::Unknown
             };
 
             let _filter_type = stmt.filter_expr.as_ref().map(|x| evaluate_type(x, state));

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/mod.rs
@@ -48,7 +48,7 @@ impl ParsingContext<'_> {
         }
     }
 
-    pub(crate) fn enter_scope(&self, scope: &str) -> ParsingContext {
+    pub(crate) fn enter_scope(&self, scope: &str) -> ParsingContext<'_> {
         let mut new_scope = self.scope.clone();
         new_scope.push(scope.to_string());
         ParsingContext {
@@ -67,7 +67,7 @@ impl ParsingContext<'_> {
         &self,
         cls_value_pair: (String, jsonish::Value),
         is_coerce: bool,
-    ) -> ParsingContext {
+    ) -> ParsingContext<'_> {
         let mut new_visited_coerce = self.visited_during_coerce.clone();
         let mut new_visited_try_cast = self.visited_during_try_cast.clone();
         if is_coerce {

--- a/engine/baml-rpc/src/ast/tops.rs
+++ b/engine/baml-rpc/src/ast/tops.rs
@@ -54,7 +54,7 @@ pub struct AST {
 }
 
 impl AST {
-    pub fn id(&self) -> ASTId {
+    pub fn id(&self) -> ASTId<'_> {
         // Get all top level ids
         let top_ids = self
             .functions

--- a/engine/baml-runtime/src/internal/ir_features.rs
+++ b/engine/baml-runtime/src/internal/ir_features.rs
@@ -54,7 +54,7 @@ impl IrFeatures {
 pub trait WithInternal {
     fn features(&self) -> IrFeatures;
 
-    fn walk_functions(&self) -> impl ExactSizeIterator<Item = FunctionWalker>;
+    fn walk_functions(&self) -> impl ExactSizeIterator<Item = FunctionWalker<'_>>;
 
-    fn walk_tests(&self) -> impl Iterator<Item = TestCaseWalker>;
+    fn walk_tests(&self) -> impl Iterator<Item = TestCaseWalker<'_>>;
 }

--- a/engine/baml-runtime/src/runtime/ir_features.rs
+++ b/engine/baml-runtime/src/runtime/ir_features.rs
@@ -13,11 +13,11 @@ impl WithInternal for InternalBamlRuntime {
         IrFeatures::from(vec![], ir.walk_functions().any(|f| f.is_v2()), vec![])
     }
 
-    fn walk_functions(&self) -> impl ExactSizeIterator<Item = FunctionWalker> {
+    fn walk_functions(&self) -> impl ExactSizeIterator<Item = FunctionWalker<'_>> {
         self.ir().walk_functions()
     }
 
-    fn walk_tests(&self) -> impl Iterator<Item = TestCaseWalker> {
+    fn walk_tests(&self) -> impl Iterator<Item = TestCaseWalker<'_>> {
         self.ir().walk_tests()
     }
 }

--- a/engine/baml-runtime/src/runtime_methods/prepare_function.rs
+++ b/engine/baml-runtime/src/runtime_methods/prepare_function.rs
@@ -107,7 +107,7 @@ impl InternalBamlRuntime {
         &self,
         function_name: String,
         params: &BamlMap<String, BamlValue>,
-    ) -> Result<PreparedFunction, PrepareFunctionError> {
+    ) -> Result<PreparedFunction<'_>, PrepareFunctionError> {
         let func = match self.get_function(&function_name) {
             Ok(func) => func,
             Err(error) => {

--- a/engine/baml-runtime/src/types/response.rs
+++ b/engine/baml-runtime/src/types/response.rs
@@ -245,7 +245,7 @@ impl PartialEq for TestFailReason<'_> {
 impl Eq for TestFailReason<'_> {}
 
 impl TestResponse {
-    pub fn status(&self) -> TestStatus {
+    pub fn status(&self) -> TestStatus<'_> {
         let func_res = &self.function_response;
         if let Some(parsed) = func_res.result_with_constraints() {
             if parsed.is_ok() {

--- a/engine/boundary-udf/src/config.rs
+++ b/engine/boundary-udf/src/config.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 /// Collects all outputs declared in the configuration file, regardless of which functions declare
 /// them.
-pub fn gather_all_outputs<'a>(udf: &'a UDFConfig) -> IndexSet<&'a str> {
+pub fn gather_all_outputs(udf: &UDFConfig) -> IndexSet<&str> {
     // DFS on tree of override sets.
     // Order doesn't matter since we just want to gather everything.
 
@@ -15,8 +15,8 @@ pub fn gather_all_outputs<'a>(udf: &'a UDFConfig) -> IndexSet<&'a str> {
     let mut set = IndexSet::new();
 
     loop {
-        set.extend(dfs_top.into_iter().flat_map(extract_outputs));
-        dfs_stack.extend(dfs_top.into_iter().map(|func| &func.overrides));
+        set.extend(dfs_top.iter().flat_map(extract_outputs));
+        dfs_stack.extend(dfs_top.iter().map(|func| &func.overrides));
 
         dfs_top = match dfs_stack.pop() {
             Some(next) => next,
@@ -26,7 +26,7 @@ pub fn gather_all_outputs<'a>(udf: &'a UDFConfig) -> IndexSet<&'a str> {
 
     return set;
 
-    fn extract_outputs<'a>(func: &'a Function) -> impl Iterator<Item = &'a str> {
+    fn extract_outputs(func: &Function) -> impl Iterator<Item = &str> {
         func.returns.keys().map(AsRef::as_ref)
     }
 }
@@ -79,7 +79,7 @@ impl UDFConfig {
     /// Verifies that the configuration is valid beyond deserialization format.
     /// Checked invariants:
     /// - At least one return is declared in the configuration: `gather_all_outputs` will return a
-    /// non-empty set.
+    ///   non-empty set.
     pub fn check(&self) -> Result<(), UDFConfigError> {
         fn find_returns(overrides: &[Function]) -> bool {
             for ov in overrides {

--- a/engine/boundary-udf/src/eval.rs
+++ b/engine/boundary-udf/src/eval.rs
@@ -1,7 +1,7 @@
 //! Manual Rust evaluator for UDFs defined in YAML.
 //!
 //! ## Problem with `if` branches
-//! Consider the Jinja expression:  
+//! Consider the Jinja expression:
 //! ```jinja
 //! raw.output_tokens_details.cached_tokens if raw.output_token_details else 1
 //! ```
@@ -146,75 +146,6 @@ struct MatchedFunction<'a> {
     // minijinja::Expression because those are handles too.
     constants: BamlMap<&'a str, Constant>,
     returns: BamlMap<&'a str, OutputExpression>,
-}
-
-#[cfg(test)]
-mod tests {
-
-    use super::*;
-    use crate::{
-        config::gather_all_outputs,
-        tests::{data, load_sample_udf},
-    };
-
-    #[test]
-    fn parse_yaml_file() {
-        let deser = load_sample_udf();
-
-        insta::assert_yaml_snapshot!(deser);
-    }
-
-    #[test]
-    fn find_all_outputs() {
-        let udf = load_sample_udf();
-
-        let result = gather_all_outputs(&udf);
-
-        insta::assert_debug_snapshot!(result);
-    }
-
-    #[test]
-    fn compute_jinja_matches() {
-        let udf = load_sample_udf();
-
-        let mock = [
-            // this one has everything
-            data::openai(),
-            // this one doesn't have one of the returns (since only openai defines it)
-            data::anthropic(),
-            // this one won't have any returns, so both should be undefined.
-            data::none_match(),
-            // this one will have returns, but they should have detected zeroes.
-            data::anthropic_with_bad_raw(),
-        ];
-
-        let all_names = gather_all_outputs(&udf);
-
-        let mut context = CompileContext::with_outputs(&all_names);
-
-        let match_res = mock.map(|mock| {
-            match_and_compute_row(&udf, serde_json::to_value(mock).unwrap(), &mut context).unwrap()
-        });
-
-        insta::assert_debug_snapshot!(match_res);
-    }
-
-    #[test]
-    fn match_functions() {
-        let udf = load_sample_udf();
-
-        let mock = [
-            data::openai(),
-            data::gemini(),
-            data::anthropic(),
-            data::none_match(),
-        ];
-
-        let results = mock
-            .map(|resp| find_function_for_row(&udf, &serde_json::to_value(resp).unwrap()).unwrap());
-
-        insta::assert_debug_snapshot!(results);
-    }
 }
 
 /// Evaluate selected outputs of function
@@ -440,4 +371,73 @@ fn find_function_for_row<'c>(
     }
 
     Ok(Some(eval))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::{
+        config::gather_all_outputs,
+        tests::{data, load_sample_udf},
+    };
+
+    #[test]
+    fn parse_yaml_file() {
+        let deser = load_sample_udf();
+
+        insta::assert_yaml_snapshot!(deser);
+    }
+
+    #[test]
+    fn find_all_outputs() {
+        let udf = load_sample_udf();
+
+        let result = gather_all_outputs(&udf);
+
+        insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn compute_jinja_matches() {
+        let udf = load_sample_udf();
+
+        let mock = [
+            // this one has everything
+            data::openai(),
+            // this one doesn't have one of the returns (since only openai defines it)
+            data::anthropic(),
+            // this one won't have any returns, so both should be undefined.
+            data::none_match(),
+            // this one will have returns, but they should have detected zeroes.
+            data::anthropic_with_bad_raw(),
+        ];
+
+        let all_names = gather_all_outputs(&udf);
+
+        let mut context = CompileContext::with_outputs(&all_names);
+
+        let match_res = mock.map(|mock| {
+            match_and_compute_row(&udf, serde_json::to_value(mock).unwrap(), &mut context).unwrap()
+        });
+
+        insta::assert_debug_snapshot!(match_res);
+    }
+
+    #[test]
+    fn match_functions() {
+        let udf = load_sample_udf();
+
+        let mock = [
+            data::openai(),
+            data::gemini(),
+            data::anthropic(),
+            data::none_match(),
+        ];
+
+        let results = mock
+            .map(|resp| find_function_for_row(&udf, &serde_json::to_value(resp).unwrap()).unwrap());
+
+        insta::assert_debug_snapshot!(results);
+    }
 }

--- a/engine/boundary-udf/src/eval/path_trie.rs
+++ b/engine/boundary-udf/src/eval/path_trie.rs
@@ -196,7 +196,6 @@ fn insert_into_trie_recursive<'src>(
                     results: vec![ret_handle],
                 }),
             });
-            return;
         }
         Some(child) => {
             // match as much of the path as possible.

--- a/engine/boundary-udf/src/yaml2jinja.rs
+++ b/engine/boundary-udf/src/yaml2jinja.rs
@@ -439,8 +439,8 @@ fn rebuild_from_flattened<'search, 'src>(
             .expect("should have compiled")
     }
 
-    fn rebuild_args<'search, 'ast, 'src>(
-        result_map: &'search mut HashMap<HashByPtr<'ast, ast::Expr<'src>>, String>,
+    fn rebuild_args<'ast, 'src>(
+        result_map: &mut HashMap<HashByPtr<'ast, ast::Expr<'src>>, String>,
         args: &'ast [ast::CallArg<'src>],
     ) -> String {
         args.iter()

--- a/engine/language_server/src/baml_source_file/mod.rs
+++ b/engine/language_server/src/baml_source_file/mod.rs
@@ -180,7 +180,7 @@ impl SourceFile {
         &self.source_text()[range]
     }
 
-    pub fn to_source_code(&self) -> SourceCode {
+    pub fn to_source_code(&self) -> SourceCode<'_, '_> {
         SourceCode {
             text: self.source_text(),
             index: self.index(),

--- a/engine/language_server/src/server/api/notifications/did_open.rs
+++ b/engine/language_server/src/server/api/notifications/did_open.rs
@@ -62,14 +62,8 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
             .to_file_path()
             .internal_error_msg(&format!("Could not convert URL '{url}' to file path"))?;
 
-        let project = session.get_or_create_project(&file_path);
-        if project.is_none() {
-            tracing::error!("Failed to get or create project for path: {:?}", file_path);
-            show_err_msg!("Failed to get or create project for path: {:?}", file_path);
-        } else {
-            let project = project.unwrap();
-            let version = project.lock().unwrap().get_common_generator_version();
-            if let Ok(version) = version {
+        if let Some(project) = session.get_or_create_project(&file_path) {
+            if let Ok(version) = project.lock().unwrap().get_common_generator_version() {
                 notifier
                     .0
                     .send(lsp_server::Message::Notification(
@@ -88,7 +82,11 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
                     ))
                     .internal_error()?;
             }
+        } else {
+            tracing::error!("Failed to get or create project for path: {:?}", file_path);
+            show_err_msg!("Failed to get or create project for path: {:?}", file_path);
         }
+
         // session.open_text_document(
         //     DocumentKey::from_path(&file_path, &file_path).internal_error()?,
         //     TextDocument::new(params.text_document.text, params.text_document.version),

--- a/engine/language_server/src/server/api/notifications/did_save_text_document.rs
+++ b/engine/language_server/src/server/api/notifications/did_save_text_document.rs
@@ -84,7 +84,7 @@ impl super::SyncNotificationHandler for DidSaveTextDocument {
 // Do not use this yet, it seems it has an outdated view of the project files and it generates
 // stale baml clients
 impl super::BackgroundDocumentNotificationHandler for DidSaveTextDocument {
-    fn document_url(params: &types::DidSaveTextDocumentParams) -> Cow<types::Url> {
+    fn document_url(params: &types::DidSaveTextDocumentParams) -> Cow<'_, types::Url> {
         Cow::Borrowed(&params.text_document.uri)
     }
 

--- a/engine/language_server/src/server/api/requests/diagnostic.rs
+++ b/engine/language_server/src/server/api/requests/diagnostic.rs
@@ -33,7 +33,7 @@ impl RequestHandler for DocumentDiagnosticRequestHandler {
 
 // // Consider fixing snapshots and running this on a background thread.
 impl BackgroundDocumentRequestHandler for DocumentDiagnosticRequestHandler {
-    fn document_url(params: &DocumentDiagnosticParams) -> std::borrow::Cow<Url> {
+    fn document_url(params: &DocumentDiagnosticParams) -> std::borrow::Cow<'_, Url> {
         Cow::Borrowed(&params.text_document.uri)
     }
 

--- a/engine/language_server/src/server/api/traits.rs
+++ b/engine/language_server/src/server/api/traits.rs
@@ -36,7 +36,7 @@ pub(super) trait SyncRequestHandler: RequestHandler {
 pub(super) trait BackgroundDocumentRequestHandler: RequestHandler {
     fn document_url(
         params: &<<Self as RequestHandler>::RequestType as Request>::Params,
-    ) -> std::borrow::Cow<lsp_types::Url>;
+    ) -> std::borrow::Cow<'_, lsp_types::Url>;
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,
@@ -73,7 +73,7 @@ pub(super) trait BackgroundDocumentNotificationHandler: NotificationHandler {
     /// implementation.
     fn document_url(
         params: &<<Self as NotificationHandler>::NotificationType as LSPNotification>::Params,
-    ) -> std::borrow::Cow<lsp_types::Url>;
+    ) -> std::borrow::Cow<'_, lsp_types::Url>;
 
     fn run_with_snapshot(
         snapshot: DocumentSnapshot,

--- a/engine/language_server/src/server/connection.rs
+++ b/engine/language_server/src/server/connection.rs
@@ -86,7 +86,7 @@ impl Connection {
     }
 
     /// An iterator over incoming messages from the client.
-    pub fn incoming(&self) -> crossbeam::channel::Iter<lsp::Message> {
+    pub fn incoming(&self) -> crossbeam::channel::Iter<'_, lsp::Message> {
         self.receiver.iter()
     }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -403,16 +403,16 @@ importers:
         version: 15.5.13
       css-loader:
         specifier: ^7.1.2
-        version: 7.1.2(webpack@5.99.9)
+        version: 7.1.2(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))
       jotai-devtools:
         specifier: 0.12.0
         version: 0.12.0(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(redux@5.0.1)(storybook@8.6.14)
       style-loader:
         specifier: ^4.0.0
-        version: 4.0.0(webpack@5.99.9)
+        version: 4.0.0(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))
       ts-loader:
         specifier: ^9.4.0
-        version: 9.5.2(typescript@5.8.3)(webpack@5.99.9)
+        version: 9.5.2(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))
       typescript:
         specifier: ^5.0.0
         version: 5.8.3
@@ -1198,6 +1198,9 @@ importers:
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
+      classnames:
+        specifier: ^2.5.1
+        version: 2.5.1
       clsx:
         specifier: 2.1.1
         version: 2.1.1
@@ -18371,17 +18374,17 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.99.9)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack@5.99.9))(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.99.9)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.99.9)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack@5.99.9))(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.99.9)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.99.9)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack@5.99.9))(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))':
     dependencies:
       webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.99.9)
@@ -19321,7 +19324,7 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-loader@7.1.2(webpack@5.99.9):
+  css-loader@7.1.2(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -24801,7 +24804,7 @@ snapshots:
     dependencies:
       boundary: 2.0.0
 
-  style-loader@4.0.0(webpack@5.99.9):
+  style-loader@4.0.0(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)):
     dependencies:
       webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
 
@@ -24966,7 +24969,7 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.12.7)(esbuild@0.25.2)(webpack@5.99.9):
+  terser-webpack-plugin@5.3.14(@swc/core@1.12.7)(esbuild@0.25.2)(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
@@ -25162,7 +25165,7 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.28.0)
       jest-util: 30.0.2
 
-  ts-loader@9.5.2(typescript@5.8.3)(webpack@5.99.9):
+  ts-loader@9.5.2(typescript@5.8.3)(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.18.2
@@ -26052,9 +26055,9 @@ snapshots:
   webpack-cli@5.1.4(webpack@5.99.9):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.99.9)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.99.9)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack@5.99.9)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack@5.99.9))(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack@5.99.9))(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack@5.99.9))(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
@@ -26131,7 +26134,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(@swc/core@1.12.7)(esbuild@0.25.2)(webpack@5.99.9)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.12.7)(esbuild@0.25.2)(webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     optionalDependencies:

--- a/typescript/packages/ui/package.json
+++ b/typescript/packages/ui/package.json
@@ -34,6 +34,7 @@
     "@radix-ui/react-tooltip": "1.2.7",
     "@tailwindcss/typography": "0.5.16",
     "class-variance-authority": "0.7.1",
+    "classnames": "^2.5.1",
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
     "cobe": "0.6.4",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix Clippy lints in `canary` by adding lifetimes, removing `concat!` macros, and refactoring error handling.
> 
>   - **Lifetimes**:
>     - Add explicit lifetimes to iterators in `baml_value.rs`, `media.rs`, `tops.rs`, `ir_features.rs`, `prepare_function.rs`, `response.rs`, `config.rs`, `eval.rs`, `did_save_text_document.rs`, `diagnostic.rs`, `traits.rs`, `connection.rs`.
>   - **Macros**:
>     - Remove unnecessary `concat!` macros in `build.rs`.
>   - **Error Handling**:
>     - Refactor error handling in `stmt.rs` to use `match` for `evaluate_type` results.
>     - Simplify error handling in `did_open.rs` and `did_save_text_document.rs` by using `if let`.
>   - **Miscellaneous**:
>     - Add `classnames` dependency to `package.json`.
>     - Remove redundant return statement in `path_trie.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 1d3accde909659c6fa209028ac13e34d4234af8e. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->