### PR TITLE
Update pdf testing documentation in playground

### DIFF
--- a/fern/03-reference/baml_client/pdf.mdx
+++ b/fern/03-reference/baml_client/pdf.mdx
@@ -146,7 +146,7 @@ test PdfFileTest {
 ```
 
 <ParamField path="file" type="string" required="true">
-  The path to the PDF file, relative to the current BAML file. PDF files must be inside `baml_src/`.
+  The path to the PDF file. Supports relative paths (resolved from the current BAML file) or absolute paths. The file does not need to be inside `baml_src/`.
 </ParamField>
 
 ## Static Methods

--- a/fern/03-reference/baml_client/pdf.mdx
+++ b/fern/03-reference/baml_client/pdf.mdx
@@ -123,6 +123,32 @@ func testPdfInput() error {
 ```
 </CodeBlocks>
 
+## Test Pdf in the Playground
+
+To test a function that accepts a `pdf` in the VSCode playground using a local file, add a `test` block to your `.baml` file:
+
+```baml
+function AnalyzePdf(myPdf: pdf) -> string {
+  client GPT4o
+  prompt #"
+    Summarize this Pdf: {{myPdf}}
+  "#
+}
+
+test PdfFileTest {
+  functions [AnalyzePdf]
+  args {
+    myPdf {
+      file "../documents/report.pdf"
+    }
+  }
+}
+```
+
+<ParamField path="file" type="string" required="true">
+  The path to the PDF file, relative to the current BAML file. PDF files must be inside `baml_src/`.
+</ParamField>
+
 ## Static Methods
 
 <ParamField


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

Added a "Test Pdf in the Playground" section to the PDF reference documentation (`fern/03-reference/baml_client/pdf.mdx`). This section provides instructions and a code example for testing functions that accept `pdf` inputs using local files in the VSCode playground.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed (Verified the content and formatting of the added section.)
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [ ] I have read and followed the contributing guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The new section mirrors the structure and content of testing instructions for other media types (e.g., images, videos) to ensure consistency across the documentation.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1757869566191379?thread_ts=1757869566.191379&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-0b2eb764-f4be-4160-81f7-2836875893e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b2eb764-f4be-4160-81f7-2836875893e9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

