### PR TITLE
Add vercel ai gateway to docs

### DIFF
--- a/fern/03-reference/baml/clients/providers/openai-generic.mdx
+++ b/fern/03-reference/baml/clients/providers/openai-generic.mdx
@@ -32,6 +32,7 @@ A non-exhaustive list of providers you can use with `openai-generic`:
 | LM Studio | [LM Studio](/ref/llm-client-providers/lmstudio) |
 | Ollama | [Ollama](/ref/llm-client-providers/ollama) |
 | OpenRouter | [OpenRouter](/ref/llm-client-providers/openrouter) |
+| Vercel AI Gateway | [Vercel AI Gateway](/ref/llm-client-providers/vercel-ai-gateway) |
 | Tinfoil | [Tinfoil](/ref/llm-client-providers/tinfoil) |
 | TogetherAI | [TogetherAI](/ref/llm-client-providers/together) |
 | Unify AI | [Unify AI](/ref/llm-client-providers/unify) |

--- a/fern/03-reference/baml/clients/providers/vercel-ai-gateway.mdx
+++ b/fern/03-reference/baml/clients/providers/vercel-ai-gateway.mdx
@@ -1,0 +1,21 @@
+---
+title: vercel-ai-gateway
+---
+
+[Vercel AI Gateway](https://vercel.com/docs/ai-gateway/openai-compat) supports the OpenAI-compatible API, so you can use the [`openai-generic`](/docs/snippets/clients/providers/openai) provider with an overridden `base_url`.
+
+```baml BAML
+client<llm> VercelClient {
+  provider "openai-generic"
+  options {
+    base_url "https://ai-gateway.vercel.sh/v1"
+    api_key env.VERCEL_AI_GATEWAY_TOKEN
+    // Example models routed via the gateway
+    // model "anthropic/claude-3-5-sonnet-latest"
+    // model "openai/gpt-4o-mini"
+  }
+}
+```
+
+See the Vercel docs for details on configuring providers and models behind your gateway: [Vercel AI Gateway (OpenAI compatible)](https://vercel.com/docs/ai-gateway/openai-compat).
+

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -793,6 +793,9 @@ navigation:
           - page: "OpenRouter (openai-generic)"
             slug: openrouter
             path: 03-reference/baml/clients/providers/openrouter.mdx
+          - page: "Vercel AI Gateway (openai-generic)"
+            slug: vercel-ai-gateway
+            path: 03-reference/baml/clients/providers/vercel-ai-gateway.mdx
           - page: "Tinfoil (openai-generic)"
             slug: tinfoil
             path: 03-reference/baml/clients/providers/tinfoil.mdx
@@ -1156,6 +1159,8 @@ redirects:
     destination: "/ref/llm-client-providers/ollama"
   - source: "/ref/llm-client-providers/openai-generic-openrouter"
     destination: "/ref/llm-client-providers/openrouter"
+  - source: "/ref/llm-client-providers/openai-generic-vercel-ai-gateway"
+    destination: "/ref/llm-client-providers/vercel-ai-gateway"
   - source: "/ref/llm-client-providers/openai-generic-togetherai"
     destination: "/ref/llm-client-providers/together"
   - source: "/ref/llm-client-providers/openai-generic-unify-ai"

--- a/fern/snippets/client-constructor.mdx
+++ b/fern/snippets/client-constructor.mdx
@@ -27,6 +27,7 @@ A non-exhaustive list of providers you can use with `openai-generic`:
 | LM Studio | [LM Studio](/ref/llm-client-providers/lmstudio) |
 | Ollama | [Ollama](/ref/llm-client-providers/ollama) |
 | OpenRouter | [OpenRouter](/ref/llm-client-providers/openrouter) |
+| Vercel AI Gateway | [Vercel AI Gateway](/ref/llm-client-providers/vercel-ai-gateway) |
 | TogetherAI | [TogetherAI](/ref/llm-client-providers/together) |
 | Unify AI | [Unify AI](/ref/llm-client-providers/unify) |
 | vLLM | [vLLM](/ref/llm-client-providers/vllm) |


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [x] This PR fixes/closes #BAML-477

## Changes
Please describe the changes proposed in this pull request

This PR adds documentation for the Vercel AI Gateway, explaining how to use it with the existing `openai-generic` provider by setting the `base_url` to `https://ai-gateway.vercel.sh/v1`.

Changes include:
- A new documentation page: `fern/03-reference/baml/clients/providers/vercel-ai-gateway.mdx`
- Updates to `fern/docs.yml` to include the new page in the navigation and add a redirect.
- Updates to `fern/03-reference/baml/clients/providers/openai-generic.mdx` and `fern/snippets/client-constructor.mdx` to list Vercel AI Gateway as a supported `openai-generic` provider.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed
  - Verified the new documentation page renders correctly.
  - Confirmed the new page is accessible via the sidebar navigation.
  - Checked that links from `openai-generic.mdx` and `client-constructor.mdx` correctly point to the new Vercel AI Gateway page.
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

This PR addresses the request to add support for the Vercel AI Gateway by documenting its compatibility with the `openai-generic` provider, as suggested in the original issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-80e809f0-4deb-43da-8699-2edccd6866ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80e809f0-4deb-43da-8699-2edccd6866ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds documentation for Vercel AI Gateway usage with `openai-generic` provider, including a new page and updates to navigation and existing docs.
> 
>   - **Documentation**:
>     - Adds `vercel-ai-gateway.mdx` to document Vercel AI Gateway usage with `openai-generic` by setting `base_url` to `https://ai-gateway.vercel.sh/v1`.
>     - Updates `docs.yml` to include the new page in navigation and add a redirect.
>     - Updates `openai-generic.mdx` and `client-constructor.mdx` to list Vercel AI Gateway as a supported `openai-generic` provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=BoundaryML%2Fbaml&utm_source=github&utm_medium=referral)<sup> for f07b012177a2b4a117854c0fb52fc96328e7245f. You can [customize](https://app.ellipsis.dev/BoundaryML/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->