### PR TITLE
Fix baml github issue 1807

### DIFF
--- a/engine/language_client_codegen/src/typescript/templates/async_client.ts.j2
+++ b/engine/language_client_codegen/src/typescript/templates/async_client.ts.j2
@@ -37,8 +37,8 @@ export class BamlAsyncClient {
     this.runtime = runtime
     this.ctxManager = ctxManager
     this.streamClient = new BamlStreamClient(runtime, ctxManager, bamlOptions)
-    this.httpRequest = new AsyncHttpRequest(runtime, ctxManager)
-    this.httpStreamRequest = new AsyncHttpStreamRequest(runtime, ctxManager)
+    this.httpRequest = new AsyncHttpRequest(runtime, ctxManager, bamlOptions)
+    this.httpStreamRequest = new AsyncHttpStreamRequest(runtime, ctxManager, bamlOptions)
     this.llmResponseParser = new LlmResponseParser(runtime, ctxManager)
     this.llmStreamParser = new LlmStreamParser(runtime, ctxManager)
     this.bamlOptions = bamlOptions || {}

--- a/engine/language_client_codegen/src/typescript/templates/async_request.ts.j2
+++ b/engine/language_client_codegen/src/typescript/templates/async_request.ts.j2
@@ -14,7 +14,10 @@ type BamlCallOptions = {
 }
 
 export class AsyncHttpRequest {
-  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager) {}
+  private bamlOptions: BamlCallOptions
+  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager, bamlOptions?: BamlCallOptions) {
+    this.bamlOptions = bamlOptions || {}
+  }
 
   {% for fn in funcs %}
   async {{ fn.name }}(
@@ -24,7 +27,8 @@ export class AsyncHttpRequest {
       __baml_options__?: BamlCallOptions
   ): Promise<HTTPRequest> {
     try {
-      const env = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
+      const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
+      const env = options.env ? { ...process.env, ...options.env } : { ...process.env };
       return await this.runtime.buildRequest(
         "{{fn.name}}",
         {
@@ -33,8 +37,8 @@ export class AsyncHttpRequest {
           {%- endfor %}
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         false,
         env
       )
@@ -46,7 +50,10 @@ export class AsyncHttpRequest {
 }
 
 export class AsyncHttpStreamRequest {
-  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager) {}
+  private bamlOptions: BamlCallOptions
+  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager, bamlOptions?: BamlCallOptions) {
+    this.bamlOptions = bamlOptions || {}
+  }
 
   {% for fn in funcs %}
   async {{ fn.name }}(
@@ -56,7 +63,8 @@ export class AsyncHttpStreamRequest {
       __baml_options__?: BamlCallOptions
   ): Promise<HTTPRequest> {
     try {
-      const env = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
+      const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
+      const env = options.env ? { ...process.env, ...options.env } : { ...process.env };
       return await this.runtime.buildRequest(
         "{{fn.name}}",
         {
@@ -65,8 +73,8 @@ export class AsyncHttpStreamRequest {
           {%- endfor %}
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         true,
         env
       )

--- a/engine/language_client_codegen/src/typescript/templates/sync_client.ts.j2
+++ b/engine/language_client_codegen/src/typescript/templates/sync_client.ts.j2
@@ -34,8 +34,8 @@ export class BamlSyncClient {
   private bamlOptions: BamlCallOptions
 
   constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager, private bamlOptions?: BamlCallOptions) {
-    this.httpRequest = new HttpRequest(runtime, ctxManager)
-    this.httpStreamRequest = new HttpStreamRequest(runtime, ctxManager)
+    this.httpRequest = new HttpRequest(runtime, ctxManager, bamlOptions)
+    this.httpStreamRequest = new HttpStreamRequest(runtime, ctxManager, bamlOptions)
     this.llmResponseParser = new LlmResponseParser(runtime, ctxManager)
     this.llmStreamParser = new LlmStreamParser(runtime, ctxManager)
     this.bamlOptions = bamlOptions || {}

--- a/engine/language_client_codegen/src/typescript/templates/sync_request.ts.j2
+++ b/engine/language_client_codegen/src/typescript/templates/sync_request.ts.j2
@@ -14,7 +14,10 @@ type BamlCallOptions = {
 }
 
 export class HttpRequest {
-  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager) {}
+  private bamlOptions: BamlCallOptions
+  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager, bamlOptions?: BamlCallOptions) {
+    this.bamlOptions = bamlOptions || {}
+  }
 
   {% for fn in funcs %}
   {{ fn.name }}(
@@ -24,7 +27,8 @@ export class HttpRequest {
       __baml_options__?: BamlCallOptions
   ): HTTPRequest {
     try {
-      const env = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
+      const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
+      const env = options.env ? { ...process.env, ...options.env } : { ...process.env };
       return this.runtime.buildRequestSync(
         "{{fn.name}}",
         {
@@ -33,8 +37,8 @@ export class HttpRequest {
           {%- endfor %}
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         false,
         env,
       )

--- a/integ-tests/typescript/baml_client/async_client.ts
+++ b/integ-tests/typescript/baml_client/async_client.ts
@@ -59,8 +59,8 @@ export class BamlAsyncClient {
     this.runtime = runtime
     this.ctxManager = ctxManager
     this.streamClient = new BamlStreamClient(runtime, ctxManager, bamlOptions)
-    this.httpRequest = new AsyncHttpRequest(runtime, ctxManager)
-    this.httpStreamRequest = new AsyncHttpStreamRequest(runtime, ctxManager)
+    this.httpRequest = new AsyncHttpRequest(runtime, ctxManager, bamlOptions)
+    this.httpStreamRequest = new AsyncHttpStreamRequest(runtime, ctxManager, bamlOptions)
     this.llmResponseParser = new LlmResponseParser(runtime, ctxManager)
     this.llmStreamParser = new LlmStreamParser(runtime, ctxManager)
     this.bamlOptions = bamlOptions || {}

--- a/integ-tests/typescript/baml_client/async_request.ts
+++ b/integ-tests/typescript/baml_client/async_request.ts
@@ -35,7 +35,10 @@ type BamlCallOptions = {
 }
 
 export class AsyncHttpRequest {
-  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager) {}
+  private bamlOptions: BamlCallOptions
+  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager, bamlOptions?: BamlCallOptions) {
+    this.bamlOptions = bamlOptions || {}
+  }
 
   
   async AaaSamOutputFormat(
@@ -43,7 +46,8 @@ export class AsyncHttpRequest {
       __baml_options__?: BamlCallOptions
   ): Promise<HTTPRequest> {
     try {
-      const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
+      const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
+      const rawEnv = options.env ? { ...process.env, ...options.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
         Object.entries(rawEnv).filter(([_, value]) => value !== undefined) as [string, string][]
       );
@@ -53,8 +57,8 @@ export class AsyncHttpRequest {
           "recipe": recipe
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         false,
         env
       )
@@ -68,7 +72,8 @@ export class AsyncHttpRequest {
       __baml_options__?: BamlCallOptions
   ): Promise<HTTPRequest> {
     try {
-      const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
+      const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
+      const rawEnv = options.env ? { ...process.env, ...options.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
         Object.entries(rawEnv).filter(([_, value]) => value !== undefined) as [string, string][]
       );
@@ -78,8 +83,8 @@ export class AsyncHttpRequest {
           "data": data
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         false,
         env
       )
@@ -103,8 +108,8 @@ export class AsyncHttpRequest {
           "money": money
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         false,
         env
       )
@@ -128,8 +133,8 @@ export class AsyncHttpRequest {
           "input": input
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         false,
         env
       )
@@ -5541,7 +5546,10 @@ export class AsyncHttpRequest {
 }
 
 export class AsyncHttpStreamRequest {
-  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager) {}
+  private bamlOptions: BamlCallOptions
+  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager, bamlOptions?: BamlCallOptions) {
+    this.bamlOptions = bamlOptions || {}
+  }
 
   
   async AaaSamOutputFormat(

--- a/integ-tests/typescript/baml_client/sync_client.ts
+++ b/integ-tests/typescript/baml_client/sync_client.ts
@@ -56,8 +56,8 @@ export class BamlSyncClient {
   private bamlOptions: BamlCallOptions
 
   constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager, bamlOptions?: BamlCallOptions) {
-    this.httpRequest = new HttpRequest(runtime, ctxManager)
-    this.httpStreamRequest = new HttpStreamRequest(runtime, ctxManager)
+    this.httpRequest = new HttpRequest(runtime, ctxManager, bamlOptions)
+    this.httpStreamRequest = new HttpStreamRequest(runtime, ctxManager, bamlOptions)
     this.llmResponseParser = new LlmResponseParser(runtime, ctxManager)
     this.llmStreamParser = new LlmStreamParser(runtime, ctxManager)
     this.bamlOptions = bamlOptions || {}

--- a/integ-tests/typescript/baml_client/sync_request.ts
+++ b/integ-tests/typescript/baml_client/sync_request.ts
@@ -32,7 +32,10 @@ type BamlCallOptions = {
 }
 
 export class HttpRequest {
-  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager) {}
+  private bamlOptions: BamlCallOptions
+  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager, bamlOptions?: BamlCallOptions) {
+    this.bamlOptions = bamlOptions || {}
+  }
 
   
   AaaSamOutputFormat(
@@ -40,7 +43,8 @@ export class HttpRequest {
       __baml_options__?: BamlCallOptions
   ): HTTPRequest {
     try {
-      const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
+      const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
+      const rawEnv = options.env ? { ...process.env, ...options.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
         Object.entries(rawEnv).filter(([_, value]) => value !== undefined) as [string, string][]
       );
@@ -50,8 +54,8 @@ export class HttpRequest {
           "recipe": recipe
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         false,
         env,
       )
@@ -75,8 +79,8 @@ export class HttpRequest {
           "data": data
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         false,
         env,
       )
@@ -100,8 +104,8 @@ export class HttpRequest {
           "money": money
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         false,
         env,
       )
@@ -5538,7 +5542,10 @@ export class HttpRequest {
 }
 
 export class HttpStreamRequest {
-  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager) {}
+  private bamlOptions: BamlCallOptions
+  constructor(private runtime: BamlRuntime, private ctxManager: BamlCtxManager, bamlOptions?: BamlCallOptions) {
+    this.bamlOptions = bamlOptions || {}
+  }
 
   
   AaaSamOutputFormat(
@@ -5546,7 +5553,8 @@ export class HttpStreamRequest {
       __baml_options__?: BamlCallOptions
   ): HTTPRequest {
     try {
-      const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
+      const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
+      const rawEnv = options.env ? { ...process.env, ...options.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
         Object.entries(rawEnv).filter(([_, value]) => value !== undefined) as [string, string][]
       );
@@ -5556,8 +5564,8 @@ export class HttpStreamRequest {
           "recipe": recipe
         },
         this.ctxManager.cloneContext(),
-        __baml_options__?.tb?.__tb(),
-        __baml_options__?.clientRegistry,
+        options.tb?.__tb(),
+        options.clientRegistry,
         true,
         env,
       )

--- a/integ-tests/typescript/tests/dynamic-enum-request.test.ts
+++ b/integ-tests/typescript/tests/dynamic-enum-request.test.ts
@@ -2,7 +2,7 @@ import TypeBuilder, { FieldType } from "../baml_client/type_builder";
 import { b, b_sync } from "./test-setup";
 
 describe("Dynamic Enum Request Tests", () => {
-  it("should include dynamic enum values in RenderDynamicEnum request", async () => {
+  it("should include dynamic enum values in RenderDynamicEnum request (direct options)", async () => {
     const tb = new TypeBuilder();
     
     // Add values to RenderTestEnum
@@ -48,6 +48,22 @@ Multiple value tests:
 
 'other' is MOTORCYCLE, as expected
 `)
+  });
+
+  it("should include dynamic enum values in RenderDynamicEnum request (withOptions default)", async () => {
+    const tb = new TypeBuilder();
+    tb.RenderTestEnum.addValue("MOTORCYCLE").alias("motorized two-wheeler");
+
+    const myB = b.withOptions({ tb });
+    const request = await myB.request.RenderDynamicEnum(
+      "BIKE",
+      "MOTORCYCLE"
+    );
+
+    const requestBody = request.body.json();
+    const messageContent = requestBody.messages[0].content[0].text;
+    expect(messageContent).toContain("Available dynamic enum values:");
+    expect(messageContent).toContain("MOTORCYCLE");
   });
 
   it("should include dynamic class properties in RenderDynamicClass request", async () => {


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [x] This PR fixes/closes #1807

## Changes
Please describe the changes proposed in this pull request

This PR addresses issue #1807 by ensuring that the `TypeBuilder` provided via `b.withOptions({ tb })` is correctly applied to requests generated using the `b.request.*` APIs in the TypeScript client. Previously, these request builders did not inherit the `TypeBuilder` from the client's default options.

The fix involves:
1.  Updating TypeScript client generator templates to propagate default `bamlOptions` (including `tb`) to `HttpRequest` and `AsyncHttpRequest` constructors.
2.  Modifying request-building methods to merge these default options with any call-specific options.
3.  Adding a new integration test to verify this behavior.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in local development environment

The fix was verified by running the targeted TypeScript integration test:
`pnpm integ-tests:dotenv -t "Dynamic Enum Request Tests"`

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The changes involved modifying the TypeScript client generator templates (`engine/language_client_codegen/src/typescript/templates/*.ts.j2`) and regenerating the client files in `integ-tests/typescript/baml_client`. A new integration test (`integ-tests/typescript/tests/dynamic-enum-request.test.ts`) was added to specifically validate that `withOptions({ tb })` is now correctly applied to requests built via `b.request.*`.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1757806485154179?thread_ts=1757806485.154179&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-8581f039-4637-4dd3-a0af-69577a8d3fe7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8581f039-4637-4dd3-a0af-69577a8d3fe7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

