### PR TITLE
Fix `recursive use` error in playground when opening sidebar

### DIFF
--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -1560,7 +1560,7 @@ impl WasmRuntime {
 
     #[wasm_bindgen]
     pub async fn run_tests(
-        &mut self,
+        &self,
         function_test_pairs: js_sys::Array,
         on_partial_response: js_sys::Function,
         get_baml_src_cb: js_sys::Function,

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -1560,6 +1560,10 @@ impl WasmRuntime {
 
     #[wasm_bindgen]
     pub async fn run_tests(
+        // NOTE: This needs to be `&self` so that the runtime can be read
+        // by the UI, e.g to re-enumerate functions. In case you *really* need `&mut` access,
+        // consider `RwLock`, ideally only for the data you're going to be mutating and not the
+        // entire runtime.
         &self,
         function_test_pairs: js_sys::Array,
         on_partial_response: js_sys::Function,


### PR DESCRIPTION
- **Use `&self` instead of `&mut self` in `run_tests`**
- **wasm: use `&self` instead of `&mut self` in `run_tests`**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Change `run_tests` function in `mod.rs` to use `&self` instead of `&mut self` to prevent recursive use errors.
> 
>   - **Function Signature Change**:
>     - Change `run_tests` function in `mod.rs` to use `&self` instead of `&mut self` to allow runtime reading by UI without mutable access.
>     - Suggests using `RwLock` for mutable access if needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for efaf8cbc0ece1124b2811a7c709045a880d110c4. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->