### PR TITLE
fix: issue with some ids for embed prompt fiddle

### DIFF
--- a/typescript/apps/fiddle-web-app/app/[project_id]/_components/EmbedDialog.tsx
+++ b/typescript/apps/fiddle-web-app/app/[project_id]/_components/EmbedDialog.tsx
@@ -19,6 +19,7 @@ import { useAtomValue } from 'jotai';
 import { currentEditorFilesAtom } from '../_atoms/atoms';
 import { createUrl } from '../../../app/actions';
 import type { BAMLProject } from '../../../lib/exampleProjects';
+import { usePathname } from 'next/navigation';
 
 const ProjectView = dynamic(() => import('./ProjectView'), { ssr: false });
 
@@ -40,6 +41,7 @@ export function EmbedDialog({
   const [activeTab, setActiveTab] = useState('link');
   const [generatedUrl, setGeneratedUrl] = useState('');
   const editorFiles = useAtomValue(currentEditorFilesAtom);
+  const pathname = usePathname();
 
   useEffect(() => {
     if (!open) return;
@@ -47,20 +49,25 @@ export function EmbedDialog({
     (async () => {
       try {
         if (typeof window === 'undefined') return;
-        // Always create a fresh share URL based on current editor state
-        const urlId = await createUrl({
-          ...project,
-          name: projectName,
-          files: editorFiles,
-        } as BAMLProject);
+
+        // Prefer existing id from URL, otherwise create a new one like the Share button
+        let urlId = pathname?.split('/')[1];
+        if (!urlId || urlId === 'new-project') {
+          urlId = await createUrl({
+            ...project,
+            name: projectName,
+            files: editorFiles,
+          } as BAMLProject);
+        }
+
         if (!cancelled) {
-          setGeneratedUrl(`${window.location.origin}/embed/${urlId}`);
+          setGeneratedUrl(`${window.location.origin}/embed?id=${urlId}`);
         }
       } catch (e) {
         // Fallback to provided shareId if creation fails
         if (!cancelled) {
           if (shareId && typeof window !== 'undefined') {
-            setGeneratedUrl(`${window.location.origin}/embed/${shareId}`);
+            setGeneratedUrl(`${window.location.origin}/embed?id=${shareId}`);
           } else {
             setGeneratedUrl('');
           }
@@ -70,7 +77,7 @@ export function EmbedDialog({
     return () => {
       cancelled = true;
     };
-  }, [open, project, projectName, editorFiles, shareId]);
+  }, [open, project, projectName, editorFiles, shareId, pathname]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/typescript/apps/fiddle-web-app/app/embed/clientwrapper.tsx
+++ b/typescript/apps/fiddle-web-app/app/embed/clientwrapper.tsx
@@ -77,34 +77,39 @@ const EventListener: React.FC = () => {
 };
 
 
+type EditorFile = { path: string; content: string };
+
 interface EmbedComponentProps {
-  bamlContent: string;
+  files: EditorFile[];
 }
 
-export default function EmbedComponent({ bamlContent }: EmbedComponentProps) {
+export default function EmbedComponent({ files }: EmbedComponentProps) {
   return (
     <JotaiProvider>
-      <EmbedComponentInner bamlContent={bamlContent} />
+      <EmbedComponentInner files={files} />
     </JotaiProvider>
   );
 }
 
-function EmbedComponentInner({ bamlContent }: EmbedComponentProps) {
-  const [files, setFiles] = useAtom(filesAtom);
+function EmbedComponentInner({ files }: EmbedComponentProps) {
+  const [editorFiles, setEditorFiles] = useAtom(filesAtom);
   const [isLoading, setIsLoading] = useState(true);
   const isWasmReady = useWaitForWasm();
   const activeFileNameAtomValue = useAtomValue(activeFileNameAtom);
 
   // Use fallback active file name when WASM is not ready
-  const activeFileName = isWasmReady ? activeFileNameAtomValue : 'main.baml';
+  const fallbackFileName = files.find((f) => f.path.endsWith('.baml'))?.path || 'main.baml';
+  const activeFileName = isWasmReady ? activeFileNameAtomValue : fallbackFileName;
 
   useEffect(() => {
-    // Set the files with the BAML content passed from the server
-    setFiles({
-      'main.baml': bamlContent,
-    });
+    // Populate files atom from provided project files
+    const record: Record<string, string> = {};
+    for (const f of files) {
+      record[f.path] = f.content;
+    }
+    setEditorFiles(record);
     setIsLoading(false);
-  }, [bamlContent, setFiles]);
+  }, [files, setEditorFiles]);
 
   // Wait for WASM to be ready before rendering
   if (isLoading || !isWasmReady) {
@@ -127,20 +132,19 @@ function EmbedComponentInner({ bamlContent }: EmbedComponentProps) {
             {activeFileName && (
               <CodeMirrorViewer
                 lang="baml"
-                fileContent={{
-                  code: files[activeFileName] || '',
+                 fileContent={{
+                  code: editorFiles[activeFileName] || '',
                   language: 'baml',
                   id: activeFileName,
                 }}
                 hideLineNumbers={true}
                 shouldScrollDown={false}
-                onContentChange={(v: string) => {
+                 onContentChange={(v: string) => {
                   const newFiles: Record<string, string> = {};
-                  Object.entries(files).map(([key, value]) => {
-                    const newVal = key === activeFileName ? v : value;
-                    newFiles[key] = newVal;
+                  Object.entries(editorFiles).forEach(([key, value]) => {
+                    newFiles[key] = key === activeFileName ? v : value;
                   });
-                  setFiles(newFiles);
+                  setEditorFiles(newFiles);
                 }}
               />
             )}

--- a/typescript/apps/fiddle-web-app/app/embed/page.tsx
+++ b/typescript/apps/fiddle-web-app/app/embed/page.tsx
@@ -1,67 +1,30 @@
 import dynamic from 'next/dynamic'
-import fs from 'fs/promises'
-import path from 'path'
+import { loadProject } from '../../lib/loadProject'
 
-const PromptPreview = dynamic(() => import('./clientwrapper'), {})
-
-// Function to load BAML file content from the file system
-async function loadBamlFile(exampleName: string): Promise<string> {
-  try {
-    // Sanitize the example name to prevent directory traversal attacks
-    const sanitizedExampleName = exampleName.replace(/[^a-zA-Z0-9-_]/g, '')
-    if (sanitizedExampleName !== exampleName) {
-      console.warn(`Example name was sanitized from ${exampleName} to ${sanitizedExampleName}`)
-    }
-
-    const filePath = path.join(process.cwd(), 'public', '_docs', sanitizedExampleName, 'baml_src', 'main.baml')
-
-    // Check if the file exists
-    try {
-      await fs.access(filePath)
-    } catch (error) {
-      console.warn(`BAML file not found for example ${sanitizedExampleName}, falling back to default example`)
-      return loadBamlFile('default-example')
-    }
-
-    return await fs.readFile(filePath, 'utf-8')
-  } catch (error) {
-    console.error(`Error loading BAML file for example ${exampleName}:`, error)
-    // Return default BAML content if all else fails
-    return `
-      function Hi() -> string {
-        client "openai/gpt-4o"
-        prompt #"
-          hi there
-        "#
-      }
-
-      test HiTest {
-        functions [Hi]
-        args {
-
-        }
-      }
-    `
-  }
-}
+const ClientWrapper = dynamic(() => import('./clientwrapper'), {})
 
 export default async function EmbedComponent({
   searchParams,
 }: {
-  searchParams: Promise<{ id: string }>
+  searchParams: Promise<{ id?: string }>
 }) {
   const params = await searchParams
-  // Get example name from URL parameters, default to 'default-example' if not provided
-  const exampleName = typeof params.id === 'string' ? params.id : 'default-example'
-  console.log('exampleName', exampleName)
+  const id = typeof params.id === 'string' ? params.id : undefined
 
-  // Load the BAML file content
-  const bamlContent = await loadBamlFile(exampleName)
+  if (!id) {
+    return <div className='flex items-center justify-center w-screen h-screen'>No project id provided</div>
+  }
+
+  const project = await loadProject(Promise.resolve({ project_id: id }))
+
+  if (!project) {
+    return <div className='flex items-center justify-center w-screen h-screen'>No project found</div>
+  }
 
   return (
     <div className='flex justify-center items-center h-screen rounded-lg border-2 border-purple-900/30 overflow-y-clip'>
       <div className='flex w-full h-full'>
-        <PromptPreview bamlContent={bamlContent} />
+        <ClientWrapper files={project.files} />
       </div>
     </div>
   )


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes URL generation and file handling in embed prompt by preferring existing IDs and updating file structure.
> 
>   - **Behavior**:
>     - `EmbedDialog.tsx`: Modifies URL generation to prefer existing ID from `pathname` over creating a new one.
>     - `page.tsx`: Loads project using `loadProject` and handles missing project ID or project gracefully.
>   - **File Handling**:
>     - `clientwrapper.tsx`: Changes `EmbedComponent` to accept `files` array and updates `EmbedComponentInner` to populate `filesAtom` with project files.
>     - Replaces `bamlContent` with `files` in `EmbedComponent` and `EmbedComponentInner`.
>   - **Misc**:
>     - Updates URL format in `EmbedDialog.tsx` to use `?id=` instead of path-based ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f0701fa9774461d6ca46f8ada6813d2a7b796877. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->