### PR TITLE
Fix jsonish crate and stream.rs issue

### DIFF
--- a/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
+++ b/engine/baml-lib/jsonish/src/deserializer/coercer/coerce_primitive.rs
@@ -147,9 +147,43 @@ fn coerce_string(
             Ok(baml_value)
         }
         crate::jsonish::Value::Null => Err(ctx.error_unexpected_null(target)),
-        v => Ok(BamlValueWithFlags::String(
-            (v.to_string(), target, Flag::JsonToString(v.clone())).into(),
-        )),
+        v => {
+            // In streaming mode, avoid stringifying parser-wrapper and structured values
+            // that would leak artifacts (AnyOf, FixedJson, Markdown, Objects, Arrays).
+            if ctx.do_not_use_mode == baml_types::StreamingMode::Streaming {
+                match v {
+                    // Parser wrapper types: don't coerce to string; reject so unions prefer
+                    // the structural types (e.g. GraphJson) rather than a string wrapper class.
+                    crate::jsonish::Value::AnyOf(..)
+                    | crate::jsonish::Value::FixedJson(..)
+                    | crate::jsonish::Value::Markdown(..) => {
+                        return Err(ctx.error_unexpected_type(target, &v));
+                    }
+                    // Structured JSON values: surface a null placeholder instead of artifact stringification.
+                    crate::jsonish::Value::Object(..)
+                    | crate::jsonish::Value::Array(..) => {
+                        return Ok(BamlValueWithFlags::Null(
+                            target.clone().as_optional(),
+                            DeserializerConditions::new().with_flag(Flag::Incomplete),
+                        ));
+                    }
+                    crate::jsonish::Value::Boolean(_)
+                    | crate::jsonish::Value::Number(_, _) => {
+                        // Allow primitive conversions (bool/number -> string)
+                    }
+                    crate::jsonish::Value::Null => {
+                        return Err(ctx.error_unexpected_null(target));
+                    }
+                    crate::jsonish::Value::String(_, _) => unreachable!(
+                        "handled in previous arm"
+                    ),
+                }
+            }
+
+            Ok(BamlValueWithFlags::String(
+                (v.to_string(), target, Flag::JsonToString(v.clone())).into(),
+            ))
+        }
     }
 }
 

--- a/engine/baml-lib/jsonish/src/tests/test_streaming.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_streaming.rs
@@ -428,6 +428,25 @@ test_partial_deserializer_streaming_failure!(
     }
 );
 
+// Regression test for BAML issue #2567: ensure we don't stringify
+// partial object artifacts into string fields during streaming.
+const STRING_FIELD_NO_ARTIFACTS: &str = r#"
+class Inspiration {
+  Description string
+}
+"#;
+
+// When the LLM starts with a partial object, we should not leak
+// parser internals (like AnyOf[...] or JSON stringified objects)
+// into the string field. It should remain null until a string arrives.
+test_partial_deserializer_streaming!(
+    test_string_field_does_not_stringify_objects_in_streaming,
+    STRING_FIELD_NO_ARTIFACTS,
+    r#"{\n  \"Description\": {\n    \"__proto\": null\n  }\n"#,
+    TypeIR::class("Inspiration"),
+    {"Description": null}
+);
+
 // Test for @stream.not_null fields receiving null values during streaming
 const STREAM_NOT_NULL_TEST: &str = r#"
 class ClassWithBlockDone {


### PR DESCRIPTION
Fixes #2567 by preventing string fields from leaking parser artifacts during streaming.

The `coerce_string` function now avoids stringifying internal parser types (e.g., `AnyOf`, `FixedJson`, `Markdown`) or structured JSON values (objects, arrays) into string fields when in streaming mode. Instead, it rejects parser wrapper types or returns a `null` placeholder for structured values, preventing incorrect partial outputs.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1759695772240959?thread_ts=1759695772.240959&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-61de3cdc-ebb4-40dc-9863-f40a97dc478b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-61de3cdc-ebb4-40dc-9863-f40a97dc478b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> In streaming mode, `coerce_string` now rejects parser-wrapper types and yields null for objects/arrays instead of stringifying, with a regression test added.
> 
> - **Deserializer**:
>   - **`coerce_string` (streaming mode)**:
>     - Rejects parser-wrapper values (`AnyOf`, `FixedJson`, `Markdown`) for `string` targets.
>     - For structured values (`Object`, `Array`), returns `Null` with `Incomplete` flag instead of stringifying.
>     - Still allows primitives (`Boolean`, `Number`) to coerce to `string`.
> - **Tests**:
>   - Add regression test ensuring string fields don’t stringify partial objects during streaming (`test_string_field_does_not_stringify_objects_in_streaming`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5d9ca9d9385d5ba8296cd7e619a995ea488ec06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->