### PR TITLE
fix: issue for hard coding the embed id

### DIFF
--- a/typescript/apps/fiddle-web-app/app/embed/page.tsx
+++ b/typescript/apps/fiddle-web-app/app/embed/page.tsx
@@ -19,14 +19,7 @@ export default async function EmbedComponent({
 }) {
   const params = await searchParams
   const id = typeof params.id === 'string' ? params.id : undefined
-  const parseBool = (v?: string) =>
-    typeof v === 'string' ? /^(1|true|yes|on)$/i.test(v) : undefined
 
-  const showFileTree = parseBool(params.showFileTree) ?? parseBool(params.fileTree) ?? false
-  const showPlayground = parseBool(params.showPlayground ?? params.playground)
-  const showFile = parseBool(params.showFile)
-  const defaultFile =
-    typeof params.defaultFile === 'string' ? params.defaultFile : undefined
 
   if (!id) {
     return <div className='flex items-center justify-center w-screen h-screen'>No project id provided</div>

--- a/typescript/apps/fiddle-web-app/lib/loadProject.ts
+++ b/typescript/apps/fiddle-web-app/lib/loadProject.ts
@@ -16,7 +16,12 @@ export async function loadProject(
     if (exampleProject) {
       data = exampleProject;
     } else {
+      // Try to load a shared URL project first
       data = await loadUrl(id);
+      // If not found, try loading from docs-based examples (public/_docs/{id}/baml_src)
+      if (!data) {
+        data = await loadDocsProject(id);
+      }
     }
   } else {
     const exampleProject = projectGroups.allProjects[0];
@@ -117,6 +122,35 @@ const getProjectFiles = async (projectPath: string): Promise<EditorFile[]> => {
     error: f.error ?? null,
   }));
 };
+
+// Attempts to load a project from the docs examples at public/_docs/{projectId}/baml_src
+async function loadDocsProject(projectId: string): Promise<BAMLProject | undefined> {
+  const docsProjectRoot = path.join(process.cwd(), 'public', '_docs', projectId, 'baml_src');
+  try {
+    const stat = await fs.stat(docsProjectRoot);
+    if (!stat.isDirectory()) {
+      return undefined;
+    }
+  } catch {
+    // Not found
+    return undefined;
+  }
+
+  const files = await getAllFiles(docsProjectRoot);
+  if (files.length === 0) {
+    return undefined;
+  }
+  return {
+    id: projectId,
+    name: projectId,
+    description: '',
+    files: files.map((f) => ({
+      path: f.path.replace(docsProjectRoot, ''),
+      content: f.content ?? '',
+      error: f.error ?? null,
+    })),
+  };
+}
 
 export type BamlProjectsGroupings = {
   allProjects: BAMLProject[];


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes hardcoded embed ID issue by adding docs-based project loading in `loadProject.ts` and updating `EmbedComponent` in `page.tsx`.
> 
>   - **Behavior**:
>     - `loadProject` in `loadProject.ts` now attempts to load projects from `public/_docs/{id}/baml_src` if not found via URL.
>     - `EmbedComponent` in `page.tsx` no longer uses hardcoded embed IDs, relying on dynamic project loading.
>   - **Functions**:
>     - Adds `loadDocsProject` function in `loadProject.ts` to load projects from docs-based examples.
>   - **Misc**:
>     - Removes unused variables `showFileTree`, `showPlayground`, `showFile`, and `defaultFile` from `page.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for a4df313487ff604b82acc6e359730009a361decd. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->