### PR TITLE
redo storage test

### DIFF
--- a/engine/baml-runtime/src/tracingv2/storage/storage.rs
+++ b/engine/baml-runtime/src/tracingv2/storage/storage.rs
@@ -744,7 +744,8 @@ impl Drop for Collector {
 // watch out when running all cargo tests in the project -- as they could mess with the global tracer state if you don't add the #[serial]. Perhaps we need #[tokio::test]
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use core::time::Duration;
+
     use baml_ids::{FunctionCallId, FunctionEventId, HttpRequestId};
     use baml_types::{
         ir_type::TypeNonStreaming,
@@ -754,10 +755,11 @@ mod tests {
             TraceEvent,
         },
     };
-    use core::time::Duration;
     use indexmap::IndexMap;
     use serial_test::serial;
     use tokio::runtime::Runtime;
+
+    use super::*;
 
     #[test]
     #[serial]
@@ -787,7 +789,8 @@ mod tests {
             }
 
             // Put a simple SetTags event
-            let event: TraceEventWithMeta = TraceEvent::new_set_tags(vec![f_id.clone()], Default::default());
+            let event: TraceEventWithMeta =
+                TraceEvent::new_set_tags(vec![f_id.clone()], Default::default());
             let event = Arc::new(event);
             {
                 let mut tracer = BAML_TRACER.lock().unwrap();
@@ -842,7 +845,8 @@ mod tests {
             }
 
             // Put a simple SetTags event
-            let event: TraceEventWithMeta = TraceEvent::new_set_tags(vec![f_id.clone()], Default::default());
+            let event: TraceEventWithMeta =
+                TraceEvent::new_set_tags(vec![f_id.clone()], Default::default());
             let event = Arc::new(event);
             {
                 let mut tracer = BAML_TRACER.lock().unwrap();
@@ -913,7 +917,8 @@ mod tests {
             }
 
             // Put a simple SetTags event
-            let event: TraceEventWithMeta = TraceEvent::new_set_tags(vec![f_id.clone()], Default::default());
+            let event: TraceEventWithMeta =
+                TraceEvent::new_set_tags(vec![f_id.clone()], Default::default());
             let event = Arc::new(event);
             {
                 let mut tracer = BAML_TRACER.lock().unwrap();
@@ -984,7 +989,9 @@ mod tests {
                 vec![f_id.clone()],
                 "test_function".into(),
                 vec![],
-                EvaluationContext { tags: Default::default() },
+                EvaluationContext {
+                    tags: Default::default(),
+                },
                 FunctionType::Native,
                 false,
             );
@@ -1049,8 +1056,14 @@ mod tests {
             collector.track_function(f_id.clone());
 
             let mut tags_map = serde_json::Map::new();
-            tags_map.insert("foo".to_string(), serde_json::Value::String("bar".to_string()));
-            tags_map.insert("some_number".to_string(), serde_json::Value::Number(42.into()));
+            tags_map.insert(
+                "foo".to_string(),
+                serde_json::Value::String("bar".to_string()),
+            );
+            tags_map.insert(
+                "some_number".to_string(),
+                serde_json::Value::Number(42.into()),
+            );
 
             let start_event: TraceEventWithMeta = TraceEvent::new_function_start(
                 vec![f_id.clone()],
@@ -1102,7 +1115,9 @@ mod tests {
                     function_type: FunctionType::Native,
                     is_stream: false,
                     args: vec![],
-                    options: EvaluationContext { tags: Default::default() },
+                    options: EvaluationContext {
+                        tags: Default::default(),
+                    },
                 }),
                 call_stack: vec![f_id.clone()],
                 timestamp: start_time,
@@ -1179,7 +1194,9 @@ mod tests {
             vec![f_id.clone()],
             function_name.into(),
             vec![],
-            EvaluationContext { tags: Default::default() },
+            EvaluationContext {
+                tags: Default::default(),
+            },
             FunctionType::Native,
             false,
         );
@@ -1192,10 +1209,8 @@ mod tests {
         // Insert LLM requests and responses
         for (i, (req, resp)) in llm_calls.into_iter().enumerate() {
             // Put the request
-            let event_req: TraceEventWithMeta = TraceEvent::new_llm_request(
-                vec![f_id.clone()],
-                Arc::new(req),
-            );
+            let event_req: TraceEventWithMeta =
+                TraceEvent::new_llm_request(vec![f_id.clone()], Arc::new(req));
             let event_req = Arc::new(event_req);
             {
                 let mut tracer = BAML_TRACER.lock().unwrap();
@@ -1203,10 +1218,8 @@ mod tests {
             }
 
             // Put the response
-            let event_resp: TraceEventWithMeta = TraceEvent::new_llm_response(
-                vec![f_id.clone()],
-                Arc::new(resp),
-            );
+            let event_resp: TraceEventWithMeta =
+                TraceEvent::new_llm_response(vec![f_id.clone()], Arc::new(resp));
             let event_resp = Arc::new(event_resp);
             {
                 let mut tracer = BAML_TRACER.lock().unwrap();

--- a/engine/baml-runtime/src/tracingv2/storage/storage.rs
+++ b/engine/baml-runtime/src/tracingv2/storage/storage.rs
@@ -742,684 +742,613 @@ impl Drop for Collector {
 // ─────────────────────────────────────────────────────────────────────────────
 
 // watch out when running all cargo tests in the project -- as they could mess with the global tracer state if you don't add the #[serial]. Perhaps we need #[tokio::test]
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use baml_types::tracing::events::{FunctionEnd, FunctionStart, TraceData, TraceEvent};
-//     use core::time::Duration;
-//     use serial_test::serial;
-//     use tokio::runtime::Runtime;
-
-//     #[test]
-//     #[serial]
-//     fn test_reference_count_lifecycle() {
-//         let rt = Runtime::new().unwrap();
-//         rt.block_on(async {
-//             // Clear and check initial state
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.clear();
-//             }
-
-//             let f_id = FunctionCallId::new();
-
-//             // Initially, no references
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 0);
-//             }
-
-//             // Create a collector to track the function ID
-//             let collector = Collector::new(Some("test_collector".to_string()));
-//             collector.track_function(f_id.clone());
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 1);
-//             }
-
-//             // Put an event
-//             let event = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId("event_abc".to_string()),
-//                 call_stack: vec![],
-//                 timestamp: web_time::SystemTime::now(),
-//                 callsite: "test_event".into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::LogMessage {
-//                     msg: "test_event1".into(),
-//                 },
-//                 tags: Default::default(),
-//             });
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(event.clone());
-//             }
-
-//             // Check events exist
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 let maybe_events = tracer.get_events(&f_id);
-//                 assert!(maybe_events.is_some());
-//                 assert_eq!(maybe_events.unwrap().len(), 1);
-//             }
-
-//             // Drop the collector => reference count goes to 0
-//             drop(collector);
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 0);
-//                 assert!(tracer.get_events(&f_id).is_none());
-//             }
-//         });
-//     }
-
-//     #[test]
-//     #[serial]
-//     fn test_collector_clone_reference_counts() {
-//         let rt = Runtime::new().unwrap();
-//         rt.block_on(async {
-//             let f_id = FunctionCallId("func_abc".to_string());
-//             // Clear global state
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.clear();
-//             }
-
-//             // Create original collector and track function
-//             let collector1 = Collector::new(Some("test_collector1".to_string()));
-//             collector1.track_function(f_id.clone());
-
-//             // Check initial reference count is 1
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 1);
-//             }
-
-//             // Clone collector and verify ref count increases
-//             let collector2 = collector1.clone();
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 2);
-//             }
-
-//             // Put an event
-//             let event = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId("event_abc".to_string()),
-//                 call_stack: vec![],
-//                 timestamp: web_time::SystemTime::now(),
-//                 callsite: "test_event".into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::LogMessage {
-//                     msg: "test_event1".into(),
-//                 },
-//                 tags: Default::default(),
-//             });
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(event.clone());
-//             }
-
-//             // Verify events exist
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 let maybe_events = tracer.get_events(&f_id);
-//                 assert!(maybe_events.is_some());
-//                 assert_eq!(maybe_events.unwrap().len(), 1);
-//             }
-
-//             // Drop first collector, verify ref count decreases but events remain
-//             drop(collector1);
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 1);
-//                 assert!(tracer.get_events(&f_id).is_some());
-//             }
-
-//             // Drop second collector, verify everything is cleaned up
-//             drop(collector2);
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 0);
-//                 assert!(tracer.get_events(&f_id).is_none());
-//             }
-//         });
-//     }
-
-//     #[test]
-//     #[serial]
-//     fn test_collector_and_function_log_clone_reference_counts() {
-//         let rt = Runtime::new().unwrap();
-//         rt.block_on(async {
-//             let f_id = FunctionCallId("func_abc".to_string());
-//             // Clear global state
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.clear();
-//             }
-
-//             // Create original collector and track function
-//             let collector1 = Collector::new(Some("test_collector1".to_string()));
-//             collector1.track_function(f_id.clone());
-
-//             // Check initial reference count is 1
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 1);
-//             }
-
-//             // Clone collector and verify ref count increases
-//             let collector2 = collector1.clone();
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 2);
-//             }
-
-//             // Create a function log and clone it
-//             let func_log1 = collector1.function_log_by_id(&f_id).unwrap();
-//             let func_log2 = func_log1.clone();
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 4);
-//             }
-
-//             // Put an event
-//             let event = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId("event_abc".to_string()),
-//                 call_stack: vec![],
-//                 timestamp: web_time::SystemTime::now(),
-//                 callsite: "test_event".into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::LogMessage {
-//                     msg: "test_event1".into(),
-//                 },
-//                 tags: Default::default(),
-//             });
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(event.clone());
-//             }
-
-//             // Verify events exist
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 let maybe_events = tracer.get_events(&f_id);
-//                 assert!(maybe_events.is_some());
-//                 assert_eq!(maybe_events.unwrap().len(), 1);
-//             }
-
-//             // Drop first function log, verify ref count decreases but events remain
-//             drop(func_log1);
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 3);
-//                 assert!(tracer.get_events(&f_id).is_some());
-//             }
-
-//             // Drop second function log
-//             drop(func_log2);
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 2);
-//                 assert!(tracer.get_events(&f_id).is_some());
-//             }
-
-//             // Drop first collector, verify ref count decreases but events remain
-//             drop(collector1);
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 1);
-//                 assert!(tracer.get_events(&f_id).is_some());
-//             }
-
-//             // Drop second collector, verify everything is cleaned up
-//             drop(collector2);
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 0);
-//                 assert!(tracer.get_events(&f_id).is_none());
-//             }
-//         });
-//     }
-
-//     #[test]
-//     #[serial]
-//     fn test_function_log_basic() {
-//         let rt = Runtime::new().unwrap();
-//         rt.block_on(async {
-//             let f_id = FunctionCallId("test_function_log_basic".to_string());
-
-//             // Clear global state
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.clear();
-//             }
-
-//             // Create a collector to track the function ID
-//             let collector = Collector::new(Some("test_collector".to_string()));
-//             collector.track_function(f_id.clone());
-
-//             // Create and insert start event
-//             let start_event = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId("start_event".to_string()),
-//                 call_stack: vec![],
-//                 timestamp: web_time::SystemTime::now(),
-//                 callsite: "unit_test_start".into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::FunctionStart(FunctionStart {
-//                     name: "test_function".into(),
-//                     args: vec![],
-//                     options: baml_types::tracing::events::BamlOptions {
-//                         type_builder: None,
-//                         client_registry: None,
-//                     },
-//                 }),
-//                 tags: Default::default(),
-//             });
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(start_event.clone());
-//             }
-
-//             // Create and insert end event
-//             let end_event = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId("end_event".to_string()),
-//                 call_stack: vec![],
-//                 timestamp: web_time::SystemTime::now(),
-//                 callsite: "unit_test_end".into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::FunctionEnd(FunctionEnd {
-//                     result: Ok(baml_types::BamlValue::Null),
-//                 }),
-//                 tags: Default::default(),
-//             });
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(end_event.clone());
-//             }
-
-//             let mut func_log = FunctionLog::new(f_id.clone());
-//             assert_eq!(func_log.id(), f_id);
-
-//             assert_eq!(func_log.function_name(), "test_function");
-//             let tpe = func_log.log_type();
-//             assert!(tpe == "call" || tpe == "stream");
-
-//             assert_eq!(func_log.usage().input_tokens, None);
-//             assert_eq!(func_log.usage().output_tokens, None);
-//             assert_eq!(func_log.calls().len(), 0);
-//             assert!(func_log.raw_llm_response().is_none());
-//             assert!(func_log.metadata().is_empty());
-
-//             // Clean up by dropping both the collector and function_log
-//             drop(collector);
-//             drop(func_log);
-
-//             // Verify everything is cleaned up
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 0);
-//                 assert!(tracer.get_events(&f_id).is_none());
-//             }
-//         });
-//     }
-
-//     #[test]
-//     #[serial]
-//     fn test_function_log_with_metadata() {
-//         let rt = Runtime::new().unwrap();
-//         rt.block_on(async {
-//             let f_id = FunctionCallId("test_function_log_with_metadata".to_string());
-
-//             // Clear global state
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.clear();
-//             }
-
-//             // Create a collector to track the function ID
-//             let collector = Collector::new(Some("test_collector".to_string()));
-//             collector.track_function(f_id.clone());
-
-//             let mut tags = serde_json::Map::new();
-//             tags.insert(
-//                 "foo".to_string(),
-//                 serde_json::Value::String("bar".to_string()),
-//             );
-//             tags.insert(
-//                 "some_number".to_string(),
-//                 serde_json::Value::Number(42.into()),
-//             );
-
-//             let start_event = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId("start_event".to_string()),
-//                 call_stack: vec![],
-//                 timestamp: web_time::SystemTime::now(),
-//                 callsite: "unit_test_start".into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::FunctionStart(FunctionStart {
-//                     name: "test_function_meta".into(),
-//                     args: vec![],
-//                     options: baml_types::tracing::events::BamlOptions {
-//                         type_builder: None,
-//                         client_registry: None,
-//                     },
-//                 }),
-//                 tags,
-//             });
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(start_event.clone());
-//             }
-
-//             let mut func_log = FunctionLog::new(f_id.clone());
-//             let meta = func_log.metadata();
-//             assert_eq!(meta.get("foo").unwrap(), "bar");
-//             assert_eq!(meta.get("some_number").unwrap(), 42);
-
-//             // Clean up by dropping both the collector and function_log
-//             drop(collector);
-//             drop(func_log);
-
-//             // Verify everything is cleaned up
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 0);
-//                 assert!(tracer.get_events(&f_id).is_none());
-//             }
-//         });
-//     }
-
-//     #[test]
-//     #[serial]
-//     fn test_timing_calculations() {
-//         let rt = Runtime::new().unwrap();
-//         rt.block_on(async {
-//             let f_id = FunctionCallId("test_timing".to_string());
-//             let collector = Collector::new(Some("test_collector".to_string()));
-//             collector.track_function(f_id.clone());
-//             let start_time = web_time::SystemTime::now();
-//             // Create start event
-//             let start_event = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId("start_event".to_string()),
-//                 call_stack: vec![],
-//                 timestamp: start_time,
-//                 callsite: "unit_test_start".into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::FunctionStart(FunctionStart {
-//                     name: "test_function_timing".into(),
-//                     args: vec![],
-//                     options: baml_types::tracing::events::BamlOptions {
-//                         type_builder: None,
-//                         client_registry: None,
-//                     },
-//                 }),
-//                 tags: Default::default(),
-//             });
-
-//             // Add start event
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(start_event.clone());
-//             }
-
-//             // Sleep to create measurable duration
-//             tokio::time::sleep(Duration::from_millis(100)).await;
-//             let end_time = web_time::SystemTime::now();
-
-//             // Create end event
-//             let end_event = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId("end_event".to_string()),
-//                 call_stack: vec![],
-//                 timestamp: end_time,
-//                 callsite: "unit_test_end".into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::FunctionEnd(FunctionEnd {
-//                     result: Ok(baml_types::BamlValue::Null),
-//                 }),
-//                 tags: Default::default(),
-//             });
-
-//             // Add end event
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(end_event.clone());
-//             }
-
-//             let mut func_log = FunctionLog::new(f_id.clone());
-//             let timing = func_log.timing();
-//             let duration = end_time.duration_since(start_time).unwrap();
-
-//             assert!(
-//                 // leeway since test is a bit flaky -- maybe due to web_time crate
-//                 (duration.as_millis() as i64 - func_log.timing().duration_ms.unwrap()).abs() <= 5
-//             );
-
-//             // Start time should be valid (non-zero)
-//             assert!(timing.start_time_utc_ms > 0);
-
-//             // Clean up
-//             drop(collector);
-//             drop(func_log);
-
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 0);
-//                 assert!(tracer.get_events(&f_id).is_none());
-//             }
-//         });
-//     }
-//     /// Helper function to inject a sequence of events for testing
-//     async fn inject_test_events(
-//         f_id: &FunctionCallId,
-//         function_name: &str,
-//         llm_calls: Vec<(LoggedLLMRequest, LoggedLLMResponse)>,
-//     ) -> Collector {
-//         // Clear out the global tracer first
-//         {
-//             let mut tracer = BAML_TRACER.lock().unwrap();
-//             tracer.clear();
-//         }
-
-//         // Create a collector and track our function
-//         let collector = Collector::new(Some("test_collector".to_string()));
-//         collector.track_function(f_id.clone());
-
-//         // Insert a FunctionStart event
-//         let start_event = Arc::new(TraceEvent {
-//             call_id: f_id.clone(),
-//             event_id: ContentId("start_id".to_string()),
-//             call_stack: vec![],
-//             timestamp: web_time::SystemTime::now(),
-//             callsite: "test_start".into(),
-//             verbosity: TraceLevel::Info,
-//             content: TraceData::FunctionStart(FunctionStart {
-//                 name: function_name.into(),
-//                 args: vec![],
-//                 options: baml_types::tracing::events::BamlOptions {
-//                     type_builder: None,
-//                     client_registry: None,
-//                 },
-//             }),
-//             tags: Default::default(),
-//         });
-//         {
-//             let mut tracer = BAML_TRACER.lock().unwrap();
-//             tracer.put(start_event);
-//         }
-
-//         // Insert LLM requests and responses
-//         for (i, (req, resp)) in llm_calls.into_iter().enumerate() {
-//             let req = Arc::new(req);
-//             let resp = Arc::new(resp);
-
-//             // Put the request
-//             let event_req = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId(format!("request_{}", i)),
-//                 call_stack: vec![],
-//                 timestamp: web_time::SystemTime::now(),
-//                 callsite: format!("llm_request_{}", i).into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::LLMRequest(req),
-//                 tags: Default::default(),
-//             });
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(event_req);
-//             }
-
-//             // Put the response
-//             let event_resp = Arc::new(TraceEvent {
-//                 call_id: f_id.clone(),
-//                 event_id: ContentId(format!("response_{}", i)),
-//                 call_stack: vec![],
-//                 timestamp: web_time::SystemTime::now(),
-//                 callsite: format!("llm_response_{}", i).into(),
-//                 verbosity: TraceLevel::Info,
-//                 content: TraceData::LLMResponse(resp),
-//                 tags: Default::default(),
-//             });
-//             {
-//                 let mut tracer = BAML_TRACER.lock().unwrap();
-//                 tracer.put(event_resp);
-//             }
-//         }
-
-//         // Insert the function end event
-//         let end_event = Arc::new(TraceEvent {
-//             call_id: f_id.clone(),
-//             event_id: ContentId("end_event".to_string()),
-//             call_stack: vec![],
-//             timestamp: web_time::SystemTime::now(),
-//             callsite: "test_end".into(),
-//             verbosity: TraceLevel::Info,
-//             content: TraceData::FunctionEnd(FunctionEnd {
-//                 result: Ok(baml_types::BamlValue::Null),
-//             }),
-//             tags: Default::default(),
-//         });
-//         {
-//             let mut tracer = BAML_TRACER.lock().unwrap();
-//             tracer.put(end_event);
-//         }
-
-//         collector
-//     }
-
-//     #[test]
-//     #[serial]
-//     fn test_usage_accumulation_within_function_log_retries() {
-//         use baml_types::tracing::events::{
-//             ContentId, FunctionEnd, FunctionStart, LLMUsage, LoggedLLMRequest, LoggedLLMResponse,
-//             FunctionCallId, TraceData, TraceEvent, TraceLevel,
-//         };
-//         use std::time::Duration;
-
-//         let rt = tokio::runtime::Runtime::new().unwrap();
-//         rt.block_on(async {
-//             let f_id = FunctionCallId("test_usage_accumulation".to_string());
-
-//             let llm_calls = vec![
-//                 (
-//                     LoggedLLMRequest {
-//                         request_id: HttpRequestId("req_1".to_string()),
-//                         client_name: "my_client".into(),
-//                         client_provider: "my_provider".into(),
-//                         params: serde_json::json!({ "temperature": 0.7 }),
-//                         prompt: serde_json::json!(["Hello world"]),
-//                     },
-//                     LoggedLLMResponse {
-//                         request_id: HttpRequestId("req_1".to_string()),
-//                         model: Some("test-model-v1".into()),
-//                         finish_reason: Some("stop".into()),
-//                         usage: Some(LLMUsage {
-//                             input_tokens: Some(12),
-//                             output_tokens: Some(8),
-//                             total_tokens: Some(20),
-//                         }),
-//                         raw_text_output: Some("Hello back".into()),
-//                         error_message: None,
-//                     },
-//                 ),
-//                 (
-//                     LoggedLLMRequest {
-//                         request_id: HttpRequestId("req_2".to_string()),
-//                         client_name: "my_client".into(),
-//                         client_provider: "my_provider".into(),
-//                         params: serde_json::json!({ "temperature": 0.9 }),
-//                         prompt: serde_json::json!(["Next message"]),
-//                     },
-//                     LoggedLLMResponse {
-//                         request_id: HttpRequestId("req_2".to_string()),
-//                         model: Some("test-model-v2".into()),
-//                         finish_reason: Some("length".into()),
-//                         usage: Some(LLMUsage {
-//                             input_tokens: Some(10),
-//                             output_tokens: Some(30),
-//                             total_tokens: Some(40),
-//                         }),
-//                         raw_text_output: Some("Super long response".into()),
-//                         error_message: None,
-//                     },
-//                 ),
-//             ];
-
-//             let collector = inject_test_events(&f_id, "test_usage_func", llm_calls).await;
-
-//             // Now create a FunctionLog and check the usage
-//             let mut func_log = FunctionLog::new(f_id.clone());
-//             let usage = func_log.usage();
-//             assert_eq!(usage.input_tokens, Some(12 + 10));
-//             assert_eq!(usage.output_tokens, Some(8 + 30));
-
-//             // Verify the calls
-//             println!("calls: {:#?}", func_log.calls());
-//             let calls = func_log.calls();
-//             assert_eq!(calls.len(), 2);
-
-//             // Clean up
-//             drop(func_log);
-//             drop(collector);
-
-//             // Ensure everything is cleaned
-//             {
-//                 let tracer = BAML_TRACER.lock().unwrap();
-//                 assert_eq!(tracer.ref_count_for(&f_id), 0);
-//                 assert!(tracer.get_events(&f_id).is_none());
-//             }
-//         });
-//     }
-
-//     // TODO: validate http request body and response body are serde objects
-//     // but need to inject these events in as well.
-//     //  let calls = func_log.calls();
-//     //  for call in calls {
-//     //      if let LLMCallKind::Basic(req) = call.clone() {
-//     //          match &req.request.as_ref().unwrap().body {
-//     //              serde_json::Value::Object(_) => {}
-//     //              _ => panic!("HTTP request body should be a serde object"),
-//     //          };
-//     //          match &req.response.as_ref().unwrap().body {
-//     //              serde_json::Value::Object(_) => {}
-//     //              _ => panic!("HTTP response body should be a serde object"),
-//     //          };
-//     //      }
-//     //      if let LLMCallKind::Stream(resp) = call.clone() {
-//     //          match &resp.request.as_ref().unwrap().body {
-//     //              serde_json::Value::Object(_) => {}
-//     //              _ => panic!("HTTP request body should be a serde object"),
-//     //          };
-//     //          match &resp.response.as_ref().unwrap().body {
-//     //              serde_json::Value::Object(_) => {}
-//     //              _ => panic!("HTTP response body should be a serde object"),
-//     //          };
-//     //      }
-//     //  }
-// }
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use baml_ids::{FunctionCallId, FunctionEventId, HttpRequestId};
+    use baml_types::{
+        ir_type::TypeNonStreaming,
+        tracing::events::{
+            EvaluationContext, FunctionEnd, FunctionStart, FunctionType, LLMChatMessage,
+            LLMChatMessagePart, LLMUsage, LoggedLLMRequest, LoggedLLMResponse, TraceData,
+            TraceEvent,
+        },
+    };
+    use core::time::Duration;
+    use indexmap::IndexMap;
+    use serial_test::serial;
+    use tokio::runtime::Runtime;
+
+    #[test]
+    #[serial]
+    fn test_reference_count_lifecycle() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            // Clear and check initial state
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.clear();
+            }
+
+            let f_id = FunctionCallId::new();
+
+            // Initially, no references
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 0);
+            }
+
+            // Create a collector to track the function ID
+            let collector = Collector::new(Some("test_collector".to_string()));
+            collector.track_function(f_id.clone());
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 1);
+            }
+
+            // Put a simple SetTags event
+            let event: TraceEventWithMeta = TraceEvent::new_set_tags(vec![f_id.clone()], Default::default());
+            let event = Arc::new(event);
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(event.clone());
+            }
+
+            // Check events exist
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                let maybe_events = tracer.get_events(&f_id);
+                assert!(maybe_events.is_some());
+                assert_eq!(maybe_events.unwrap().len(), 1);
+            }
+
+            // Drop the collector => reference count goes to 0
+            drop(collector);
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 0);
+                assert!(tracer.get_events(&f_id).is_none());
+            }
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_collector_clone_reference_counts() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            let f_id = FunctionCallId::new();
+            // Clear global state
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.clear();
+            }
+
+            // Create original collector and track function
+            let collector1 = Collector::new(Some("test_collector1".to_string()));
+            collector1.track_function(f_id.clone());
+
+            // Check initial reference count is 1
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 1);
+            }
+
+            // Clone collector and verify ref count increases
+            let collector2 = collector1.clone();
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 2);
+            }
+
+            // Put a simple SetTags event
+            let event: TraceEventWithMeta = TraceEvent::new_set_tags(vec![f_id.clone()], Default::default());
+            let event = Arc::new(event);
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(event.clone());
+            }
+
+            // Verify events exist
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                let maybe_events = tracer.get_events(&f_id);
+                assert!(maybe_events.is_some());
+                assert_eq!(maybe_events.unwrap().len(), 1);
+            }
+
+            // Drop first collector, verify ref count decreases but events remain
+            drop(collector1);
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 1);
+                assert!(tracer.get_events(&f_id).is_some());
+            }
+
+            // Drop second collector, verify everything is cleaned up
+            drop(collector2);
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 0);
+                assert!(tracer.get_events(&f_id).is_none());
+            }
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_collector_and_function_log_clone_reference_counts() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            let f_id = FunctionCallId::new();
+            // Clear global state
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.clear();
+            }
+
+            // Create original collector and track function
+            let collector1 = Collector::new(Some("test_collector1".to_string()));
+            collector1.track_function(f_id.clone());
+
+            // Check initial reference count is 1
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 1);
+            }
+
+            // Clone collector and verify ref count increases
+            let collector2 = collector1.clone();
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 2);
+            }
+
+            // Create a function log and clone it
+            let func_log1 = collector1.function_log_by_id(&f_id).unwrap();
+            let func_log2 = func_log1.clone();
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 4);
+            }
+
+            // Put a simple SetTags event
+            let event: TraceEventWithMeta = TraceEvent::new_set_tags(vec![f_id.clone()], Default::default());
+            let event = Arc::new(event);
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(event.clone());
+            }
+
+            // Verify events exist
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                let maybe_events = tracer.get_events(&f_id);
+                assert!(maybe_events.is_some());
+                assert_eq!(maybe_events.unwrap().len(), 1);
+            }
+
+            // Drop first function log, verify ref count decreases but events remain
+            drop(func_log1);
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 3);
+                assert!(tracer.get_events(&f_id).is_some());
+            }
+
+            // Drop second function log
+            drop(func_log2);
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 2);
+                assert!(tracer.get_events(&f_id).is_some());
+            }
+
+            // Drop first collector, verify ref count decreases but events remain
+            drop(collector1);
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 1);
+                assert!(tracer.get_events(&f_id).is_some());
+            }
+
+            // Drop second collector, verify everything is cleaned up
+            drop(collector2);
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 0);
+                assert!(tracer.get_events(&f_id).is_none());
+            }
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_function_log_basic() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            let f_id = FunctionCallId::new();
+
+            // Clear global state
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.clear();
+            }
+
+            // Create a collector to track the function ID
+            let collector = Collector::new(Some("test_collector".to_string()));
+            collector.track_function(f_id.clone());
+
+            // Create and insert start event
+            let start_event: TraceEventWithMeta = TraceEvent::new_function_start(
+                vec![f_id.clone()],
+                "test_function".into(),
+                vec![],
+                EvaluationContext { tags: Default::default() },
+                FunctionType::Native,
+                false,
+            );
+            let start_event = Arc::new(start_event);
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(start_event.clone());
+            }
+
+            // Create and insert end event
+            let end_event: TraceEventWithMeta = TraceEvent::new_function_end(
+                vec![f_id.clone()],
+                Ok(baml_types::BamlValueWithMeta::Null(TypeNonStreaming::null())),
+            );
+            let end_event = Arc::new(end_event);
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(end_event.clone());
+            }
+
+            let mut func_log = FunctionLog::new(f_id.clone());
+            assert_eq!(func_log.id(), f_id);
+
+            assert_eq!(func_log.function_name(), "test_function");
+            let tpe = func_log.log_type();
+            assert!(tpe == "call" || tpe == "stream");
+
+            assert_eq!(func_log.usage().input_tokens, None);
+            assert_eq!(func_log.usage().output_tokens, None);
+            assert_eq!(func_log.calls().len(), 0);
+            assert!(func_log.raw_llm_response().is_none());
+            assert!(func_log.metadata().is_empty());
+
+            // Clean up by dropping both the collector and function_log
+            drop(collector);
+            drop(func_log);
+
+            // Verify everything is cleaned up
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 0);
+                assert!(tracer.get_events(&f_id).is_none());
+            }
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_function_log_with_metadata() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            let f_id = FunctionCallId::new();
+
+            // Clear global state
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.clear();
+            }
+
+            // Create a collector to track the function ID
+            let collector = Collector::new(Some("test_collector".to_string()));
+            collector.track_function(f_id.clone());
+
+            let mut tags_map = serde_json::Map::new();
+            tags_map.insert("foo".to_string(), serde_json::Value::String("bar".to_string()));
+            tags_map.insert("some_number".to_string(), serde_json::Value::Number(42.into()));
+
+            let start_event: TraceEventWithMeta = TraceEvent::new_function_start(
+                vec![f_id.clone()],
+                "test_function_meta".into(),
+                vec![],
+                EvaluationContext { tags: tags_map },
+                FunctionType::Native,
+                false,
+            );
+            let start_event = Arc::new(start_event);
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(start_event.clone());
+            }
+
+            let mut func_log = FunctionLog::new(f_id.clone());
+            let meta = func_log.metadata();
+            assert_eq!(meta.get("foo").unwrap(), "bar");
+            assert_eq!(meta.get("some_number").unwrap(), 42);
+
+            // Clean up by dropping both the collector and function_log
+            drop(collector);
+            drop(func_log);
+
+            // Verify everything is cleaned up
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 0);
+                assert!(tracer.get_events(&f_id).is_none());
+            }
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn test_timing_calculations() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            let f_id = FunctionCallId::new();
+            let collector = Collector::new(Some("test_collector".to_string()));
+            collector.track_function(f_id.clone());
+            let start_time = web_time::SystemTime::now();
+            // Create start event
+            let start_event = Arc::new(TraceEvent {
+                call_id: f_id.clone(),
+                function_event_id: FunctionEventId::new(),
+                content: TraceData::FunctionStart(FunctionStart {
+                    name: "test_function_timing".into(),
+                    function_type: FunctionType::Native,
+                    is_stream: false,
+                    args: vec![],
+                    options: EvaluationContext { tags: Default::default() },
+                }),
+                call_stack: vec![f_id.clone()],
+                timestamp: start_time,
+            });
+
+            // Add start event
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(start_event.clone());
+            }
+
+            // Sleep to create measurable duration
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let end_time = web_time::SystemTime::now();
+
+            // Create end event
+            let end_event = Arc::new(TraceEvent {
+                call_id: f_id.clone(),
+                function_event_id: FunctionEventId::new(),
+                content: TraceData::FunctionEnd(FunctionEnd::Success(
+                    baml_types::BamlValueWithMeta::Null(TypeNonStreaming::null()),
+                )),
+                call_stack: vec![f_id.clone()],
+                timestamp: end_time,
+            });
+
+            // Add end event
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(end_event.clone());
+            }
+
+            let mut func_log = FunctionLog::new(f_id.clone());
+            let timing = func_log.timing();
+            let duration = end_time.duration_since(start_time).unwrap();
+
+            assert!(
+                // leeway since test is a bit flaky -- maybe due to web_time crate
+                (duration.as_millis() as i64 - func_log.timing().duration_ms.unwrap()).abs() <= 5
+            );
+
+            // Start time should be valid (non-zero)
+            assert!(timing.start_time_utc_ms > 0);
+
+            // Clean up
+            drop(collector);
+            drop(func_log);
+
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 0);
+                assert!(tracer.get_events(&f_id).is_none());
+            }
+        });
+    }
+    /// Helper function to inject a sequence of events for testing
+    async fn inject_test_events(
+        f_id: &FunctionCallId,
+        function_name: &str,
+        llm_calls: Vec<(LoggedLLMRequest, LoggedLLMResponse)>,
+    ) -> Collector {
+        // Clear out the global tracer first
+        {
+            let mut tracer = BAML_TRACER.lock().unwrap();
+            tracer.clear();
+        }
+
+        // Create a collector and track our function
+        let collector = Collector::new(Some("test_collector".to_string()));
+        collector.track_function(f_id.clone());
+
+        // Insert a FunctionStart event
+        let start_event: TraceEventWithMeta = TraceEvent::new_function_start(
+            vec![f_id.clone()],
+            function_name.into(),
+            vec![],
+            EvaluationContext { tags: Default::default() },
+            FunctionType::Native,
+            false,
+        );
+        let start_event = Arc::new(start_event);
+        {
+            let mut tracer = BAML_TRACER.lock().unwrap();
+            tracer.put(start_event);
+        }
+
+        // Insert LLM requests and responses
+        for (i, (req, resp)) in llm_calls.into_iter().enumerate() {
+            // Put the request
+            let event_req: TraceEventWithMeta = TraceEvent::new_llm_request(
+                vec![f_id.clone()],
+                Arc::new(req),
+            );
+            let event_req = Arc::new(event_req);
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(event_req);
+            }
+
+            // Put the response
+            let event_resp: TraceEventWithMeta = TraceEvent::new_llm_response(
+                vec![f_id.clone()],
+                Arc::new(resp),
+            );
+            let event_resp = Arc::new(event_resp);
+            {
+                let mut tracer = BAML_TRACER.lock().unwrap();
+                tracer.put(event_resp);
+            }
+        }
+
+        // Insert the function end event
+        let end_event: TraceEventWithMeta = TraceEvent::new_function_end(
+            vec![f_id.clone()],
+            Ok(baml_types::BamlValueWithMeta::Null(TypeNonStreaming::null())),
+        );
+        let end_event = Arc::new(end_event);
+        {
+            let mut tracer = BAML_TRACER.lock().unwrap();
+            tracer.put(end_event);
+        }
+
+        collector
+    }
+
+    #[test]
+    #[serial]
+    fn test_usage_accumulation_within_function_log_retries() {
+        use baml_types::tracing::events::{LLMUsage, LoggedLLMRequest, LoggedLLMResponse};
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let f_id = FunctionCallId::new();
+
+            let id1 = HttpRequestId::new();
+            let id2 = HttpRequestId::new();
+            let llm_calls = vec![
+                (
+                    LoggedLLMRequest {
+                        request_id: id1.clone(),
+                        client_name: "my_client".into(),
+                        client_provider: "my_provider".into(),
+                        params: {
+                            let mut m: IndexMap<String, serde_json::Value> = IndexMap::new();
+                            m.insert("temperature".to_string(), serde_json::json!(0.7));
+                            m
+                        },
+                        prompt: vec![LLMChatMessage {
+                            role: "user".to_string(),
+                            content: vec![LLMChatMessagePart::Text("Hello world".to_string())],
+                        }],
+                    },
+                    LoggedLLMResponse {
+                        request_id: id1,
+                        client_stack: vec!["MyOpenai".to_string()],
+                        model: Some("test-model-v1".into()),
+                        finish_reason: Some("stop".into()),
+                        usage: Some(LLMUsage {
+                            input_tokens: Some(12),
+                            output_tokens: Some(8),
+                            total_tokens: Some(20),
+                        }),
+                        raw_text_output: Some("Hello back".into()),
+                        error_message: None,
+                    },
+                ),
+                (
+                    LoggedLLMRequest {
+                        request_id: id2.clone(),
+                        client_name: "my_client".into(),
+                        client_provider: "my_provider".into(),
+                        params: {
+                            let mut m: IndexMap<String, serde_json::Value> = IndexMap::new();
+                            m.insert("temperature".to_string(), serde_json::json!(0.9));
+                            m
+                        },
+                        prompt: vec![LLMChatMessage {
+                            role: "user".to_string(),
+                            content: vec![LLMChatMessagePart::Text("Next message".to_string())],
+                        }],
+                    },
+                    LoggedLLMResponse {
+                        request_id: id2,
+                        client_stack: vec!["MyOpenai".to_string()],
+                        model: Some("test-model-v2".into()),
+                        finish_reason: Some("length".into()),
+                        usage: Some(LLMUsage {
+                            input_tokens: Some(10),
+                            output_tokens: Some(30),
+                            total_tokens: Some(40),
+                        }),
+                        raw_text_output: Some("Super long response".into()),
+                        error_message: None,
+                    },
+                ),
+            ];
+
+            let collector = inject_test_events(&f_id, "test_usage_func", llm_calls).await;
+
+            // Now create a FunctionLog and check the usage
+            let mut func_log = FunctionLog::new(f_id.clone());
+            let usage = func_log.usage();
+            assert_eq!(usage.input_tokens, Some(12 + 10));
+            assert_eq!(usage.output_tokens, Some(8 + 30));
+
+            // Verify the calls
+            println!("calls: {:#?}", func_log.calls());
+            let calls = func_log.calls();
+            assert_eq!(calls.len(), 2);
+
+            // Clean up
+            drop(func_log);
+            drop(collector);
+
+            // Ensure everything is cleaned
+            {
+                let tracer = BAML_TRACER.lock().unwrap();
+                assert_eq!(tracer.ref_count_for(&f_id), 0);
+                assert!(tracer.get_events(&f_id).is_none());
+            }
+        });
+    }
+
+    // TODO: validate http request body and response body are serde objects
+    // but need to inject these events in as well.
+    //  let calls = func_log.calls();
+    //  for call in calls {
+    //      if let LLMCallKind::Basic(req) = call.clone() {
+    //          match &req.request.as_ref().unwrap().body {
+    //              serde_json::Value::Object(_) => {}
+    //              _ => panic!("HTTP request body should be a serde object"),
+    //          };
+    //          match &req.response.as_ref().unwrap().body {
+    //              serde_json::Value::Object(_) => {}
+    //              _ => panic!("HTTP response body should be a serde object"),
+    //          };
+    //      }
+    //      if let LLMCallKind::Stream(resp) = call.clone() {
+    //          match &resp.request.as_ref().unwrap().body {
+    //              serde_json::Value::Object(_) => {}
+    //              _ => panic!("HTTP request body should be a serde object"),
+    //          };
+    //          match &resp.response.as_ref().unwrap().body {
+    //              serde_json::Value::Object(_) => {}
+    //              _ => panic!("HTTP response body should be a serde object"),
+    //          };
+    //      }
+    //  }
+}

--- a/engine/baml-runtime/src/type_builder/mod.rs
+++ b/engine/baml-runtime/src/type_builder/mod.rs
@@ -1221,7 +1221,7 @@ mod tests {
             }
         "##;
 
-        builder.add_baml(baml, runtime.internal())?;
+        builder.add_baml(baml, runtime.inner.as_ref())?;
         println!("{builder}");
         builder.to_overrides();
         Ok(())


### PR DESCRIPTION
- **readd storage.rs test**
- **readd storage**

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reintroduces tests for `storage.rs` and modifies a function call in `mod.rs` for runtime access.
> 
>   - **Tests**:
>     - Reintroduces tests in `storage.rs` for reference counting, collector cloning, function log creation, and usage accumulation.
>     - Tests cover scenarios like lifecycle of reference counts, cloning of collectors and function logs, and metadata handling.
>   - **Code Changes**:
>     - Modifies `add_baml()` call in `mod.rs` to use `runtime.inner.as_ref()` instead of `runtime.internal()`.
>   - **Misc**:
>     - Ensures tests are run serially to avoid interference with global tracer state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for ec872124f4c6c6c78af55a5a03d7ff8db2e08683. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->