### PR TITLE
Allow openapi generator to remove unknown files from output dir

### DIFF
--- a/engine/generators/languages/openapi/src/lib.rs
+++ b/engine/generators/languages/openapi/src/lib.rs
@@ -1,6 +1,8 @@
 use std::hash::Hash;
 
-use dir_writer::{FileCollector, GeneratorArgs, IntermediateRepr, LanguageFeatures};
+use dir_writer::{
+    FileCollector, GeneratorArgs, IntermediateRepr, LanguageFeatures, RemoveDirBehavior,
+};
 use indexmap::IndexMap;
 use serde::Serialize;
 
@@ -18,6 +20,10 @@ impl LanguageFeatures for OpenApiLanguageFeatures {
     fn name() -> &'static str {
         "openapi"
     }
+
+    /// OpenAPI codegen creates a lot of files that BAML can't know about in
+    /// advance, so we allow removing them.
+    const REMOVE_DIR_BEHAVIOR: RemoveDirBehavior = RemoveDirBehavior::Unsafe;
 
     const CONTENT_PREFIX: &'static str = r#"
 ###############################################################################

--- a/engine/language_client_codegen/src/lib.rs
+++ b/engine/language_client_codegen/src/lib.rs
@@ -14,7 +14,7 @@ use regex::Regex;
 use sugar_path::SugarPath;
 use version_check::{check_version, GeneratorType, VersionCheckMode};
 
-mod dir_writer;
+// mod dir_writer;
 // mod go;
 // pub mod openapi;
 // mod python;


### PR DESCRIPTION
Fix #2273 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `REMOVE_DIR_BEHAVIOR` to `OpenApiLanguageFeatures` to allow removal of unknown files from output directory.
> 
>   - **Behavior**:
>     - Add `REMOVE_DIR_BEHAVIOR` constant to `OpenApiLanguageFeatures` in `openapi/src/lib.rs`, allowing removal of unknown files from output directory.
>   - **Code Structure**:
>     - Comment out `dir_writer` module import in `language_client_codegen/src/lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 9fe929533215f6bf51baea8e49eaf472ab961456. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->