### PR TITLE
Fix disappearing test title behind nav bar

### DIFF
--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/CardView.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/CardView.tsx
@@ -52,10 +52,9 @@ const TestResult = ({ testId, historicalResponse }: TestResultProps) => {
 
   useEffect(() => {
     if (isSelected && cardRef.current) {
-      cardRef.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-      })
+      // Ensure the selected card's title isn't hidden under any sticky/fixed nav
+      // Use start alignment so CSS scroll-margin is respected
+      cardRef.current.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' })
     }
   }, [isSelected])
 
@@ -74,6 +73,8 @@ const TestResult = ({ testId, historicalResponse }: TestResultProps) => {
       ref={cardRef}
       className={cn(
         'flex cursor-pointer flex-col gap-2 rounded-lg border p-3 transition-colors hover:bg-muted/70 dark:bg-muted/20',
+        // Provide a top scroll margin so headings aren't obscured by sticky navbars
+        'scroll-mt-16',
         isSelected && 'border-purple-500/20 shadow-sm dark:border-purple-900/30 dark:bg-muted/90',
       )}
       onClick={() => setSelectedItem(testId.functionName, testId.testName)}

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
@@ -144,10 +144,8 @@ export const TabularView: React.FC<TabularViewProps> = ({ currentRun }) => {
 
   React.useEffect(() => {
     if (selectedItem && selectedRowRef.current) {
-      selectedRowRef.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'nearest',
-      })
+      // Ensure the selected row title isn't hidden beneath the navbar
+      selectedRowRef.current.scrollIntoView({ behavior: 'smooth', block: 'start', inline: 'nearest' })
     }
   }, [selectedItem])
 
@@ -235,7 +233,8 @@ export const TabularView: React.FC<TabularViewProps> = ({ currentRun }) => {
                 key={index}
                 ref={isSelected ? selectedRowRef : null}
                 className={cn(
-                  'relative cursor-pointer transition-colors hover:bg-muted/70',
+                  // Provide a top scroll margin for sticky headers/navbars
+                  'relative cursor-pointer transition-colors hover:bg-muted/70 scroll-mt-16',
                   isSelected && 'border-purple-500/20 shadow-sm dark:border-purple-900/30 dark:bg-muted/90',
                 )}
                 onClick={() => setSelectedItem(test.functionName, test.testName)}


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

This PR fixes an issue where, after pressing 'play' in the playground, the automatic scroll to the running test would hide the test title and the play button bar behind the fixed navigation bar. The scroll behavior has been adjusted to ensure these elements remain visible.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in `fiddle-frontend` playground

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [ ] I have read and followed the contributing guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

**Files Modified:**
*   `typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/CardView.tsx`
*   `typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx`

**Key Changes:**
*   Updated `scrollIntoView` calls to use `block: 'start'` to ensure CSS scroll margins are respected.
*   Added the `scroll-mt-16` Tailwind class to the selected card/row containers to provide a 64px top offset, preventing content from being obscured by the fixed navbar.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1759449276434229?thread_ts=1759449276.434229&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-e4e2c7d2-f997-4e81-925b-709cf93e64ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4e2c7d2-f997-4e81-925b-709cf93e64ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Align scroll targets to the top and add a top scroll margin so selected tests remain visible beneath fixed headers.
> 
> - **Frontend**
>   - **Scrolling behavior**
>     - Update `scrollIntoView` to `{ behavior: 'smooth', block: 'start', inline: 'nearest' }` in `CardView.tsx` and `TabularView.tsx`.
>     - Add Tailwind `scroll-mt-16` to selected test containers/rows to provide a top offset for sticky headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca01fe19c3f5e4dc8ada4b543c464ff7c09eaf37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->