### PR TITLE
feat: baml cli lint command

### DIFF
--- a/engine/baml-runtime/src/cli/check.rs
+++ b/engine/baml-runtime/src/cli/check.rs
@@ -6,12 +6,12 @@ use internal_baml_core::configuration::GeneratorDefaultClientMode;
 use crate::{baml_src_files, BamlRuntime, InternalRuntimeInterface};
 
 #[derive(clap::Args, Debug)]
-pub struct LintArgs {
+pub struct CheckArgs {
     #[arg(long, help = "path/to/baml_src", default_value = "./baml_src")]
     pub from: PathBuf,
     #[arg(
         long,
-        help = "Lint without checking for version mismatch",
+        help = "Checks for erros and warnings without checking for version mismatch",
         default_value_t = false
     )]
     pub(super) no_version_check: bool,
@@ -24,23 +24,23 @@ pub struct LintArgs {
     // pub(super) only_errors: bool,
 }
 
-impl LintArgs {
+impl CheckArgs {
     pub fn run(
         &self,
         defaults: super::RuntimeCliDefaults,
         feature_flags: internal_baml_core::feature_flags::FeatureFlags,
     ) -> Result<()> {
-        let result = self.lint(defaults, feature_flags);
+        let result = self.check(defaults, feature_flags);
 
         if let Err(e) = result {
-            baml_log::error!("Error linting: {:?}", e);
+            baml_log::error!("Error checking: {:?}", e);
             return Err(e);
         }
 
         Ok(())
     }
 
-    fn lint(
+    fn check(
         &self,
         defaults: super::RuntimeCliDefaults,
         feature_flags: internal_baml_core::feature_flags::FeatureFlags,

--- a/engine/baml-runtime/src/cli/lint.rs
+++ b/engine/baml-runtime/src/cli/lint.rs
@@ -1,0 +1,76 @@
+use std::{path::PathBuf, process::exit};
+
+use anyhow::{Context, Result};
+use internal_baml_core::configuration::GeneratorDefaultClientMode;
+
+use crate::{baml_src_files, BamlRuntime, InternalRuntimeInterface};
+
+#[derive(clap::Args, Debug)]
+pub struct LintArgs {
+    #[arg(long, help = "path/to/baml_src", default_value = "./baml_src")]
+    pub from: PathBuf,
+    #[arg(
+        long,
+        help = "Lint without checking for version mismatch",
+        default_value_t = false
+    )]
+    pub(super) no_version_check: bool,
+    // TODO: Implement this flag
+    // #[arg(
+    //     long,
+    //     help = "Only display errors, not warnings",
+    //     default_value_t = false
+    // )]
+    // pub(super) only_errors: bool,
+}
+
+impl LintArgs {
+    pub fn run(
+        &self,
+        defaults: super::RuntimeCliDefaults,
+        feature_flags: internal_baml_core::feature_flags::FeatureFlags,
+    ) -> Result<()> {
+        let result = self.lint(defaults, feature_flags);
+
+        if let Err(e) = result {
+            baml_log::error!("Error linting: {:?}", e);
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
+    fn lint(
+        &self,
+        defaults: super::RuntimeCliDefaults,
+        feature_flags: internal_baml_core::feature_flags::FeatureFlags,
+    ) -> Result<()> {
+        // Log enabled features
+        if feature_flags.is_beta_enabled() {
+            baml_log::info!("Beta features enabled - experimental warnings will be suppressed");
+        }
+        if feature_flags.should_display_warnings() {
+            baml_log::info!("Warning display enabled - all warnings will be shown");
+        }
+
+        let env_vars: std::collections::HashMap<String, String> = std::env::vars().collect();
+        let runtime = BamlRuntime::from_directory(&self.from, env_vars, feature_flags.clone());
+
+        match runtime {
+            Err(e) => {
+                println!("{:?}", e);
+
+                // We should probably name this exit code more specifically
+                exit(1);
+            }
+            Ok(runtime) => {
+                let diagnostics = runtime.inner.diagnostics();
+                if diagnostics.has_warnings() {
+                    println!("{}", diagnostics.warnings_to_pretty_string());
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/engine/baml-runtime/src/cli/mod.rs
+++ b/engine/baml-runtime/src/cli/mod.rs
@@ -7,6 +7,7 @@ pub mod init_ui;
 pub mod repl;
 pub mod serve;
 pub mod testing;
+pub mod lint;
 
 use internal_baml_core::configuration::GeneratorOutputType;
 

--- a/engine/baml-runtime/src/cli/mod.rs
+++ b/engine/baml-runtime/src/cli/mod.rs
@@ -1,10 +1,10 @@
+pub mod check;
 pub mod dev;
 mod dotenv;
 pub mod dump_intermediate;
 pub mod generate;
 pub mod init;
 pub mod init_ui;
-pub mod lint;
 pub mod repl;
 pub mod serve;
 pub mod testing;

--- a/engine/baml-runtime/src/cli/mod.rs
+++ b/engine/baml-runtime/src/cli/mod.rs
@@ -4,10 +4,10 @@ pub mod dump_intermediate;
 pub mod generate;
 pub mod init;
 pub mod init_ui;
+pub mod lint;
 pub mod repl;
 pub mod serve;
 pub mod testing;
-pub mod lint;
 
 use internal_baml_core::configuration::GeneratorOutputType;
 

--- a/engine/cli/src/commands.rs
+++ b/engine/cli/src/commands.rs
@@ -28,8 +28,8 @@ pub(crate) enum Commands {
     #[command(about = "Runs all generators in the baml_src directory")]
     Generate(baml_runtime::cli::generate::GenerateArgs),
 
-    #[command(about = "Lints the baml_src directory")]
-    Lint(baml_runtime::cli::lint::LintArgs),
+    #[command(about = "Checks for errors and warnings in the baml_src directory")]
+    Check(baml_runtime::cli::check::CheckArgs),
 
     #[command(about = "Starts a server that translates LLM responses to BAML responses")]
     Serve(baml_runtime::cli::serve::ServeArgs),
@@ -110,7 +110,7 @@ impl RuntimeCli {
                     }
                 }
             }
-            Commands::Lint(args) => {
+            Commands::Check(args) => {
                 args.from = BamlRuntime::parse_baml_src_path(&args.from)?;
                 match args.run(defaults, feature_flags.clone()) {
                     Ok(()) => Ok(crate::ExitCode::Success),

--- a/engine/cli/src/commands.rs
+++ b/engine/cli/src/commands.rs
@@ -28,6 +28,9 @@ pub(crate) enum Commands {
     #[command(about = "Runs all generators in the baml_src directory")]
     Generate(baml_runtime::cli::generate::GenerateArgs),
 
+    #[command(about = "Lints the baml_src directory")]
+    Lint(baml_runtime::cli::lint::LintArgs),
+
     #[command(about = "Starts a server that translates LLM responses to BAML responses")]
     Serve(baml_runtime::cli::serve::ServeArgs),
 
@@ -98,6 +101,16 @@ impl RuntimeCli {
 
         match &mut self.command {
             Commands::Generate(args) => {
+                args.from = BamlRuntime::parse_baml_src_path(&args.from)?;
+                match args.run(defaults, feature_flags.clone()) {
+                    Ok(()) => Ok(crate::ExitCode::Success),
+                    Err(e) => {
+                        eprintln!("Error: {e}");
+                        Ok(crate::ExitCode::Other)
+                    }
+                }
+            }
+            Commands::Lint(args) => {
                 args.from = BamlRuntime::parse_baml_src_path(&args.from)?;
                 match args.run(defaults, feature_flags.clone()) {
                     Ok(()) => Ok(crate::ExitCode::Success),


### PR DESCRIPTION
Closes https://github.com/BoundaryML/baml/issues/2479

Notes:
`--only-errors` flag implementation is missing. 