### PR TITLE
fix(lang-server): handle non-baml-src baml files

### DIFF
--- a/engine/baml-lib/baml/tests/mermaid_graph_tests.rs
+++ b/engine/baml-lib/baml/tests/mermaid_graph_tests.rs
@@ -14,7 +14,7 @@ const ROOT: &str = concat!(
 fn headers_mermaid_snapshots() {
     let dir = Path::new(ROOT);
     if !dir.exists() {
-        panic!("fixtures dir missing: {}", ROOT);
+        panic!("fixtures dir missing: {ROOT}");
     }
 
     let mut ran: usize = 0;
@@ -88,8 +88,8 @@ fn headers_mermaid_snapshots() {
                                     ran += 1;
                                 } else {
                                     eprintln!("[mermaid] {:<12} | {}", "FAIL(err)", rel_name);
-                                    eprintln!("EXPECTED ({}):\n{}\n---", rel_name, exp_n);
-                                    eprintln!("GOT      ({}):\n{}\n---", rel_name, got_n);
+                                    eprintln!("EXPECTED ({rel_name}):\n{exp_n}\n---");
+                                    eprintln!("GOT      ({rel_name}):\n{got_n}\n---");
                                     failed += 1;
                                     ran += 1;
                                     continue;
@@ -125,8 +125,8 @@ fn headers_mermaid_snapshots() {
                                 ran += 1;
                             } else {
                                 eprintln!("[mermaid] {:<12} | {}", "FAIL", rel_name);
-                                eprintln!("EXPECTED ({}):\n{}\n---", rel_name, exp_n);
-                                eprintln!("GOT      ({}):\n{}\n---", rel_name, got_n);
+                                eprintln!("EXPECTED ({rel_name}):\n{exp_n}\n---");
+                                eprintln!("GOT      ({rel_name}):\n{got_n}\n---");
                                 failed += 1;
                                 ran += 1;
                                 continue;
@@ -170,8 +170,8 @@ fn headers_mermaid_snapshots() {
                                 ran += 1;
                             } else {
                                 eprintln!("[mermaid] {:<12} | {}", "FAIL(err)", rel_name);
-                                eprintln!("EXPECTED ({}):\n{}\n---", rel_name, exp_n);
-                                eprintln!("GOT      ({}):\n{}\n---", rel_name, got_n);
+                                eprintln!("EXPECTED ({rel_name}):\n{exp_n}\n---");
+                                eprintln!("GOT      ({rel_name}):\n{got_n}\n---");
                                 failed += 1;
                                 ran += 1;
                                 continue;
@@ -189,20 +189,19 @@ fn headers_mermaid_snapshots() {
         }
     }
 
-    assert!(ran > 0, "no valid fixtures were executed in {}", ROOT);
+    assert!(ran > 0, "no valid fixtures were executed in {ROOT}");
     assert!(
         failed == 0,
-        "{} fixtures failed; see output for details",
-        failed
+        "{failed} fixtures failed; see output for details"
     );
     println!("[mermaid] Summary");
-    println!("  ran:     {}", ran);
-    println!("  pass:    {}", passed);
-    println!("  updated: {}", updated);
+    println!("  ran:     {ran}");
+    println!("  pass:    {passed}");
+    println!("  updated: {updated}");
     println!("  skip:");
-    println!("    panic:  {}", skipped_panic);
-    println!("    expect: {}", missing_expect);
-    println!("  fail:    {}", failed);
+    println!("    panic:  {skipped_panic}");
+    println!("    expect: {missing_expect}");
+    println!("  fail:    {failed}");
 }
 
 fn normalize(s: &str) -> String {

--- a/engine/baml-runtime/src/cli/repl.rs
+++ b/engine/baml-runtime/src/cli/repl.rs
@@ -123,7 +123,7 @@ fn append_history_line(path: &Path, line: &str) {
         let _ = create_dir_all(parent);
     }
     if let Ok(mut f) = OpenOptions::new().create(true).append(true).open(path) {
-        let _ = writeln!(f, "{}", line);
+        let _ = writeln!(f, "{line}");
     }
 }
 
@@ -924,7 +924,7 @@ impl ReplArgs {
                 if busy {
                     let s = status.clone().unwrap_or_else(|| "Working...".into());
                     let status_icon = spinner_frames[spinner_idx % spinner_frames.len()];
-                    let spans = shimmer_spans(&format!(" {} {}", status_icon, s));
+                    let spans = shimmer_spans(&format!(" {status_icon} {s}"));
                     let idx = last_user_insert_idx.unwrap_or(lines.len());
                     let idx = idx.min(lines.len());
                     lines.insert(idx, Line::from(spans));
@@ -1078,7 +1078,7 @@ impl ReplArgs {
 
                 if search_mode {
                     let preview = input.clone();
-                    let left_text = format!(" (reverse-i-search)`{}`: {}", search_query, preview);
+                    let left_text = format!(" (reverse-i-search)`{search_query}`: {preview}");
                     let left_para = Paragraph::new(Line::from(vec![TuiSpan::styled(
                         left_text,
                         Style::default()

--- a/engine/language_server/src/server/api.rs
+++ b/engine/language_server/src/server/api.rs
@@ -3,6 +3,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use anyhow::Context;
 use diagnostics::{file_diagnostics, project_diagnostics};
 use log::info;
 use lsp_server;
@@ -134,12 +135,12 @@ pub(super) fn request<'a>(req: lsp_server::Request) -> Task<'a> {
 
                     let params = serde_json::from_value::<DiagnosticRequestParams>(req.params)
                         .map_err(|e| anyhow::anyhow!("Failed to parse JSON: {e}"))?;
-                    let url = Url::parse(&params.project_id)
-                        .map_err(|e| anyhow::anyhow!("Failed to parse URL: {e}"))?;
-                    if !url.to_string().contains("baml_src") {
-                        return Ok(());
-                    }
+                    let url = Url::parse(&params.project_id).context("Failed to parse URL")?;
 
+                    let Ok(project) = session.get_or_create_project(&url.to_file_path().unwrap())
+                    else {
+                        return Ok(());
+                    };
                     let project = session
                         .get_or_create_project(url.to_file_path().unwrap())
                         .expect("Already checked for project's existence");
@@ -298,22 +299,19 @@ fn background_request_task<'a, R: traits::BackgroundDocumentRequestHandler>(
         .to_file_path()
         .internal_error_msg("Could not convert URL to path")?;
     Ok(Task::background(schedule, move |session: &Session| {
-        let Some(_snapshot) = session.take_snapshot(url) else {
+        let Some(snapshot) = session.take_snapshot(url) else {
             return Box::new(|_, _| {});
         };
         // info!(
         //     "session.projects.len(): {:?}",
         //     session.baml_src_projects.lock().len()
         // );
-        let _db = session.get_or_create_project(&path).clone();
-        if _db.is_none() {
-            tracing::error!("Could not find project for path");
+        let Ok(project) = session.get_or_create_project(&path) else {
             return Box::new(|_, _| {});
-        }
-        let _db = _db.unwrap();
+        };
 
-        Box::new(move |_notifier, _responder| {
-            let _ = R::run_with_snapshot(_snapshot, _db, _notifier, params);
+        Box::new(move |notifier, _responder| {
+            let _ = R::run_with_snapshot(snapshot, project, notifier, params);
         })
     }))
 }

--- a/engine/language_server/src/server/api.rs
+++ b/engine/language_server/src/server/api.rs
@@ -137,7 +137,7 @@ pub(super) fn request<'a>(req: lsp_server::Request) -> Task<'a> {
                         .map_err(|e| anyhow::anyhow!("Failed to parse JSON: {e}"))?;
                     let url = Url::parse(&params.project_id).context("Failed to parse URL")?;
 
-                    let Ok(project) = session.get_or_create_project(&url.to_file_path().unwrap())
+                    let Ok(project) = session.get_or_create_project(url.to_file_path().unwrap())
                     else {
                         return Ok(());
                     };

--- a/engine/language_server/src/server/api/diagnostics.rs
+++ b/engine/language_server/src/server/api/diagnostics.rs
@@ -96,13 +96,13 @@ pub fn publish_session_lsp_diagnostics(
 ) -> Result<()> {
     // let keys = session.index().documents.keys();
     let path = file_url.to_file_path().unwrap_or_default();
-    if !file_url.to_string().contains("baml_src") {
+    let Ok(project) = session.get_or_create_project(&path) else {
+        tracing::info!(
+            "BAML file not in baml_src directory, not publishing diagnostics: {}",
+            file_url
+        );
         return Ok(());
-    }
-    tracing::info!("publishing diagnostics for {}", file_url);
-    let project = session
-        .get_or_create_project(&path)
-        .expect("We just ensured the session is valid.");
+    };
 
     let default_flags = vec!["beta".to_string()];
     let feature_flags = session
@@ -458,4 +458,28 @@ fn ensure_absolute(project_root: &Path, file_path: &Path) -> PathBuf {
     } else {
         project_root.join(file_path_relative)
     }
+}
+
+/// Creates an error diagnostic for BAML files outside baml_src directories
+pub fn not_in_baml_src_diagnostic(file_url: &Url) -> lsp_types::PublishDiagnosticsParams {
+    let range = lsp_types::Range::new(
+        lsp_types::Position::new(0, 0),
+        // Choose a position reasonably likely to be either at or past the end of the file.
+        // IDEs should correctly defend against this, ideally clamping it to the end of the file.
+        lsp_types::Position::new(10_000, 0),
+    );
+
+    lsp_types::PublishDiagnosticsParams {
+                        uri: file_url.clone(),
+                        diagnostics: vec![lsp_types::Diagnostic::new(
+            range,
+            Some(lsp_types::DiagnosticSeverity::ERROR),
+            None,
+            None,
+            "BAML files must be placed in a baml_src/ directory, see https://docs.boundaryml.com/guide/introduction/baml_src.".to_string(),
+            None,
+            None,
+        )],
+                        version: None,
+                    }
 }

--- a/engine/language_server/src/server/api/notifications/did_change.rs
+++ b/engine/language_server/src/server/api/notifications/did_change.rs
@@ -8,7 +8,7 @@ use playground_server::{FrontendMessage, WebviewRouterMessage};
 use crate::{
     server::{
         api::{
-            diagnostics::publish_diagnostics,
+            diagnostics::{not_in_baml_src_diagnostic, publish_diagnostics},
             traits::{NotificationHandler, SyncNotificationHandler},
             ResultExt,
         },
@@ -36,22 +36,19 @@ impl SyncNotificationHandler for DidChangeTextDocumentHandler {
         let start_time_total = Instant::now();
 
         let url = params.text_document.uri;
-        if !url.to_string().contains("baml_src") {
-            return Ok(());
-        }
-
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
 
         // Get or create the project using the unified method
-        let project = session.get_or_create_project(&path);
-        if project.is_none() {
-            tracing::error!("Failed to get or create project for path: {:?}", path);
-            show_err_msg!("Failed to get or create project for path: {:?}", path);
-        }
-
-        let project = project.unwrap();
+        let Ok(project) = session.get_or_create_project(&path) else {
+            notifier
+                .notify::<lsp_types::notification::PublishDiagnostics>(not_in_baml_src_diagnostic(
+                    &url,
+                ))
+                .internal_error()?;
+            return Ok(());
+        };
         let document_key =
             DocumentKey::from_url(project.lock().root_path(), &url).internal_error()?;
 

--- a/engine/language_server/src/server/api/notifications/did_change_watched_files.rs
+++ b/engine/language_server/src/server/api/notifications/did_change_watched_files.rs
@@ -24,11 +24,12 @@ impl super::SyncNotificationHandler for DidChangeWatchedFiles {
         params: types::DidChangeWatchedFilesParams,
     ) -> Result<()> {
         tracing::info!("#### DidChangeWatchedFiles {:?}", params.changes);
-        if !params
-            .changes
-            .iter()
-            .any(|change| change.uri.to_string().contains("baml_src"))
-        {
+        if params.changes.iter().any(|change| {
+            let Ok(path) = change.uri.to_file_path() else {
+                return true;
+            };
+            session.get_or_create_project(&path).is_err()
+        }) {
             return Ok(());
         }
 

--- a/engine/language_server/src/server/api/notifications/did_close.rs
+++ b/engine/language_server/src/server/api/notifications/did_close.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
 use lsp_server::ErrorCode;
-use lsp_types::{notification::DidCloseTextDocument, DidCloseTextDocumentParams};
+use lsp_types::{
+    notification::DidCloseTextDocument, DidCloseTextDocumentParams, PublishDiagnosticsParams,
+};
 
 // use crate::server::api::diagnostics::clear_diagnostics;
 use crate::server::api::traits::{NotificationHandler, SyncNotificationHandler};
@@ -27,37 +29,31 @@ impl NotificationHandler for DidCloseTextDocumentHandler {
 impl SyncNotificationHandler for DidCloseTextDocumentHandler {
     fn run(
         session: &mut Session,
-        _notifier: Notifier,
+        notifier: Notifier,
         _requester: &mut Requester,
         params: DidCloseTextDocumentParams,
     ) -> Result<()> {
         let url = params.text_document.uri;
-        if !url.to_string().contains("baml_src") {
-            return Ok(());
-        }
-
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
+        let Ok(project) = session.get_or_create_project(&path) else {
+            return Ok(());
+        };
 
-        match session.get_or_create_project(&path) {
-            None => {}
-            Some(project) => {
-                let document_key =
-                    DocumentKey::from_url(&PathBuf::from(project.lock().root_path()), &url)
-                        .internal_error()?;
-                session
-                    .close_document(&document_key)
-                    .with_failure_code(ErrorCode::InternalError)?;
-                // Remove the unsaved file from the project as well
-                // TODO: ideally the baml project just has a view of unsaved files directly from the Session itself, and not maintain its own state / copy of the unsaved files
-                project
-                    .lock()
-                    .baml_project
-                    .remove_unsaved_file(&document_key);
-            }
-        }
-        session.reload(Some(_notifier)).internal_error()?;
+        let document_key = DocumentKey::from_url(&PathBuf::from(project.lock().root_path()), &url)
+            .internal_error()?;
+        session
+            .close_document(&document_key)
+            .with_failure_code(ErrorCode::InternalError)?;
+        // Remove the unsaved file from the project as well
+        // TODO: ideally the baml project just has a view of unsaved files directly from the Session itself, and not maintain its own state / copy of the unsaved files
+        project
+            .lock()
+            .baml_project
+            .remove_unsaved_file(&document_key);
+
+        session.reload(Some(notifier)).internal_error()?;
 
         Ok(())
     }

--- a/engine/language_server/src/server/api/notifications/did_open.rs
+++ b/engine/language_server/src/server/api/notifications/did_open.rs
@@ -6,7 +6,7 @@ use lsp_types::{
 use crate::{
     server::{
         api::{
-            diagnostics::publish_session_lsp_diagnostics,
+            diagnostics::{not_in_baml_src_diagnostic, publish_session_lsp_diagnostics},
             notifications::{
                 baml_src_version::BamlSrcVersionPayload,
                 did_save_text_document::send_generator_version,
@@ -41,9 +41,17 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
         tracing::info!("DidOpenTextDocumentHandler");
 
         let url = params.text_document.uri;
-        if !url.to_string().contains("baml_src") {
+        let path = url
+            .to_file_path()
+            .internal_error_msg(&format!("Could not convert URL to path"))?;
+        let Ok(project) = session.get_or_create_project(&path) else {
+            notifier
+                .notify::<lsp_types::notification::PublishDiagnostics>(not_in_baml_src_diagnostic(
+                    &url,
+                ))
+                .internal_error()?;
             return Ok(());
-        }
+        };
 
         // TODO: do this when server initializes instead of every time a file is opened
         // note this just schedules the task. It will run after the current task is done.
@@ -67,28 +75,18 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
             )
             .internal_error()?;
 
-        let file_path = url
-            .to_file_path()
-            .internal_error_msg(&format!("Could not convert URL '{url}' to file path"))?;
-
         // tracing::info!("before get_or_create_project");
-        if let Some(project) = session.get_or_create_project(&file_path) {
-            let locked = project.lock();
-            let default_flags = vec!["beta".to_string()];
-            let effective_flags = session
-                .baml_settings
-                .feature_flags
-                .as_ref()
-                .unwrap_or(&default_flags);
-            let client_version = session.baml_settings.get_client_version();
+        let locked = project.lock();
+        let default_flags = vec!["beta".to_string()];
+        let effective_flags = session
+            .baml_settings
+            .feature_flags
+            .as_ref()
+            .unwrap_or(&default_flags);
+        let client_version = session.baml_settings.get_client_version();
 
-            let generator_version = locked.get_common_generator_version();
-            send_generator_version(&notifier, &locked, generator_version.as_ref().ok());
-        } else {
-            tracing::error!("Failed to get or create project for path: {:?}", file_path);
-            show_err_msg!("Failed to get or create project for path: {:?}", file_path);
-        }
-        tracing::info!("after get_or_create_project");
+        let generator_version = locked.get_common_generator_version();
+        send_generator_version(&notifier, &locked, generator_version.as_ref().ok());
 
         // session.open_text_document(
         //     DocumentKey::from_path(&file_path, &file_path).internal_error()?,

--- a/engine/language_server/src/server/api/notifications/did_open.rs
+++ b/engine/language_server/src/server/api/notifications/did_open.rs
@@ -43,7 +43,7 @@ impl SyncNotificationHandler for DidOpenTextDocumentHandler {
         let url = params.text_document.uri;
         let path = url
             .to_file_path()
-            .internal_error_msg(&format!("Could not convert URL to path"))?;
+            .internal_error_msg("Could not convert URL to path")?;
         let Ok(project) = session.get_or_create_project(&path) else {
             notifier
                 .notify::<lsp_types::notification::PublishDiagnostics>(not_in_baml_src_diagnostic(

--- a/engine/language_server/src/server/api/notifications/did_save_text_document.rs
+++ b/engine/language_server/src/server/api/notifications/did_save_text_document.rs
@@ -1,11 +1,17 @@
 use std::borrow::Cow;
 
-use lsp_types::{self as types, notification as notif, request::Request, ConfigurationParams};
+use lsp_types::{
+    self as types, notification as notif, request::Request, ConfigurationParams,
+    PublishDiagnosticsParams,
+};
 
 use crate::{
     baml_project::{common_version_up_to_patch, Project},
     server::{
-        api::{self, notifications::baml_src_version::BamlSrcVersionPayload, ResultExt},
+        api::{
+            self, diagnostics::not_in_baml_src_diagnostic,
+            notifications::baml_src_version::BamlSrcVersionPayload, ResultExt,
+        },
         client::{Notifier, Requester},
         Result, Task,
     },
@@ -27,13 +33,18 @@ impl super::SyncNotificationHandler for DidSaveTextDocument {
     ) -> Result<()> {
         tracing::info!("Did save text document---------");
         let url = params.text_document.uri;
-        if !url.to_string().contains("baml_src") {
-            return Ok(());
-        }
-
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
+        let Ok(project) = session.get_or_create_project(&path) else {
+            notifier
+                .notify::<lsp_types::notification::PublishDiagnostics>(not_in_baml_src_diagnostic(
+                    &url,
+                ))
+                .internal_error()?;
+            return Ok(());
+        };
+
         session.clear_unsaved_files();
         session.reload(Some(notifier.clone())).internal_error()?;
 
@@ -45,9 +56,6 @@ impl super::SyncNotificationHandler for DidSaveTextDocument {
         }
 
         tracing::info!("About to run generator. URL path: {:?}", path);
-        let project = session
-            .get_or_create_project(&path)
-            .expect("Ensured that a project db exists");
         let mut locked = project.lock();
 
         let default_flags = vec!["beta".to_string()];
@@ -160,30 +168,32 @@ impl super::BackgroundDocumentNotificationHandler for DidSaveTextDocument {
 
         // Note: In the background version, we need to get the project from the snapshot
         // instead of modifying the session directly
-        if let Some(project) = snapshot.project() {
-            let default_flags = vec!["beta".to_string()];
-            let effective_flags = snapshot
-                .session_baml_settings()
-                .feature_flags
-                .as_ref()
-                .unwrap_or(&default_flags);
-            project.lock().run_generators_without_debounce(
-                effective_flags,
-                |message| {
-                    tracing::info!("About to notify client that generator has run.");
-                    notifier.notify_baml_info(&message).unwrap_or(())
-                },
-                |e| {
-                    tracing::error!("Error generating: {e}");
-                    notifier.notify_baml_error(&e).unwrap_or(())
-                },
-            );
-        } else {
+
+        let Ok(project) = snapshot.project() else {
             tracing::error!("No project found in snapshot for file {:?}", path);
             notifier
                 .notify_baml_error(&format!("No project found for file {path:?}"))
                 .unwrap_or(());
-        }
+            return Ok(());
+        };
+
+        let default_flags = vec!["beta".to_string()];
+        let effective_flags = snapshot
+            .session_baml_settings()
+            .feature_flags
+            .as_ref()
+            .unwrap_or(&default_flags);
+        project.lock().run_generators_without_debounce(
+            effective_flags,
+            |message| {
+                tracing::info!("About to notify client that generator has run.");
+                notifier.notify_baml_info(&message).unwrap_or(())
+            },
+            |e| {
+                tracing::error!("Error generating: {e}");
+                notifier.notify_baml_error(&e).unwrap_or(())
+            },
+        );
 
         Ok(())
     }

--- a/engine/language_server/src/server/api/requests/code_action.rs
+++ b/engine/language_server/src/server/api/requests/code_action.rs
@@ -46,19 +46,14 @@ impl SyncRequestHandler for CodeActionHandler {
         //         tracing::error!("Failed to send codeAction notification to playground: {e}");
         //     });
 
-        let mut actions = vec![];
-
         let uri = params.text_document.uri.clone();
-        if !uri.to_string().contains("baml_src") {
-            return Ok(None);
-        }
-
         let path = uri
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-        let project = session
-            .get_or_create_project(&path)
-            .expect("Ensured that a project db exists");
+        let Ok(project) = session.get_or_create_project(&path) else {
+            return Ok(None);
+        };
+
         let document_key =
             DocumentKey::from_url(project.lock().root_path(), &uri).internal_error()?;
 
@@ -85,8 +80,7 @@ impl SyncRequestHandler for CodeActionHandler {
             disabled: None,
             data: None,
         });
-        actions.push(action);
 
-        Ok(Some(actions))
+        Ok(Some(vec![action]))
     }
 }

--- a/engine/language_server/src/server/api/requests/code_lens.rs
+++ b/engine/language_server/src/server/api/requests/code_lens.rs
@@ -34,18 +34,12 @@ impl SyncRequestHandler for CodeLens {
     ) -> Result<Option<Vec<lsp_types::CodeLens>>> {
         tracing::info!("CodeLens request");
         let url = params.text_document.uri.clone();
-        if !url.to_string().contains("baml_src") {
-            return Ok(None);
-        }
-
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-
-        // session.reload(Some(notifier)).internal_error()?;
-        let project = session
-            .get_or_create_project(&path)
-            .expect("Ensured that a project db exists");
+        let Ok(project) = session.get_or_create_project(&path) else {
+            return Ok(None);
+        };
         let fake_env = HashMap::new();
         let default_flags = vec!["beta".to_string()];
         let baml_diagnostics = match project.lock().baml_project.runtime(

--- a/engine/language_server/src/server/api/requests/completion.rs
+++ b/engine/language_server/src/server/api/requests/completion.rs
@@ -28,9 +28,12 @@ impl SyncRequestHandler for Completion {
         params: CompletionParams,
     ) -> Result<Option<lsp_types::CompletionResponse>> {
         let url = params.text_document_position.text_document.uri;
-        if !url.to_string().contains("baml_src") {
+        let path = url
+            .to_file_path()
+            .internal_error_msg("Could not convert URL to path")?;
+        let Ok(project) = session.get_or_create_project(&path) else {
             return Ok(None);
-        }
+        };
 
         // TODO: Enable this only if you
         // 1. test on windows, with chinese characters

--- a/engine/language_server/src/server/api/requests/diagnostic.rs
+++ b/engine/language_server/src/server/api/requests/diagnostic.rs
@@ -53,7 +53,11 @@ impl SyncRequestHandler for DocumentDiagnosticRequestHandler {
         params: DocumentDiagnosticParams,
     ) -> Result<DocumentDiagnosticReportResult> {
         let url = params.text_document.uri.clone();
-        if !url.to_string().contains("baml_src") {
+        let path = url
+            .to_file_path()
+            .internal_error_msg("Could not convert URL to path")?;
+
+        let Ok(project) = session.get_or_create_project(&path) else {
             return Ok(DocumentDiagnosticReportResult::Report(
                 DocumentDiagnosticReport::Unchanged(RelatedUnchangedDocumentDiagnosticReport {
                     related_documents: None,
@@ -62,15 +66,7 @@ impl SyncRequestHandler for DocumentDiagnosticRequestHandler {
                     },
                 }),
             ));
-        }
-
-        let path = url
-            .to_file_path()
-            .internal_error_msg("Could not convert URL to path")?;
-
-        let project = session
-            .get_or_create_project(&path)
-            .expect("Project should exist");
+        };
 
         let default_flags = vec!["beta".to_string()];
         let effective_flags = session

--- a/engine/language_server/src/server/api/requests/format.rs
+++ b/engine/language_server/src/server/api/requests/format.rs
@@ -29,9 +29,6 @@ impl SyncRequestHandler for DocumentFormatting {
         params: DocumentFormattingParams,
     ) -> Result<Option<Vec<lsp_types::TextEdit>>> {
         let url = params.text_document.uri;
-        if !url.to_string().contains("baml_src") {
-            return Ok(None);
-        }
 
         // let url = &params.text_document.uri;
         // let path = url

--- a/engine/language_server/src/server/api/requests/go_to_definition.rs
+++ b/engine/language_server/src/server/api/requests/go_to_definition.rs
@@ -37,16 +37,13 @@ impl SyncRequestHandler for GotoDefinition {
             .text_document
             .uri
             .clone();
-        if !url.to_string().contains("baml_src") {
-            return Ok(None);
-        }
-
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-        let project = session
-            .get_or_create_project(&path)
-            .expect("Ensured that a project db exists");
+        let Ok(project) = session.get_or_create_project(&path) else {
+            return Ok(None);
+        };
+
         {
             let default_flags = vec!["beta".to_string()];
             project.lock().update_runtime(

--- a/engine/language_server/src/server/api/requests/hover.rs
+++ b/engine/language_server/src/server/api/requests/hover.rs
@@ -28,16 +28,12 @@ impl SyncRequestHandler for Hover {
         params: HoverParams,
     ) -> Result<Option<types::Hover>> {
         let url = &params.text_document_position_params.text_document.uri;
-        if !url.to_string().contains("baml_src") {
-            return Ok(None);
-        }
-
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-        let project = session
-            .get_or_create_project(&path)
-            .expect("Ensured that a project db exists");
+        let Ok(project) = session.get_or_create_project(&path) else {
+            return Ok(None);
+        };
 
         let document_key =
             DocumentKey::from_url(project.lock().root_path(), url).internal_error()?;

--- a/engine/language_server/src/server/api/requests/rename.rs
+++ b/engine/language_server/src/server/api/requests/rename.rs
@@ -32,16 +32,12 @@ impl SyncRequestHandler for Rename {
         params: RenameParams,
     ) -> Result<Option<lsp_types::WorkspaceEdit>> {
         let url = params.text_document_position.text_document.uri;
-        if !url.to_string().contains("baml_src") {
-            return Ok(None);
-        }
-
         let path = url
             .to_file_path()
             .internal_error_msg("Could not convert URL to path")?;
-        let project = session
-            .get_or_create_project(&path)
-            .expect("Ensured that a project db exists");
+        let Ok(project) = session.get_or_create_project(&path) else {
+            return Ok(None);
+        };
 
         let res = {
             let mut guard = project.lock();

--- a/engine/language_server/src/session.rs
+++ b/engine/language_server/src/session.rs
@@ -159,7 +159,17 @@ impl Session {
             }
         }
     }
+}
+#[derive(Debug, Clone)]
+pub struct NotInBamlSrc;
 
+impl std::fmt::Display for NotInBamlSrc {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Cannot resolve baml project")
+    }
+}
+
+impl Session {
     /// Gets or creates a project for the given path.
     ///
     /// This is the primary method for working with projects, replacing the multiple
@@ -171,30 +181,33 @@ impl Session {
     pub fn get_or_create_project(
         &self,
         path: impl AsRef<Path> + std::fmt::Debug,
-    ) -> Option<Arc<Mutex<Project>>> {
+    ) -> Result<Arc<Mutex<Project>>, NotInBamlSrc> {
         // Try to find the baml_src directory
-        let baml_src = find_top_level_parent(path.as_ref())?;
+        let baml_src_root_path = find_top_level_parent(path.as_ref()).ok_or(NotInBamlSrc)?;
 
         // Lock once and perform all operations within this scope
         let mut projects = self.baml_src_projects.lock();
 
         // If project exists, return it
-        if let Some(project) = projects.get(&baml_src) {
-            return Some(project.clone());
+        if let Some(project) = projects.get(&baml_src_root_path) {
+            return Ok(project.clone());
         }
 
         // Create a new project if needed
-        tracing::info!("Creating new project for baml_src path: {:?}", baml_src);
+        tracing::info!(
+            "Creating new project for baml_src: {:?}",
+            baml_src_root_path
+        );
         let new_project = Arc::new(Mutex::new(Project::new(BamlProject {
-            root_dir_name: baml_src.clone(),
+            root_dir_name: baml_src_root_path.clone(),
             files: HashMap::new(),
             unsaved_files: HashMap::new(),
             cached_runtime: None,
         })));
 
         // Insert and return the new project
-        projects.insert(baml_src, new_project.clone());
-        Some(new_project)
+        projects.insert(baml_src_root_path, new_project.clone());
+        Ok(new_project)
     }
 
     pub fn print_baml_projects(&self) {
@@ -300,7 +313,7 @@ impl Session {
     /// Creates a document snapshot with the URL referencing the document to snapshot.
     pub fn take_snapshot(&self, url: Url) -> Option<DocumentSnapshot> {
         let file_path = url.to_file_path().ok()?;
-        let project = self.get_or_create_project(&file_path)?;
+        let project = self.get_or_create_project(&file_path).ok()?;
 
         let document_key =
             DocumentKey::from_url(&project.lock().baml_project.root_dir_name, &url).ok()?;
@@ -440,8 +453,12 @@ impl DocumentSnapshot {
         self.position_encoding
     }
 
-    pub(crate) fn project(&self) -> Option<Arc<Mutex<Project>>> {
-        let file_path = self.document_ref.file_url().to_file_path().ok()?;
+    pub(crate) fn project(&self) -> Result<Arc<Mutex<Project>>, NotInBamlSrc> {
+        let file_path = self
+            .document_ref
+            .file_url()
+            .to_file_path()
+            .expect("Failed to convert URL to path");
         self.session.get_or_create_project(&file_path)
     }
 
@@ -505,21 +522,21 @@ mod tests {
 
         // Create a project for key1
         let project1 = session.get_or_create_project(&key1);
-        assert!(project1.is_some(), "Project should be created for key1");
+        assert!(project1.is_ok(), "Project should be created for key1");
 
         // Verify that get_or_create_project returns the same project when called again
         let project1_again = session.get_or_create_project(&key1);
-        assert!(project1_again.is_some(), "Project should be found for key1");
+        assert!(project1_again.is_ok(), "Project should be found for key1");
 
         // Create a project for key2
         let project2 = session.get_or_create_project(&key2);
-        assert!(project2.is_some(), "Project should be created for key2");
+        assert!(project2.is_ok(), "Project should be created for key2");
 
         // Test with a file path inside key2
         let file_path_in_key2 = key2.join("chat.baml");
         let found_project = session.get_or_create_project(&file_path_in_key2);
         assert!(
-            found_project.is_some(),
+            found_project.is_ok(),
             "Project should be found for file path within key2"
         );
 

--- a/engine/test_simple_expr_fn.baml
+++ b/engine/test_simple_expr_fn.baml
@@ -1,4 +1,0 @@
-function SimpleExpr(x: int) -> int {
-    let y = x + 1
-    y
-}


### PR DESCRIPTION
This also removes a bunch of panics, because if we can't resolve a `.baml` file to a `baml_src` project we will no longer crash.