### PR TITLE
feat(python): export set_log_max_message_length

### DIFF
--- a/engine/generators/languages/python/src/_templates/config.py
+++ b/engine/generators/languages/python/src/_templates/config.py
@@ -73,10 +73,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/language_client_python/python_src/baml_py/logging.py
+++ b/engine/language_client_python/python_src/baml_py/logging.py
@@ -1,3 +1,12 @@
 from .baml_py import set_log_level, set_log_json_mode, get_log_level, set_log_max_chunk_length
 
-__all__ = ["set_log_level", "set_log_json_mode", "get_log_level", "set_log_max_chunk_length"]
+# Alias to match docs naming
+set_log_max_message_length = set_log_max_chunk_length
+
+__all__ = [
+    "set_log_level",
+    "set_log_json_mode",
+    "get_log_level",
+    "set_log_max_chunk_length",
+    "set_log_max_message_length",
+]

--- a/integ-tests/python-v1/baml_client/config.py
+++ b/integ-tests/python-v1/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/integ-tests/python/baml_client/config.py
+++ b/integ-tests/python/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]


### PR DESCRIPTION
The internal name is set_log_max_chunk_length, but that's not a good user-visible name