### PR TITLE
fix double trace call

### DIFF
--- a/engine/baml-runtime/src/async_vm_runtime.rs
+++ b/engine/baml-runtime/src/async_vm_runtime.rs
@@ -149,20 +149,14 @@ impl BamlAsyncVmRuntime {
         env_vars: HashMap<String, String>,
         cancel_tripwire: Arc<TripWire>,
     ) -> (anyhow::Result<FunctionResult>, FunctionCallId) {
-        let current_call_id = self
-            .llm_runtime
-            .tracer_wrapper
-            .get_or_create_tracer(&env_vars)
-            .start_call(&function_name, ctx, params, true, false, collectors.clone())
-            .curr_call_id();
-
         // Find the function.
         let Some((function_index, function_kind)) =
             self.program.resolved_function_names.get(&function_name)
         else {
+            // TODO: We don't have an ID here! We can't call tracer here for llm functions here.
             return (
                 Err(anyhow!("function '{function_name}' not found")),
-                current_call_id,
+                FunctionCallId::new(),
             );
         };
 
@@ -183,6 +177,12 @@ impl BamlAsyncVmRuntime {
                 )
                 .await;
         }
+        let current_call_id = self
+            .llm_runtime
+            .tracer_wrapper
+            .get_or_create_tracer(&env_vars)
+            .start_call(&function_name, ctx, params, true, false, collectors.clone())
+            .curr_call_id();
 
         let Some(expr_fn) = self
             .llm_runtime


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes double trace call in `call_function` method of `BamlAsyncVmRuntime` by moving trace call after function lookup.
> 
>   - **Behavior**:
>     - Fixes double trace call in `call_function` method of `BamlAsyncVmRuntime`.
>     - Moves trace call to occur after function lookup to avoid unnecessary tracing when function is not found.
>   - **Misc**:
>     - Removes unused variable `current_call_id` before function lookup in `call_function`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for 56ecca4776439c52e5b2a7075d839564a87a12a3. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->