### PR TITLE
[Promptfiddle] fix play button disappearing

### DIFF
--- a/engine/language_client_python/uv.lock
+++ b/engine/language_client_python/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.13"
 
 [[package]]
 name = "baml-py"
-version = "0.208.2"
+version = "0.210.0"
 source = { editable = "." }

--- a/typescript/apps/fiddle-web-app/app/[project_id]/_components/ProjectView.tsx
+++ b/typescript/apps/fiddle-web-app/app/[project_id]/_components/ProjectView.tsx
@@ -171,7 +171,7 @@ const ProjectViewImpl = ({ project }: { project: BAMLProject }) => {
                 {!isMobile && (
                   <ResizablePanel defaultSize={50} className="tour-playground">
                     <div className="flex flex-col h-full overflow-hidden">
-                      <div className="flex-1 min-h-0 overflow-hidden">
+                      <div className="h-full min-h-0 overflow-hidden">
                         <PlaygroundView />
                       </div>
                     </div>
@@ -204,7 +204,7 @@ export const FunctionSelectorProvider = () => {
 };
 
 export const ProjectSidebar = () => (
-  <div className="w-64 h-full dark:bg-[#020309] bg-muted overflow-hidden">
+  <div className="w-[200px] h-full dark:bg-[#020309] bg-muted overflow-hidden">
     <div className="flex flex-row justify-center items-center pt-4 w-full">
       <a
         href={'/'}

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/index.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/index.tsx
@@ -74,7 +74,7 @@ export const PromptPreview = () => {
 
   return (
     <>
-      <SidebarProvider defaultOpen={vscode.isVscode()} className="h-full">
+      <SidebarProvider defaultOpen={vscode.isVscode()} className="h-full min-h-0">
         <SidebarInset>
           {wasm ? (
             <div className="h-full flex flex-col overflow-hidden relative">

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/test-panel/components/TabularView.tsx
@@ -235,7 +235,7 @@ export const TabularView: React.FC<TabularViewProps> = ({ currentRun }) => {
                 key={index}
                 ref={isSelected ? selectedRowRef : null}
                 className={cn(
-                  'relative cursor-pointer transition-colors hover:bg-muted/70',
+                  'relative cursor-pointer transition-colors hover:bg-muted/70 ',
                   isSelected && 'border-purple-500/20 shadow-sm dark:border-purple-900/30 dark:bg-muted/90',
                 )}
                 onClick={() => setSelectedItem(test.functionName, test.testName)}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the playground pane maintains full height (preventing controls from disappearing) and narrows the project sidebar width.
> 
> - **Frontend/UI**:
>   - **Playground layout**: Use `h-full` instead of `flex-1` in `ProjectView.tsx` and add `min-h-0` to `PromptPreview`'s `SidebarProvider` to prevent overflow and keep controls visible.
>   - **Sidebar**: Change `ProjectSidebar` width from `w-64` to `w-[200px]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9eafcb3f5c433ed357be33154917f60a5af756b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->