### PR TITLE
VM benches

### DIFF
--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1324,6 +1324,7 @@ dependencies = [
  "baml-compiler",
  "baml-types",
  "colored 2.2.0",
+ "criterion",
  "internal-baml-core",
  "internal-baml-diagnostics",
  "internal-baml-parser-database",

--- a/engine/baml-vm/Cargo.toml
+++ b/engine/baml-vm/Cargo.toml
@@ -20,3 +20,8 @@ baml-compiler = { path = "../baml-compiler" }
 internal-baml-core = { path = "../baml-lib/baml-core" }
 internal-baml-diagnostics = { path = "../baml-lib/diagnostics" }
 internal-baml-parser-database = { path = "../baml-lib/parser-database" }
+criterion = "0.5"
+
+[[bench]]
+name = "fib"
+harness = false

--- a/engine/baml-vm/benches/fib.rs
+++ b/engine/baml-vm/benches/fib.rs
@@ -34,7 +34,7 @@ fn bootstrap_vm(input: Program) -> Vm {
 }
 
 pub fn bench_recursive_fib(c: &mut Criterion) {
-    c.bench_function("recursive fib 30", |b| {
+    c.bench_function("recursive fib 25", |b| {
         b.iter_batched(
             || {
                 bootstrap_vm(Program {
@@ -48,7 +48,7 @@ pub fn bench_recursive_fib(c: &mut Criterion) {
                         }
                     "#,
                     function: "fib",
-                    args: vec![Value::Int(30)],
+                    args: vec![Value::Int(25)],
                 })
             },
             |mut vm| {
@@ -60,7 +60,7 @@ pub fn bench_recursive_fib(c: &mut Criterion) {
 }
 
 pub fn bench_iterative_fib(c: &mut Criterion) {
-    c.bench_function("iterative fib 30", |b| {
+    c.bench_function("iterative fib 3000", |b| {
         b.iter_batched(
             || {
                 bootstrap_vm(Program {
@@ -84,7 +84,7 @@ pub fn bench_iterative_fib(c: &mut Criterion) {
                         }
                     "#,
                     function: "fib",
-                    args: vec![Value::Int(30)],
+                    args: vec![Value::Int(3000)],
                 })
             },
             |mut vm| {

--- a/engine/baml-vm/benches/fib.rs
+++ b/engine/baml-vm/benches/fib.rs
@@ -1,0 +1,98 @@
+use baml_vm::{BamlVmProgram, Frame, Value, Vm};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+
+struct Program {
+    source: &'static str,
+    function: &'static str,
+    args: Vec<Value>,
+}
+
+fn bootstrap_vm(input: Program) -> Vm {
+    let ast = baml_compiler::test::ast(input.source).unwrap();
+    let BamlVmProgram {
+        objects,
+        globals,
+        resolved_function_names,
+    } = baml_compiler::compile(&ast).unwrap();
+
+    // Find the target function index by name
+    let (target_function_index, _) = resolved_function_names[input.function];
+
+    Vm {
+        frames: vec![Frame {
+            function: target_function_index,
+            instruction_ptr: 0,
+            locals_offset: 0,
+        }],
+        stack: std::iter::once(Value::Object(target_function_index))
+            .chain(input.args)
+            .collect(),
+        runtime_allocs_offset: objects.len(),
+        objects,
+        globals,
+    }
+}
+
+pub fn bench_recursive_fib(c: &mut Criterion) {
+    c.bench_function("recursive fib 30", |b| {
+        b.iter_batched(
+            || {
+                bootstrap_vm(Program {
+                    source: r#"
+                        function fib(n: int) -> int {
+                            if n <= 1 {
+                                n
+                            } else {
+                                fib(n - 1) + fib(n - 2)
+                            }
+                        }
+                    "#,
+                    function: "fib",
+                    args: vec![Value::Int(30)],
+                })
+            },
+            |mut vm| {
+                vm.exec().unwrap();
+            },
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+pub fn bench_iterative_fib(c: &mut Criterion) {
+    c.bench_function("iterative fib 30", |b| {
+        b.iter_batched(
+            || {
+                bootstrap_vm(Program {
+                    source: r#"
+                        function fib(n: int) -> int {
+                            let mut a = 0;
+                            let mut b = 1;
+
+                            if n == 0 {
+                                b
+                            } else {
+                                let mut i = 0;
+                                while i < n {
+                                    let c = a + b;
+                                    a = b;
+                                    b = c;
+                                }
+                                b
+                            }
+                        }
+                    "#,
+                    function: "fib",
+                    args: vec![Value::Int(30)],
+                })
+            },
+            |mut vm| {
+                vm.exec().unwrap();
+            },
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+criterion_group!(benches, bench_recursive_fib, bench_iterative_fib);
+criterion_main!(benches);

--- a/engine/baml-vm/benches/fib.rs
+++ b/engine/baml-vm/benches/fib.rs
@@ -77,6 +77,7 @@ pub fn bench_iterative_fib(c: &mut Criterion) {
                                     let c = a + b;
                                     a = b;
                                     b = c;
+                                    i += 1;
                                 }
                                 b
                             }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Criterion-based benchmarks for recursive and iterative Fibonacci functions in BAML VM.
> 
>   - **Benchmarking**:
>     - Adds `criterion` as a dependency in `Cargo.toml` for benchmarking.
>     - Introduces `fib.rs` in `benches` to benchmark recursive and iterative Fibonacci functions.
>     - Uses `criterion_group!` and `criterion_main!` to define and run benchmarks.
>   - **Functions**:
>     - `bootstrap_vm()` initializes a VM with a given program source and function.
>     - `bench_recursive_fib()` benchmarks a recursive Fibonacci function with input 25.
>     - `bench_iterative_fib()` benchmarks an iterative Fibonacci function with input 3000.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 20e138cbad090420c504e1f5f54f8b67ce2c1eb5. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->