### PR TITLE
Emit `POP_REPLACE` instruction only when last statement produces a value

### DIFF
--- a/engine/baml-compiler/src/codegen.rs
+++ b/engine/baml-compiler/src/codegen.rs
@@ -348,10 +348,10 @@ impl<'g> HirCompiler<'g> {
             self.compile_statement(statement);
         }
 
-        let scope_has_ending_expr = matches!(
-            block.statements.last(),
-            Some(hir::Statement::Expression { .. })
-        );
+        let scope_has_ending_expr = block.statements.last().is_some_and(|stmt| match stmt {
+            hir::Statement::Expression { expr, .. } => expr.produces_final_value(),
+            _ => false,
+        });
 
         self.exit_scope(scope_has_ending_expr);
     }
@@ -1103,6 +1103,77 @@ impl<'g> HirCompiler<'g> {
             .expect("should have been pushed before when grabbing old_status");
 
         (loop_info, result)
+    }
+}
+
+impl hir::Expression {
+    /// Returns true if the block ends with an expression that has a final value.
+    ///
+    /// For example, it would return true for this block:
+    ///
+    /// ```ignore
+    /// let a = {
+    ///     let b = 1;
+    ///     if b == 1 {
+    ///         1
+    ///     } else {
+    ///         2
+    ///     }
+    /// };
+    /// ```
+    ///
+    /// But false for this one:
+    ///
+    /// ```ignore
+    /// let mut a = 0;
+    /// if a == 0 {
+    ///     a = 1;
+    /// } else {
+    ///     a = 2;
+    /// }
+    /// ```
+    ///
+    /// TODO: This seems completely unecessary, the typechecker will already
+    /// check at some point that return values match the expected type. After
+    /// that we should alreay have enough information to decide whether a block
+    /// returns or not.
+    fn produces_final_value(&self) -> bool {
+        match self {
+            // First call will happen on a block. Recurse on the final expression.
+            hir::Expression::ExpressionBlock(block, _) => match block.statements.last() {
+                Some(hir::Statement::Expression { expr, .. }) => expr.produces_final_value(),
+
+                // Does not produce a value.
+                _ => false,
+            },
+
+            // If statements as last expression need to check if they return
+            // any value. We won't recurse into the else branch because both
+            // need to match, if one of them returns a value the other one must
+            // return the same type. This is typechecker bug if it's wrong, so
+            // I won't bother here.
+            hir::Expression::If { if_branch, .. } => if_branch.produces_final_value(),
+
+            // This is an expression that produces a value, so true. We're
+            // forcing non-exhaustive match here because other types of
+            // expressions that we add in the future might need to be considered.
+            hir::Expression::Array(_, _)
+            | hir::Expression::Map(_, _)
+            | hir::Expression::JinjaExpressionValue(_, _)
+            | hir::Expression::ArrayAccess { .. }
+            | hir::Expression::FieldAccess { .. }
+            | hir::Expression::MethodCall { .. }
+            | hir::Expression::BoolValue(_, _)
+            | hir::Expression::NumericValue(_, _)
+            | hir::Expression::Identifier(_, _)
+            | hir::Expression::StringValue(_, _)
+            | hir::Expression::RawStringValue(_, _)
+            | hir::Expression::Call { .. }
+            | hir::Expression::ClassConstructor(_, _)
+            | hir::Expression::BinaryOperation { .. }
+            | hir::Expression::UnaryOperation { .. }
+            | hir::Expression::Paren(_, _) => true,
+        }
     }
 }
 
