### PR TITLE
chore: manage protoc-gen-go using mise

### DIFF
--- a/.github/actions/setup-all/action.yml
+++ b/.github/actions/setup-all/action.yml
@@ -77,10 +77,6 @@ inputs:
     description: 'Go version to install'
     required: false
     default: '1.24'
-  go-install-protoc-gen-go:
-    description: 'Install protoc-gen-go'
-    required: false
-    default: 'true'
   go-install-goimports:
     description: 'Install goimports'
     required: false

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -6,10 +6,6 @@ inputs:
     description: "Go version to install"
     required: false
     default: "1.23.11"
-  install-protoc-gen-go:
-    description: "Install protoc-gen-go"
-    required: false
-    default: "true"
   cache:
     description: "Enable Go module caching"
     required: false
@@ -51,12 +47,6 @@ runs:
         if [ "${{ inputs.target-arch }}" != "" ]; then
           echo "GOARCH=${{ inputs.target-arch }}" >> $GITHUB_ENV
         fi
-      shell: bash
-
-    - name: Install protoc-gen-go
-      if: inputs.install-protoc-gen-go == 'true'
-      # locked to match the version in mise.toml
-      run: go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.6
       shell: bash
 
     - name: Install goimports

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -11,7 +11,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup mise
-      if: inputs.install-mise == 'true'
       uses: jdx/mise-action@v2
       with:
-        cache: false
+        install: false
+        cache: true

--- a/.github/actions/setup-tools/action.yml
+++ b/.github/actions/setup-tools/action.yml
@@ -13,5 +13,5 @@ runs:
     - name: Setup mise
       uses: jdx/mise-action@v2
       with:
-        install: false
+        install_args: "protoc-gen-go"
         cache: true

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -14,7 +14,7 @@ on:
         required: false
   push:
     branches:
-      - protoc-fix
+      - sam/mise-protoc-gen-go
 env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
   # Turbo remote caching
@@ -82,18 +82,10 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
 
-      - name: Install protoc-gen-go into .cargo/bin
-        shell: bash
-        run: |
-          # The cross-compile environment sanitizes the PATH, so we install the plugin
-          # directly into a directory that is guaranteed to be in the PATH for cargo.
-          # We also create a symlink from the go/bin to the cargo/bin for consistency.
-          mkdir -p .cargo/bin
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install golang.org/x/tools/cmd/goimports@latest
-          cp "$HOME/go/bin/protoc-gen-go" ".cargo/bin/"
-          echo "Installed protoc-gen-go into .cargo/bin:"
-          ls -la .cargo/bin
+
+      - uses: jdx/mise-action@v2
+        with:
+          install_args: "protoc-gen-go"
 
       - name: Test protoc-gen-go availability
         id: protoc_gen_go_setup

--- a/engine/language_client_cffi/build.rs
+++ b/engine/language_client_cffi/build.rs
@@ -369,12 +369,9 @@ fn main() -> std::io::Result<()> {
             {
                 Ok(output) if output.status.success() => {
                     let path = String::from_utf8_lossy(&output.stdout);
-                    if !path.is_empty() {
-                        eprintln!("Using protoc-gen-go from mise: {}", path);
-                        protoc.plugin(path.trim());
-                    } else {
-                        eprintln!("protoc-gen-go fallback: mise which returned empty path, relying on PATH");
-                    }
+                    let path = path.trim();
+                    eprintln!("Using protoc-gen-go from mise: {:?}", path);
+                    protoc.plugin(path);
                 }
                 Ok(_) => {
                     eprintln!(

--- a/engine/language_client_cffi/build.rs
+++ b/engine/language_client_cffi/build.rs
@@ -361,6 +361,33 @@ fn main() -> std::io::Result<()> {
         // Allow overriding the protoc-gen-go plugin path
         if let Ok(path) = std::env::var("PROTOC_GEN_GO_PATH") {
             protoc.plugin(&path);
+        } else {
+            // Try to find protoc-gen-go using mise
+            match std::process::Command::new("mise")
+                .args(["which", "protoc-gen-go"])
+                .output()
+            {
+                Ok(output) if output.status.success() => {
+                    let path = String::from_utf8_lossy(&output.stdout);
+                    if !path.is_empty() {
+                        eprintln!("Using protoc-gen-go from mise: {}", path);
+                        protoc.plugin(path.trim());
+                    } else {
+                        eprintln!("protoc-gen-go fallback: mise which returned empty path, relying on PATH");
+                    }
+                }
+                Ok(_) => {
+                    eprintln!(
+                        "protoc-gen-go fallback: mise which protoc-gen-go failed, relying on PATH"
+                    );
+                }
+                Err(e) => {
+                    eprintln!(
+                        "protoc-gen-go fallback: mise command failed ({}), relying on PATH",
+                        e
+                    );
+                }
+            }
         }
 
         protoc

--- a/mise.toml
+++ b/mise.toml
@@ -17,10 +17,7 @@ node = "lts"     # For pnpm
 # Go tools
 # locked to match the version in .github/actions/setup-go/action.yml
 "protoc-gen-go" = "v1.34.1"
-"go:golang.org/x/tools/cmd/goimports" = "latest"
-"go:github.com/chrishrb/go-grip" = "latest"
-
-
+"go:golang.org/x/tools/cmd/goimports" = "0.36.0"
 
 # Python tools
 "pipx:uv" = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ node = "lts"     # For pnpm
 
 # Go tools
 # locked to match the version in .github/actions/setup-go/action.yml
-"go:google.golang.org/protobuf/cmd/protoc-gen-go" = "v1.36.6"
+"protoc-gen-go" = "v1.34.1"
 "go:golang.org/x/tools/cmd/goimports" = "latest"
 "go:github.com/chrishrb/go-grip" = "latest"
 


### PR DESCRIPTION
When we build `engine/language_client_cffi` locally it's easy for `protoc-gen-go` to use the system path and not the mise-managed path. Force it to use the mise-managed path so that we can control the tool versioning better.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Manage `protoc-gen-go` using `mise` for consistent versioning, removing direct installations from GitHub Actions.
> 
>   - **Behavior**:
>     - Force `protoc-gen-go` to use `mise`-managed path in `engine/language_client_cffi/build.rs`.
>     - Remove `protoc-gen-go` installation from `setup-go/action.yml` and `setup-all/action.yml`.
>     - Use `mise` to manage `protoc-gen-go` in `setup-tools/action.yml` and `build-cli-release.reusable.yaml`.
>   - **Configuration**:
>     - Update `mise.toml` to specify `protoc-gen-go` version `v1.34.1`.
>   - **Misc**:
>     - Change branch name in `build-cli-release.reusable.yaml` from `protoc-fix` to `sam/mise-protoc-gen-go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c93a15812c08c861e56a7801f0a448b0b6dfbb60. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->