### PR TITLE
fix: deadlock in language-server didOpen handling

### DIFF
--- a/engine/language_server/src/server/api/notifications/did_open.rs
+++ b/engine/language_server/src/server/api/notifications/did_open.rs
@@ -72,10 +72,7 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
                             "baml_src_generator_version".to_string(),
                             BamlSrcVersionPayload {
                                 version,
-                                root_path: project
-                                    .root_path()
-                                    .to_string_lossy()
-                                    .to_string(),
+                                root_path: project.root_path().to_string_lossy().to_string(),
                             },
                         ),
                     ))

--- a/engine/language_server/src/server/api/notifications/did_open.rs
+++ b/engine/language_server/src/server/api/notifications/did_open.rs
@@ -63,7 +63,8 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
             .internal_error_msg(&format!("Could not convert URL '{url}' to file path"))?;
 
         if let Some(project) = session.get_or_create_project(&file_path) {
-            if let Ok(version) = project.lock().unwrap().get_common_generator_version() {
+            let project = project.lock().unwrap();
+            if let Ok(version) = project.get_common_generator_version() {
                 notifier
                     .0
                     .send(lsp_server::Message::Notification(
@@ -72,8 +73,6 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
                             BamlSrcVersionPayload {
                                 version,
                                 root_path: project
-                                    .lock()
-                                    .unwrap()
                                     .root_path()
                                     .to_string_lossy()
                                     .to_string(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fix deadlock in `DidOpenTextDocumentHandler` by acquiring project lock once before method calls.
> 
>   - **Fix Deadlock**:
>     - In `DidOpenTextDocumentHandler`, acquire project lock once before calling `get_common_generator_version` and `root_path`.
>     - Prevents multiple lock acquisitions on the same project object, resolving deadlock.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for d3e729701d3575f67a4cbe283aa17ec827276055. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->