### PR TITLE
Evaluate baml attribute jinja templates

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/walker.rs
+++ b/engine/baml-lib/baml-core/src/ir/walker.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use anyhow::Result;
 use baml_types::{
-    type_meta::base::StreamingBehavior, BamlValue, EvaluationContext, UnresolvedValue,
+    type_meta::base::StreamingBehavior, BamlValue, EvaluationContext, GetEnvVar, UnresolvedValue,
 };
 use indexmap::{IndexMap, IndexSet};
 use internal_baml_ast::ast::WithIdentifier;
@@ -16,6 +16,35 @@ use crate::ir::{
     Class, Client, Enum, EnumValue, ExprFunctionNode, Field, Function, FunctionNode, IRHelper,
     Impl, IntermediateRepr, RetryPolicy, TemplateString, TestCase, TypeAlias, TypeIR, Walker,
 };
+
+fn build_attr_template_ctx(
+    ctx: &EvaluationContext<'_>,
+) -> std::collections::HashMap<String, minijinja::Value> {
+    let mut map = std::collections::HashMap::new();
+    if let Some(vars) = ctx.vars_map() {
+        map.insert("env".to_string(), minijinja::Value::from_serialize(vars));
+    }
+    map
+}
+
+fn resolve_attribute_string(
+    v: &baml_types::StringOr,
+    ctx: &EvaluationContext<'_>,
+) -> Result<String> {
+    use baml_types::StringOr;
+    match v {
+        StringOr::EnvVar(name) => ctx.get_env_var(name),
+        StringOr::Value(s) => {
+            let env = crate::ir::jinja_helpers::get_env();
+            let args = minijinja::Value::from_serialize(&build_attr_template_ctx(ctx));
+            Ok(env.render_str(s, &args)?)
+        }
+        StringOr::JinjaExpression(expr) => {
+            let ctx_map = build_attr_template_ctx(ctx);
+            Ok(render_expression(expr, &ctx_map)?)
+        }
+    }
+}
 
 impl<'a> Walker<'a, &'a ExprFunctionNode> {
     pub fn name(&self) -> &'a str {
@@ -161,7 +190,7 @@ impl<'a> Walker<'a, &'a Enum> {
         self.item
             .attributes
             .alias()
-            .map(|v| v.resolve(ctx))
+            .map(|v| resolve_attribute_string(v, ctx))
             .transpose()
     }
 
@@ -169,7 +198,7 @@ impl<'a> Walker<'a, &'a Enum> {
         self.item
             .attributes
             .description()
-            .map(|v| v.resolve(ctx))
+            .map(|v| resolve_attribute_string(v, ctx))
             .transpose()
     }
 
@@ -214,7 +243,7 @@ impl<'a> Walker<'a, &'a EnumValue> {
         self.item
             .attributes
             .alias()
-            .map(|v| v.resolve(ctx))
+            .map(|v| resolve_attribute_string(v, ctx))
             .transpose()
     }
 
@@ -222,7 +251,7 @@ impl<'a> Walker<'a, &'a EnumValue> {
         self.item
             .attributes
             .description()
-            .map(|v| v.resolve(ctx))
+            .map(|v| resolve_attribute_string(v, ctx))
             .transpose()
     }
 }
@@ -336,7 +365,7 @@ impl<'a> Walker<'a, &'a Class> {
         self.item
             .attributes
             .alias()
-            .map(|v| v.resolve(ctx))
+            .map(|v| resolve_attribute_string(v, ctx))
             .transpose()
     }
 
@@ -344,7 +373,7 @@ impl<'a> Walker<'a, &'a Class> {
         self.item
             .attributes
             .description()
-            .map(|v| v.resolve(ctx))
+            .map(|v| resolve_attribute_string(v, ctx))
             .transpose()
     }
 
@@ -485,7 +514,7 @@ impl<'a> Walker<'a, &'a Field> {
         self.item
             .attributes
             .alias()
-            .map(|v| v.resolve(ctx))
+            .map(|v| resolve_attribute_string(v, ctx))
             .transpose()
     }
 
