### PR TITLE
Fix json parser in cases where it would output intermediate representations

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
@@ -147,13 +147,24 @@ fn coerce_string(
             Ok(baml_value)
         }
         crate::jsonish::Value::Null => Err(ctx.error_unexpected_null(target)),
-        // Handle AnyOf explicitly to extract the original string content
-        // instead of using the Display impl which shows "AnyOf[...]"
-        crate::jsonish::Value::AnyOf(_, original_string) => {
-            let mut baml_value =
-                BamlValueWithFlags::String((original_string.clone(), target).into());
-            let completion_state = value.completion_state();
-            if completion_state == &CompletionState::Incomplete {
+        // Handle AnyOf explicitly to extract the string content.
+        // If one of the variants is a String, prefer that over the raw input.
+        // Otherwise, use the original raw string.
+        crate::jsonish::Value::AnyOf(choices, original_string) => {
+            // Try to find a String variant in the choices
+            let string_value = choices.iter().find_map(|choice| {
+                if let crate::jsonish::Value::String(s, completion_state) = choice {
+                    Some((s.clone(), completion_state.clone()))
+                } else {
+                    None
+                }
+            });
+
+            let (string_val, completion_state) = string_value
+                .unwrap_or_else(|| (original_string.clone(), value.completion_state().clone()));
+
+            let mut baml_value = BamlValueWithFlags::String((string_val, target).into());
+            if completion_state == CompletionState::Incomplete {
                 baml_value.add_flag(Flag::Incomplete);
             }
             Ok(baml_value)
@@ -492,7 +503,7 @@ mod tests {
         let result = coerce_string(&ctx, &target, Some(&anyof_value));
 
         // The bug would cause this to return "AnyOf[..."
-        // The fix should return the original raw string
+        // The fix should prefer the String variant from the choices if available
         assert!(result.is_ok());
         let baml_value = result.unwrap();
         match baml_value {
@@ -503,8 +514,48 @@ mod tests {
                     "Got parsing artifact in string: {}",
                     v.value
                 );
-                // Should be the original string instead
-                assert_eq!(v.value, "[json\nAnyOf[{,AnyOf[{,{},],]");
+                // Should be the String variant from the choices, not the Display repr
+                assert_eq!(v.value, "[json\n");
+            }
+            _ => panic!("Expected String, got {:?}", baml_value),
+        }
+    }
+
+    #[test]
+    fn test_coerce_anyof_to_string_no_string_variant() {
+        use crate::{
+            helpers::{load_test_ir, render_output_format},
+            jsonish::Value,
+        };
+
+        // Create an AnyOf value with NO string variant - should fall back to raw string
+        let anyof_value = Value::AnyOf(
+            vec![
+                Value::Object(vec![], CompletionState::Incomplete),
+                Value::Array(vec![], CompletionState::Incomplete),
+            ],
+            "some raw input".to_string(),
+        );
+
+        let ir = load_test_ir("");
+        let target = TypeIR::Primitive(TypeValue::String, Default::default());
+        let output_format = render_output_format(
+            &ir,
+            &target,
+            &Default::default(),
+            baml_types::StreamingMode::Streaming,
+        )
+        .unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::Streaming);
+
+        let result = coerce_string(&ctx, &target, Some(&anyof_value));
+
+        assert!(result.is_ok());
+        let baml_value = result.unwrap();
+        match baml_value {
+            BamlValueWithFlags::String(v) => {
+                // Should fall back to the raw input string
+                assert_eq!(v.value, "some raw input");
             }
             _ => panic!("Expected String, got {:?}", baml_value),
         }

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
@@ -150,7 +150,8 @@ fn coerce_string(
         // Handle AnyOf explicitly to extract the original string content
         // instead of using the Display impl which shows "AnyOf[...]"
         crate::jsonish::Value::AnyOf(_, original_string) => {
-            let mut baml_value = BamlValueWithFlags::String((original_string.clone(), target).into());
+            let mut baml_value =
+                BamlValueWithFlags::String((original_string.clone(), target).into());
             let completion_state = value.completion_state();
             if completion_state == &CompletionState::Incomplete {
                 baml_value.add_flag(Flag::Incomplete);
@@ -463,8 +464,10 @@ mod tests {
 
     #[test]
     fn test_coerce_anyof_to_string() {
-        use crate::jsonish::Value;
-        use crate::helpers::{load_test_ir, render_output_format};
+        use crate::{
+            helpers::{load_test_ir, render_output_format},
+            jsonish::Value,
+        };
 
         // Create an AnyOf value similar to what the parser creates
         let anyof_value = Value::AnyOf(
@@ -477,7 +480,13 @@ mod tests {
 
         let ir = load_test_ir("");
         let target = TypeIR::Primitive(TypeValue::String, Default::default());
-        let output_format = render_output_format(&ir, &target, &Default::default(), baml_types::StreamingMode::Streaming).unwrap();
+        let output_format = render_output_format(
+            &ir,
+            &target,
+            &Default::default(),
+            baml_types::StreamingMode::Streaming,
+        )
+        .unwrap();
         let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::Streaming);
 
         let result = coerce_string(&ctx, &target, Some(&anyof_value));

--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
@@ -147,6 +147,16 @@ fn coerce_string(
             Ok(baml_value)
         }
         crate::jsonish::Value::Null => Err(ctx.error_unexpected_null(target)),
+        // Handle AnyOf explicitly to extract the original string content
+        // instead of using the Display impl which shows "AnyOf[...]"
+        crate::jsonish::Value::AnyOf(_, original_string) => {
+            let mut baml_value = BamlValueWithFlags::String((original_string.clone(), target).into());
+            let completion_state = value.completion_state();
+            if completion_state == &CompletionState::Incomplete {
+                baml_value.add_flag(Flag::Incomplete);
+            }
+            Ok(baml_value)
+        }
         v => Ok(BamlValueWithFlags::String(
             (v.to_string(), target, Flag::JsonToString(v.clone())).into(),
         )),
@@ -448,6 +458,46 @@ mod tests {
                 result, expected,
                 "Failed to parse '{input}'. Expected {expected:?}, got {result:?}"
             );
+        }
+    }
+
+    #[test]
+    fn test_coerce_anyof_to_string() {
+        use crate::jsonish::Value;
+        use crate::helpers::{load_test_ir, render_output_format};
+
+        // Create an AnyOf value similar to what the parser creates
+        let anyof_value = Value::AnyOf(
+            vec![
+                Value::String("[json\n".to_string(), CompletionState::Incomplete),
+                Value::Object(vec![], CompletionState::Incomplete),
+            ],
+            "[json\nAnyOf[{,AnyOf[{,{},],]".to_string(), // This is the raw string
+        );
+
+        let ir = load_test_ir("");
+        let target = TypeIR::Primitive(TypeValue::String, Default::default());
+        let output_format = render_output_format(&ir, &target, &Default::default(), baml_types::StreamingMode::Streaming).unwrap();
+        let ctx = ParsingContext::new(&output_format, baml_types::StreamingMode::Streaming);
+
+        let result = coerce_string(&ctx, &target, Some(&anyof_value));
+
+        // The bug would cause this to return "AnyOf[..."
+        // The fix should return the original raw string
+        assert!(result.is_ok());
+        let baml_value = result.unwrap();
+        match baml_value {
+            BamlValueWithFlags::String(v) => {
+                // Should NOT start with "AnyOf[" - that's the bug!
+                assert!(
+                    !v.value.starts_with("AnyOf["),
+                    "Got parsing artifact in string: {}",
+                    v.value
+                );
+                // Should be the original string instead
+                assert_eq!(v.value, "[json\nAnyOf[{,AnyOf[{,{},],]");
+            }
+            _ => panic!("Expected String, got {:?}", baml_value),
         }
     }
 }

--- a/engine/baml-lib/jsonish/src/tests/test_streaming.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_streaming.rs
@@ -563,3 +563,31 @@ test_partial_deserializer_streaming!(
     TypeIR::class("Foo"),
     {"y": "hello"}
 );
+
+// Regression test for GitHub issue #2567: Streaming Bug with Parsing Artifacts
+// When streaming with partial data, AnyOf values should extract the original
+// string content, not leak internal parsing representations like "AnyOf[..."
+const STREAMING_ANYOF_BUG: &str = r#"
+class Inspiration {
+  Description string
+}
+"#;
+
+test_partial_deserializer_streaming!(
+    test_streaming_anyof_string_field,
+    STREAMING_ANYOF_BUG,
+    r#"{"Description": "A beautiful sunset over the ocean"#,
+    TypeIR::class("Inspiration"),
+    {"Description": "A beautiful sunset over the ocean"}
+);
+
+// Test with a more complex partial input that might trigger AnyOf creation
+// This simulates the scenario where the parser is uncertain about structure
+test_partial_deserializer_streaming!(
+    test_streaming_anyof_with_markdown_partial,
+    STREAMING_ANYOF_BUG,
+    r#"```json
+{"Description": "Test"#,
+    TypeIR::class("Inspiration"),
+    {"Description": "Test"}
+);


### PR DESCRIPTION
Summary

  Issue: GitHub #2567 - Streaming Bug: Parsing Artifacts in Partial Objects

  Root Cause: When BAML's streaming API encounters ambiguous/incomplete JSON during parsing, it creates an AnyOf value that contains multiple possible
  interpretations plus the original raw string. When this AnyOf value needs to be coerced to a string field, the coerce_string function was calling
  v.to_string() which uses the Display implementation. This caused internal parsing representations like "AnyOf[{,AnyOf[{,{},],]" to leak into the final
   output instead of using the original string content.

  Fix Location: /Users/aaronvillalpando/Projects/baml/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs:150-159

  Fix Applied: Added explicit handling for Value::AnyOf in the coerce_string function to extract the original string (the second field of the AnyOf
  variant) instead of using the Display implementation.

  Tests Added:
  1. Unit test test_coerce_anyof_to_string in coerce_primitive.rs that directly tests the fix
  2. Integration tests test_streaming_anyof_string_field and test_streaming_anyof_with_markdown_partial in test_streaming.rs

  All 458 existing tests still pass, confirming the fix doesn't break any existing functionality.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle `AnyOf` during string coercion to prevent leaking parsing artifacts and add unit/streaming regression tests.
> 
> - **Deserializer**:
>   - **`coerce_string`** in `engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs`: add explicit handling for `Value::AnyOf`, preferring a `String` variant if present; otherwise fall back to the original raw string. Preserve `Incomplete` flag.
> - **Tests**:
>   - Unit: `test_coerce_anyof_to_string`, `test_coerce_anyof_to_string_no_string_variant` in `coerce_primitive.rs`.
>   - Streaming: `test_streaming_anyof_string_field`, `test_streaming_anyof_with_markdown_partial` in `engine/baml-lib/jsonish/src/tests/test_streaming.rs`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ab0f6d461dcc4460f9abd32762b3adc786cf80f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->