### PR TITLE
Update vertex ai provider docs with api key info

### DIFF
--- a/fern/03-reference/baml/clients/providers/vertex.mdx
+++ b/fern/03-reference/baml/clients/providers/vertex.mdx
@@ -45,6 +45,35 @@ can expect authentication to work out of the box.
 Setting [`options.credentials`](#credentials) will take precedence and force `vertex-ai` to load
 service account credentials from that file path.
 
+### Using a Vertex API Key (Express Mode)
+
+<Info>
+  To get started quickly, we recommend using Express Mode with a Vertex API Key.
+  This avoids service account setup and works well for prototyping.
+
+  See Google's guide: [Use Vertex API keys (Express Mode)](https://cloud.google.com/vertex-ai/generative-ai/docs/start/api-keys?usertype=expressmode).
+</Info>
+
+When using a Vertex API Key, set the `key` query parameter and specify your `project_id` and `location`:
+
+```baml BAML
+client<llm> VertexApiKeyClient {
+  provider vertex-ai
+  options {
+    model gemini-2.5-pro
+    location us-central1
+    project_id my-project-id
+    query_params {
+      key env.VERTEX_API_KEY
+    }
+  }
+}
+```
+
+Notes:
+- `project_id` cannot be inferred when using an API key; set it explicitly.
+- Keep `credentials` unset when using an API key, so BAML does not prefer service account auth.
+
 ### Playground
 To use a `vertex-ai` client in the playground, all you need to do is run `gcloud
 auth application-default login` in the terminal. The playground will then use these
@@ -332,6 +361,27 @@ client<llm> MyClient {
   }
 }
 ```
+</ParamField>
+
+<ParamField path="query_params" type="object">
+  Query string parameters appended to the request URL.
+
+Example (use a Vertex API Key with Express Mode):
+```baml BAML
+client<llm> MyClient {
+  provider vertex-ai
+  options {
+    model gemini-2.5-pro
+    project_id my-project-id
+    location us-central1
+    query_params {
+      key env.VERTEX_API_KEY
+    }
+  }
+}
+```
+
+  When using an API key, omit `credentials` and set `project_id` explicitly.
 </ParamField>
 
 <Markdown src="/snippets/role-selection.mdx" />


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
This PR adds documentation for using Vertex AI API Keys (Express Mode) to the Vertex AI provider docs. This aims to simplify the initial setup for users by recommending a faster alternative to service account authentication.

The changes include:
- A new section detailing how to configure a Vertex AI client with an API key using `query_params`.
- An `Info` note recommending Express Mode for quick starts and linking to Google's official guide.
- Clarification on explicitly setting `project_id` and omitting `credentials` when using an API key.
- An updated `ParamField` for `query_params` to include the API key example.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [X] Manual testing performed (verified documentation renders correctly)
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [X] I have read and followed the contributing guidelines
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

## Additional Notes
This change directly addresses the user request to document the Vertex API Key (Express Mode) for faster onboarding, including a recommendation and a link to the official Google documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bc51542-2ea0-491b-9712-6fa91f28ed99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0bc51542-2ea0-491b-9712-6fa91f28ed99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

