### PR TITLE
fix: package the baml-py license correctly

### DIFF
--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -36,19 +36,23 @@ jobs:
             #   # Workaround ring 0.17 build issue
             #   # see https://github.com/briansmith/ring/issues/1728
             #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
+            run_license_test: false
 
           - target: x86_64-unknown-linux-musl
             runs_on: ubuntu-latest
             # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
             manylinux: musllinux_1_1
+            run_license_test: false
 
           - target: aarch64-unknown-linux-musl
             runs_on: ubuntu-latest
             # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
             manylinux: musllinux_1_1
+            run_license_test: false
 
           - target: x86_64-apple-darwin
             runs_on: macos-latest
+            run_license_test: false
 
           - target: aarch64-apple-darwin
             runs_on: macos-latest
@@ -64,6 +68,23 @@ jobs:
     runs-on: ${{ matrix._.runs_on }}
     # See also https://github.com/mcrumiller/polars/.github/workflows/release-python.yml#L282
     steps:
+      - name: Test LICENSE packaging
+        if: matrix._.run_license_test != false
+        run: |
+          set -euo pipefail
+
+          mkdir -p ../python-license-test
+          cd ../python-license-test
+          uv init --bare --python 3.10
+          uv add pip-licenses-cli
+          pwd
+          ls ../baml/engine/language_client_python/dist/
+          uv pip install $(ls ../baml/engine/language_client_python/dist/*.whl)
+          uv run pip-licenses | tee license-audit.log
+
+          # Due to `set -e`, this will fail if no matches are found
+          grep 'baml.*Apache-2.0' license-audit.log
+
       - name: Setup build environment (ARM64 Windows)
         if: matrix._.target == 'aarch64-pc-windows-msvc'
         shell:
@@ -149,22 +170,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-
-      - name: Test LICENSE packaging
-        run: |
-          set -euo pipefail
-
-          mkdir -p ../python-license-test
-          cd ../python-license-test
-          uv init --bare --python 3.10
-          uv add pip-licenses-cli
-          pwd
-          ls ../baml/engine/language_client_python/dist/
-          uv pip install $(ls ../baml/engine/language_client_python/dist/*.whl)
-          uv run pip-licenses | tee license-audit.log
-
-          # Due to `set -e`, this will fail if no matches are found
-          grep 'baml.*Apache-2.0' license-audit.log
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -36,23 +36,23 @@ jobs:
             #   # Workaround ring 0.17 build issue
             #   # see https://github.com/briansmith/ring/issues/1728
             #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
-            run_license_test: false
+            license_test: skip
 
           - target: x86_64-unknown-linux-musl
             runs_on: ubuntu-latest
             # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
             manylinux: musllinux_1_1
-            run_license_test: false
+            license_test: skip
 
           - target: aarch64-unknown-linux-musl
             runs_on: ubuntu-latest
             # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
             manylinux: musllinux_1_1
-            run_license_test: false
+            license_test: skip
 
           - target: x86_64-apple-darwin
             runs_on: macos-latest
-            run_license_test: false
+            license_test: skip
 
           - target: aarch64-apple-darwin
             runs_on: macos-latest
@@ -69,7 +69,7 @@ jobs:
     # See also https://github.com/mcrumiller/polars/.github/workflows/release-python.yml#L282
     steps:
       - name: Test LICENSE packaging
-        if: matrix._.run_license_test != false
+        if: matrix._.license_test != 'skip'
         run: |
           set -euo pipefail
 

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -131,7 +131,7 @@ jobs:
           # see https://github.com/PyO3/maturin/issues/2110
           XWIN_VERSION: "16"
         with:
-          maturin-version: "1.9.2"
+          maturin-version: "1.9.1"
           target: ${{ matrix._.target }}
           command: build
           # building in engine/ ensures that we pick up .cargo/config.toml

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -158,8 +158,9 @@ jobs:
           cd ../python-license-test
           uv init --bare --python 3.10
           uv add pip-licenses-cli
-          uv pip install ../engine/language_client_python/dist/*.whl
-          uv pip-licenses | tee license-audit.log
+          ls ../engine/language_client_python/dist/
+          uv pip install $(ls ../engine/language_client_python/dist/*.whl)
+          uv run pip-licenses | tee license-audit.log
 
           # Due to `set -e`, this will fail if no matches are found
           grep 'baml.*Apache-2.0' license-audit.log

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -68,23 +68,6 @@ jobs:
     runs-on: ${{ matrix._.runs_on }}
     # See also https://github.com/mcrumiller/polars/.github/workflows/release-python.yml#L282
     steps:
-      - name: Test LICENSE packaging
-        if: matrix._.license_test != 'skip'
-        run: |
-          set -euo pipefail
-
-          mkdir -p ../python-license-test
-          cd ../python-license-test
-          uv init --bare --python 3.10
-          uv add pip-licenses-cli
-          pwd
-          ls ../baml/engine/language_client_python/dist/
-          uv pip install $(ls ../baml/engine/language_client_python/dist/*.whl)
-          uv run pip-licenses | tee license-audit.log
-
-          # Due to `set -e`, this will fail if no matches are found
-          grep 'baml.*Apache-2.0' license-audit.log
-
       - name: Setup build environment (ARM64 Windows)
         if: matrix._.target == 'aarch64-pc-windows-msvc'
         shell:
@@ -170,6 +153,23 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+
+      - name: Test LICENSE packaging
+        if: matrix._.license_test != 'skip'
+        run: |
+          set -euo pipefail
+
+          mkdir -p ../python-license-test
+          cd ../python-license-test
+          uv init --bare --python 3.10
+          uv add pip-licenses-cli
+          pwd
+          ls ../baml/engine/language_client_python/dist/
+          uv pip install $(ls ../baml/engine/language_client_python/dist/*.whl)
+          uv run pip-licenses | tee license-audit.log
+
+          # Due to `set -e`, this will fail if no matches are found
+          grep 'baml.*Apache-2.0' license-audit.log >/dev/null
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call: {}
   push:
     branches:
-      - baml-py-win
+      - sam/license-fix
 
 concurrency:
   # suffix is important to prevent a concurrency deadlock with the calling workflow
@@ -25,40 +25,40 @@ jobs:
             runs_on: ubuntu-latest
             manylinux: 2_17
 
-          - target: aarch64-unknown-linux-gnu
-            runs_on: ubuntu-latest
-            manylinux: 2_24
-            # I'm not sure if this actually works; I can't 'pip install ./local-path.whl'
-            # from inside a container based off quay.io/pypa/manylinux2014_aarch64
-            # see https://github.com/astral-sh/uv/issues/3439#issuecomment-2110448346
-            # manylinux: 2_28
-            # env:
-            #   # Workaround ring 0.17 build issue
-            #   # see https://github.com/briansmith/ring/issues/1728
-            #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
+          # - target: aarch64-unknown-linux-gnu
+          #   runs_on: ubuntu-latest
+          #   manylinux: 2_24
+          #   # I'm not sure if this actually works; I can't 'pip install ./local-path.whl'
+          #   # from inside a container based off quay.io/pypa/manylinux2014_aarch64
+          #   # see https://github.com/astral-sh/uv/issues/3439#issuecomment-2110448346
+          #   # manylinux: 2_28
+          #   # env:
+          #   #   # Workaround ring 0.17 build issue
+          #   #   # see https://github.com/briansmith/ring/issues/1728
+          #   #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
 
-          - target: x86_64-unknown-linux-musl
-            runs_on: ubuntu-latest
-            # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
-            manylinux: musllinux_1_1
+          # - target: x86_64-unknown-linux-musl
+          #   runs_on: ubuntu-latest
+          #   # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
+          #   manylinux: musllinux_1_1
 
-          - target: aarch64-unknown-linux-musl
-            runs_on: ubuntu-latest
-            # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
-            manylinux: musllinux_1_1
+          # - target: aarch64-unknown-linux-musl
+          #   runs_on: ubuntu-latest
+          #   # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
+          #   manylinux: musllinux_1_1
 
-          - target: x86_64-apple-darwin
-            runs_on: macos-latest
+          # - target: x86_64-apple-darwin
+          #   runs_on: macos-latest
 
-          - target: aarch64-apple-darwin
-            runs_on: macos-latest
+          # - target: aarch64-apple-darwin
+          #   runs_on: macos-latest
 
-          - target: x86_64-pc-windows-msvc
-            runs_on: windows-latest
+          # - target: x86_64-pc-windows-msvc
+          #   runs_on: windows-latest
 
-          - target: aarch64-pc-windows-msvc
-            runs_on: windows-11-arm
-            architecture: arm64
+          # - target: aarch64-pc-windows-msvc
+          #   runs_on: windows-11-arm
+          #   architecture: arm64
 
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.runs_on }}
@@ -131,6 +131,7 @@ jobs:
           # see https://github.com/PyO3/maturin/issues/2110
           XWIN_VERSION: "16"
         with:
+          maturin-version: "1.9.2"
           target: ${{ matrix._.target }}
           command: build
           # building in engine/ ensures that we pick up .cargo/config.toml

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -158,8 +158,9 @@ jobs:
           cd ../python-license-test
           uv init --bare --python 3.10
           uv add pip-licenses-cli
-          ls ../engine/language_client_python/dist/
-          uv pip install $(ls ../engine/language_client_python/dist/*.whl)
+          pwd
+          ls ../baml/engine/language_client_python/dist/
+          uv pip install $(ls ../baml/engine/language_client_python/dist/*.whl)
           uv run pip-licenses | tee license-audit.log
 
           # Due to `set -e`, this will fail if no matches are found

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -156,7 +156,7 @@ jobs:
 
           mkdir -p ../python-license-test
           cd ../python-license-test
-          uv init --bare
+          uv init
           uv add pip-licenses-cli
           uv pip install ../engine/language_client_python/dist/*.whl
           uv pip-licenses | tee license-audit.log

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -147,7 +147,7 @@ jobs:
                 :
             fi
 
-      - name: Test wheels
+      - name: Test LICENSE packaging
         run: |
           set -euo pipefail
 
@@ -158,6 +158,7 @@ jobs:
           uv pip install ../engine/language_client_python/dist/*.whl
           uv pip-licenses | tee license-audit.log
 
+          # Due to `set -e`, this will fail if no matches are found
           grep 'baml.*Apache-2.0' license-audit.log
 
       - name: Upload wheels

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -21,9 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         _:
-          - target: x86_64-unknown-linux-gnu
-            runs_on: ubuntu-latest
-            manylinux: 2_17
+          # - target: x86_64-unknown-linux-gnu
+          #   runs_on: ubuntu-latest
+          #   manylinux: 2_17
 
           # - target: aarch64-unknown-linux-gnu
           #   runs_on: ubuntu-latest
@@ -50,8 +50,8 @@ jobs:
           # - target: x86_64-apple-darwin
           #   runs_on: macos-latest
 
-          # - target: aarch64-apple-darwin
-          #   runs_on: macos-latest
+          - target: aarch64-apple-darwin
+            runs_on: macos-latest
 
           # - target: x86_64-pc-windows-msvc
           #   runs_on: windows-latest

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -147,6 +147,9 @@ jobs:
                 :
             fi
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+
       - name: Test LICENSE packaging
         run: |
           set -euo pipefail

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -156,7 +156,7 @@ jobs:
 
           mkdir -p ../python-license-test
           cd ../python-license-test
-          uv init
+          uv init -- --bare --python 3.10
           uv add pip-licenses-cli
           uv pip install ../engine/language_client_python/dist/*.whl
           uv pip-licenses | tee license-audit.log

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -21,44 +21,44 @@ jobs:
       fail-fast: false
       matrix:
         _:
-          # - target: x86_64-unknown-linux-gnu
-          #   runs_on: ubuntu-latest
-          #   manylinux: 2_17
+          - target: x86_64-unknown-linux-gnu
+            runs_on: ubuntu-latest
+            manylinux: 2_17
 
-          # - target: aarch64-unknown-linux-gnu
-          #   runs_on: ubuntu-latest
-          #   manylinux: 2_24
-          #   # I'm not sure if this actually works; I can't 'pip install ./local-path.whl'
-          #   # from inside a container based off quay.io/pypa/manylinux2014_aarch64
-          #   # see https://github.com/astral-sh/uv/issues/3439#issuecomment-2110448346
-          #   # manylinux: 2_28
-          #   # env:
-          #   #   # Workaround ring 0.17 build issue
-          #   #   # see https://github.com/briansmith/ring/issues/1728
-          #   #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
+          - target: aarch64-unknown-linux-gnu
+            runs_on: ubuntu-latest
+            manylinux: 2_24
+            # I'm not sure if this actually works; I can't 'pip install ./local-path.whl'
+            # from inside a container based off quay.io/pypa/manylinux2014_aarch64
+            # see https://github.com/astral-sh/uv/issues/3439#issuecomment-2110448346
+            # manylinux: 2_28
+            # env:
+            #   # Workaround ring 0.17 build issue
+            #   # see https://github.com/briansmith/ring/issues/1728
+            #   CFLAGS_aarch64_unknown_linux_gnu: "-D__ARM_ARCH=8"
 
-          # - target: x86_64-unknown-linux-musl
-          #   runs_on: ubuntu-latest
-          #   # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
-          #   manylinux: musllinux_1_1
+          - target: x86_64-unknown-linux-musl
+            runs_on: ubuntu-latest
+            # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
+            manylinux: musllinux_1_1
 
-          # - target: aarch64-unknown-linux-musl
-          #   runs_on: ubuntu-latest
-          #   # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
-          #   manylinux: musllinux_1_1
+          - target: aarch64-unknown-linux-musl
+            runs_on: ubuntu-latest
+            # see https://github.com/astral-sh/uv/blob/9bb55c4ac0582e05d1a7a5bbd99cc7b2c82f1847/.github/workflows/build-binaries.yml#L594
+            manylinux: musllinux_1_1
 
-          # - target: x86_64-apple-darwin
-          #   runs_on: macos-latest
+          - target: x86_64-apple-darwin
+            runs_on: macos-latest
 
           - target: aarch64-apple-darwin
             runs_on: macos-latest
 
-          # - target: x86_64-pc-windows-msvc
-          #   runs_on: windows-latest
+          - target: x86_64-pc-windows-msvc
+            runs_on: windows-latest
 
-          # - target: aarch64-pc-windows-msvc
-          #   runs_on: windows-11-arm
-          #   architecture: arm64
+          - target: aarch64-pc-windows-msvc
+            runs_on: windows-11-arm
+            architecture: arm64
 
     name: ${{ matrix._.target }}
     runs-on: ${{ matrix._.runs_on }}
@@ -146,6 +146,19 @@ jobs:
                 # sudo apt update -y && apt-get install -y libssl-dev openssl pkg-config
                 :
             fi
+
+      - name: Test wheels
+        run: |
+          set -euo pipefail
+
+          mkdir -p ../python-license-test
+          cd ../python-license-test
+          uv init --bare
+          uv add pip-licenses-cli
+          uv pip install ../engine/language_client_python/dist/*.whl
+          uv pip-licenses | tee license-audit.log
+
+          grep 'baml.*Apache-2.0' license-audit.log
 
       - name: Upload wheels
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -148,7 +148,7 @@ jobs:
             fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v1
+        uses: astral-sh/setup-uv@v6
 
       - name: Test LICENSE packaging
         run: |
@@ -156,7 +156,7 @@ jobs:
 
           mkdir -p ../python-license-test
           cd ../python-license-test
-          uv init -- --bare --python 3.10
+          uv init --bare --python 3.10
           uv add pip-licenses-cli
           uv pip install ../engine/language_client_python/dist/*.whl
           uv pip-licenses | tee license-audit.log


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes BAML license packaging by adding a test step in the GitHub Actions workflow and updates branch trigger and Maturin version.
> 
>   - **Workflow Changes**:
>     - Update branch trigger to `sam/license-fix` in `build-python-release.reusable.yaml`.
>     - Add `license_test: skip` to several build targets in `build-python-release.reusable.yaml`.
>     - Set `maturin-version` to `1.9.1` in `build-python-release.reusable.yaml`.
>   - **License Testing**:
>     - Add step to test LICENSE packaging using `uv` and `pip-licenses-cli` in `build-python-release.reusable.yaml`.
>     - Ensure `baml` package is marked as `Apache-2.0` in `license-audit.log`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ed7f8feec90f1269101781d1da7c1da66f0de043. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->