### PR TITLE
feat: add env var docs for studio v2

### DIFF
--- a/fern/01-guide/03-development/environment-variables.mdx
+++ b/fern/01-guide/03-development/environment-variables.mdx
@@ -22,5 +22,16 @@ client<llm> GPT4o {
 
 <Markdown src="/snippets/setting-env-vars.mdx" />
 
+## Boundary Studio Integration
+
+When you use BAML in your application, logs and traces are automatically sent to Boundary Studio for monitoring and debugging. To enable this integration, you need to set the `BOUNDARY_API_KEY` environment variable with an API key from your Boundary Studio dashboard.
+
+The API key is used to:
+- Authenticate your application with Boundary Studio
+- Associate logs and traces with your specific project and environment
+- Control access permissions for different operations
+
+<Markdown src="/snippets/setting-env-vars.mdx" />
+
 ## Setting LLM API Keys per Request
 You can set the API key for an LLM dynamically by passing in the key as a header or as a parameter (depending on the provider), using the [ClientRegistry](/guide/baml-advanced/llm-client-registry).

--- a/fern/01-guide/07-observability/studio.mdx
+++ b/fern/01-guide/07-observability/studio.mdx
@@ -8,15 +8,14 @@ For 2025 Q1, Boundary Studio is free for new accounts!
 Boundary Studio 2 will be released in 2025 Q2 with a new pricing model.
 </Tip>
 
-To enable observability with BAML, you'll first need to sign up for a [Boundary Studio](https://app.boundaryml.com) account. 
+To enable observability with BAML, you'll first need to sign up for a [Boundary Studio](https://app.boundaryml.com) account.
 
-Once you've signed up, you'll be able to create a new project and get your project token.
+Once you've signed up, you'll be able to create a new project and get your API key.
 
-Then simply add the following environment variables prior to running your application:
+Then simply add the following environment variable prior to running your application:
 
 ```bash
-export BOUNDARY_PROJECT_ID=project_uuid
-export BOUNDARY_SECRET=your_token
+export BOUNDARY_API_KEY=your_api_key_here
 ```
 
 There you'll be able to see all the metrics and logs from your application including:
@@ -110,7 +109,7 @@ package main
 import (
     "context"
     "fmt"
-    
+
     b "example.com/baml_client"
 )
 
@@ -121,13 +120,13 @@ type AuthorInfo struct {
 
 func main() {
     ctx := context.Background()
-    
+
     // BAML functions are automatically traced when using Boundary Studio
     bookSummary, err := b.GenerateBookSummary(
         ctx,
         "The Great Gatsby",
         AuthorInfo{
-            FirstName: "F. Scott", 
+            FirstName: "F. Scott",
             LastName:  "Fitzgerald",
         },
         "A classic American novel...",
@@ -135,9 +134,9 @@ func main() {
     if err != nil {
         panic(fmt.Sprintf("Failed to generate book summary: %v", err))
     }
-    
+
     fmt.Printf("Book Summary: %s\n", bookSummary)
-    
+
     // Note: Tracing non-BAML functions is not yet supported in Go.
     // Custom function tracing will be available in a future release.
     // Please contact us if this feature is needed for your use case.

--- a/fern/01-guide/08-frameworks/01-react-nextjs/01-quick-start.mdx
+++ b/fern/01-guide/08-frameworks/01-react-nextjs/01-quick-start.mdx
@@ -194,8 +194,7 @@ To enable observability with BAML, you'll first need to sign up for a [Boundary 
 
 
 ```.env .env.local
-BOUNDARY_PROJECT_ID=sk-...
-BOUNDARY_SECRET=sk-...
+BOUNDARY_API_KEY=your_api_key_here
 
 OPENAI_API_KEY=sk-...
 ```

--- a/fern/snippets/setting-env-vars.mdx
+++ b/fern/snippets/setting-env-vars.mdx
@@ -8,6 +8,37 @@ Once you open a `.baml` file in VSCode, you should see a small button over every
 
 Or type `BAML Playground` in the VSCode Command Bar (`CMD + Shift + P` or `CTRL + Shift + P`) to open the playground.
 
+### For Boundary Studio Integration
+
+To send logs and traces to Boundary Studio, you need to set the `BOUNDARY_API_KEY` environment variable. This key is provided when you create an API key in your Boundary Studio dashboard.
+
+<Tabs>
+  <Tab title="Next.js">
+    ```bash
+    # .env.local
+    BOUNDARY_API_KEY=your_api_key_here
+    ```
+  </Tab>
+  <Tab title="Express.js">
+    ```bash
+    # .env
+    BOUNDARY_API_KEY=your_api_key_here
+    ```
+  </Tab>
+  <Tab title="Flask">
+    ```bash
+    # .env
+    BOUNDARY_API_KEY=your_api_key_here
+    ```
+  </Tab>
+  <Tab title="Rails">
+    ```yaml
+    # config/application.yml
+    BOUNDARY_API_KEY: your_api_key_here
+    ```
+  </Tab>
+</Tabs>
+
 ### For Your App (Default)
 
 BAML will do its best to load environment variables from your program. Any of the following strategies for setting env vars are compatible with BAML:
@@ -38,7 +69,7 @@ python my_program_using_baml.py
     ```
   </Tab>
   <Tab title="typescript">
-    
+
     ```typescript
     import dotenv from 'dotenv'
     import { b } from './baml_client'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add documentation for `BOUNDARY_API_KEY` environment variable for Boundary Studio integration, replacing older variables and providing framework-specific examples.
> 
>   - **Environment Variables**:
>     - Add `BOUNDARY_API_KEY` documentation for Boundary Studio integration in `environment-variables.mdx`.
>     - Replace `BOUNDARY_PROJECT_ID` and `BOUNDARY_SECRET` with `BOUNDARY_API_KEY` in `studio.mdx` and `01-quick-start.mdx`.
>   - **Framework Examples**:
>     - Add examples for setting `BOUNDARY_API_KEY` in `setting-env-vars.mdx` for Next.js, Express.js, Flask, and Rails.
>   - **Misc**:
>     - Minor whitespace changes in `studio.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for de7efebea538e9ba170097d589a376409c7f0fae. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->