### PR TITLE
Change default PDF name to "document" for bedrock models

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/aws/aws_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/aws/aws_client.rs
@@ -89,7 +89,7 @@ fn media_to_content_block_json(media: &BamlMedia) -> Result<serde_json::Value> {
                 if let Some(mime) = media.mime_type.as_deref() {
                     doc_obj.insert("format".into(), json!(strip_mime_prefix(mime)));
                 }
-                doc_obj.insert("name".into(), json!("document.pdf"));
+                doc_obj.insert("name".into(), json!("document"));
                 doc_obj.insert("source".into(), json!({ "bytes": b64.base64 }));
                 Ok(json!({ "document": serde_json::Value::Object(doc_obj) }))
             }
@@ -1079,7 +1079,7 @@ impl AwsClient {
                         Ok(bedrock::types::ContentBlock::Document(
                             bedrock::types::DocumentBlock::builder()
                                 .set_format(Some(bedrock::types::DocumentFormat::Pdf))
-                                .set_name(Some("document.pdf".to_string())) // Default name for URL-based Pdfs
+                                .set_name(Some("document".to_string())) // Default name for URL-based Pdfs
                                 .set_source(Some(bedrock::types::DocumentSource::Bytes(Blob::new(
                                     url_media.url.as_bytes().to_vec(),
                                 ))))
@@ -1092,7 +1092,7 @@ impl AwsClient {
                         Ok(bedrock::types::ContentBlock::Document(
                             bedrock::types::DocumentBlock::builder()
                                 .set_format(Some(bedrock::types::DocumentFormat::Pdf))
-                                .set_name(Some("document.pdf".to_string())) // Default name for Base64 Pdfs
+                                .set_name(Some("document".to_string())) // Default name for Base64 Pdfs
                                 .set_source(Some(bedrock::types::DocumentSource::Bytes(Blob::new(
                                     aws_smithy_types::base64::decode(b64_media.base64.clone())?,
                                 ))))


### PR DESCRIPTION
We found that claude on Bedrock doesn't like the name `document.pdf`, but `document` is fine.

Tested locally.