### PR TITLE
Fix media file path resolution on Windows

### DIFF
--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -1725,8 +1725,35 @@ fn js_fn_to_baml_src_reader(get_baml_src_cb: js_sys::Function) -> BamlSrcReader 
             let path = path.to_string();
             let get_baml_src_cb = get_baml_src_cb.clone();
             async move {
+                // Windows-specific hotfix: VSCode resolves relative paths relative to workspace root
+                // instead of BAML file location. For BAML files directly in baml_src/, prepend "baml_src/".
+                // Since WASM can't use cfg!(windows), we detect Windows by checking for backslashes in paths
+                // or by checking the user agent, but for simplicity, we'll check if the path contains backslashes.
+                let is_windows = web_sys::window()
+                    .and_then(|w| w.navigator().user_agent().ok())
+                    .map(|ua| ua.contains("Windows"))
+                    .unwrap_or(false);
+
+                let adjusted_path =
+                    if is_windows && (path.starts_with("../") || path.starts_with("./")) {
+                        let result = format!("baml_src/{}", path);
+                        web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+                            "WASM Windows path fix applied: '{}' → '{}'",
+                            path, result
+                        )));
+                        result
+                    } else {
+                        web_sys::console::log_1(&wasm_bindgen::JsValue::from_str(&format!(
+                            "WASM path unchanged: '{}' (windows={}, relative={})",
+                            path,
+                            is_windows,
+                            path.starts_with("../") || path.starts_with("./")
+                        )));
+                        path.clone()
+                    };
+
                 let null = JsValue::NULL;
-                let Ok(read) = get_baml_src_cb.call1(&null, &JsValue::from(path.clone())) else {
+                let Ok(read) = get_baml_src_cb.call1(&null, &JsValue::from(adjusted_path)) else {
                     anyhow::bail!("readFileRef did not return a promise");
                 };
 

--- a/typescript/apps/vscode-ext/src/panels/WebviewPanelHost.ts
+++ b/typescript/apps/vscode-ext/src/panels/WebviewPanelHost.ts
@@ -593,10 +593,26 @@ export class WebviewPanelHost {
             // relpath will be 'baml_src://path/to-image.png'
             const relpath = vscodeMessage.path;
 
-            // NB(san): this is a violation of the "never URI.parse rule"
-            // (see https://www.notion.so/gloochat/windows-uri-treatment-fe87b22abebb4089945eb8cd1ad050ef)
-            // but this relpath is already a file URI, it seems...
-            const uriPath = Uri.parse(relpath);
+            let uriPath: Uri;
+            if (relpath.includes('://')) {
+              // It's already a URI, parse it directly
+              uriPath = Uri.parse(relpath);
+              console.log('GET_WEBVIEW_URI: Parsed as URI', { relpath, uriPath: uriPath.fsPath });
+            } else if (relpath.startsWith('/') || relpath.match(/^[A-Za-z]:/)) {
+              // It's an absolute path (Unix: starts with /, Windows: starts with C:)
+              uriPath = Uri.file(relpath);
+              console.log('GET_WEBVIEW_URI: Parsed as absolute path', { relpath, resolvedPath: uriPath.fsPath });
+            } else {
+              // It's a relative path, resolve it against workspace root
+              const workspaceFolders = vscode.workspace.workspaceFolders;
+              const workspaceUri = workspaceFolders?.[0]?.uri ?? Uri.parse("nonsense");
+              uriPath = Uri.joinPath(workspaceUri, relpath);
+              console.log('GET_WEBVIEW_URI: Resolved relative path', { 
+                relpath, 
+                workspaceUri: workspaceUri.fsPath, 
+                resolvedPath: uriPath.fsPath 
+              });
+            }
             const uri = this._panel.webview.asWebviewUri(uriPath).toString();
 
             console.log('GET_WEBVIEW_URI', {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes Windows-specific path resolution for media files in VSCode extension and WASM runtime by adjusting path handling logic.
> 
>   - **Behavior**:
>     - Fixes Windows-specific path resolution in `js_fn_to_baml_src_reader()` in `mod.rs` by checking for backslashes and adjusting paths to prepend `baml_src/` if necessary.
>     - Updates `GET_WEBVIEW_URI` command in `WebviewPanelHost.ts` to handle absolute and relative paths correctly, resolving them against the workspace root if needed.
>   - **Logging**:
>     - Adds console logs in `mod.rs` and `WebviewPanelHost.ts` to trace path adjustments and URI parsing steps.
>   - **Misc**:
>     - Minor refactoring in `WebviewPanelHost.ts` to improve path handling logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 1094d71c4425ca1f2d911f15686564f22fe66f09. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->