### PR TITLE
Add string concatenation: `"a" + "b"`

### DIFF
--- a/engine/baml-compiler/src/hir/mod.rs
+++ b/engine/baml-compiler/src/hir/mod.rs
@@ -310,6 +310,46 @@ pub enum BinaryOperator {
     Or,
 }
 
+impl BinaryOperator {
+    pub fn is_arithmetic(&self) -> bool {
+        matches!(
+            self,
+            BinaryOperator::Add
+                | BinaryOperator::Sub
+                | BinaryOperator::Mul
+                | BinaryOperator::Div
+                | BinaryOperator::Mod
+        )
+    }
+
+    pub fn is_bitwise(&self) -> bool {
+        matches!(
+            self,
+            BinaryOperator::BitAnd
+                | BinaryOperator::BitOr
+                | BinaryOperator::BitXor
+                | BinaryOperator::Shl
+                | BinaryOperator::Shr
+        )
+    }
+
+    pub fn is_comparison(&self) -> bool {
+        matches!(
+            self,
+            BinaryOperator::Eq
+                | BinaryOperator::Neq
+                | BinaryOperator::Lt
+                | BinaryOperator::LtEq
+                | BinaryOperator::Gt
+                | BinaryOperator::GtEq
+        )
+    }
+
+    pub fn is_logical(&self) -> bool {
+        matches!(self, BinaryOperator::And | BinaryOperator::Or)
+    }
+}
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum UnaryOperator {
     Not,

--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -1892,7 +1892,7 @@ pub fn typecheck_expression(
                     Some(TypeIR::Primitive(baml_types::TypeValue::Bool, _)),
                     _,
                     Some(TypeIR::Primitive(baml_types::TypeValue::Bool, _)),
-                ) if !operator.is_arithmetic() && !operator.is_bitwise() => Some(TypeIR::bool()),
+                ) if operator.is_logical() => Some(TypeIR::bool()),
 
                 // Err: Operation on int and float
                 (
@@ -1930,10 +1930,38 @@ pub fn typecheck_expression(
                 }
 
                 _ => {
-                    diagnostics.push_error(DatamodelError::new_validation_error(
-                        "Invalid binary operation",
-                        span.clone(),
-                    ));
+                    match (left.meta().1.as_ref(), right.meta().1.as_ref()) {
+                        (None, Some(_)) => {
+                            diagnostics.push_error(DatamodelError::new_validation_error(
+                                "Invalid binary operation: cannot infer type of left operand",
+                                span.clone(),
+                            ))
+                        }
+
+                        (Some(_), None) => {
+                            diagnostics.push_error(DatamodelError::new_validation_error(
+                                "Invalid binary operation: cannot infer type of right operand",
+                                span.clone(),
+                            ))
+                        }
+
+                        (Some(left_type), Some(right_type)) => {
+                            diagnostics.push_error(DatamodelError::new_validation_error(
+                                &format!("Invalid binary operation ({operator}) on different types: {} {operator} {}",
+                                    left_type.name_for_user(),
+                                    right_type.name_for_user()
+                                ),
+                                span.clone(),
+                            ));
+                        }
+
+                        (None, None) => {
+                            diagnostics.push_error(DatamodelError::new_validation_error(
+                                "Invalid binary operation: cannot infer type of operands",
+                                span.clone(),
+                            ));
+                        }
+                    };
 
                     None
                 }

--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -1829,12 +1829,70 @@ pub fn typecheck_expression(
             operator,
             right,
             span,
-        } => thir::Expr::BinaryOperation {
-            left: Arc::new(typecheck_expression(left, context, diagnostics)),
-            operator: *operator,
-            right: Arc::new(typecheck_expression(right, context, diagnostics)),
-            meta: (span.clone(), None),
-        },
+        } => {
+            let left = typecheck_expression(left, context, diagnostics);
+            let right = typecheck_expression(right, context, diagnostics);
+
+            match (left.meta().1.as_ref(), operator, right.meta().1.as_ref()) {
+                // Ok: string + string
+                (
+                    Some(TypeIR::Primitive(baml_types::TypeValue::String, _)),
+                    hir::BinaryOperator::Add,
+                    Some(TypeIR::Primitive(baml_types::TypeValue::String, _)),
+                ) => {}
+
+                // Other invalid operation for strings.
+                (
+                    Some(TypeIR::Primitive(baml_types::TypeValue::String, _)),
+                    _,
+                    Some(TypeIR::Primitive(baml_types::TypeValue::String, _)),
+                ) => diagnostics.push_error(DatamodelError::new_validation_error(
+                    &format!("Cannot apply {operator} operator to strings"),
+                    span.clone(),
+                )),
+
+                // OK: operation on ints
+                (
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Int, _)),
+                    _,
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Int, _)),
+                ) => {}
+
+                // OK: Operation on floats
+                (
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Float, _)),
+                    _,
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Float, _)),
+                ) => {}
+
+                // Err: Operation on int and float
+                (
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Int, _)),
+                    _,
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Float, _)),
+                )
+                | (
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Float, _)),
+                    _,
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Int, _)),
+                ) => diagnostics.push_error(DatamodelError::new_validation_error(
+                    "Cannot apply {operator} operator to int and float",
+                    span.clone(),
+                )),
+
+                _ => diagnostics.push_error(DatamodelError::new_validation_error(
+                    "Invalid binary operation",
+                    span.clone(),
+                )),
+            }
+
+            thir::Expr::BinaryOperation {
+                left: Arc::new(left),
+                operator: *operator,
+                right: Arc::new(right),
+                meta: (span.clone(), None),
+            }
+        }
         hir::Expression::UnaryOperation {
             operator,
             expr,

--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -23,7 +23,7 @@ use baml_types::{ir_type::TypeIR, BamlMap, BamlValueWithMeta, TypeValue};
 use internal_baml_diagnostics::{DatamodelError, Diagnostics, Span};
 
 use crate::{
-    hir::{self, dump::TypeDocumentRender, Hir},
+    hir::{self, dump::TypeDocumentRender, BinaryOperator, Hir},
     thir::{self as thir, ExprMetadata, THir},
 };
 
@@ -1833,37 +1833,66 @@ pub fn typecheck_expression(
             let left = typecheck_expression(left, context, diagnostics);
             let right = typecheck_expression(right, context, diagnostics);
 
-            match (left.meta().1.as_ref(), operator, right.meta().1.as_ref()) {
+            // TODO: Probably easier to check operator first then expected types.
+            // Doing it like this (the other way around) seems cumbersome.
+            let expr_type = match (left.meta().1.as_ref(), operator, right.meta().1.as_ref()) {
                 // Ok: string + string
                 (
                     Some(TypeIR::Primitive(baml_types::TypeValue::String, _)),
                     hir::BinaryOperator::Add,
                     Some(TypeIR::Primitive(baml_types::TypeValue::String, _)),
-                ) => {}
+                ) => Some(TypeIR::string()),
 
                 // Other invalid operation for strings.
                 (
                     Some(TypeIR::Primitive(baml_types::TypeValue::String, _)),
                     _,
                     Some(TypeIR::Primitive(baml_types::TypeValue::String, _)),
-                ) => diagnostics.push_error(DatamodelError::new_validation_error(
-                    &format!("Cannot apply {operator} operator to strings"),
-                    span.clone(),
-                )),
+                ) => {
+                    diagnostics.push_error(DatamodelError::new_validation_error(
+                        &format!("Cannot apply {operator} operator to strings"),
+                        span.clone(),
+                    ));
+
+                    None
+                }
 
                 // OK: operation on ints
                 (
                     Some(TypeIR::Primitive(baml_types::TypeValue::Int, _)),
                     _,
                     Some(TypeIR::Primitive(baml_types::TypeValue::Int, _)),
-                ) => {}
+                ) if !operator.is_logical() => {
+                    if operator.is_arithmetic() || operator.is_bitwise() {
+                        Some(TypeIR::int())
+                    } else if operator.is_comparison() {
+                        Some(TypeIR::bool())
+                    } else {
+                        None
+                    }
+                }
 
                 // OK: Operation on floats
                 (
                     Some(TypeIR::Primitive(baml_types::TypeValue::Float, _)),
                     _,
                     Some(TypeIR::Primitive(baml_types::TypeValue::Float, _)),
-                ) => {}
+                ) if !operator.is_logical() && !operator.is_bitwise() => {
+                    if operator.is_arithmetic() {
+                        Some(TypeIR::float())
+                    } else if operator.is_comparison() {
+                        Some(TypeIR::bool())
+                    } else {
+                        None
+                    }
+                }
+
+                // OK: Operation on bools
+                (
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Bool, _)),
+                    _,
+                    Some(TypeIR::Primitive(baml_types::TypeValue::Bool, _)),
+                ) if !operator.is_arithmetic() && !operator.is_bitwise() => Some(TypeIR::bool()),
 
                 // Err: Operation on int and float
                 (
@@ -1875,24 +1904,49 @@ pub fn typecheck_expression(
                     Some(TypeIR::Primitive(baml_types::TypeValue::Float, _)),
                     _,
                     Some(TypeIR::Primitive(baml_types::TypeValue::Int, _)),
-                ) => diagnostics.push_error(DatamodelError::new_validation_error(
-                    "Cannot apply {operator} operator to int and float",
-                    span.clone(),
-                )),
+                ) => {
+                    diagnostics.push_error(DatamodelError::new_validation_error(
+                        &format!("Cannot apply {operator} operator to int and float"),
+                        span.clone(),
+                    ));
+                    None
+                }
 
