### PR TITLE
Mutable variables: BC snapshot + validate type on assign

### DIFF
--- a/engine/baml-compiler/src/codegen.rs
+++ b/engine/baml-compiler/src/codegen.rs
@@ -1317,4 +1317,46 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn mutable_variables() -> anyhow::Result<()> {
+        assert_compiles(Program {
+            source: r#"
+                fn DeclareMutableInFunction(x: int) -> int {
+                
+                    let mut y = 3;
+                
+                    y = 5;
+                
+                    y
+                }
+                
+                fn MutableInArg(mut x: int) -> int {
+                    x = 3;
+                    x
+                }
+            "#,
+            expected: vec![
+                (
+                    "DeclareMutableInFunction",
+                    vec![
+                        Instruction::LoadConst(0),
+                        Instruction::LoadConst(1),
+                        Instruction::StoreVar(2),
+                        Instruction::LoadVar(2),
+                        Instruction::Return,
+                    ],
+                ),
+                (
+                    "MutableInArg",
+                    vec![
+                        Instruction::LoadConst(0),
+                        Instruction::StoreVar(1),
+                        Instruction::LoadVar(1),
+                        Instruction::Return,
+                    ],
+                ),
+            ],
+        })
+    }
 }

--- a/engine/baml-compiler/src/hir/mod.rs
+++ b/engine/baml-compiler/src/hir/mod.rs
@@ -53,7 +53,111 @@ impl<T: Default> TypeM<T> {
     }
 }
 
