### PR TITLE
fix(jetbrains): use the production-facing LSP installer logic

### DIFF
--- a/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlLanguageServer.kt
+++ b/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlLanguageServer.kt
@@ -10,19 +10,19 @@ class BamlLanguageServer(private val project: Project) : OSProcessStreamConnecti
 
     init {
         // UNCOMMENT FOR DEBUGGING LOCALLY
-        val commandLine = GeneralCommandLine(
-            Path.of(System.getProperty("user.home"),
-                "/Documents/boundary/baml-main/baml/engine/target/debug", "baml-cli").toString(), "lsp")
-        super.setCommandLine(commandLine)
+        // val commandLine = GeneralCommandLine(
+        //     Path.of(System.getProperty("user.home"),
+        //         "/Documents/boundary/baml-main/baml/engine/target/debug", "baml-cli").toString(), "lsp")
+        // super.setCommandLine(commandLine)
 
-//        val cacheDir = Path.of(System.getProperty("user.home"), ".baml/jetbrains")
-//        val version  = Files.readString(cacheDir.resolve("baml-cli-installed.txt")).trim()
-//
-//        val (arch, platform, _) = BamlLanguageServerInstaller.getPlatformTriple()
-//        val exe = if (platform == "pc-windows-msvc") "baml-cli.exe" else "baml-cli"
-//        val cli = cacheDir.resolve("baml-cli-$version-$arch-$platform").resolve(exe)
-//
-//        super.setCommandLine(GeneralCommandLine(cli.toString(), "lsp"))
+        val cacheDir = Path.of(System.getProperty("user.home"), ".baml/jetbrains")
+        val version  = Files.readString(cacheDir.resolve("baml-cli-installed.txt")).trim()
+
+        val (arch, platform, _) = BamlLanguageServerInstaller.getPlatformTriple()
+        val exe = if (platform == "pc-windows-msvc") "baml-cli.exe" else "baml-cli"
+        val cli = cacheDir.resolve("baml-cli-$version-$arch-$platform").resolve(exe)
+
+        super.setCommandLine(GeneralCommandLine(cli.toString(), "lsp"))
 
     }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Switches `BamlLanguageServer` initialization to use production command line setup instead of local debugging.
> 
>   - **Behavior**:
>     - In `BamlLanguageServer`, switches from local debugging command line to production command line setup.
>     - Uses `baml-cli` from `.baml/jetbrains` directory based on platform and architecture.
>   - **Code Changes**:
>     - Comments out local debugging command line setup in `BamlLanguageServer.kt`.
>     - Uncomments production command line setup logic in `BamlLanguageServer.kt`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c06d9e7a73dc2162f086c73fd614bea2990763cf. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->