### PR TITLE
Properly leave the secondary screen after non-erroring baml-cli init

### DIFF
--- a/engine/baml-runtime/src/cli/init_ui.rs
+++ b/engine/baml-runtime/src/cli/init_ui.rs
@@ -219,6 +219,8 @@ impl InitUI {
         let height = self.steps.len() as u16 + 4; // Steps + title + spacing
         execute!(io::stdout(), crossterm::cursor::MoveDown(height))?;
 
+        execute!(io::stdout(), LeaveAlternateScreen)?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
Fixes #2564 