@@ -493,7 +522,7 @@ impl<'a> Walker<'a, &'a Field> {
         self.item
             .attributes
             .description()
-            .map(|v| v.resolve(ctx))
+            .map(|v| resolve_attribute_string(v, ctx))
             .transpose()
     }
 

--- a/engine/baml-lib/baml-types/src/value_expr.rs
+++ b/engine/baml-lib/baml-types/src/value_expr.rs
@@ -332,6 +332,11 @@ impl<'a> EvaluationContext<'a> {
             fill_missing_env_vars,
         }
     }
+
+    /// Expose the underlying environment variables map for template rendering contexts
+    pub fn vars_map(&self) -> Option<&'a HashMap<String, String>> {
+        self.env_vars
+    }
 }
 
 impl Default for EvaluationContext<'_> {

--- a/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
+++ b/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
@@ -794,4 +794,47 @@ Answer in JSON using this schema:
         assert_eq!(foo.fields[0].1, TypeIR::r#string());
         assert_eq!(foo.fields[0].2, Some("d".to_string()));
     }
+
+    #[test]
+    fn test_attribute_alias_jinja_expression_and_description_template() {
+        let files = vec![(
+            "test-file.baml",
+            r#"
+                class Foo {
+                    // alias is a bare jinja expression, description is a string template
+                    bar string @alias({{ 1 + 1 }}) @description("Hello {{ env.NAME }}")
+                }
+                "#,
+        )]
+        .into_iter()
+        .collect();
+        let mut env_vars = HashMap::new();
+        env_vars.insert("NAME".to_string(), "World".to_string());
+        let baml_runtime =
+            BamlRuntime::from_file_content(".", &files, env_vars.clone(), FeatureFlags::new())
+                .unwrap();
+        let ctx_manager = baml_runtime.create_ctx_manager(BamlValue::Null, None);
+        let ctx: RuntimeContext = ctx_manager
+            .create_ctx(None, None, env_vars.clone(), vec![FunctionCallId::new()])
+            .expect("Should create context");
+
+        let field_type = TypeIR::class("Foo");
+        let render_output = render_output_format(
+            baml_runtime.inner.ir.as_ref(),
+            &ctx,
+            &field_type,
+            StreamingMode::NonStreaming,
+        )
+        .unwrap();
+
+        let foo = render_output
+            .find_class(&StreamingMode::NonStreaming, "Foo")
+            .unwrap();
+        assert_eq!(
+            foo.fields[0].0,
+            Name::new_with_alias("bar".to_string(), Some("2".to_string()))
+        );
+        assert_eq!(foo.fields[0].1, TypeIR::r#string());
+        assert_eq!(foo.fields[0].2, Some("Hello World".to_string()));
+    }
 }


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
This PR enables Jinja templating for `@alias` and `@description` attributes in BAML, allowing users to inject dynamic content (e.g., environment variables or simple expressions) into these attributes.

-   Updated `engine/baml-lib/baml-core/src/ir/walker.rs` to resolve `@alias` and `@description` attribute strings using Jinja.
    -   Introduced `resolve_attribute_string` to handle `StringOr::Value` as Jinja templates, `StringOr::JinjaExpression` for direct evaluation, and `StringOr::EnvVar`.
-   Added `vars_map()` to `engine/baml-lib/baml-types/src/value_expr.rs` to expose environment variables to the Jinja rendering context.

## Testing
Please describe how you tested these changes

-   [x] Unit tests added/updated
    -   Added `test_attribute_alias_jinja_expression_and_description_template` in `engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs`.
-   [x] Manual testing performed
    -   Tested locally using `cargo test -p baml-runtime --lib`.
-   [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

-   [ ] I have read and followed the contributing guidelines
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Additional Notes
To avoid building unrelated workspace members (and their Ruby dependencies), tests were run selectively using `cargo test -p baml-runtime --lib`.

[Add any additional notes here...]

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1758147078686229?thread_ts=1758147078.686229&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-fe0121ac-8d76-49ab-92a9-f90265eebcc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fe0121ac-8d76-49ab-92a9-f90265eebcc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

