### PR TITLE
bugfix: media types in jinja should evaluate to true in jinja bool conversions

### DIFF
--- a/engine/baml-lib/jinja-runtime/src/baml_value_to_jinja_value.rs
+++ b/engine/baml-lib/jinja-runtime/src/baml_value_to_jinja_value.rs
@@ -84,7 +84,7 @@ impl IntoMiniJinjaValue for BamlValue {
     }
 }
 
-struct MinijinjaBamlMedia {
+pub(crate) struct MinijinjaBamlMedia {
     media: BamlMedia,
 }
 
@@ -134,6 +134,10 @@ impl minijinja::value::Object for MinijinjaBamlMedia {
             minijinja::ErrorKind::UnknownMethod,
             format!("BamlImage has no callable attribute '{args:#?}'"),
         ))
+    }
+
+    fn is_true(self: &Arc<Self>) -> bool {
+        true
     }
 
     fn render(self: &Arc<Self>, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/engine/baml-lib/jinja-runtime/src/lib.rs
+++ b/engine/baml-lib/jinja-runtime/src/lib.rs
@@ -7,6 +7,8 @@ mod output_format;
 mod test_enum_comparison;
 #[cfg(test)]
 mod test_enum_template;
+#[cfg(test)]
+mod test_media;
 use indexmap::IndexMap;
 use internal_baml_core::ir::{jinja_helpers::get_env, repr::IntermediateRepr};
 pub use output_format::types;

--- a/engine/baml-lib/jinja-runtime/src/test_media.rs
+++ b/engine/baml-lib/jinja-runtime/src/test_media.rs
@@ -1,0 +1,25 @@
+use baml_types::BamlMedia;
+use minijinja::{context, value::Value, Environment};
+
+use crate::baml_value_to_jinja_value::MinijinjaBamlMedia;
+
+#[test]
+fn test_media_value() {
+    // Test that enum compares to value name, not alias
+    let media_val = Value::from_object(MinijinjaBamlMedia::from(BamlMedia::url(
+        baml_types::BamlMediaType::Image,
+        "https://example.com/image.png".to_string(),
+        None,
+    )));
+
+    let template = r#"
+{{ media }}
+{{ media|bool }}
+    "#;
+    let mut env = Environment::new();
+
+    env.add_template("test1", template).unwrap();
+    let tmpl = env.get_template("test1").unwrap();
+    let output = tmpl.render(context! { media => media_val }).unwrap();
+    assert_eq!(output.trim(), "BAML_MEDIA_MAGIC_STRING_DELIMITER:baml-start-media:{\"media_type\":\"Image\",\"mime_type\":null,\"content\":{\"Url\":{\"url\":\"https://example.com/image.png\"}}}:baml-end-media:BAML_MEDIA_MAGIC_STRING_DELIMITER\ntrue");
+}

--- a/engine/baml-lib/jinja-runtime/src/test_media.rs
+++ b/engine/baml-lib/jinja-runtime/src/test_media.rs
@@ -5,7 +5,7 @@ use crate::baml_value_to_jinja_value::MinijinjaBamlMedia;
 
 #[test]
 fn test_media_value() {
-    // Test that enum compares to value name, not alias
+    // Test that a media object evaluates to the raw string representation
     let media_val = Value::from_object(MinijinjaBamlMedia::from(BamlMedia::url(
         baml_types::BamlMediaType::Image,
         "https://example.com/image.png".to_string(),
@@ -25,7 +25,7 @@ fn test_media_value() {
 
 #[test]
 fn test_media_comparison() {
-    // Test that enum compares to value name, not alias
+    // Test that a media object evaluates to true in boolean context
     let media_val = Value::from_object(MinijinjaBamlMedia::from(BamlMedia::url(
         baml_types::BamlMediaType::Image,
         "https://example.com/image.png".to_string(),

--- a/engine/baml-lib/jinja-runtime/src/test_media.rs
+++ b/engine/baml-lib/jinja-runtime/src/test_media.rs
@@ -14,6 +14,25 @@ fn test_media_value() {
 
     let template = r#"
 {{ media }}
+    "#;
+    let mut env = Environment::new();
+
+    env.add_template("test1", template).unwrap();
+    let tmpl = env.get_template("test1").unwrap();
+    let output = tmpl.render(context! { media => media_val }).unwrap();
+    assert_eq!(output.trim(), "BAML_MEDIA_MAGIC_STRING_DELIMITER:baml-start-media:{\"media_type\":\"Image\",\"mime_type\":null,\"content\":{\"Url\":{\"url\":\"https://example.com/image.png\"}}}:baml-end-media:BAML_MEDIA_MAGIC_STRING_DELIMITER");
+}
+
+#[test]
+fn test_media_comparison() {
+    // Test that enum compares to value name, not alias
+    let media_val = Value::from_object(MinijinjaBamlMedia::from(BamlMedia::url(
+        baml_types::BamlMediaType::Image,
+        "https://example.com/image.png".to_string(),
+        None,
+    )));
+
+    let template = r#"
 {{ media|bool }}
     "#;
     let mut env = Environment::new();
@@ -21,5 +40,5 @@ fn test_media_value() {
     env.add_template("test1", template).unwrap();
     let tmpl = env.get_template("test1").unwrap();
     let output = tmpl.render(context! { media => media_val }).unwrap();
-    assert_eq!(output.trim(), "BAML_MEDIA_MAGIC_STRING_DELIMITER:baml-start-media:{\"media_type\":\"Image\",\"mime_type\":null,\"content\":{\"Url\":{\"url\":\"https://example.com/image.png\"}}}:baml-end-media:BAML_MEDIA_MAGIC_STRING_DELIMITER\ntrue");
+    assert_eq!(output.trim(), "true");
 }


### PR DESCRIPTION
- **bugfix: media types in jinja should evaluate to true for comparisons**
- **cleaner tests**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes media type evaluation in Jinja templates to always be true and adds tests for media object behavior.
> 
>   - **Behavior**:
>     - Fixes bug where media types in Jinja templates did not evaluate to true in comparisons by implementing `is_true` method in `MinijinjaBamlMedia`.
>   - **Tests**:
>     - Adds `test_media.rs` to test media object evaluation in Jinja templates.
>     - Includes tests for media object string representation and boolean evaluation.
>   - **Misc**:
>     - Makes `MinijinjaBamlMedia` struct `pub(crate)` in `baml_value_to_jinja_value.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 02f8f331f6960eb16c7ee1aedecce48a1a0d92eb. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->