-                _ => diagnostics.push_error(DatamodelError::new_validation_error(
-                    "Invalid binary operation",
-                    span.clone(),
-                )),
-            }
+                (Some(right), BinaryOperator::Eq | BinaryOperator::Neq, Some(left)) => {
+                    if left.map_meta(|_| ()) == right.map_meta(|_| ()) {
+                        Some(TypeIR::bool())
+                    } else {
+                        diagnostics.push_error(DatamodelError::new_validation_error(
+                            &format!(
+                                "Invalid equality/inequality operation on objects of different type: {} {operator} {}",
+                                left.name_for_user(),
+                                right.name_for_user()
+                            ),
+                            span.clone()
+                        ));
+
+                        None
+                    }
+                }
+
+                _ => {
+                    diagnostics.push_error(DatamodelError::new_validation_error(
+                        "Invalid binary operation",
+                        span.clone(),
+                    ));
+
+                    None
+                }
+            };
 
             thir::Expr::BinaryOperation {
                 left: Arc::new(left),
                 operator: *operator,
                 right: Arc::new(right),
-                meta: (span.clone(), None),
+                meta: (span.clone(), expr_type),
             }
         }
+        // TODO: Typecheck unary.
         hir::Expression::UnaryOperation {
             operator,
             expr,

--- a/engine/baml-lib/ast/src/parser/datamodel.pest
+++ b/engine/baml-lib/ast/src/parser/datamodel.pest
@@ -273,7 +273,7 @@ INVALID_STMT_STARTING_CHAR = { !ASCII_ALPHA ~ !WHITESPACE ~ !NEWLINE ~ !BLOCK_OP
 ADD = { "+" ~ !"=" }
 SUB = { "-" ~ !"=" }
 MUL = { "*" ~ !"=" }
-DIV = { "/" ~ !"=" }
+DIV = { "/" ~ !("=" | "/") } // Needed for trailing comments.
 MOD = { "%" ~ !"=" }
 
 // Bitwise

--- a/engine/baml-lib/baml/tests/validation_files/loops/c_for.baml
+++ b/engine/baml-lib/baml/tests/validation_files/loops/c_for.baml
@@ -74,6 +74,12 @@ fn BreakContinue() -> int {
 // 20 | 
 // 21 | for (; i <= 10; i += 1) {
 //    | 
+// error: Error validating: Invalid binary operation: cannot infer type of left operand
+//   -->  loops/c_for.baml:21
+//    | 
+// 20 | 
+// 21 | for (; i <= 10; i += 1) {
+//    | 
 // error: Error validating: Unknown variable i
 //   -->  loops/c_for.baml:21
 //    | 

--- a/engine/baml-vm/src/vm.rs
+++ b/engine/baml-vm/src/vm.rs
@@ -1113,7 +1113,6 @@ impl Vm {
 
                 Instruction::BinOp(op) => {
                     let right = self.stack.ensure_pop()?;
-
                     let left = self.stack.ensure_pop()?;
 
                     let result = match (left, right) {
@@ -1168,6 +1167,22 @@ impl Vm {
                                     }));
                                 }
                             })
+                        }
+
+                        (Value::Object(_), Value::Object(_)) if op == BinOp::Add => {
+                            let left = self.objects.as_string(&left)?;
+                            let right = self.objects.as_string(&right)?;
+
+                            let mut concat = left.clone();
+                            concat.push_str(right);
+
+                            let concat_str_object =
+                                Value::Object(self.objects.insert(Object::String(concat)));
+
+                            // Borrow check.
+                            function = self.objects[frame.function].as_function()?;
+
+                            concat_str_object
                         }
 
                         _ => {

--- a/engine/baml-vm/tests/strings.rs
+++ b/engine/baml-vm/tests/strings.rs
@@ -1,0 +1,37 @@
+//! VM tests for strings.
+
+use baml_vm::{ObjectIndex, Value, VmExecState};
+
+mod common;
+use common::{assert_vm_executes_with_inspection, Program};
+
+// Array tests
+#[test]
+fn concat_strings() -> anyhow::Result<()> {
+    assert_vm_executes_with_inspection(
+        Program {
+            source: r#"
+                fn main() -> string {
+                    let a = "Hello";
+                    let b = " World";
+
+                    a + b
+                }
+            "#,
+            function: "main",
+            expected: VmExecState::Complete(Value::Object(ObjectIndex::from_raw(8))),
+        },
+        |vm| {
+            let baml_vm::Object::String(s) = &vm.objects[ObjectIndex::from_raw(8)] else {
+                panic!(
+                    "expected string, got {:?}",
+                    &vm.objects[ObjectIndex::from_raw(8)]
+                );
+            };
+
+            assert_eq!(s, "Hello World");
+
+            Ok(())
+        },
+    )
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for string concatenation using `+` operator, update type checking and VM execution, and add a test for verification.
> 
>   - **Behavior**:
>     - Add support for string concatenation using `+` operator in `typecheck_expression()` in `typecheck.rs`.
>     - Update `BinOp` in `vm.rs` to handle string concatenation by converting objects to strings and concatenating them.
>   - **Parsing**:
>     - Modify `DIV` rule in `datamodel.pest` to prevent parsing issues with comments.
>   - **Testing**:
>     - Add `concat_strings()` test in `strings.rs` to verify string concatenation functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 1da190caac3fd1c9bb2fcaf8f4e127c48c66433b. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->