### PR TITLE
chore(vscode): clean up run_test internals

### DIFF
--- a/typescript/apps/vscode-ext/src/extension.ts
+++ b/typescript/apps/vscode-ext/src/extension.ts
@@ -203,12 +203,9 @@ export function activate(context: vscode.ExtensionContext) {
       requestDiagnostics()
 
       openPlaygroundConfig.lastOpenedFunction = args?.functionName ?? 'default'
-      WebviewPanelHost.currentPanel?.postMessage('select_function', {
-        root_path: 'default',
-        function_name: args?.functionName ?? 'default',
-      })
 
       WebviewPanelHost.currentPanel?.postMessage('run_test', {
+        function_name: args?.functionName ?? 'default',
         test_name: args?.testCaseName ?? 'default',
       })
 

--- a/typescript/packages/playground-common/src/baml_wasm_web/EventListener.tsx
+++ b/typescript/packages/playground-common/src/baml_wasm_web/EventListener.tsx
@@ -246,7 +246,10 @@ export const EventListener: React.FC = () => {
           }
         | {
             command: 'run_test';
-            content: { test_name: string };
+            content: {
+              function_name: string;
+              test_name: string;
+            };
           }
       >,
     ) => {
@@ -304,14 +307,11 @@ export const EventListener: React.FC = () => {
           break;
 
         case 'run_test':
-          if (selectedFunc) {
-            setSelectedTestcase(content.test_name);
-            runBamlTests([
-              { functionName: selectedFunc, testName: content.test_name },
-            ]);
-          } else {
-            console.error('No function selected');
-          }
+          setSelectedFunction(content.function_name);
+          setSelectedTestcase(content.test_name);
+          runBamlTests([
+            { functionName: content.function_name, testName: content.test_name },
+          ]);
           // run([content.test_name])
           // setShowTests(true)
           // setClientGraph(false)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Improves 'run test' functionality by ensuring correct function name is used in `run_test` messages in `extension.ts` and `EventListener.tsx`.
> 
>   - **Behavior**:
>     - In `extension.ts`, removed `select_function` message and added `function_name` to `run_test` message.
>     - In `EventListener.tsx`, updated `run_test` command to set `function_name` and `test_name` before running tests.
>   - **Misc**:
>     - Removed redundant `select_function` message handling in `extension.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 816b1361303af260ed355d9926d8b1c206071ef9. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->