### PR TITLE
jinja template string linter

### DIFF
--- a/engine/baml-lib/baml/tests/validation_files/functions_v2/prompt_errors/prompt1.baml
+++ b/engine/baml-lib/baml/tests/validation_files/functions_v2/prompt_errors/prompt1.baml
@@ -50,6 +50,24 @@ function Bar1(a: string) -> int {
 // 23 |   prompt #"
 // 24 |     {{ Foo(a) }}
 //    | 
+// warning: Function 'Foo' referenced without parentheses. Did you mean 'Foo()'?
+//   -->  functions_v2/prompt_errors/prompt1.baml:32
+//    | 
+// 31 |     {% if a == "a" %}
+// 32 |       {% set b = Foo %}
+//    | 
+// warning: Function 'Foo2' referenced without parentheses. Did you mean 'Foo2()'?
+//   -->  functions_v2/prompt_errors/prompt1.baml:34
+//    | 
+// 33 |     {% else %}
+// 34 |       {% set b = Foo2 %}
+//    | 
+// warning: 'b' is undefined, expected function
+//   -->  functions_v2/prompt_errors/prompt1.baml:37
+//    | 
+// 36 | 
+// 37 |     {{ b() }}
+//    | 
 // warning: Variable `b` does not exist. Did you mean one of these: `_`, `ctx`?
 //   -->  functions_v2/prompt_errors/prompt1.baml:6
 //    | 

--- a/engine/baml-lib/jinja/src/evaluate_type/expr.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/expr.rs
@@ -700,6 +700,14 @@ fn infer_const_type(v: &minijinja::value::Value) -> Type {
 
 pub fn evaluate_type(expr: &ast::Expr, types: &PredefinedTypes) -> Result<Type, Vec<TypeError>> {
     let mut state = ScopeTracker::new();
+    // Lint: bare function reference without call, e.g. `{{ MyTemplateString }}` vs `{{ MyTemplateString() }}`
+    if let ast::Expr::Var(var) = expr {
+        if let Some((_, _)) = types.as_function(var.id) {
+            state
+                .errors
+                .push(TypeError::new_function_reference_without_call(var.id, var.span()));
+        }
+    }
     let result = tracker_visit_expr(expr, &mut state, types);
 
     if state.errors.is_empty() {

--- a/engine/baml-lib/jinja/src/evaluate_type/expr.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/expr.rs
@@ -705,7 +705,10 @@ pub fn evaluate_type(expr: &ast::Expr, types: &PredefinedTypes) -> Result<Type, 
         if let Some((_, _)) = types.as_function(var.id) {
             state
                 .errors
-                .push(TypeError::new_function_reference_without_call(var.id, var.span()));
+                .push(TypeError::new_function_reference_without_call(
+                    var.id,
+                    var.span(),
+                ));
         }
     }
     let result = tracker_visit_expr(expr, &mut state, types);

--- a/engine/baml-lib/jinja/src/evaluate_type/mod.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/mod.rs
@@ -191,6 +191,15 @@ impl TypeError {
         Self { message: format!("{message}\n\nSee: https://docs.rs/minijinja/latest/minijinja/filters/index.html#functions for the compelete list"), span }
     }
 
+    pub fn new_function_reference_without_call(func: &str, span: Span) -> Self {
+        Self {
+            message: format!(
+                "Function '{func}' referenced without parentheses. Did you mean '{func}()'?"
+            ),
+            span,
+        }
+    }
+
     fn new_enum_literal_suggestion(
         expr: &Expr,
         enum_name: &str,

--- a/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
@@ -361,3 +361,23 @@ fn sum_filter() {
         vec![r#"'[hi,1]' is a list[(literal["hi"] | literal[1])], expected (int|float)[]"#]
     );
 }
+
+#[test]
+fn test_function_reference_without_call_expr() {
+    let mut types = PredefinedTypes::default(JinjaContext::Prompt);
+    types.add_function("SomeFunc", Type::Float, vec![]);
+
+    let parsed = parse_expr("SomeFunc").unwrap();
+    let result = evaluate_type(&parsed, &types);
+    assert!(result.is_err());
+    let msgs: Vec<_> = result
+        .err()
+        .unwrap()
+        .into_iter()
+        .map(|e| e.message)
+        .collect();
+    assert_eq!(
+        msgs,
+        vec!["Function 'SomeFunc' referenced without parentheses. Did you mean 'SomeFunc()'?".to_string()]
+    );
+}

--- a/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
@@ -378,6 +378,9 @@ fn test_function_reference_without_call_expr() {
         .collect();
     assert_eq!(
         msgs,
-        vec!["Function 'SomeFunc' referenced without parentheses. Did you mean 'SomeFunc()'?".to_string()]
+        vec![
+            "Function 'SomeFunc' referenced without parentheses. Did you mean 'SomeFunc()'?"
+                .to_string()
+        ]
     );
 }

--- a/engine/baml-lib/jinja/src/evaluate_type/test_stmt.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/test_stmt.rs
@@ -269,3 +269,17 @@ fn if_else() {
         types
     );
 }
+
+#[test]
+fn function_reference_without_call_in_template() {
+    let mut types = PredefinedTypes::default(JinjaContext::Prompt);
+    types.add_function("MyTemplateString", Type::String, vec![]);
+    assert_fails_to!(
+        r#"
+{{ MyTemplateString }}
+"#
+        .trim(),
+        types,
+        vec!["Function 'MyTemplateString' referenced without parentheses. Did you mean 'MyTemplateString()'?".to_string()]
+    );
+}


### PR DESCRIPTION
- **Add warning when template string is called in jinja without parens**
- **lint**

# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

[Describe your changes here...]

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

[Add any additional notes here...]