### PR TITLE
Pass `abort_controller` to `Runtime::stream_function`

### DIFF
--- a/engine/generators/languages/python/src/_templates/runtime.py.j2
+++ b/engine/generators/languages/python/src/_templates/runtime.py.j2
@@ -77,7 +77,7 @@ class {{ call_manager_name }}:
                 env_vars[k] = v
             else:
                 env_vars.pop(k, None)
-        
+
         abort_controller = self.__baml_options.get("abort_controller")
 
         on_tick = self.__baml_options.get("on_tick")
@@ -107,11 +107,11 @@ class {{ call_manager_name }}:
         self, *, function_name: str, args: typing.Dict[str, typing.Any]
     ) -> baml_py.baml_py.FunctionResult:
         resolved_options = self.__resolve()
-        
+
         # Check if already aborted
         if resolved_options.abort_controller is not None and resolved_options.abort_controller.aborted:
             raise Exception("BamlAbortError: Operation was aborted")
-        
+
         return await __runtime__.call_function(
             function_name,
             args,
@@ -133,11 +133,11 @@ class {{ call_manager_name }}:
         self, *, function_name: str, args: typing.Dict[str, typing.Any]
     ) -> baml_py.baml_py.FunctionResult:
         resolved_options = self.{{ managled_resolve_fn }}()
-        
+
         # Check if already aborted
         if resolved_options.abort_controller is not None and resolved_options.abort_controller.aborted:
             raise Exception("BamlAbortError: Operation was aborted")
-        
+
         ctx = __ctx__manager__.get()
         return __runtime__.call_function_sync(
             function_name,
@@ -182,6 +182,8 @@ class {{ call_manager_name }}:
             resolved_options.env_vars,
             # on_tick
             resolved_options.on_tick,
+            # abort_controller
+            resolved_options.abort_controller,
         )
         return ctx, result
 

--- a/integ-tests/python-v1/baml_client/runtime.py
+++ b/integ-tests/python-v1/baml_client/runtime.py
@@ -89,7 +89,7 @@ class DoNotUseDirectlyCallManager:
                 env_vars[k] = v
             else:
                 env_vars.pop(k, None)
-        
+
         abort_controller = self.__baml_options.get("abort_controller")
 
         on_tick = self.__baml_options.get("on_tick")
@@ -119,11 +119,11 @@ class DoNotUseDirectlyCallManager:
         self, *, function_name: str, args: typing.Dict[str, typing.Any]
     ) -> baml_py.baml_py.FunctionResult:
         resolved_options = self.__resolve()
-        
+
         # Check if already aborted
         if resolved_options.abort_controller is not None and resolved_options.abort_controller.aborted:
             raise Exception("BamlAbortError: Operation was aborted")
-        
+
         return await __runtime__.call_function(
             function_name,
             args,
@@ -145,11 +145,11 @@ class DoNotUseDirectlyCallManager:
         self, *, function_name: str, args: typing.Dict[str, typing.Any]
     ) -> baml_py.baml_py.FunctionResult:
         resolved_options = self.__resolve()
-        
+
         # Check if already aborted
         if resolved_options.abort_controller is not None and resolved_options.abort_controller.aborted:
             raise Exception("BamlAbortError: Operation was aborted")
-        
+
         ctx = __ctx__manager__.get()
         return __runtime__.call_function_sync(
             function_name,
@@ -194,6 +194,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.env_vars,
             # on_tick
             resolved_options.on_tick,
+            # abort_controller
+            resolved_options.abort_controller,
         )
         return ctx, result
 

--- a/integ-tests/python/baml_client/runtime.py
+++ b/integ-tests/python/baml_client/runtime.py
@@ -89,7 +89,7 @@ class DoNotUseDirectlyCallManager:
                 env_vars[k] = v
             else:
                 env_vars.pop(k, None)
-        
+
         abort_controller = self.__baml_options.get("abort_controller")
 
         on_tick = self.__baml_options.get("on_tick")
@@ -119,11 +119,11 @@ class DoNotUseDirectlyCallManager:
         self, *, function_name: str, args: typing.Dict[str, typing.Any]
     ) -> baml_py.baml_py.FunctionResult:
         resolved_options = self.__resolve()
-        
+
         # Check if already aborted
         if resolved_options.abort_controller is not None and resolved_options.abort_controller.aborted:
             raise Exception("BamlAbortError: Operation was aborted")
-        
+
         return await __runtime__.call_function(
             function_name,
             args,
@@ -145,11 +145,11 @@ class DoNotUseDirectlyCallManager:
         self, *, function_name: str, args: typing.Dict[str, typing.Any]
     ) -> baml_py.baml_py.FunctionResult:
         resolved_options = self.__resolve()
-        
+
         # Check if already aborted
         if resolved_options.abort_controller is not None and resolved_options.abort_controller.aborted:
             raise Exception("BamlAbortError: Operation was aborted")
-        
+
         ctx = __ctx__manager__.get()
         return __runtime__.call_function_sync(
             function_name,
@@ -194,6 +194,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.env_vars,
             # on_tick
             resolved_options.on_tick,
+            # abort_controller
+            resolved_options.abort_controller,
         )
         return ctx, result
 


### PR DESCRIPTION
Fix https://github.com/BoundaryML/baml/pull/2184#issuecomment-3258803262
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Passes `abort_controller` to `stream_function` in async and sync stream methods to support operation abortion.
> 
>   - **Behavior**:
>     - Passes `abort_controller` to `stream_function` in `create_async_stream()` and `create_sync_stream()` in `runtime.py.j2`, `runtime.py` (python-v1), and `runtime.py` (python).
>     - Ensures operations can be aborted by checking `abort_controller.aborted` before proceeding in `call_function_async()` and `call_function_sync()`.
>   - **Misc**:
>     - Minor whitespace adjustments in `runtime.py.j2`, `runtime.py` (python-v1), and `runtime.py` (python).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 340d6563da97fb031e7c27a3c77674e688351ba8. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->