### PR TITLE
Fix openai file url handling

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/openai/openai_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/openai/openai_client.rs
@@ -203,7 +203,8 @@ impl ProviderStrategy {
                                                             baml_types::BamlMediaContent::Base64(b64_media) => {
                                                                 Ok(json!({
                                                                     "type": if msg.role == "assistant" { "output_file" } else { "input_file" },
-                                                                    "file_url": format!("data:{};base64,{}", media.mime_type_as_ok()?, b64_media.base64)
+                                                                    "filename": "document.pdf",
+                                                                    "file_data": b64_media.base64
                                                                 }))
                                                             }
                                                         }

--- a/integ-tests/python/tests/providers/test_openai_responses.py
+++ b/integ-tests/python/tests/providers/test_openai_responses.py
@@ -66,7 +66,7 @@ async def test_expose_request_openai_responses_audio():
 
 @pytest.mark.asyncio
 async def test_expose_request_openai_responses_pdf_base64():
-    # Test that base64 PDFs are converted to data URLs
+    # Test that base64 PDFs are sent as filename + file_data
     test_pdf_b64 = "JVBERi0xLjQKMSAwIG9iago8PC9UeXBlIC9DYXRhbG9nCi9QYWdlcyAyIDAgUgo+PgplbmRvYmoKMiAwIG9iago8PC9UeXBlIC9QYWdlcwovS2lkcyBbMyAwIFJdCi9Db3VudCAxCj4+CmVuZG9iagozIDAgb2JqCjw8L1R5cGUgL1BhZ2UKL1BhcmVudCAyIDAgUgovTWVkaWFCb3ggWzAgMCA1OTUgODQyXQovQ29udGVudHMgNSAwIFIKL1Jlc291cmNlcyA8PC9Qcm9jU2V0IFsvUERGIC9UZXh0XQovRm9udCA8PC9GMSA0IDAgUj4+Cj4+Cj4+CmVuZG9iago0IDAgb2JqCjw8L1R5cGUgL0ZvbnQKL1N1YnR5cGUgL1R5cGUxCi9OYW1lIC9GMQovQmFzZUZvbnQgL0hlbHZldGljYQovRW5jb2RpbmcgL01hY1JvbWFuRW5jb2RpbmcKPj4KZW5kb2JqCjUgMCBvYmoKPDwvTGVuZ3RoIDUzCj4+CnN0cmVhbQpCVAovRjEgMjAgVGYKMjIwIDQwMCBUZAooRHVtbXkgUERGKSBUagpFVAplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZgowMDAwMDAwMDA5IDAwMDAwIG4KMDAwMDAwMDA2MyAwMDAwMCBuCjAwMDAwMDAxMjQgMDAwMDAgbgowMDAwMDAwMjc3IDAwMDAwIG4KMDAwMDAwMDM5MiAwMDAwMCBuCnRyYWlsZXIKPDwvU2l6ZSA2Ci9Sb290IDEgMCBSCj4+CnN0YXJ0eHJlZgo0OTUKJSVFT0YK"
     test_pdf = Pdf.from_base64(test_pdf_b64)
     request = await b.request.TestOpenAIResponsesImageInput(test_pdf)
@@ -83,7 +83,8 @@ async def test_expose_request_openai_responses_pdf_base64():
                             {"type": "input_text", "text": "what is in this content?"},
                             {
                                 "type": "input_file",
-                                "file_url": f"data:application/pdf;base64,{test_pdf_b64}",
+                                "filename": "document.pdf",
+                                "file_data": test_pdf_b64,
                             },
                         ],
                     }

--- a/integ-tests/python/tests/providers/test_openai_responses.py
+++ b/integ-tests/python/tests/providers/test_openai_responses.py
@@ -66,8 +66,14 @@ async def test_expose_request_openai_responses_audio():
 
 @pytest.mark.asyncio
 async def test_expose_request_openai_responses_pdf_base64():
-    # Test that base64 PDFs are sent as filename + file_data
-    test_pdf_b64 = "JVBERi0xLjQKMSAwIG9iago8PC9UeXBlIC9DYXRhbG9nCi9QYWdlcyAyIDAgUgo+PgplbmRvYmoKMiAwIG9iago8PC9UeXBlIC9QYWdlcwovS2lkcyBbMyAwIFJdCi9Db3VudCAxCj4+CmVuZG9iagozIDAgb2JqCjw8L1R5cGUgL1BhZ2UKL1BhcmVudCAyIDAgUgovTWVkaWFCb3ggWzAgMCA1OTUgODQyXQovQ29udGVudHMgNSAwIFIKL1Jlc291cmNlcyA8PC9Qcm9jU2V0IFsvUERGIC9UZXh0XQovRm9udCA8PC9GMSA0IDAgUj4+Cj4+Cj4+CmVuZG9iago0IDAgb2JqCjw8L1R5cGUgL0ZvbnQKL1N1YnR5cGUgL1R5cGUxCi9OYW1lIC9GMQovQmFzZUZvbnQgL0hlbHZldGljYQovRW5jb2RpbmcgL01hY1JvbWFuRW5jb2RpbmcKPj4KZW5kb2JqCjUgMCBvYmoKPDwvTGVuZ3RoIDUzCj4+CnN0cmVhbQpCVAovRjEgMjAgVGYKMjIwIDQwMCBUZAooRHVtbXkgUERGKSBUagpFVAplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZgowMDAwMDAwMDA5IDAwMDAwIG4KMDAwMDAwMDA2MyAwMDAwMCBuCjAwMDAwMDAxMjQgMDAwMDAgbgowMDAwMDAwMjc3IDAwMDAwIG4KMDAwMDAwMDM5MiAwMDAwMCBuCnRyYWlsZXIKPDwvU2l6ZSA2Ci9Sb290IDEgMCBSCj4+CnN0YXJ0eHJlZgo0OTUKJSVFT0YK"
+    # Test that base64 PDFs are sent as filename + file_data using a real file
+    import base64
+    from pathlib import Path
+
+    pdf_path = Path(__file__).resolve().parents[3] / "baml_src" / "dummy.pdf"
+    with open(pdf_path, "rb") as f:
+        test_pdf_b64 = base64.b64encode(f.read()).decode("ascii")
+
     test_pdf = Pdf.from_base64(test_pdf_b64)
     request = await b.request.TestOpenAIResponsesImageInput(test_pdf)
 


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

This PR corrects how base64 encoded files are sent to the OpenAI Responses API. Previously, base64 data was incorrectly placed in the `file_url` field. This change updates the Rust implementation to use `filename` and `file_data` for base64 content, aligning with the OpenAI API specification. `file_url` will now exclusively be used for actual file URLs.

The Python integration test for OpenAI Responses PDF handling has also been updated to reflect this new structure and now uses a real PDF file for base64 encoding.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [X] Manual testing performed
- [X] Tested in `baml-runtime` (Rust unit tests)

The `baml-runtime` Rust unit tests were run successfully. The Python integration test was updated to reflect the new expected payload, and its logic was manually verified.

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The Python integration test was not fully executed due to `uv` not being installed in the environment, but the test code was updated to reflect the correct API usage.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1757870844484489?thread_ts=1757870844.484489&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-fb25ecfc-6abc-4fa8-9871-e69c18f6dc4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb25ecfc-6abc-4fa8-9871-e69c18f6dc4d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

