### PR TITLE
Fix baml issue 2446 and add linter

### DIFF
--- a/engine/baml-lib/jinja/src/evaluate_type/expr.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/expr.rs
@@ -700,6 +700,14 @@ fn infer_const_type(v: &minijinja::value::Value) -> Type {
 
 pub fn evaluate_type(expr: &ast::Expr, types: &PredefinedTypes) -> Result<Type, Vec<TypeError>> {
     let mut state = ScopeTracker::new();
+    // Lint: bare function reference without call, e.g. `{{ MyTemplateString }}` vs `{{ MyTemplateString() }}`
+    if let ast::Expr::Var(var) = expr {
+        if let Some((_, _)) = types.as_function(var.id) {
+            state
+                .errors
+                .push(TypeError::new_function_reference_without_call(var.id, var.span()));
+        }
+    }
     let result = tracker_visit_expr(expr, &mut state, types);
 
     if state.errors.is_empty() {

--- a/engine/baml-lib/jinja/src/evaluate_type/mod.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/mod.rs
@@ -191,6 +191,15 @@ impl TypeError {
         Self { message: format!("{message}\n\nSee: https://docs.rs/minijinja/latest/minijinja/filters/index.html#functions for the compelete list"), span }
     }
 
+    pub fn new_function_reference_without_call(func: &str, span: Span) -> Self {
+        Self {
+            message: format!(
+                "Function '{func}' referenced without parentheses. Did you mean '{func}()'?"
+            ),
+            span,
+        }
+    }
+
     fn new_enum_literal_suggestion(
         expr: &Expr,
         enum_name: &str,

--- a/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
@@ -361,3 +361,23 @@ fn sum_filter() {
         vec![r#"'[hi,1]' is a list[(literal["hi"] | literal[1])], expected (int|float)[]"#]
     );
 }
+
+#[test]
+fn test_function_reference_without_call_expr() {
+    let mut types = PredefinedTypes::default(JinjaContext::Prompt);
+    types.add_function("SomeFunc", Type::Float, vec![]);
+
+    let parsed = parse_expr("SomeFunc").unwrap();
+    let result = evaluate_type(&parsed, &types);
+    assert!(result.is_err());
+    let msgs: Vec<_> = result
+        .err()
+        .unwrap()
+        .into_iter()
+        .map(|e| e.message)
+        .collect();
+    assert_eq!(
+        msgs,
+        vec!["Function 'SomeFunc' referenced without parentheses. Did you mean 'SomeFunc()'?".to_string()]
+    );
+}

--- a/engine/baml-lib/jinja/src/evaluate_type/test_stmt.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/test_stmt.rs
@@ -269,3 +269,17 @@ fn if_else() {
         types
     );
 }
+
+#[test]
+fn function_reference_without_call_in_template() {
+    let mut types = PredefinedTypes::default(JinjaContext::Prompt);
+    types.add_function("MyTemplateString", Type::String, vec![]);
+    assert_fails_to!(
+        r#"
+{{ MyTemplateString }}
+"#
+        .trim(),
+        types,
+        vec!["Function 'MyTemplateString' referenced without parentheses. Did you mean 'MyTemplateString()'?".to_string()]
+    );
+}


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [x] This PR fixes/closes #2446

## Changes
Please describe the changes proposed in this pull request

This PR introduces a new lint rule in the Jinja type checker to address an issue where template string macros (functions) could be referenced without being called. Previously, `{{ MyTemplateString }}` would silently evaluate to the function itself, leading to unexpected behavior.

The change:
- Adds a new `TypeError::new_function_reference_without_call` variant.
- Implements a check in `engine/baml-lib/jinja/src/evaluate_type/expr.rs` to detect when a variable resolving to a function is used as a bare expression.
- Emits a linter error with a clear message and suggestion (e.g., "Function 'X' referenced without parentheses. Did you mean 'X()'?"), guiding users to explicitly call the function.

## Testing
Please describe how you tested these changes

- [x] Unit tests added/updated
  - Added `test_function_reference_without_call_expr` in `engine/baml-lib/jinja/src/evaluate_type/test_expr.rs` for expression context.
  - Added `function_reference_without_call_in_template` in `engine/baml-lib/jinja/src/evaluate_type/test_stmt.rs` for template context.
- [x] Manual testing performed
  - Ran `cargo test -p internal-baml-jinja-types --lib` to execute the relevant unit tests.
- [x] Tested in `internal-baml-jinja-types` crate

## Screenshots
If applicable, add screenshots to help explain your changes

[N/A]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

This lint significantly improves developer experience by preventing a common source of confusion and subtle bugs when working with template string macros, providing immediate feedback on incorrect usage.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1758136431235149?thread_ts=1758136431.235149&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-ee331042-564d-4456-ac0a-91c40e235fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ee331042-564d-4456-ac0a-91c40e235fd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

