### PR TITLE
fix(python): update internal type annotations

### DIFF
--- a/engine/language_client_python/python_src/baml_py/baml_py.pyi
+++ b/engine/language_client_python/python_src/baml_py/baml_py.pyi
@@ -29,7 +29,7 @@ def set_log_max_chunk_length(length: int) -> None:
 class AbortController:
     """Controller for cancelling BAML operations."""
 
-    def __init__(self, timeout_ms: Optional[int] = None) -> None: 
+    def __init__(self, timeout_ms: Optional[int] = None) -> None:
         """
         Creates a new abort controller with an optional timeout in milliseconds.
         Once aborted, the AbortController will forever remain in an an aborted state.
@@ -39,16 +39,15 @@ class AbortController:
             timeout_ms: The timeout in milliseconds. If not provided, AbortController will not timeout.
         """
         ...
-    
 
-    def abort(self) -> None: 
+    def abort(self) -> None:
         """
         Immediately abort all operations.
         """
         ...
 
     @property
-    def aborted(self) -> bool: 
+    def aborted(self) -> bool:
         """
         Check the state of this controller.
         Once aborted, the AbortController will forever remain in an an aborted state.
@@ -78,6 +77,7 @@ class FunctionResult:
         class_module: Any,
         partial_class_module: Any,
         allow_partials: bool,
+        runtime: BamlRuntime,
     ) -> Any: ...
 
     # This is a debug function that returns the internal representation of the response


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update type annotations and remove trailing spaces in `baml_py.pyi`.
> 
>   - **Type Annotations**:
>     - Add `runtime: BamlRuntime` parameter to `cast_to()` in `FunctionResult` class in `baml_py.pyi`.
>   - **Whitespace**:
>     - Remove trailing spaces in `AbortController` methods `__init__()`, `abort()`, and `aborted()` in `baml_py.pyi`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ae99b692666c3bf759c161f767f4b772f9f5b98a. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->