### PR TITLE
fix: handle missing `parts` field in gemini flash responses

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/google/types.rs
@@ -234,6 +234,7 @@ pub struct Candidate {
 #[serde(rename_all = "camelCase")]
 pub struct Content {
     pub role: Option<String>,
+    #[serde(default)]
     pub parts: Vec<Part>,
 }
 


### PR DESCRIPTION
 Gemini Flash 2.0 & 2.5 sometimes omits the parts field when returning very short responses (e.g., single words), causing deserialization to fail with `missing field parts` error. 
 
 This pr adds `#[serde(default)]` to `Content.parts` to gracefully handle these cases by defaulting to an empty vector.
 
 Fixes #1749 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `#[serde(default)]` to `Content.parts` in `types.rs` to handle missing `parts` field, fixing deserialization errors for short responses.
> 
>   - **Behavior**:
>     - Adds `#[serde(default)]` to `Content.parts` in `types.rs` to handle missing `parts` field by defaulting to an empty vector.
>     - Fixes deserialization errors for short responses from Gemini Flash 2.0 & 2.5.
>   - **Misc**:
>     - Fixes issue #1749.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c523f8b8081172dc6d7a22332b6ad9731def81eb. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->