### PR TITLE
fix: missed some abortSignal docs

### DIFF
--- a/fern/01-guide/04-baml-basics/abort-signal.mdx
+++ b/fern/01-guide/04-baml-basics/abort-signal.mdx
@@ -24,7 +24,7 @@ Abort controllers allow you to cancel ongoing LLM operations, which is essential
     // Modern approach: Use AbortSignal.timeout() for automatic timeout
     try {
       const result = await b.ExtractResume(text, {
-        abortSignal: AbortSignal.timeout(5000) // 5 second timeout
+        signal: AbortSignal.timeout(5000) // 5 second timeout
       })
     } catch (error) {
       if (error.name === 'BamlAbortError') {
@@ -35,7 +35,7 @@ Abort controllers allow you to cancel ongoing LLM operations, which is essential
     // Manual approach: Create controller and cancel later
     const controller = new AbortController()
     const promise = b.ExtractResume(text, {
-      abortSignal: controller.signal
+      signal: controller.signal
     })
 
     // Cancel after 5 seconds
@@ -114,7 +114,7 @@ Automatically cancel operations that take too long:
     async function extractWithTimeout(text: string, timeoutMs: number = 30000) {
       try {
         const result = await b.ExtractResume(text, {
-          abortSignal: AbortSignal.timeout(timeoutMs)
+          signal: AbortSignal.timeout(timeoutMs)
         })
         return result
       } catch (error) {
@@ -136,7 +136,7 @@ Automatically cancel operations that take too long:
 
       try {
         const result = await b.ExtractResume(text, {
-          abortSignal: controller.signal
+          signal: controller.signal
         })
         clearTimeout(timeoutId)
         return result
@@ -223,7 +223,7 @@ Build responsive backend services that allow users to cancel long-running operat
       
       try {
         const result = await b.ExtractResume(text, {
-          abortSignal: controller.signal
+          signal: controller.signal
         })
         res.json({ result })
       } catch (error) {
@@ -296,7 +296,7 @@ Abort controllers work seamlessly with streaming responses:
     const controller = new AbortController()
 
     const stream = b.stream.GenerateStory(prompt, {
-      abortSignal: controller.signal
+      signal: controller.signal
     })
 
     let wordCount = 0
@@ -379,7 +379,7 @@ Properly handle abort errors to distinguish cancellations from other failures:
 
     try {
       const result = await b.ExtractResume(text, {
-        abortSignal: controller.signal
+        signal: controller.signal
       })
       return { success: true, data: result }
     } catch (error) {
@@ -458,13 +458,13 @@ Properly handle abort errors to distinguish cancellations from other failures:
     ```typescript
     // ✅ Use AbortSignal.timeout() for simple timeouts
     const result = await b.ExtractResume(text, {
-      abortSignal: AbortSignal.timeout(30000)
+      signal: AbortSignal.timeout(30000)
     })
     
     // ✅ Use manual AbortController when you need to cancel conditionally
     const controller = new AbortController()
     const promise = b.ExtractResume(text, {
-      abortSignal: controller.signal
+      signal: controller.signal
     })
     
     // Cancel based on user action or business logic
@@ -477,7 +477,7 @@ Properly handle abort errors to distinguish cancellations from other failures:
     const timeoutId = setTimeout(() => controller.abort('timeout'), 30000)
     
     const result = await b.ExtractResume(text, {
-      abortSignal: controller.signal
+      signal: controller.signal
     })
     
     clearTimeout(timeoutId)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Renames `abortSignal` to `signal` across TypeScript client templates, tests, and documentation for consistency.
> 
>   - **Behavior**:
>     - Renames `abortSignal` to `signal` in `BamlAsyncClient` and `BamlSyncClient` classes in `async_client.ts.j2` and `sync_client.ts.j2`.
>     - Updates `BamlStreamClient` to use `signal` instead of `abortSignal` in `async_client.ts.j2` and `sync_client.ts.j2`.
>     - Modifies integration tests in `abort-handlers-manual.test.ts` and `abort-handlers.test.ts` to use `signal`.
>   - **Documentation**:
>     - Updates `abort-signal.mdx` in `fern/01-guide/04-baml-basics` and `fern/03-reference/baml_client` to reflect the `signal` rename.
>   - **Misc**:
>     - Changes in `integ-tests/typescript-esm/baml_client` and `integ-tests/typescript/baml_client` to use `signal` in both async and sync clients.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for c9b421304c3ceeab230106a3023e727283eff94b. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->