+impl<T> TypeM<T> {
+    pub fn name_for_user(&self) -> &'static str {
+        match self {
+            TypeM::Int(_) => "int",
+            TypeM::String(_) => "string",
+            TypeM::Float(_) => "float",
+            TypeM::Bool(_) => "bool",
+            TypeM::Null(_) => "null type",
+            TypeM::Array(type_m, _) => "array",
+            TypeM::Map(type_m, type_m1, _) => "map",
+            TypeM::ClassName(_, _) => "class",
+            TypeM::EnumName(_, _) => "enum",
+            TypeM::Union(type_ms, _) => "union",
+            TypeM::Arrow(arrow, _) => "function",
+        }
+    }
+}
+
 impl Type {
+    /// Returns true if two types are exactly equal except for their spans.
+    pub fn eq_up_to_span(&self, other: &Type) -> bool {
+        match (self, other) {
+            (TypeM::Int(a), TypeM::Int(b)) => a.eq_up_to_span(b),
+            (TypeM::Float(a), TypeM::Float(b)) => a.eq_up_to_span(b),
+            (TypeM::String(a), TypeM::String(b)) => a.eq_up_to_span(b),
+            (TypeM::Bool(a), TypeM::Bool(b)) => a.eq_up_to_span(b),
+            (TypeM::Null(a), TypeM::Null(b)) => a.eq_up_to_span(b),
+
+            (TypeM::Array(a, a_meta), TypeM::Array(b, b_meta)) => {
+                a.eq_up_to_span(b) && a_meta.eq_up_to_span(b_meta)
+            }
+
+            (TypeM::Map(a_key, a_val, a_meta), TypeM::Map(b_key, b_val, b_meta)) => {
+                a_key.eq_up_to_span(b_key)
+                    && a_val.eq_up_to_span(b_val)
+                    && a_meta.eq_up_to_span(b_meta)
+            }
+
+            (TypeM::ClassName(a, a_meta), TypeM::ClassName(b, b_meta)) => {
+                a == b && a_meta.eq_up_to_span(b_meta)
+            }
+
+            (TypeM::EnumName(a, a_meta), TypeM::EnumName(b, b_meta)) => {
+                a == b && a_meta.eq_up_to_span(b_meta)
+            }
+
+            (TypeM::Union(a_members, a_meta), TypeM::Union(b_members, b_meta)) => {
+                a_members.len() == b_members.len()
+                    && a_members
+                        .iter()
+                        .zip(b_members.iter())
+                        .all(|(a, b)| a.eq_up_to_span(b))
+                    && a_meta.eq_up_to_span(b_meta)
+            }
+
+            (TypeM::Arrow(a_fn, a_meta), TypeM::Arrow(b_fn, b_meta)) => {
+                a_fn.inputs.len() == b_fn.inputs.len()
+                    && a_fn
+                        .inputs
+                        .iter()
+                        .zip(b_fn.inputs.iter())
+                        .all(|(a, b)| a.eq_up_to_span(b))
+                    && a_fn.output.eq_up_to_span(&b_fn.output)
+                    && a_meta.eq_up_to_span(b_meta)
+            }
+
+            _ => false,
+        }
+    }
+
+    #[track_caller]
+    pub fn can_be_assigned(&self, other: &Type) -> bool {
+        // TODO: add diagnostics
+        match (self, other) {
+            (TypeM::Null(_), TypeM::Null(_))
+            | (TypeM::Bool(_), TypeM::Bool(_))
+            | (TypeM::Float(_), TypeM::Float(_))
+            | (TypeM::String(_), TypeM::String(_))
+            | (TypeM::Int(_), TypeM::Int(_)) => true,
+
+            (TypeM::Array(a, _), TypeM::Array(b, _)) => a.can_be_assigned(b),
+
+            (TypeM::Map(key_a, val_a, _), TypeM::Map(key_b, val_b, _)) => {
+                key_a.can_be_assigned(key_b) && val_a.can_be_assigned(val_b)
+            }
+
+            (TypeM::EnumName(a, _), TypeM::EnumName(b, _))
+            | (TypeM::ClassName(a, _), TypeM::ClassName(b, _)) => a == b,
+
+            (TypeM::Union(a, _), TypeM::Union(b, _)) => {
+                // there can't be any type in b that is not assignable to a.
+                b.iter()
+                    .all(|b_ty| a.iter().any(|a_ty| a_ty.can_be_assigned(b_ty)))
+            }
+            (TypeM::Union(inner, _), non_union) => {
+                inner.iter().any(|i| i.can_be_assigned(non_union))
+            }
+
+            // for functions we only want the same inputs & same outputs, otherwise an
+            // auto-cast mechanism would need to be in place.
+            (a @ TypeM::Arrow(_, _), b @ TypeM::Arrow(_, _)) => a.eq_up_to_span(b),
+
+            (_, _) => false,
+        }
+    }
     #[track_caller]
     pub fn assert_eq_up_to_span(&self, other: &Type) {
         match (self, other) {
@@ -127,6 +231,17 @@ impl TypeMeta {
     #[track_caller]
     pub fn eq_up_to_span(&self, other: &TypeMeta) -> bool {
         self.constraints == other.constraints && self.streaming_behavior == other.streaming_behavior
+    }
+
+    #[track_caller]
+    pub fn diagnose_eq_up_to_span(&self, other: &TypeMeta) -> anyhow::Result<()> {
+        if self.constraints != other.constraints {
+            return Err(anyhow::anyhow!("constraints do not match"));
+        }
+        if self.streaming_behavior != other.streaming_behavior {
+            return Err(anyhow::anyhow!("streaming behaviors do not match"));
+        }
+        Ok(())
     }
 }
 

--- a/engine/baml-compiler/src/thir.rs
+++ b/engine/baml-compiler/src/thir.rs
@@ -595,6 +595,10 @@ impl Expr<ExprMetadata> {
         }
     }
 
+    pub fn span(&self) -> &Span {
+        &self.meta().0
+    }
+
     pub fn fresh_names(&self, arity: usize) -> Vec<Name> {
         let free_vars = self.free_vars();
         let mut i = 0;

--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use baml_types::{BamlMap, BamlValueWithMeta};
-use internal_baml_diagnostics::{DatamodelError, Diagnostics};
+use internal_baml_diagnostics::{DatamodelError, DatamodelWarning, Diagnostics, Span};
 
 use crate::{
     hir::{self, Hir, Type},
@@ -74,7 +74,7 @@ pub fn typecheck(hir: &Hir, diagnostics: &mut Diagnostics) -> THir<ExprMetadata>
                 name.clone(),
                 VarInfo {
                     ty: inferred_type,
-                    is_mutable: false,
+                    if_mutable: None,
                 },
             );
         }
@@ -91,7 +91,9 @@ pub fn typecheck(hir: &Hir, diagnostics: &mut Diagnostics) -> THir<ExprMetadata>
                 param.name.clone(),
                 VarInfo {
                     ty: param.r#type.clone(),
-                    is_mutable: param.is_mutable,
+                    if_mutable: param.is_mutable.then(|| MutableVarInfo {
+                        ty_infer_span: Some(param.span.clone()),
+                    }),
                 },
             );
         }
@@ -126,9 +128,15 @@ pub fn typecheck(hir: &Hir, diagnostics: &mut Diagnostics) -> THir<ExprMetadata>
 }
 
 #[derive(Clone, Debug)]
+pub struct MutableVarInfo {
+    /// If `ty` is not a placeholder, the span of the statement that made the inference.
+    pub ty_infer_span: Option<Span>,
+}
+
+#[derive(Clone, Debug)]
 pub struct VarInfo {
     pub ty: Type,
-    pub is_mutable: bool,
+    pub if_mutable: Option<MutableVarInfo>,
 }
 
 #[derive(Clone, Debug)]
