### PR TITLE
Update docs for remap roles feature

### DIFF
--- a/fern/snippets/role-selection.mdx
+++ b/fern/snippets/role-selection.mdx
@@ -1,3 +1,4 @@
+<>
 <ParamField
   path="default_role"
   type="string"
@@ -24,61 +25,16 @@
 
   For google-ai provider, the default is: `{ "assistant": "model" }`
 
-  ### What does remap_roles do?
+  This allows you to use standard role names in your prompts (like "user", "assistant", "system") but send different role names to the API. The remapping happens after role validation and default role assignment.
 
-  `remap_roles` allows you to use standard role names in your BAML prompts (like "user", "assistant", "system") but send different role names to the LLM API. This is useful when:
+  **Example:**
+  ```json
+  {
+    "user": "human",
+    "assistant": "ai",
+  }
+  ```
   
-  - An LLM provider uses non-standard role names (e.g., Anthropic Claude in some configurations uses "human" and "ai" instead of "user" and "assistant")
-  - You want to maintain consistent role names across your BAML code while supporting multiple providers with different naming conventions
-  - You want to standardize on common role names internally regardless of provider-specific requirements
-
-  ### How it works
-
-  The remapping happens **after** role validation and default role assignment, as the final step before sending to the API:
-
-  1. BAML first checks if the role is in `allowed_roles`
-  2. If not, it replaces it with `default_role`
-  3. Finally, it applies the `remap_roles` mapping to transform the role name
-
-  ### Examples
-
-  **Basic remapping:**
-  ```baml
-  client<llm> MyClient {
-    provider openai
-    options {
-      model "gpt-4o"
-      allowed_roles ["user", "assistant", "system"]
-      remap_roles {
-        user "human"
-        assistant "ai"
-      }
-    }
-  }
-  ```
-
-  With this configuration:
-  - `{{ _.role("user") }}` in your prompt → sends role "human" to the API
-  - `{{ _.role("assistant") }}` in your prompt → sends role "ai" to the API
-  - `{{ _.role("system") }}` in your prompt → sends role "system" to the API (unchanged, not in remap)
-
-  **With default_role:**
-  ```baml
-  client<llm> MyClient {
-    provider openai
-    options {
-      model "gpt-4o"
-      allowed_roles ["user", "system"]
-      default_role "system"
-      remap_roles {
-        system "instructions"
-      }
-    }
-  }
-  ```
-
-  With this configuration:
-  - `{{ _.role("user") }}` → sends role "user" to the API (allowed, not remapped)
-  - `{{ _.role("assistant") }}` → sends role "instructions" to the API (not in allowed_roles → becomes "system" → remapped to "instructions")
-  - `{{ _.role("system") }}` → sends role "instructions" to the API (remapped)
+  With this configuration, `{{ _.role("user") }}` in your prompt will result in a message with role "human" being sent to the API.
 </ParamField>
+</>

--- a/fern/snippets/role-selection.mdx
+++ b/fern/snippets/role-selection.mdx
@@ -24,15 +24,61 @@
 
   For google-ai provider, the default is: `{ "assistant": "model" }`
 
-  This allows you to use standard role names in your prompts (like "user", "assistant", "system") but send different role names to the API. The remapping happens after role validation and default role assignment.
+  ### What does remap_roles do?
 
-  **Example:**
-  ```json
-  {
-    "user": "human",
-    "assistant": "ai",
+  `remap_roles` allows you to use standard role names in your BAML prompts (like "user", "assistant", "system") but send different role names to the LLM API. This is useful when:
+  
+  - An LLM provider uses non-standard role names (e.g., Anthropic Claude in some configurations uses "human" and "ai" instead of "user" and "assistant")
+  - You want to maintain consistent role names across your BAML code while supporting multiple providers with different naming conventions
+  - You want to standardize on common role names internally regardless of provider-specific requirements
+
+  ### How it works
+
+  The remapping happens **after** role validation and default role assignment, as the final step before sending to the API:
+
+  1. BAML first checks if the role is in `allowed_roles`
+  2. If not, it replaces it with `default_role`
+  3. Finally, it applies the `remap_roles` mapping to transform the role name
+
+  ### Examples
+
+  **Basic remapping:**
+  ```baml
+  client<llm> MyClient {
+    provider openai
+    options {
+      model "gpt-4o"
+      allowed_roles ["user", "assistant", "system"]
+      remap_roles {
+        user "human"
+        assistant "ai"
+      }
+    }
   }
   ```
-  
-  With this configuration, `{{ _.role("user") }}` in your prompt will result in a message with role "human" being sent to the API.
+
+  With this configuration:
+  - `{{ _.role("user") }}` in your prompt → sends role "human" to the API
+  - `{{ _.role("assistant") }}` in your prompt → sends role "ai" to the API
+  - `{{ _.role("system") }}` in your prompt → sends role "system" to the API (unchanged, not in remap)
+
+  **With default_role:**
+  ```baml
+  client<llm> MyClient {
+    provider openai
+    options {
+      model "gpt-4o"
+      allowed_roles ["user", "system"]
+      default_role "system"
+      remap_roles {
+        system "instructions"
+      }
+    }
+  }
+  ```
+
+  With this configuration:
+  - `{{ _.role("user") }}` → sends role "user" to the API (allowed, not remapped)
+  - `{{ _.role("assistant") }}` → sends role "instructions" to the API (not in allowed_roles → becomes "system" → remapped to "instructions")
+  - `{{ _.role("system") }}` → sends role "instructions" to the API (remapped)
 </ParamField>


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

This PR updates the documentation for the `remap_roles` client option in `fern/snippets/role-selection.mdx`. The changes clarify:
- The purpose and use cases of `remap_roles`.
- The order of operations: `remap_roles` is applied *after* role validation and default role assignment.
- Two new examples demonstrating basic remapping and its interaction with `default_role`.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed (verified documentation content and structure)
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The updated `role-selection.mdx` snippet is automatically included in all provider documentation pages (OpenAI, Anthropic, Google AI, Azure, AWS Bedrock, Vertex AI, Ollama, and OpenAI Generic), ensuring consistent and clear explanations across the board.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1759347595097099?thread_ts=1759347595.097099&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-33500d59-4f81-4fad-9315-61c1b3a5a815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33500d59-4f81-4fad-9315-61c1b3a5a815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