@@ -1939,6 +2010,107 @@ mod tests {
                     Instruction::Jump(-20),
                     Instruction::Jump(2),
                     // exit loop: pop condition and return a
+                    Instruction::Pop(1),
+                    Instruction::LoadVar(1),
+                    Instruction::Return,
+                ],
+            )],
+        })
+    }
+
+    // This tests that we don't emit POP_REPLACE for if expressions when they
+    // do not return values.
+    #[test]
+    fn nested_block_expr_with_ending_normal_if() -> anyhow::Result<()> {
+        assert_compiles(Program {
+            source: "
+                fn main() -> int {
+                    let mut a = 1;
+
+                    {
+                        let b = 2;
+                        let c = 3;
+                        a = b + c;
+
+                        if a == 5 {
+                            a = 10;
+                        }
+                    }
+
+                    a
+                }
+            ",
+            expected: vec![(
+                "main",
+                vec![
+                    Instruction::LoadConst(0),
+                    Instruction::LoadConst(1),
+                    Instruction::LoadConst(2),
+                    Instruction::LoadVar(2),
+                    Instruction::LoadVar(3),
+                    Instruction::BinOp(BinOp::Add),
+                    Instruction::StoreVar(1),
+                    Instruction::LoadVar(1),
+                    Instruction::LoadConst(3),
+                    Instruction::CmpOp(CmpOp::Eq),
+                    Instruction::JumpIfFalse(5),
+                    Instruction::Pop(1),
+                    Instruction::LoadConst(4),
+                    Instruction::StoreVar(1),
+                    Instruction::Jump(2),
+                    Instruction::Pop(1),
+                    Instruction::Pop(2),
+                    Instruction::LoadVar(1),
+                    Instruction::Return,
+                ],
+            )],
+        })
+    }
+
+    // This tests that we don't emit POP_REPLACE for if expressions when they
+    // do not return values.
+    #[test]
+    fn while_loop_with_ending_if() -> anyhow::Result<()> {
+        assert_compiles(Program {
+            source: "
+                fn main() -> int {
+                    let mut a = 1;
+
+                    while a < 5 {
+                        a += 1;
+
+                        if a == 2 {
+                            break;
+                        }
+                    }
+
+                    a
+                }
+            ",
+            expected: vec![(
+                "main",
+                vec![
+                    Instruction::LoadConst(0),
+                    Instruction::LoadVar(1),
+                    Instruction::LoadConst(1),
+                    Instruction::CmpOp(CmpOp::Lt),
+                    Instruction::JumpIfFalse(17),
+                    Instruction::Pop(1),
+                    Instruction::LoadVar(1),
+                    Instruction::LoadConst(2),
+                    Instruction::BinOp(BinOp::Add),
+                    Instruction::StoreVar(1),
+                    Instruction::LoadVar(1),
+                    Instruction::LoadConst(3),
+                    Instruction::CmpOp(CmpOp::Eq),
+                    Instruction::JumpIfFalse(4),
+                    Instruction::Pop(1),
+                    Instruction::Jump(4),
+                    Instruction::Jump(2),
+                    Instruction::Pop(1),
+                    Instruction::Jump(-17),
+                    Instruction::Pop(1),
+                    Instruction::Jump(2),
                     Instruction::Pop(1),
                     Instruction::LoadVar(1),
                     Instruction::Return,

--- a/engine/baml-compiler/src/hir/lowering.rs
+++ b/engine/baml-compiler/src/hir/lowering.rs
@@ -415,17 +415,17 @@ impl Block {
         }
 
         if let Some(block_final_expr) = block.expr.as_ref() {
-            let lifted_expr = Expression::from_ast(block_final_expr);
+            let final_expr = Expression::from_ast(block_final_expr);
 
             // Then add the final statement
             statements.push(if is_function_body {
                 Statement::Return {
-                    expr: lifted_expr,
+                    expr: final_expr,
                     span: block_final_expr.span().clone(),
                 }
             } else {
                 Statement::Expression {
-                    expr: lifted_expr,
+                    expr: final_expr,
                     span: block_final_expr.span().clone(),
                 }
             });

--- a/engine/baml-lib/ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/ast/src/parser/datamodel.pest
@@ -326,7 +326,7 @@ expr_block = { BLOCK_OPEN ~ NEWLINE? ~ (stmt | comment_block | empty_lines)* ~ e
 // With operator overloading (implicit function call) + side effects.
 //
 // Just allow any expr and fix the parser.
-stmt = { (((let_expr | assign_op_stmt | assign_stmt | fn_app | generic_fn_app | BREAK_KEYWORD | CONTINUE_KEYWORD) ~ SEMICOLON) | for_loop | if_expression | while_loop) ~ trailing_comment? ~ NEWLINE? }
+stmt = { (((let_expr | assign_op_stmt | assign_stmt | fn_app | generic_fn_app | BREAK_KEYWORD | CONTINUE_KEYWORD) ~ SEMICOLON) | for_loop | if_expression | while_loop | expr_block) ~ trailing_comment? ~ NEWLINE? }
 
 // Let-binding statement.
 let_expr = { "let" ~ MUT_KEYWORD? ~ identifier ~ "=" ~ expression }

--- a/engine/baml-lib/ast/src/parser/parse_expr.rs
+++ b/engine/baml-lib/ast/src/parser/parse_expr.rs
@@ -249,6 +249,8 @@ pub fn parse_statement(token: Pair<'_>, diagnostics: &mut Diagnostics) -> Option
         Rule::if_expression => parse_if_expression(stmt_token, diagnostics).map(Stmt::Expression),
         Rule::fn_app => parse_fn_app(stmt_token, diagnostics).map(Stmt::Expression),
         Rule::generic_fn_app => parse_generic_fn_app(stmt_token, diagnostics).map(Stmt::Expression),
+        Rule::expr_block => parse_expr_block(stmt_token, diagnostics)
+            .map(|expr_block| Stmt::Expression(Expression::ExprBlock(expr_block, span.clone()))),
         _ => {
             diagnostics.push_error(DatamodelError::new_static(
                 "Expected statement",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `HirCompiler` now emits `POP_REPLACE` only when the last statement produces a value, with new tests and parser updates to support this behavior.
> 
>   - **Behavior**:
>     - `HirCompiler` in `codegen.rs` now emits `POP_REPLACE` only if the last statement produces a value.
>     - Adds `produces_final_value()` to `hir::Expression` to determine if an expression produces a final value.
>   - **Tests**:
>     - Adds tests `nested_block_expr_with_ending_normal_if` and `while_loop_with_ending_if` in `codegen.rs` to verify correct `POP_REPLACE` emission.
>   - **Parser**:
>     - Updates `stmt` rule in `datamodel.pest` to include `expr_block`.
>     - Modifies `parse_statement()` in `parse_expr.rs` to handle `expr_block` as a statement.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for a3ab98aa581e94fd04a79f463a9287c435ad4caf. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->