@@ -143,18 +151,21 @@ pub struct TypeContext {
 impl TypeContext {
     pub fn new() -> Self {
         let mut vars = BamlMap::new();
+
+        // TODO: convert true/false into symbols (no infer span), ensure that they are reachable
+
         vars.insert(
             "true".to_string(),
             VarInfo {
                 ty: Type::Bool(hir::TypeMeta::default()),
-                is_mutable: false,
+                if_mutable: None,
             },
         );
         vars.insert(
             "false".to_string(),
             VarInfo {
                 ty: Type::Bool(hir::TypeMeta::default()),
-                is_mutable: false,
+                if_mutable: None,
             },
         );
         Self {
@@ -168,10 +179,6 @@ impl TypeContext {
             .get(name)
             .map(|v| &v.ty)
             .or_else(|| self.symbols.get(name))
-    }
-
-    pub fn is_mutable(&self, name: &str) -> Option<bool> {
-        self.vars.get(name).map(|v| v.is_mutable)
     }
 
     pub fn infer_type(&mut self, expr: &hir::Expression) -> Option<Type> {
@@ -282,7 +289,7 @@ fn typecheck_statement(
                     name.clone(),
                     VarInfo {
                         ty: inferred_type,
-                        is_mutable: false,
+                        if_mutable: None,
                     },
                 );
             } else {
@@ -292,7 +299,7 @@ fn typecheck_statement(
                     name.clone(),
                     VarInfo {
                         ty: hir::TypeM::Int(hir::TypeMeta::default()),
-                        is_mutable: false,
+                        if_mutable: None,
                     },
                 );
             }
@@ -324,7 +331,9 @@ fn typecheck_statement(
                 name.clone(),
                 VarInfo {
                     ty: hir::TypeM::Int(hir::TypeMeta::default()),
-                    is_mutable: true,
+                    if_mutable: Some(MutableVarInfo {
+                        ty_infer_span: None,
+                    }),
                 },
             );
             Some(thir::Statement::Declare {
@@ -333,25 +342,51 @@ fn typecheck_statement(
             })
         }
         hir::Statement::Assign { name, value } => {
-            // Mutability check: only mutable variables can be assigned
-            match context.is_mutable(name) {
-                Some(true) => {}
-                Some(false) => diagnostics.push_error(DatamodelError::new_validation_error(
-                    &format!("Cannot assign to immutable variable {}", name),
-                    value.span(),
-                )),
-                None => diagnostics.push_error(DatamodelError::new_validation_error(
-                    &format!("Unknown variable {}", name),
-                    value.span(),
-                )),
-            }
             let typed_value = typecheck_expression(value, context, diagnostics);
-            // Update the variable's type in the context if known
-            if let Some(var_info) = context.vars.get_mut(name) {
-                if let Some(inferred_type) = typed_value.meta().1.clone() {
-                    var_info.ty = inferred_type;
+
+            // validate/update type.
+            match context.vars.get_mut(name) {
+                Some(info) => match info.if_mutable.as_mut() {
+                    Some(mut_info) => {
+                        if let Some(inferred_type) = typed_value.meta().1.as_ref() {
+                            if let Some(infer_span) = mut_info.ty_infer_span.as_ref() {
+                                // known type - typecheck against it.
+                                if !info.ty.can_be_assigned(inferred_type) {
+                                    diagnostics.push_error(DatamodelError::new_validation_error(
+                                        &format!(
+                                            "Cannot assign {} to {}",
+                                            inferred_type.name_for_user(),
+                                            info.ty.name_for_user()
+                                        ),
+                                        value.span(),
+                                    ));
+
+                                    diagnostics.push_warning(DatamodelWarning::new(
+                                        format!("type for '{name}' was inferred here"),
+                                        infer_span.clone(),
+                                    ));
+                                }
+                            } else {
+                                // type is not known yet - use this assignment as the type.
+                                info.ty = inferred_type.clone();
+
+                                mut_info.ty_infer_span = Some(value.span())
+                            }
+                        }
+                    }
+                    None => diagnostics.push_error(DatamodelError::new_validation_error(
+                        &format!("Cannot assign to immutable variable {}", name),
+                        value.span(),
+                    )),
+                },
+                None => {
+                    diagnostics.push_error(DatamodelError::new_validation_error(
+                        &format!("Unknown variable {}", name),
+                        value.span(),
+                    ));
                 }
             }
+
             Some(thir::Statement::Assign {
                 name: name.clone(),
                 value: typed_value,
@@ -367,7 +402,9 @@ fn typecheck_statement(
                     name.clone(),
                     VarInfo {
                         ty: inferred_type,
-                        is_mutable: true,
+                        if_mutable: Some(MutableVarInfo {
+                            ty_infer_span: Some(typed_value.span().clone()),
+                        }),
                     },
                 );
             } else {
@@ -377,7 +414,9 @@ fn typecheck_statement(
                     name.clone(),
                     VarInfo {
                         ty: hir::TypeM::Int(hir::TypeMeta::default()),
-                        is_mutable: true,
+                        if_mutable: Some(MutableVarInfo {
+                            ty_infer_span: None,
+                        }),
                     },
                 );
             }
@@ -420,7 +459,7 @@ fn typecheck_statement(
                         identifier.clone(),
                         VarInfo {
                             ty: *inner_type.clone(),
-                            is_mutable: false,
+                            if_mutable: None,
                         },
                     );
                 }

--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -370,7 +370,7 @@ fn typecheck_statement(
                                 // type is not known yet - use this assignment as the type.
                                 info.ty = inferred_type.clone();
 
-                                mut_info.ty_infer_span = Some(value.span())
+                                mut_info.ty_infer_span = Some(value.span().clone())
                             }
                         }
                     }

--- a/engine/baml-lib/baml/tests/bytecode_files/mut_variables.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/mut_variables.baml
@@ -1,0 +1,31 @@
+fn DeclareMutableInFunction(x: int) -> int {
+
+	let mut y = 3;
+
+	y = 5;
+
+	y
+}
+
+fn MutableInArg(mut x: int) -> int {
+	x = 3;
+	x
+}
+
+// Function: DeclareMutableInFunction
+// 2   0   LOAD_CONST 0   (3)
+//
+// 4   1   LOAD_CONST 1   (5)
+//     2   STORE_VAR 2    (y)
+//
+// 6   3   LOAD_VAR 2     (y)
+//     4   RETURN         
+//
+// Function: MutableInArg
+// 10   0   LOAD_CONST 0   (3)
+//      1   STORE_VAR 1    (x)
+//
+// 11   2   LOAD_VAR 1     (x)
+//      3   RETURN         
+//
+// Class: std::Request with 3 fields

--- a/engine/baml-lib/baml/tests/validation_files/assign_wrong_type.baml
+++ b/engine/baml-lib/baml/tests/validation_files/assign_wrong_type.baml
@@ -1,0 +1,28 @@
+fn AssignWrongType(x: int) -> int {
+
+	let mut y = 3;
+
+	y = "hello";
+
+
+	42
+}
+
+// warning: Workflow functions are experimental, and will break in the future.
+//   -->  assign_wrong_type.baml:1
+//    | 
+//    | 
+//  1 | fn AssignWrongType(x: int) -> int {
+//    | 
+// warning: type for 'y' was inferred here
+//   -->  assign_wrong_type.baml:3
+//    | 
+//  2 | 
+//  3 | let mut y = 3;
+//    | 
+// error: Error validating: Cannot assign string to int
+//   -->  assign_wrong_type.baml:5
+//    | 
+//  4 | 
+//  5 | y = "hello";
+//    | 

--- a/engine/baml-vm/tests/vm.rs
+++ b/engine/baml-vm/tests/vm.rs
@@ -435,3 +435,37 @@ fn block_expr() -> anyhow::Result<()> {
         expected: VmExecState::Complete(Value::Int(1)),
     })
 }
+
+#[test]
+fn exec_declare_mutable_in_function() -> anyhow::Result<()> {
+    assert_vm_executes(Program {
+        source: r#"
+            fn main() -> int {
+                let mut y = 3;
+                y = 5;
+                y
+            }
+        "#,
+        function: "main",
+        expected: VmExecState::Complete(Value::Int(5)),
+    })
+}
+
+#[test]
+fn exec_mutable_in_arg() -> anyhow::Result<()> {
+    assert_vm_executes(Program {
+        source: r#"
+            fn MutableInArg(mut x: int) -> int {
+                x = 3;
+                x
+            }
+
+            fn main() -> int {
+                let r = MutableInArg(42);
+                r
+            }
+        "#,
+        function: "main",
+        expected: VmExecState::Complete(Value::Int(3)),
+    })
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds support for mutable variables in BAML with type validation on assignment, including tests and bytecode generation updates.
> 
>   - **Behavior**:
>     - Adds support for mutable variables in BAML, allowing reassignment within functions.
>     - Implements type validation on assignment to mutable variables, ensuring type consistency.
>     - Logs errors and warnings for type mismatches during assignment.
>   - **Code Changes**:
>     - Updates `typecheck.rs` to handle mutable variables and validate types on assignment.
>     - Modifies `codegen.rs` to generate bytecode for mutable variable operations.
>     - Adds `name_for_user()` and `can_be_assigned()` methods to `TypeM` in `mod.rs` for type handling.
>   - **Tests**:
>     - Adds tests in `vm.rs` for execution of functions with mutable variables.
>     - Adds `mut_variables.baml` for bytecode tests and `assign_wrong_type.baml` for validation tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for eafb51c4588678f28aeb64d17a7e89275875b4b3. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->