### PR TITLE
Investigate method call blockers

### DIFF
--- a/engine/baml-compiler/src/codegen.rs
+++ b/engine/baml-compiler/src/codegen.rs
@@ -1930,7 +1930,8 @@ mod tests {
                     Instruction::AllocArray(3),
                     Instruction::LoadGlobal(2),
                     Instruction::LoadVar(1),
-                    Instruction::Call(0),
+                    // call with one argument (self)
+                    Instruction::Call(1),
                     Instruction::Return,
                 ],
             )],

--- a/engine/baml-lib/baml/tests/bytecode_files/array_access.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/array_access.baml
@@ -45,3 +45,4 @@ function ArrayAccessWithVariable(arr: float[], idx: int) -> float {
 //      4   RETURN               
 //
 // Class: std::Request with 3 fields
+// Function: len

--- a/engine/baml-lib/baml/tests/bytecode_files/function_calls.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/function_calls.baml
@@ -53,3 +53,4 @@ function Nested(x: int) -> int {
 //      10   RETURN          
 //
 // Class: std::Request with 3 fields
+// Function: len

--- a/engine/baml-lib/baml/tests/bytecode_files/literal_values.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/literal_values.baml
@@ -46,3 +46,4 @@ function ReturnArray() -> int[] {
 //      6   RETURN          
 //
 // Class: std::Request with 3 fields
+// Function: len

--- a/engine/baml-lib/baml/tests/bytecode_files/llm_functions.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/llm_functions.baml
@@ -36,3 +36,4 @@ function AnalyzeSentiment(text: string) -> Sentiment {
 // Function: AnalyzeSentiment
 //
 // Class: std::Request with 3 fields
+// Function: len

--- a/engine/baml-lib/baml/tests/bytecode_files/loops/break.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/loops/break.baml
@@ -90,3 +90,4 @@ fn Nested() -> int {
 //      22   RETURN              
 //
 // Class: std::Request with 3 fields
+// Function: len

--- a/engine/baml-lib/baml/tests/bytecode_files/loops/continue.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/loops/continue.baml
@@ -93,3 +93,4 @@ fn ContinueNested() -> int {
 //      18   RETURN              
 //
 // Class: std::Request with 3 fields
+// Function: len

--- a/engine/baml-lib/baml/tests/bytecode_files/loops/while_loops.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/loops/while_loops.baml
@@ -42,3 +42,4 @@ fn GCD(mut a: int, mut b: int) -> int {
 //      23   RETURN              
 //
 // Class: std::Request with 3 fields
+// Function: len

--- a/engine/baml-lib/baml/tests/bytecode_files/mut_variables.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/mut_variables.baml
@@ -29,3 +29,4 @@ fn MutableInArg(mut x: int) -> int {
 //      3   RETURN         
 //
 // Class: std::Request with 3 fields
+// Function: len

--- a/engine/baml-lib/baml/tests/bytecode_files/simple_function.baml
+++ b/engine/baml-lib/baml/tests/bytecode_files/simple_function.baml
@@ -8,3 +8,4 @@ function GetName(person: string) -> string {
 //     1   RETURN         
 //
 // Class: std::Request with 3 fields
+// Function: len

--- a/engine/baml-lib/baml/tests/hir_files/syntax_errors.baml
+++ b/engine/baml-lib/baml/tests/hir_files/syntax_errors.baml
@@ -25,3 +25,4 @@ function Test() -> int {
 //    | 
 //  1 | function Test() -> int {
 //    | 
+//

--- a/engine/baml-vm/src/native.rs
+++ b/engine/baml-vm/src/native.rs
@@ -33,7 +33,8 @@ impl Vm {
 pub type NativeFunction = fn(&mut Vm, &[Value]) -> Result<Value, VmError>;
 
 pub fn functions() -> HashMap<String, (NativeFunction, usize)> {
-    let fns: [(&str, (NativeFunction, usize)); _] = [("len", (Vm::len, 1))];
+    let native_fn: NativeFunction = Vm::len;
+    let fns = [("len", (native_fn, 1))];
 
     HashMap::from_iter(fns.into_iter().map(|(name, func)| (name.to_string(), func)))
 }

--- a/engine/baml-vm/src/native.rs
+++ b/engine/baml-vm/src/native.rs
@@ -12,10 +12,17 @@ use crate::{
 impl Vm {
     /// Array length.
     pub fn len(&mut self, args: &[Value]) -> Result<Value, VmError> {
+        if args.len() != 1 {
+            return Err(VmError::new(InternalError::InvalidArgumentCount {
+                expected: 1,
+                got: args.len(),
+            }));
+        }
+
         let Value::Object(array) = args[0] else {
             return Err(VmError::from(InternalError::TypeError {
                 expected: Type::Object,
-                got: Type::Object,
+                got: Type::of(&args[0]),
             }));
         };
 

--- a/engine/baml-vm/src/vm.rs
+++ b/engine/baml-vm/src/vm.rs
@@ -1143,7 +1143,7 @@ impl Vm {
                             self.stack.drain(locals_offset..);
                             self.stack.push(result);
 
-                            // Some Rust bullshit because we're passing VM as
+                            // Rust borrow check workaround because we're passing VM as
                             // mut and technically the frame pointer could be
                             // invalidated. Frame is Copy so we can maintain a
                             // local owned copy to avoid this but then we'd need

--- a/engine/baml-vm/tests/vm.rs
+++ b/engine/baml-vm/tests/vm.rs
@@ -266,11 +266,13 @@ fn array_constructor() -> anyhow::Result<()> {
                 }
             ",
             function: "main",
-            expected: VmExecState::Complete(Value::Object(2)),
+            expected: VmExecState::Complete(Value::Object(3)),
         },
         |vm| {
-            let Object::Array(array) = &vm.objects[2] else {
-                panic!("expected Array, got {:?}", vm.objects[2]);
+            dbg!(&vm.objects);
+
+            let Object::Array(array) = &vm.objects[3] else {
+                panic!("expected Array, got {:?}", vm.objects[3]);
             };
 
             assert_eq!(array, &[Value::Int(1), Value::Int(2), Value::Int(3)]);
@@ -297,11 +299,11 @@ fn class_constructor() -> anyhow::Result<()> {
                 }
             ",
             function: "main",
-            expected: VmExecState::Complete(Value::Object(3)),
+            expected: VmExecState::Complete(Value::Object(4)),
         },
         |vm| {
-            let Object::Instance(instance) = &vm.objects[3] else {
-                panic!("expected Instance, got {:?}", vm.objects[3]);
+            let Object::Instance(instance) = &vm.objects[4] else {
+                panic!("expected Instance, got {:?}", vm.objects[4]);
             };
 
             assert_eq!(instance.fields, &[Value::Int(1), Value::Int(2)]);
@@ -333,11 +335,11 @@ fn class_constructor_with_spread_operator() -> anyhow::Result<()> {
                 }
             ",
             function: "main",
-            expected: VmExecState::Complete(Value::Object(4)),
+            expected: VmExecState::Complete(Value::Object(5)),
         },
         |vm| {
-            let Object::Instance(instance) = &vm.objects[4] else {
-                panic!("expected Instance, got {:?}", vm.objects[4]);
+            let Object::Instance(instance) = &vm.objects[5] else {
+                panic!("expected Instance, got {:?}", vm.objects[5]);
             };
 
             assert_eq!(


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix method call argument count and add validation for `len` function in Baml VM.
> 
>   - **Behavior**:
>     - Fixes method call argument count in `codegen.rs` by changing `Instruction::Call(0)` to `Instruction::Call(1)` to include `self`.
>     - Adds argument count validation in `len()` in `native.rs` to ensure exactly one argument is passed.
>   - **Tests**:
>     - Updates expected object indices in `vm.rs` tests to reflect changes in object allocation.
>     - Adds `Function: len` comment in multiple `.baml` test files to document the presence of the `len` function.
>   - **Misc**:
>     - Minor comment clarification in `vm.rs` regarding Rust borrow check workaround.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 2dd327dffe699eb7784d971788ccca47b3a741d6. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->