### PR TITLE
Split VM / Async  Runtime integ tests and ignore LLM calls in CI

### DIFF
--- a/integ-tests/python/run_tests.sh
+++ b/integ-tests/python/run_tests.sh
@@ -9,4 +9,11 @@ uv run maturin develop --uv --manifest-path ../../engine/language_client_python/
 uv run baml-cli generate --from ../baml_src
 
 # These tests are excluded because they require credentials.
-uv run pytest "$@" --ignore=tests/test_functions.py --ignore=tests/test_collector.py --ignore=tests/test_with_options.py --ignore=tests/test_modular_api.py --ignore=tests/test_logger.py --ignore=tests/test_typebuilder.py
+uv run pytest "$@" \
+    --ignore=tests/test_functions.py \
+    --ignore=tests/test_collector.py \
+    --ignore=tests/test_with_options.py \
+    --ignore=tests/test_modular_api.py \
+    --ignore=tests/test_logger.py \
+    --ignore=tests/test_typebuilder.py \
+    --ignore=tests/test_vm_async_runtime.py

--- a/integ-tests/python/tests/test_vm.py
+++ b/integ-tests/python/tests/test_vm.py
@@ -1,71 +1,52 @@
 """
 Baml VM / compiler / expression functions tests.
+
+Important: No LLM calls here, this will run in CI.
 """
 
-# import pytest
-# 
-# from ..baml_client import b
-# from ..baml_client.sync_client import b as sync_b
-# from ..baml_client.runtime import disassemble
-# 
-# 
-# def test_return_one():
-#     assert sync_b.ReturnOne() == 1
-# 
-# 
-# def test_return_number():
-#     assert sync_b.ReturnNumber(42) == 42
-# 
-# 
-# def test_call_return_one():
-#     assert sync_b.CallReturnOne() == 1
-# 
-# 
-# def test_chained_calls():
-#     assert sync_b.ChainedCalls() == 1
-# 
-# 
-# def test_store_fn_call_in_local_var():
-#     assert sync_b.StoreFnCallInLocalVar(42) == 42
-# 
-# 
-# def test_bool_to_int_with_if_else():
-#     assert sync_b.BoolToIntWithIfElse(True) == 1
-#     assert sync_b.BoolToIntWithIfElse(False) == 0
-# 
-# 
-# def test_return_else_if_expr():
-#     disassemble(sync_b.ReturnElseIfExpr)
-#     assert sync_b.ReturnElseIfExpr(True, False) == 1
-#     assert sync_b.ReturnElseIfExpr(False, True) == 2
-#     assert sync_b.ReturnElseIfExpr(False, False) == 3
-# 
-# 
-# def test_assign_else_if_expr():
-#     disassemble(sync_b.AssignElseIfExpr)
-#     assert sync_b.AssignElseIfExpr(True, False) == 1
-#     assert sync_b.AssignElseIfExpr(False, True) == 2
-#     assert sync_b.AssignElseIfExpr(False, False) == 3
-# 
-# 
-# def test_normal_else_if_stmt():
-#     disassemble(sync_b.NormalElseIfStmt)
-#     assert sync_b.NormalElseIfStmt(True, False) == 0
-# 
-# 
-# @pytest.mark.asyncio
-# async def test_llm_call_in_expr_fn():
-#     assert await b.ReturnNumberCallingLlm(42) == 42
-# 
-# 
-# @pytest.mark.asyncio
-# async def test_store_llm_call_in_local_var():
-#     assert await b.StoreLlmCallInLocalVar(42) == 42
-# 
-# 
-# @pytest.mark.asyncio
-# async def test_bool_to_int_with_if_else_calling_llm():
-#     disassemble(b.BoolToIntWithIfElseCallingLlm)
-#     assert await b.BoolToIntWithIfElseCallingLlm(True) == 1
-#     assert await b.BoolToIntWithIfElseCallingLlm(False) == 0
-# 
+from ..baml_client.sync_client import b
+from ..baml_client.runtime import disassemble
+
+
+def test_return_one():
+    assert b.ReturnOne() == 1
+
+
+def test_return_number():
+    assert b.ReturnNumber(42) == 42
+
+
+def test_call_return_one():
+    assert b.CallReturnOne() == 1
+
+
+def test_chained_calls():
+    assert b.ChainedCalls() == 1
+
+
+def test_store_fn_call_in_local_var():
+    assert b.StoreFnCallInLocalVar(42) == 42
+
+
+def test_bool_to_int_with_if_else():
+    assert b.BoolToIntWithIfElse(True) == 1
+    assert b.BoolToIntWithIfElse(False) == 0
+
+
+def test_return_else_if_expr():
+    disassemble(b.ReturnElseIfExpr)
+    assert b.ReturnElseIfExpr(True, False) == 1
+    assert b.ReturnElseIfExpr(False, True) == 2
+    assert b.ReturnElseIfExpr(False, False) == 3
+
+
+def test_assign_else_if_expr():
+    disassemble(b.AssignElseIfExpr)
+    assert b.AssignElseIfExpr(True, False) == 1
+    assert b.AssignElseIfExpr(False, True) == 2
+    assert b.AssignElseIfExpr(False, False) == 3
+
+
+def test_normal_else_if_stmt():
+    disassemble(b.NormalElseIfStmt)
+    assert b.NormalElseIfStmt(True, False) == 0

--- a/integ-tests/python/tests/test_vm_async_runtime.py
+++ b/integ-tests/python/tests/test_vm_async_runtime.py
@@ -1,0 +1,25 @@
+"""
+Baml VM / compiler / expression functions with LLM calls. Ignored in CI.
+"""
+
+import pytest
+
+from ..baml_client import b
+from ..baml_client.runtime import disassemble
+
+
+@pytest.mark.asyncio
+async def test_llm_call_in_expr_fn():
+    assert await b.ReturnNumberCallingLlm(42) == 42
+
+
+@pytest.mark.asyncio
+async def test_store_llm_call_in_local_var():
+    assert await b.StoreLlmCallInLocalVar(42) == 42
+
+
+@pytest.mark.asyncio
+async def test_bool_to_int_with_if_else_calling_llm():
+    disassemble(b.BoolToIntWithIfElseCallingLlm)
+    assert await b.BoolToIntWithIfElseCallingLlm(True) == 1
+    assert await b.BoolToIntWithIfElseCallingLlm(False) == 0


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Split VM and async runtime tests, ignoring LLM calls in CI for improved test reliability.
> 
>   - **Tests**:
>     - Split `test_vm.py` to separate LLM-related tests into `test_vm_async_runtime.py`.
>     - `test_vm.py` now only contains tests without LLM calls, suitable for CI.
>     - `test_vm_async_runtime.py` contains tests with LLM calls, ignored in CI.
>   - **CI Configuration**:
>     - Update `run_tests.sh` to ignore `test_vm_async_runtime.py` in CI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 3985f3f6b1adb45ac7610d955900b4355ac956ca. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->