### PR TITLE
Make `baml-cli test` run expression functions

### DIFF
--- a/engine/baml-runtime/src/test_executor/mod.rs
+++ b/engine/baml-runtime/src/test_executor/mod.rs
@@ -140,19 +140,40 @@ fn file_reader_pinned(
 
 impl TestExecutor for BamlRuntime {
     fn cli_list_tests(&self, args: &TestFilter) -> Result<()> {
-        let func_test_pairs = self
-            .inner
-            .ir
-            .walk_tests()
-            .filter_map(|node_pair| {
+        let func_test_pairs = {
+            let ir = &self.inner.ir;
+            // Regular LLM function tests
+            let from_fn_tests = ir.walk_tests().filter_map(|node_pair| {
                 let (function_name, test_name) = node_pair.name();
                 if args.includes(function_name, test_name) {
-                    Some((function_name, test_name))
+                    Some((function_name.to_string(), test_name.to_string()))
                 } else {
                     None
                 }
-            })
-            .collect::<BTreeSet<_>>();
+            });
+
+            // Expr function tests (pretending as functions)
+            let expr_fns = internal_baml_core::ir::ExprFnAsFunctionWalker::new(ir);
+            let expr_fn_tests_owned: Vec<(String, String)> = expr_fns
+                .walk_functions()
+                .flat_map(|f| {
+                    f.walk_tests()
+                        .filter_map(|node_pair| {
+                            let (function_name, test_name) = node_pair.name();
+                            if args.includes(function_name, test_name) {
+                                Some((function_name.to_string(), test_name.to_string()))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+
+            from_fn_tests
+                .chain(expr_fn_tests_owned)
+                .collect::<BTreeSet<_>>()
+        };
 
         println!("Found {} tests", func_test_pairs.len());
 
@@ -182,11 +203,10 @@ impl TestExecutor for BamlRuntime {
         env_vars: &HashMap<String, String>,
     ) -> TestRunStatus {
         let renderer = AggregateRenderer::new(output_format, junit_path);
-        let selected_tests = self
-            .inner
-            .ir
-            .walk_tests()
-            .filter_map(|node_pair| {
+        let selected_tests = {
+            let ir = &self.inner.ir;
+            // Regular LLM function tests
+            let from_fn_tests = ir.walk_tests().filter_map(|node_pair| {
                 let (function_name, test_name) = node_pair.name();
                 if args.includes(function_name, test_name) {
                     node_pair.span().map(|s| {
@@ -198,8 +218,39 @@ impl TestExecutor for BamlRuntime {
                 } else {
                     None
                 }
-            })
-            .collect::<BTreeMap<_, _>>();
+            });
+
+            // Expr function tests (pretending as functions)
+            let expr_fns = internal_baml_core::ir::ExprFnAsFunctionWalker::new(ir);
+            let expr_fn_tests_owned: Vec<((String, String), String)> = expr_fns
+                .walk_functions()
+                .flat_map(|f| {
+                    f.walk_tests()
+                        .filter_map(|node_pair| {
+                            let (function_name, test_name) = node_pair.name();
+                            if args.includes(function_name, test_name) {
+                                node_pair.span().map(|s| {
+                                    (
+                                        (function_name.to_string(), test_name.to_string()),
+                                        format!(
+                                            "{}:{}",
+                                            s.file.path(),
+                                            s.line_and_column().0 .0 + 1
+                                        ),
+                                    )
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect();
+
+            from_fn_tests
+                .chain(expr_fn_tests_owned.into_iter())
+                .collect::<BTreeMap<_, _>>()
+        };
 
         if selected_tests.is_empty() {
             println!("No tests selected");

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
 
         toolchain = with fenix.packages.${system}; combine [
           complete.cargo
+          complete.clippy
           complete.rustc
           complete.rust-std
           complete.rustfmt


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance `baml-cli test` to include expression functions in test execution and add `clippy` to Rust toolchain.
> 
>   - **Behavior**:
>     - `cli_list_tests` and `cli_run_tests` in `mod.rs` now include expression functions in test execution.
>     - Expression functions are treated as regular functions for test listing and execution.
>   - **Toolchain**:
>     - Added `clippy` to Rust toolchain in `flake.nix`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 94f90c96df00f944d2a3bf1c62e6574d445d5e42. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->