### PR TITLE
syntax highlighting for pdf type

### DIFF
--- a/typescript/apps/vscode-ext/syntaxes/baml.tmLanguage.json
+++ b/typescript/apps/vscode-ext/syntaxes/baml.tmLanguage.json
@@ -350,7 +350,7 @@
     "type_definition": {
       "patterns": [
         {
-          "match": "\\b(bool|int|float|string|null|image|audio)\\b",
+          "match": "\\b(bool|int|float|string|null|image|audio|pdf)\\b",
           "name": "storage.type.baml"
         },
         {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `pdf` to recognized types in `type_definition` pattern in `baml.tmLanguage.json`.
> 
>   - **Syntax Highlighting**:
>     - Add `pdf` to recognized types in `type_definition` pattern in `baml.tmLanguage.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 56f1a244dd89e27488e6e42114970d48e84cc66f. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->