### PR TITLE
add version number on generations

### DIFF
--- a/engine/baml-runtime/src/cli/generate.rs
+++ b/engine/baml-runtime/src/cli/generate.rs
@@ -34,6 +34,11 @@ impl GenerateArgs {
         let mut env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
         env_vars.insert("BAML_GENERATE".to_string(), "1".to_string());
 
+        baml_log::info!(
+            "Generating clients with CLI version: {}",
+            env!("CARGO_PKG_VERSION")
+        );
+
         let runtime = BamlRuntime::from_directory(&self.from, env_vars)
             .context("Failed to build BAML runtime")?;
         let src_files = baml_src_files(&self.from)

--- a/engine/language_server/src/baml_project/mod.rs
+++ b/engine/language_server/src/baml_project/mod.rs
@@ -1231,10 +1231,12 @@ impl Project {
                     // (File system operations would be performed here.)
                 }
                 let elapsed = start.elapsed();
+                let version = env!("CARGO_PKG_VERSION");
                 if generated_file_count > 0 {
                     on_success(format!(
-                        "BAML client generated! (took {}ms)",
-                        elapsed.as_millis()
+                        "BAML client generated! (took {}ms). CLI version: {}",
+                        elapsed.as_millis(),
+                        version
                     ));
                 }
             }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add logging of CLI version during client generation in `generate.rs` and `mod.rs`.
> 
>   - **Logging**:
>     - Add logging of CLI version using `env!("CARGO_PKG_VERSION")` in `generate_clients()` in `generate.rs`.
>     - Add logging of CLI version in `run_generators_without_debounce()` in `mod.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 91da32a71ac679bcc8db1de77efeb34b28e1311c. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->