### PR TITLE
remove the BamlRuntime/InternalBamlRuntime split

### DIFF
--- a/engine/baml-runtime/src/async_interpreter_runtime.rs
+++ b/engine/baml-runtime/src/async_interpreter_runtime.rs
@@ -22,7 +22,6 @@ use crate::on_log_event::LogEventCallbackSync;
 use crate::{
     client_registry::ClientRegistry,
     internal::llm_client::{orchestrator::OrchestrationScope, LLMResponse},
-    runtime::InternalBamlRuntime,
     runtime_interface::ExperimentalTracingInterface,
     tracing::TracingCall,
     tracingv2::storage::storage::Collector,
@@ -59,7 +58,7 @@ impl TryFrom<LlmRuntime> for BamlAsyncInterpreterRuntime {
         let async_runtime = Arc::clone(&llm_runtime.async_runtime);
 
         // Stage 1: AST -> HIR
-        let hir_program = hir::Hir::from_ast(&llm_runtime.inner.db.ast);
+        let hir_program = hir::Hir::from_ast(&llm_runtime.db.ast);
 
         // Stage 2: HIR -> THIR (typecheck)
         let mut diagnostics = Diagnostics::new("dummy".into());
@@ -81,8 +80,8 @@ impl TryFrom<LlmRuntime> for BamlAsyncInterpreterRuntime {
 }
 
 impl BamlAsyncInterpreterRuntime {
-    pub fn internal(&self) -> &Arc<InternalBamlRuntime> {
-        &self.llm_runtime.inner
+    pub fn internal(&self) -> &LlmRuntime {
+        &self.llm_runtime
     }
 
     pub fn disassemble(&self, function_name: &str) {
@@ -236,7 +235,6 @@ impl BamlAsyncInterpreterRuntime {
             async move {
                 // Find the LLM function to get parameter names
                 let llm_fn = llm_runtime
-                    .inner
                     .ir()
                     .find_function(&fn_name)
                     .map_err(|e| anyhow::anyhow!("LLM function not found: {}: {}", fn_name, e))?;
@@ -596,7 +594,6 @@ impl BamlAsyncInterpreterRuntime {
         test_name: &str,
     ) -> Result<Option<TypeBuilder>> {
         self.llm_runtime
-            .inner
             .get_test_type_builder(function_name, test_name)
     }
 
@@ -759,11 +756,11 @@ fn baml_value_with_meta_to_baml_value(
 
 impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncInterpreterRuntime {
     fn features(&self) -> crate::internal::ir_features::IrFeatures {
-        self.llm_runtime.inner.features()
+        self.llm_runtime.features()
     }
 
     fn diagnostics(&self) -> &internal_baml_core::internal_baml_diagnostics::Diagnostics {
-        self.llm_runtime.inner.diagnostics()
+        self.llm_runtime.diagnostics()
     }
 
     fn orchestration_graph(
@@ -771,7 +768,7 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncInterpreter
         client_name: &internal_llm_client::ClientSpec,
         ctx: &crate::runtime_context::RuntimeContext,
     ) -> Result<Vec<crate::internal::llm_client::orchestrator::OrchestratorNode>> {
-        self.llm_runtime.inner.orchestration_graph(client_name, ctx)
+        self.llm_runtime.orchestration_graph(client_name, ctx)
     }
 
     fn function_graph(
@@ -779,14 +776,14 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncInterpreter
         function_name: &str,
         ctx: &crate::runtime_context::RuntimeContext,
     ) -> Result<String> {
-        self.llm_runtime.inner.function_graph(function_name, ctx)
+        self.llm_runtime.function_graph(function_name, ctx)
     }
 
     fn get_function<'ir>(
         &'ir self,
         function_name: &str,
     ) -> Result<internal_baml_core::ir::FunctionWalker<'ir>> {
-        self.llm_runtime.inner.get_function(function_name)
+        self.llm_runtime.get_function(function_name)
     }
 
     fn get_expr_function<'ir>(
@@ -794,7 +791,7 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncInterpreter
         function_name: &str,
         ctx: &crate::runtime_context::RuntimeContext,
     ) -> Result<internal_baml_core::ir::ExprFunctionWalker<'ir>> {
-        self.llm_runtime.inner.get_expr_function(function_name, ctx)
+        self.llm_runtime.get_expr_function(function_name, ctx)
     }
 
     async fn render_prompt(
@@ -809,7 +806,6 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncInterpreter
         internal_llm_client::AllowedRoleMetadata,
     )> {
         self.llm_runtime
-            .inner
             .render_prompt(function_name, ctx, params, node_index)
             .await
     }
@@ -823,13 +819,12 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncInterpreter
         node_index: Option<usize>,
     ) -> Result<String> {
         self.llm_runtime
-            .inner
             .render_raw_curl(function_name, ctx, prompt, render_settings, node_index)
             .await
     }
 
     fn ir(&self) -> &internal_baml_core::ir::repr::IntermediateRepr {
-        self.llm_runtime.inner.ir()
+        self.llm_runtime.ir()
     }
 
     fn get_test_params(
@@ -840,7 +835,6 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncInterpreter
         strict: bool,
     ) -> Result<BamlMap<String, BamlValue>> {
         self.llm_runtime
-            .inner
             .get_test_params(function_name, test_name, ctx, strict)
     }
 
@@ -851,7 +845,6 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncInterpreter
         ctx: &crate::runtime_context::RuntimeContext,
     ) -> Result<Vec<baml_types::Constraint>> {
         self.llm_runtime
-            .inner
             .get_test_constraints(function_name, test_name, ctx)
     }
 
@@ -861,7 +854,6 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncInterpreter
         test_name: &str,
     ) -> Result<Option<TypeBuilder>> {
         self.llm_runtime
-            .inner
             .get_test_type_builder(function_name, test_name)
     }
 }

--- a/engine/baml-runtime/src/async_vm_runtime.rs
+++ b/engine/baml-runtime/src/async_vm_runtime.rs
@@ -25,7 +25,6 @@ use crate::on_log_event::LogEventCallbackSync;
 use crate::{
     client_registry::ClientRegistry,
     internal::llm_client::{orchestrator::OrchestrationScope, LLMResponse},
-    runtime::InternalBamlRuntime,
     runtime_interface::ExperimentalTracingInterface,
     tracing::TracingCall,
     tracingv2::storage::storage::Collector,
@@ -65,7 +64,7 @@ impl TryFrom<LlmRuntime> for BamlAsyncVmRuntime {
         #[cfg(not(target_arch = "wasm32"))]
         let async_runtime = Arc::clone(&llm_runtime.async_runtime);
 
-        let program = baml_compiler::compile(&llm_runtime.inner.db)?;
+        let program = baml_compiler::compile(&llm_runtime.db)?;
 
         Ok(Self {
             llm_runtime: Arc::new(llm_runtime),
@@ -78,8 +77,8 @@ impl TryFrom<LlmRuntime> for BamlAsyncVmRuntime {
 }
 
 impl BamlAsyncVmRuntime {
-    pub fn internal(&self) -> &Arc<InternalBamlRuntime> {
-        &self.llm_runtime.inner
+    pub fn internal(&self) -> &LlmRuntime {
+        &self.llm_runtime
     }
 
     pub fn disassemble(&self, function_name: &str) {
@@ -212,7 +211,6 @@ impl BamlAsyncVmRuntime {
 
         let Some(expr_fn) = self
             .llm_runtime
-            .inner
             .ir()
             .expr_fns
             .iter()
@@ -358,7 +356,6 @@ impl BamlAsyncVmRuntime {
                         baml_vm::FutureKind::Llm => {
                             let llm_fn = match self
                                 .llm_runtime
-                                .inner
                                 .ir()
                                 .find_function(&pending_future.function)
                             {
@@ -519,7 +516,7 @@ impl BamlAsyncVmRuntime {
                                 let current_call_id = current_call_id.to_owned();
 
                                 let output_format = jsonish::helpers::render_output_format(
-                                    &self.llm_runtime.inner.ir,
+                                    &self.llm_runtime.ir,
                                     &parse_as_type,
                                     &baml_types::EvaluationContext::default(),
                                     baml_types::StreamingMode::NonStreaming,
@@ -915,8 +912,7 @@ impl BamlAsyncVmRuntime {
         test_name: &str,
     ) -> Result<Option<TypeBuilder>, anyhow::Error> {
         self.llm_runtime
-            .inner
-            .get_test_type_builder(function_name, test_name)
+            .get_test_type_builder_impl(function_name, test_name)
     }
 
     pub fn tracer_wrapper(&self) -> &Arc<BamlTracerWrapper> {
@@ -1206,11 +1202,11 @@ fn try_vm_value_from_function_result(
 
 impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncVmRuntime {
     fn features(&self) -> crate::internal::ir_features::IrFeatures {
-        self.llm_runtime.inner.features()
+        self.llm_runtime.features()
     }
 
     fn diagnostics(&self) -> &internal_baml_core::internal_baml_diagnostics::Diagnostics {
-        self.llm_runtime.inner.diagnostics()
+        self.llm_runtime.diagnostics()
     }
 
     fn orchestration_graph(
@@ -1218,7 +1214,7 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncVmRuntime {
         client_name: &internal_llm_client::ClientSpec,
         ctx: &crate::runtime_context::RuntimeContext,
     ) -> anyhow::Result<Vec<crate::internal::llm_client::orchestrator::OrchestratorNode>> {
-        self.llm_runtime.inner.orchestration_graph(client_name, ctx)
+        self.llm_runtime.orchestration_graph(client_name, ctx)
     }
 
     fn function_graph(
@@ -1226,14 +1222,14 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncVmRuntime {
         function_name: &str,
         ctx: &crate::runtime_context::RuntimeContext,
     ) -> anyhow::Result<String> {
-        self.llm_runtime.inner.function_graph(function_name, ctx)
+        self.llm_runtime.function_graph(function_name, ctx)
     }
 
     fn get_function<'ir>(
         &'ir self,
         function_name: &str,
     ) -> anyhow::Result<internal_baml_core::ir::FunctionWalker<'ir>> {
-        self.llm_runtime.inner.get_function(function_name)
+        self.llm_runtime.get_function(function_name)
     }
 
     fn get_expr_function<'ir>(
@@ -1241,7 +1237,7 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncVmRuntime {
         function_name: &str,
         ctx: &crate::runtime_context::RuntimeContext,
     ) -> anyhow::Result<internal_baml_core::ir::ExprFunctionWalker<'ir>> {
-        self.llm_runtime.inner.get_expr_function(function_name, ctx)
+        self.llm_runtime.get_expr_function(function_name, ctx)
     }
 
     async fn render_prompt(
@@ -1256,7 +1252,6 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncVmRuntime {
         internal_llm_client::AllowedRoleMetadata,
     )> {
         self.llm_runtime
-            .inner
             .render_prompt(function_name, ctx, params, node_index)
             .await
     }
@@ -1270,13 +1265,12 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncVmRuntime {
         node_index: Option<usize>,
     ) -> anyhow::Result<String> {
         self.llm_runtime
-            .inner
             .render_raw_curl(function_name, ctx, prompt, render_settings, node_index)
             .await
     }
 
     fn ir(&self) -> &internal_baml_core::ir::repr::IntermediateRepr {
-        self.llm_runtime.inner.ir()
+        self.llm_runtime.ir()
     }
 
     fn get_test_params(
@@ -1287,7 +1281,6 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncVmRuntime {
         strict: bool,
     ) -> anyhow::Result<BamlMap<String, BamlValue>> {
         self.llm_runtime
-            .inner
             .get_test_params(function_name, test_name, ctx, strict)
     }
 
@@ -1298,7 +1291,6 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncVmRuntime {
         ctx: &crate::runtime_context::RuntimeContext,
     ) -> anyhow::Result<Vec<baml_types::Constraint>> {
         self.llm_runtime
-            .inner
             .get_test_constraints(function_name, test_name, ctx)
     }
 
@@ -1308,7 +1300,6 @@ impl crate::runtime_interface::InternalRuntimeInterface for BamlAsyncVmRuntime {
         test_name: &str,
     ) -> anyhow::Result<Option<TypeBuilder>> {
         self.llm_runtime
-            .inner
             .get_test_type_builder(function_name, test_name)
     }
 }

--- a/engine/baml-runtime/src/cli/check.rs
+++ b/engine/baml-runtime/src/cli/check.rs
@@ -64,7 +64,7 @@ impl CheckArgs {
                 exit(1);
             }
             Ok(runtime) => {
-                let diagnostics = runtime.inner.diagnostics();
+                let diagnostics = &runtime.diagnostics;
                 if diagnostics.has_warnings() {
                     println!("{}", diagnostics.warnings_to_pretty_string());
                 }

--- a/engine/baml-runtime/src/cli/generate.rs
+++ b/engine/baml-runtime/src/cli/generate.rs
@@ -60,7 +60,7 @@ impl GenerateArgs {
             .context("Failed to build BAML runtime")?;
 
         // Display warnings only if the feature flag is enabled
-        let diagnostics = runtime.inner.diagnostics();
+        let diagnostics = &runtime.diagnostics;
         if feature_flags.should_display_warnings() && diagnostics.has_warnings() {
             eprintln!("{}", diagnostics.warnings_to_pretty_string());
         }

--- a/engine/baml-runtime/src/cli/repl.rs
+++ b/engine/baml-runtime/src/cli/repl.rs
@@ -272,7 +272,7 @@ impl ReplState {
         }
         let mut names = Vec::new();
         if let Some(runtime) = &self.runtime {
-            let internal = &runtime.inner;
+            let internal = &runtime;
             for function in internal.db.walk_functions() {
                 names.push(function.name().to_string());
             }
@@ -285,7 +285,7 @@ impl ReplState {
     fn function_parameters(&self) -> Result<HashMap<String, Vec<String>>> {
         let hir = match self.runtime.as_ref() {
             Some(runtime) => {
-                let internal = &runtime.inner;
+                let internal = &runtime;
                 Hir::from_ast(&internal.db.ast)
             }
             None => Hir::empty(),
@@ -311,7 +311,7 @@ impl ReplState {
             .as_ref()
             .ok_or_else(|| anyhow!("No BAML sources loaded. Use :load <path> to load sources."))?;
 
-        let internal = &runtime.inner;
+        let internal = &runtime;
 
         // Convert AST to HIR
         let hir = Hir::from_ast(&internal.db.ast);
@@ -460,7 +460,7 @@ impl ReplState {
         let hir = match self.runtime.as_ref() {
             Some(runtime) => {
                 // Get the internal runtime to access the existing context
-                let internal = &runtime.inner;
+                let internal = &runtime;
 
                 // Convert AST to HIR from existing loaded sources
                 Hir::from_ast(&internal.db.ast)
@@ -596,7 +596,7 @@ impl ReplState {
         let hir = match self.runtime.as_ref() {
             Some(runtime) => {
                 // Get the internal runtime to access the existing context
-                let internal = &runtime.inner;
+                let internal = &runtime;
 
                 // Convert AST to HIR from existing loaded sources
                 Hir::from_ast(&internal.db.ast)
@@ -679,7 +679,7 @@ impl ReplState {
 
         // Add functions and declarations from THIR if available
         if let Some(runtime) = &self.runtime {
-            let internal = &runtime.inner;
+            let internal = &runtime;
 
             // Add function names
             for function in internal.db.walk_functions() {

--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -640,7 +640,7 @@ Streaming is available via http://localhost:{port}/stream/{{FunctionName}}, but 
         .map_err(|_| BamlError::InternalError {
             message: "Failed to make placeholder generator".to_string(),
         })?;
-        let schema: OpenApiSchema = OpenApiSchema::from_ir(locked.inner.ir.as_ref());
+        let schema: OpenApiSchema = OpenApiSchema::from_ir(locked.ir.as_ref());
         serde_json::to_string(&schema).map_err(|e| {
             log::warn!("Failed to serialize openapi schema: {e}");
             BamlError::InternalError {

--- a/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
+++ b/engine/baml-runtime/src/internal/prompt_renderer/render_output_format.rs
@@ -528,7 +528,7 @@ mod tests {
 
         let field_type = TypeIR::r#enum("Foo");
         let render_output = render_output_format(
-            baml_runtime.inner.ir.as_ref(),
+            baml_runtime.ir.as_ref(),
             &ctx,
             &field_type,
             StreamingMode::NonStreaming,
@@ -594,7 +594,7 @@ class Resume {
 
         let field_type = TypeIR::class("Resume");
         let render_output = render_output_format(
-            baml_runtime.inner.ir.as_ref(),
+            baml_runtime.ir.as_ref(),
             &ctx,
             &field_type,
             StreamingMode::NonStreaming,
@@ -699,7 +699,7 @@ class Resume {
 
         let field_type = TypeIR::class("Resume");
         let render_output = render_output_format(
-            baml_runtime.inner.ir.as_ref(),
+            baml_runtime.ir.as_ref(),
             &ctx,
             &field_type,
             StreamingMode::NonStreaming,
@@ -777,7 +777,7 @@ Answer in JSON using this schema:
 
         let field_type = TypeIR::class("Foo");
         let render_output = render_output_format(
-            baml_runtime.inner.ir.as_ref(),
+            baml_runtime.ir.as_ref(),
             &ctx,
             &field_type,
             StreamingMode::NonStreaming,

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -47,8 +47,7 @@ use baml_types::{
 use cfg_if::cfg_if;
 #[cfg(not(target_arch = "wasm32"))]
 pub use cli::RuntimeCliDefaults;
-use client_registry::ClientRegistry;
-use dashmap::DashMap;
+use client_registry::{ClientProperty, ClientRegistry};
 use futures::{
     channel::mpsc,
     future::{join, join_all},
@@ -61,9 +60,10 @@ use indexmap::IndexMap;
 use internal::{
     llm_client::{
         llm_provider::LLMProvider,
-        orchestrator::OrchestrationScope,
-        primitive::{json_body, json_headers, JsonBodyInput},
+        orchestrator::{IterOrchestrator, OrchestrationScope},
+        primitive::{json_body, json_headers, JsonBodyInput, LLMPrimitiveProvider},
         retry_policy::CallablePolicy,
+        traits::{WithClientProperties, WithPrompt, WithRenderRawCurl},
     },
     prompt_renderer::PromptRenderer,
 };
@@ -79,6 +79,7 @@ use internal_baml_core::{
 pub use internal_baml_core::{
     internal_baml_diagnostics,
     internal_baml_diagnostics::Diagnostics as DiagnosticsError,
+    internal_baml_parser_database::ParserDatabase,
     ir::{ir_helpers::infer_type, scope_diagnostics, IRHelper, TypeIR, TypeValue},
 };
 #[cfg(feature = "internal")]
@@ -88,13 +89,12 @@ pub(crate) use internal_baml_jinja::{ChatMessagePart, RenderedPrompt};
 use internal_llm_client::{AllowedRoleMetadata, ClientSpec};
 use jsonish::{ResponseBamlValue, ResponseValueMeta};
 use on_log_event::LogEventCallbackSync;
-use runtime::InternalBamlRuntime;
 pub use runtime_context::BamlSrcReader;
 #[cfg(feature = "internal")]
 pub use runtime_interface::InternalRuntimeInterface;
 #[cfg(not(feature = "internal"))]
 pub(crate) use runtime_interface::InternalRuntimeInterface;
-use runtime_interface::{ExperimentalTracingInterface, InternalClientLookup, RuntimeConstructor};
+use runtime_interface::{ExperimentalTracingInterface, RuntimeConstructor};
 pub(crate) use runtime_methods::prepare_function::PreparedFunctionArgs;
 use serde_json::{self, json};
 use tracing::{BamlTracer, TracingCall};
@@ -151,44 +151,98 @@ impl BamlTracerWrapper {
 
     /// Create a new BamlTracerWrapper and insert a tracer for the given env vars.
     pub fn new(env_vars: &HashMap<String, String>) -> Result<Self> {
-        let tracers = DashMap::new();
         let filtered = Self::filter_relevant_env_vars(env_vars);
         let key = Self::env_vars_key(env_vars);
         let tracer = Arc::new(BamlTracer::new(None, filtered.clone().into_iter())?);
-        tracers.insert(key, tracer);
-        Ok(Self { tracers })
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let tracers = Arc::new(Mutex::new(HashMap::new()));
+            tracers.lock().unwrap().insert(key, tracer);
+            Ok(Self { tracers })
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let tracers = DashMap::new();
+            tracers.insert(key, tracer);
+            Ok(Self { tracers })
+        }
     }
 
     /// Get the tracer for the given env vars, creating a new one if the config changed.
     pub fn get_or_create_tracer(&self, env_vars: &HashMap<String, String>) -> Arc<BamlTracer> {
         let filtered = Self::filter_relevant_env_vars(env_vars);
         let key = Self::env_vars_key(env_vars);
-        if let Some(existing) = self.tracers.get(&key) {
-            if existing.config_matches_env_vars(&filtered) {
-                let cloned = existing.clone();
-                return cloned;
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let mut tracers = self.tracers.lock().unwrap();
+            if let Some(existing) = tracers.get(&key) {
+                if existing.config_matches_env_vars(&filtered) {
+                    return existing.clone();
+                }
             }
+            // Config changed, clear all and insert new
+            tracers.clear();
+            let new_tracer = Arc::new(
+                BamlTracer::new(None, filtered.clone().into_iter())
+                    .expect("Failed to create BamlTracer"),
+            );
+            tracers.insert(key, new_tracer.clone());
+            new_tracer
         }
-        // Config changed, clear all and insert new
-        self.tracers.clear();
-        let new_tracer = Arc::new(
-            BamlTracer::new(None, filtered.clone().into_iter())
-                .expect("Failed to create BamlTracer"),
-        );
-        self.tracers.insert(key, new_tracer.clone());
-        new_tracer
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            if let Some(existing) = self.tracers.get(&key) {
+                if existing.config_matches_env_vars(&filtered) {
+                    let cloned = existing.clone();
+                    return cloned;
+                }
+            }
+            // Config changed, clear all and insert new
+            self.tracers.clear();
+            let new_tracer = Arc::new(
+                BamlTracer::new(None, filtered.clone().into_iter())
+                    .expect("Failed to create BamlTracer"),
+            );
+            self.tracers.insert(key, new_tracer.clone());
+            new_tracer
+        }
     }
 
     /// Get the current tracer (the only one in the map, if any).
     pub fn get_tracer(&self) -> Arc<BamlTracer> {
-        // Return the first tracer if any, else panic (should always have one)
-        self.tracers.iter().next().expect("No tracer found").clone()
+        #[cfg(target_arch = "wasm32")]
+        {
+            let tracers = self.tracers.lock().unwrap();
+            tracers.values().next().expect("No tracer found").clone()
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.tracers.iter().next().expect("No tracer found").clone()
+        }
     }
 }
 
+cfg_if::cfg_if!(
+    if #[cfg(target_arch = "wasm32")] {
+        type DashMap<K, V> = std::sync::Arc<std::sync::Mutex<std::collections::HashMap<K, V>>>;
+    } else {
+        use dashmap::DashMap;
+    }
+);
+
 #[derive(Clone)]
 pub struct BamlRuntime {
-    pub inner: Arc<InternalBamlRuntime>,
+    // Core IR and parsing (formerly InternalBamlRuntime)
+    pub ir: Arc<IntermediateRepr>,
+    pub db: ParserDatabase,
+    pub diagnostics: DiagnosticsError,
+    clients: DashMap<String, runtime::CachedClient>,
+    retry_policies: DashMap<String, CallablePolicy>,
+    source_files: Vec<internal_baml_core::internal_baml_diagnostics::SourceFile>,
+
+    // Runtime infrastructure
     pub tracer_wrapper: Arc<BamlTracerWrapper>,
     #[cfg(not(target_arch = "wasm32"))]
     pub async_runtime: Arc<tokio::runtime::Runtime>,
@@ -240,13 +294,35 @@ impl BamlRuntime {
         }
     }
 
-    fn new_runtime(inner: InternalBamlRuntime, env_vars: &HashMap<String, String>) -> Result<Self> {
+    fn new_runtime(
+        ir: Arc<IntermediateRepr>,
+        db: ParserDatabase,
+        diagnostics: DiagnosticsError,
+        source_files: Vec<internal_baml_core::internal_baml_diagnostics::SourceFile>,
+        env_vars: &HashMap<String, String>,
+    ) -> Result<Self> {
         #[cfg(not(target_arch = "wasm32"))]
         let rt = Self::get_tokio_singleton()?;
-        let inner = Arc::new(inner);
+
+        let runtime_clone = BamlRuntime {
+            ir: ir.clone(),
+            db: db.clone(),
+            diagnostics: diagnostics.clone(),
+            clients: Default::default(),
+            retry_policies: Default::default(),
+            source_files: source_files.clone(),
+            tracer_wrapper: Arc::new(BamlTracerWrapper::new(env_vars)?),
+            #[cfg(not(target_arch = "wasm32"))]
+            async_runtime: rt.clone(),
+        };
 
         let runtime = BamlRuntime {
-            inner: inner.clone(),
+            ir: ir.clone(),
+            db,
+            diagnostics,
+            clients: Default::default(),
+            retry_policies: Default::default(),
+            source_files,
             tracer_wrapper: Arc::new(BamlTracerWrapper::new(env_vars)?),
             #[cfg(not(target_arch = "wasm32"))]
             async_runtime: rt.clone(),
@@ -254,9 +330,11 @@ impl BamlRuntime {
 
         tracingv2::publisher::start_publisher(
             Arc::new(
-                (inner, env_vars.clone()).try_into().context(
-                    "Internal error: Failed to create a event publisher for BAML runtime",
-                )?,
+                (Arc::new(runtime_clone), env_vars.clone())
+                    .try_into()
+                    .context(
+                        "Internal error: Failed to create a event publisher for BAML runtime",
+                    )?,
             ),
             #[cfg(not(target_arch = "wasm32"))]
             rt.clone(),
@@ -314,10 +392,26 @@ impl BamlRuntime {
             .collect();
         baml_log::set_from_env(&copy)?;
 
-        Self::new_runtime(
-            InternalBamlRuntime::from_directory(&path, feature_flags)?,
-            &copy,
-        )
+        let files = baml_src_files(&path)?;
+        let contents: Vec<internal_baml_core::internal_baml_diagnostics::SourceFile> = files
+            .iter()
+            .map(|path| match std::fs::read_to_string(path) {
+                Ok(contents) => Ok(
+                    internal_baml_core::internal_baml_diagnostics::SourceFile::from((
+                        path.clone(),
+                        contents,
+                    )),
+                ),
+                Err(e) => Err(e),
+            })
+            .filter_map(|res| res.ok())
+            .collect();
+        let mut schema = internal_baml_core::validate(&path, contents.clone(), feature_flags);
+        schema.diagnostics.to_result()?;
+
+        let ir = IntermediateRepr::from_parser_database(&schema.db, schema.configuration)?;
+
+        Self::new_runtime(Arc::new(ir), schema.db, schema.diagnostics, contents, &copy)
     }
 
     pub fn from_file_content<T: AsRef<str> + std::fmt::Debug, U: AsRef<str>>(
@@ -333,15 +427,29 @@ impl BamlRuntime {
             .collect();
         baml_log::set_from_env(&copy)?;
 
-        Self::new_runtime(
-            InternalBamlRuntime::from_file_content(root_path, files, feature_flags)?,
-            &copy,
-        )
-    }
+        let contents = files
+            .iter()
+            .map(|(path, contents)| {
+                Ok(
+                    internal_baml_core::internal_baml_diagnostics::SourceFile::from((
+                        PathBuf::from(path.as_ref()),
+                        contents.as_ref().to_string(),
+                    )),
+                )
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let mut schema = internal_baml_core::validate(
+            &PathBuf::from(root_path),
+            contents.clone(),
+            feature_flags,
+        );
+        schema.diagnostics.to_result()?;
 
-    #[cfg(feature = "internal")]
-    pub fn internal(&self) -> &Arc<InternalBamlRuntime> {
-        &self.inner
+        let ir = IntermediateRepr::from_parser_database(&schema.db, schema.configuration)?;
+        ir.validate_test_args(&mut schema.diagnostics);
+        schema.diagnostics.to_result()?;
+
+        Self::new_runtime(Arc::new(ir), schema.db, schema.diagnostics, contents, &copy)
     }
 
     pub fn create_ctx_manager(
@@ -392,16 +500,48 @@ impl BamlRuntime {
 }
 
 impl BamlRuntime {
-    pub async fn render_prompt(
+    pub(crate) async fn render_prompt_impl(
         &self,
         function_name: &str,
         ctx: &RuntimeContext,
         params: &BamlMap<String, BamlValue>,
         node_index: Option<usize>,
     ) -> Result<(RenderedPrompt, OrchestrationScope, AllowedRoleMetadata)> {
-        self.inner
-            .render_prompt(function_name, ctx, params, node_index)
+        let func = self.get_function(function_name)?;
+        let function_params = func.inputs();
+        let baml_args = self.ir().check_function_params(
+            function_params,
+            params,
+            internal_baml_core::ir::ArgCoercer {
+                span_path: None,
+                allow_implicit_cast_to_string: false,
+            },
+        )?;
+
+        let renderer = PromptRenderer::from_function(&func, self.ir(), ctx)?;
+
+        let client_spec = renderer.client_spec();
+        let client = self.get_llm_provider_impl(client_spec, ctx)?;
+        let mut selected =
+            client.iter_orchestrator(&mut Default::default(), Default::default(), ctx, self)?;
+        let node_index = node_index.unwrap_or(0);
+
+        if node_index >= selected.len() {
+            return Err(anyhow::anyhow!(
+                "Execution Node out of bounds (render prompt): {} >= {} for client {}",
+                node_index,
+                selected.len(),
+                client_spec,
+            ));
+        }
+
+        let baml_args =
+            BamlValue::Map(baml_args.into_iter().map(|(k, v)| (k, v.value())).collect());
+        let node = selected.swap_remove(node_index);
+        node.provider
+            .render_prompt(self.ir(), &renderer, ctx, &baml_args)
             .await
+            .map(|prompt| (prompt, node.scope, node.provider.allowed_metadata().clone()))
     }
 
     pub fn llm_provider_from_function(
@@ -409,13 +549,10 @@ impl BamlRuntime {
         function_name: &str,
         ctx: &RuntimeContext,
     ) -> Result<Arc<LLMProvider>> {
-        let renderer = PromptRenderer::from_function(
-            &self.inner.get_function(function_name)?,
-            self.inner.ir(),
-            ctx,
-        )?;
+        let renderer =
+            PromptRenderer::from_function(&self.get_function(function_name)?, self.ir(), ctx)?;
 
-        self.inner.get_llm_provider(renderer.client_spec(), ctx)
+        self.get_llm_provider_impl(renderer.client_spec(), ctx)
     }
 
     pub fn get_test_params_and_constraints(
@@ -425,26 +562,194 @@ impl BamlRuntime {
         ctx: &RuntimeContext,
         strict: bool,
     ) -> Result<(BamlMap<String, BamlValue>, Vec<Constraint>)> {
-        let params = self
-            .inner
-            .get_test_params(function_name, test_name, ctx, strict)?;
+        let params = self.get_test_params_impl(function_name, test_name, ctx, strict)?;
         let constraints = self
-            .inner
-            .get_test_constraints(function_name, test_name, ctx)
+            .get_test_constraints_impl(function_name, test_name, ctx)
             .unwrap_or_default(); // TODO: Fix this.
-                                  // .get_test_constraints(function_name, test_name, ctx)?;
+                                  // .get_test_constraints_impl(function_name, test_name, ctx)?;
         Ok((params, constraints))
     }
 
-    pub fn get_test_params(
+    pub(crate) fn get_test_params_impl(
         &self,
         function_name: &str,
         test_name: &str,
         ctx: &RuntimeContext,
         strict: bool,
     ) -> Result<BamlMap<String, BamlValue>> {
-        self.inner
-            .get_test_params(function_name, test_name, ctx, strict)
+        log::info!("get_test_params: {function_name} {test_name}");
+        let maybe_test_and_params = self.get_function(function_name).and_then(|func| {
+            let test = self.ir().find_test(&func, test_name)?;
+            let test_case_params = test.test_case_params(&ctx.eval_ctx(strict))?;
+            let inputs = func.inputs().clone();
+            let span = test.span();
+            Ok((test_case_params, inputs, span.cloned()))
+        });
+        let maybe_expr_test_and_params =
+            self.get_expr_function(function_name, ctx).and_then(|func| {
+                let test = self.ir().find_expr_fn_test(&func, test_name)?;
+                let test_case_params = test.test_case_params(&ctx.eval_ctx(strict))?;
+                let inputs = func.inputs().clone();
+                let span = test.span();
+                Ok((test_case_params, inputs, span.cloned()))
+            });
+
+        let maybe_params = maybe_test_and_params.or(maybe_expr_test_and_params);
+
+        let eval_ctx = ctx.eval_ctx(strict);
+
+        match maybe_params {
+            Ok((params, function_params, span)) => {
+                let mut errors = Vec::new();
+                let params = params
+                    .into_iter()
+                    .map(|(k, v)| match v {
+                        Ok(v) => (k, v),
+                        Err(e) => {
+                            errors.push(e);
+                            (k, BamlValue::Null)
+                        }
+                    })
+                    .collect::<BamlMap<_, _>>();
+
+                if !errors.is_empty() {
+                    return Err(anyhow::anyhow!(
+                        "Unable to resolve test params: {:?}",
+                        errors
+                    ));
+                }
+
+                self.ir()
+                    .check_function_params(
+                        &function_params,
+                        &params,
+                        internal_baml_core::ir::ArgCoercer {
+                            span_path: span.map(|s| s.file.path_buf().clone()),
+                            allow_implicit_cast_to_string: true,
+                        },
+                    )
+                    .map(|bv| bv.into_iter().map(|(k, v)| (k, v.value())).collect())
+            }
+            Err(e) => Err(anyhow::anyhow!("Unable to resolve test params: {:?}", e)),
+        }
+    }
+
+    pub(crate) fn get_test_constraints_impl(
+        &self,
+        function_name: &str,
+        test_name: &str,
+        ctx: &RuntimeContext,
+    ) -> Result<Vec<Constraint>> {
+        if let Ok(func) = self.get_function(function_name) {
+            let walker = self.ir().find_test(&func, test_name)?;
+            return Ok(walker.item.1.elem.constraints.clone());
+        }
+
+        let expr_fn = self.get_expr_function(function_name, ctx)?;
+        let test = self.ir().find_expr_fn_test(&expr_fn, test_name)?;
+        Ok(test.item.1.elem.constraints.clone())
+    }
+
+    pub(crate) fn get_test_type_builder_impl(
+        &self,
+        function_name: &str,
+        test_name: &str,
+    ) -> Result<Option<TypeBuilder>> {
+        if let Ok(func) = self.get_function(function_name) {
+            let test = self.ir().find_test(&func, test_name)?;
+
+            if test.type_builder_contents().is_empty() {
+                return Ok(None);
+            }
+
+            let type_builder = TypeBuilder::new();
+            type_builder.add_entries(test.type_builder_contents());
+            type_builder
+                .recursive_type_aliases()
+                .lock()
+                .unwrap()
+                .extend(test.type_builder_recursive_aliases().iter().cloned());
+            type_builder
+                .recursive_classes()
+                .lock()
+                .unwrap()
+                .extend(test.type_builder_recursive_classes().iter().cloned());
+
+            return Ok(Some(type_builder));
+        }
+
+        let expr_fn = self.ir().find_expr_fn(function_name)?;
+        let test = expr_fn.find_test(test_name).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Test '{}' not found for expr function '{}'",
+                test_name,
+                function_name
+            )
+        })?;
+
+        if test.item.1.elem.type_builder.entries.is_empty() {
+            return Ok(None);
+        }
+
+        let type_builder = TypeBuilder::new();
+        type_builder.add_entries(&test.item.1.elem.type_builder.entries);
+        type_builder
+            .recursive_type_aliases()
+            .lock()
+            .unwrap()
+            .extend(
+                test.item
+                    .1
+                    .elem
+                    .type_builder
+                    .recursive_aliases
+                    .iter()
+                    .cloned(),
+            );
+        type_builder.recursive_classes().lock().unwrap().extend(
+            test.item
+                .1
+                .elem
+                .type_builder
+                .recursive_classes
+                .iter()
+                .cloned(),
+        );
+
+        Ok(Some(type_builder))
+    }
+
+    pub(crate) async fn render_raw_curl_impl(
+        &self,
+        function_name: &str,
+        ctx: &RuntimeContext,
+        prompt: &[internal_baml_jinja::RenderedChatMessage],
+        render_settings: RenderCurlSettings,
+        node_index: Option<usize>,
+    ) -> Result<String> {
+        let func = self.get_function(function_name)?;
+        let renderer = PromptRenderer::from_function(&func, self.ir(), ctx)?;
+
+        let client_spec = renderer.client_spec();
+        let client = self.get_llm_provider_impl(client_spec, ctx)?;
+        let mut selected =
+            client.iter_orchestrator(&mut Default::default(), Default::default(), ctx, self)?;
+
+        let node_index = node_index.unwrap_or(0);
+
+        if node_index >= selected.len() {
+            return Err(anyhow::anyhow!(
+                "Execution Node out of bounds (raw curl): {} >= {} for client {}",
+                node_index,
+                selected.len(),
+                client_spec,
+            ));
+        }
+
+        let node = selected.swap_remove(node_index);
+        node.provider
+            .render_raw_curl(ctx, prompt, render_settings)
+            .await
     }
 
     pub async fn run_test_with_expr_events<F, G>(
@@ -479,7 +784,7 @@ impl BamlRuntime {
                 tags.as_ref(),
             );
 
-        let expr_fn = self.inner.ir().find_expr_fn(function_name);
+        let expr_fn = self.ir().find_expr_fn(function_name);
         let is_expr_fn = expr_fn.is_ok();
 
         // If it's an expr function, use the simpler expr execution path
@@ -497,8 +802,7 @@ impl BamlRuntime {
                 self.get_test_params_and_constraints(function_name, test_name, &rctx_no_tb, true)?;
 
             let type_builder = self
-                .inner
-                .get_test_type_builder(function_name, test_name)
+                .get_test_type_builder_impl(function_name, test_name)
                 .unwrap();
 
             let rctx = ctx.create_ctx(
@@ -508,7 +812,7 @@ impl BamlRuntime {
                 call.new_call_id_stack.clone(),
             )?;
 
-            let mut stream = self.inner.stream_function_impl(
+            let mut stream = self.stream_function_impl(
                 function_name.to_string(),
                 &params,
                 self.tracer_wrapper.get_or_create_tracer(&env_vars),
@@ -657,10 +961,7 @@ impl BamlRuntime {
         };
 
         // Get constraints for the test
-        let constraints = match self
-            .inner
-            .get_test_constraints(function_name, test_name, &rctx)
-        {
+        let constraints = match self.get_test_constraints_impl(function_name, test_name, &rctx) {
             Ok(c) => c,
             Err(e) => return (Err(e), FunctionCallId::new()),
         };
@@ -874,23 +1175,21 @@ impl BamlRuntime {
                 Ok(rctx) => {
                     let call_id_stack = rctx.call_id_stack.clone();
                     // TODO: is this the right naming?
-                    let prepared_func =
-                        match self.inner.prepare_function(function_name.clone(), params) {
-                            Ok(prepared_func) => prepared_func,
-                            Err(e) => {
-                                let err_anyhow = e.into_error();
-                                let trace_event = TraceEvent::new_function_end(
-                                    call_id_stack.clone(),
-                                    Err((&err_anyhow).to_baml_error()),
-                                );
-                                BAML_TRACER.lock().unwrap().put(Arc::new(trace_event));
-                                return (Err(err_anyhow), curr_call_id);
-                            }
-                        };
+                    let prepared_func = match self.prepare_function(function_name.clone(), params) {
+                        Ok(prepared_func) => prepared_func,
+                        Err(e) => {
+                            let err_anyhow = e.into_error();
+                            let trace_event = TraceEvent::new_function_end(
+                                call_id_stack.clone(),
+                                Err((&err_anyhow).to_baml_error()),
+                            );
+                            BAML_TRACER.lock().unwrap().put(Arc::new(trace_event));
+                            return (Err(err_anyhow), curr_call_id);
+                        }
+                    };
 
                     // Call (CANNOT RETURN HERE until trace event is finished)
                     let result = self
-                        .inner
                         .call_function_impl(prepared_func, rctx, cancel_tripwire)
                         .await;
                     // Trace event
@@ -898,9 +1197,9 @@ impl BamlRuntime {
                         call_id_stack.clone(),
                         match &result {
                             Ok(result) => match result.result_with_constraints_content() {
-                                Ok(value) => Ok(value
-                                    .0
-                                    .map_meta(|f| f.3.to_non_streaming_type(self.inner.ir()))),
+                                Ok(value) => {
+                                    Ok(value.0.map_meta(|f| f.3.to_non_streaming_type(self.ir())))
+                                }
                                 Err(e) => Err((&e).to_baml_error()),
                             },
                             Err(e) => Err(e.to_baml_error()),
@@ -957,7 +1256,7 @@ impl BamlRuntime {
         cancel_tripwire: Arc<TripWire>,
     ) -> Result<FunctionResultStream> {
         baml_log::set_from_env(&env_vars).unwrap();
-        self.inner.stream_function_impl(
+        self.stream_function_impl(
             function_name,
             params,
             self.tracer_wrapper.get_or_create_tracer(&env_vars),
@@ -1111,13 +1410,10 @@ impl BamlRuntime {
         baml_log::set_from_env(&env_vars).unwrap();
         let ctx = ctx.create_ctx(tb, cb, env_vars, vec![])?;
 
-        let renderer = PromptRenderer::from_function(
-            &self.inner.get_function(&function_name)?,
-            self.inner.ir(),
-            &ctx,
-        )?;
+        let renderer =
+            PromptRenderer::from_function(&self.get_function(&function_name)?, self.ir(), &ctx)?;
 
-        renderer.parse(self.inner.ir(), &ctx, &llm_response, allow_partials)
+        renderer.parse(self.ir(), &ctx, &llm_response, allow_partials)
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -1140,7 +1436,7 @@ impl BamlRuntime {
             }
         }
 
-        let files = generators_lib::generate_sdk(self.inner.ir.clone(), args)?;
+        let files = generators_lib::generate_sdk(self.ir.clone(), args)?;
         Ok(GenerateOutput {
             client_type: *client_type,
             output_dir_shorthand: args.output_dir().to_path_buf(),
@@ -1153,13 +1449,12 @@ impl BamlRuntime {
 // Interfaces for generators
 impl BamlRuntime {
     pub fn function_names(&self) -> impl Iterator<Item = &str> {
-        self.inner.ir().function_names()
+        self.ir().function_names()
     }
 
     /// Determine the file containing the generators.
     pub fn generator_path(&self) -> Option<PathBuf> {
         let path_counts: HashMap<&PathBuf, u32> = self
-            .inner
             .ir()
             .configuration()
             .generators
@@ -1180,8 +1475,7 @@ impl BamlRuntime {
     }
 
     pub fn cloud_projects(&self) -> Vec<&CloudProject> {
-        self.inner
-            .ir()
+        self.ir()
             .configuration()
             .generators
             .iter()
@@ -1193,8 +1487,7 @@ impl BamlRuntime {
     }
 
     pub fn codegen_generators(&self) -> impl Iterator<Item = &CodegenGenerator> {
-        self.inner
-            .ir()
+        self.ir()
             .configuration()
             .generators
             .iter()
@@ -1268,7 +1561,7 @@ impl BamlRuntime {
                     }
                 }
 
-                let files = generators_lib::generate_sdk(self.inner.ir.clone(), args)?;
+                let files = generators_lib::generate_sdk(self.ir.clone(), args)?;
                 Ok(GenerateOutput {
                     client_type: generator.output_type,
                     output_dir_shorthand: generator.output_dir(),
@@ -1280,17 +1573,142 @@ impl BamlRuntime {
     }
 }
 
-impl<'a> InternalClientLookup<'a> for BamlRuntime {
+impl<'a> runtime_interface::InternalClientLookup<'a> for BamlRuntime {
     fn get_llm_provider(
         &'a self,
         client_spec: &ClientSpec,
         ctx: &RuntimeContext,
     ) -> Result<Arc<LLMProvider>> {
-        self.inner.get_llm_provider(client_spec, ctx)
+        self.get_llm_provider_impl(client_spec, ctx)
     }
 
     fn get_retry_policy(&self, policy_name: &str, ctx: &RuntimeContext) -> Result<CallablePolicy> {
-        self.inner.get_retry_policy(policy_name, ctx)
+        self.get_retry_policy_impl(policy_name, ctx)
+    }
+}
+
+impl BamlRuntime {
+    pub(crate) fn ir(&self) -> &IntermediateRepr {
+        use std::ops::Deref;
+        self.ir.deref()
+    }
+
+    pub(crate) fn get_llm_provider_impl(
+        &self,
+        client_spec: &ClientSpec,
+        ctx: &RuntimeContext,
+    ) -> Result<Arc<LLMProvider>> {
+        match client_spec {
+            ClientSpec::Shorthand(provider, model) => {
+                let client_property = ClientProperty::from_shorthand(provider, model);
+                let llm_primitive_provider =
+                    LLMPrimitiveProvider::try_from((&client_property, ctx))
+                        .context(format!("Failed to parse client: {provider}/{model}"))?;
+
+                Ok(Arc::new(LLMProvider::Primitive(Arc::new(
+                    llm_primitive_provider,
+                ))))
+            }
+            ClientSpec::Named(client_name) => {
+                if let Some(client) = ctx
+                    .client_overrides
+                    .as_ref()
+                    .and_then(|(_, c)| c.get(client_name))
+                {
+                    return Ok(client.clone());
+                }
+
+                #[cfg(target_arch = "wasm32")]
+                let mut clients = self.clients.lock().unwrap();
+                #[cfg(not(target_arch = "wasm32"))]
+                let clients = &self.clients;
+
+                if clients.contains_key(client_name) {
+                    #[allow(clippy::map_clone)]
+                    let client = clients.get(client_name).map(|c| c.clone()).unwrap();
+                    if !client.has_env_vars_changed(ctx.env_vars()) {
+                        return Ok(client.provider.clone());
+                    } else {
+                        clients.remove(client_name);
+                    }
+                }
+
+                let walker = self
+                    .ir()
+                    .find_client(client_name)
+                    .context(format!("Could not find client with name: {client_name}"))?;
+                let new_client = LLMProvider::try_from((&walker, ctx)).map(Arc::new)?;
+
+                let mut required_env_vars = HashMap::new();
+                let fail_on_missing_required_env_vars = !ctx.is_modular_api()
+                    && !matches!(
+                        walker.item.elem.provider,
+                        internal_llm_client::ClientProvider::AwsBedrock
+                            | internal_llm_client::ClientProvider::Vertex
+                    );
+
+                for key in walker.required_env_vars() {
+                    if let Some(value) = ctx.env_vars().get(&key) {
+                        if fail_on_missing_required_env_vars && value.trim().is_empty() {
+                            baml_log::warn!(
+                                "Required environment variable '{key}' for client '{client_name}' is set but is empty: {key}='{value}'"
+                            );
+                        }
+                        required_env_vars.insert(key, value.to_owned());
+                    } else if fail_on_missing_required_env_vars {
+                        anyhow::bail!(
+                            "LLM client '{client_name}' requires environment variable '{key}' to be set but it is not"
+                        );
+                    }
+                }
+
+                clients.insert(
+                    client_name.into(),
+                    runtime::CachedClient::new(new_client.clone(), required_env_vars),
+                );
+
+                Ok(new_client)
+            }
+        }
+    }
+
+    pub(crate) fn get_retry_policy_impl(
+        &self,
+        policy_name: &str,
+        _ctx: &RuntimeContext,
+    ) -> Result<CallablePolicy> {
+        #[cfg(target_arch = "wasm32")]
+        let mut retry_policies = self.retry_policies.lock().unwrap();
+        #[cfg(not(target_arch = "wasm32"))]
+        let retry_policies = &self.retry_policies;
+
+        let inserter = || {
+            self.ir()
+                .walk_retry_policies()
+                .find(|walker| walker.name() == policy_name)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Could not find retry policy with name: {}", policy_name)
+                })
+                .map(CallablePolicy::from)
+        };
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            if let Some(policy_ref) = retry_policies.get(policy_name) {
+                return Ok(policy_ref.clone());
+            }
+            let new_policy = inserter()?;
+            retry_policies.insert(policy_name.into(), new_policy.clone());
+            Ok(new_policy)
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let policy_ref = retry_policies
+                .entry(policy_name.into())
+                .or_try_insert_with(inserter)?;
+            Ok(policy_ref.value().clone())
+        }
     }
 }
 
@@ -1397,6 +1815,104 @@ impl ExperimentalTracingInterface for BamlRuntime {
             .get_tracer()
             .set_log_event_callback(log_event_callback);
         Ok(())
+    }
+}
+
+impl InternalRuntimeInterface for BamlRuntime {
+    fn diagnostics(&self) -> &DiagnosticsError {
+        &self.diagnostics
+    }
+
+    fn orchestration_graph(
+        &self,
+        client_spec: &ClientSpec,
+        ctx: &RuntimeContext,
+    ) -> Result<Vec<internal::llm_client::orchestrator::OrchestratorNode>> {
+        let client = self.get_llm_provider_impl(client_spec, ctx)?;
+        client.iter_orchestrator(&mut Default::default(), Default::default(), ctx, self)
+    }
+
+    fn function_graph(&self, _function_name: &str, _ctx: &RuntimeContext) -> Result<String> {
+        let ast = self.db.ast();
+        let graph =
+            internal_baml_core::ast::BamlVisDiagramGenerator::generate_headers_flowchart(ast);
+        Ok(graph)
+    }
+
+    fn features(&self) -> internal::ir_features::IrFeatures {
+        internal::ir_features::WithInternal::features(self)
+    }
+
+    async fn render_prompt(
+        &self,
+        function_name: &str,
+        ctx: &RuntimeContext,
+        params: &BamlMap<String, BamlValue>,
+        node_index: Option<usize>,
+    ) -> Result<(RenderedPrompt, OrchestrationScope, AllowedRoleMetadata)> {
+        self.render_prompt_impl(function_name, ctx, params, node_index)
+            .await
+    }
+
+    async fn render_raw_curl(
+        &self,
+        function_name: &str,
+        ctx: &RuntimeContext,
+        prompt: &[internal_baml_jinja::RenderedChatMessage],
+        render_settings: RenderCurlSettings,
+        node_index: Option<usize>,
+    ) -> Result<String> {
+        self.render_raw_curl_impl(function_name, ctx, prompt, render_settings, node_index)
+            .await
+    }
+
+    fn get_function<'ir>(
+        &'ir self,
+        function_name: &str,
+    ) -> Result<internal_baml_core::ir::FunctionWalker<'ir>> {
+        let walker = self.ir().find_function(function_name)?;
+        Ok(walker)
+    }
+
+    fn get_expr_function<'ir>(
+        &'ir self,
+        function_name: &str,
+        _ctx: &RuntimeContext,
+    ) -> Result<internal_baml_core::ir::ExprFunctionWalker<'ir>> {
+        let walker = self.ir().find_expr_fn(function_name)?;
+        Ok(walker)
+    }
+
+    fn ir(&self) -> &IntermediateRepr {
+        use std::ops::Deref;
+        self.ir.deref()
+    }
+
+    fn get_test_params(
+        &self,
+        function_name: &str,
+        test_name: &str,
+        ctx: &RuntimeContext,
+        strict: bool,
+    ) -> Result<BamlMap<String, BamlValue>> {
+        self.get_test_params_impl(function_name, test_name, ctx, strict)
+    }
+
+    fn get_test_constraints(
+        &self,
+        function_name: &str,
+        test_name: &str,
+        ctx: &RuntimeContext,
+    ) -> Result<Vec<Constraint>> {
+        self.get_test_constraints_impl(function_name, test_name, ctx)
+    }
+
+    fn get_test_type_builder(
+        &self,
+        function_name: &str,
+        test_name: &str,
+    ) -> Result<Option<TypeBuilder>> {
+        self.get_test_type_builder_impl(function_name, test_name)
     }
 }
 

--- a/engine/baml-runtime/src/runtime/ir_features.rs
+++ b/engine/baml-runtime/src/runtime/ir_features.rs
@@ -1,12 +1,11 @@
 use internal_baml_core::ir::{FunctionWalker, TestCaseWalker};
 
-use super::InternalBamlRuntime;
 use crate::{
     internal::ir_features::{IrFeatures, WithInternal},
-    InternalRuntimeInterface,
+    BamlRuntime, InternalRuntimeInterface,
 };
 
-impl WithInternal for InternalBamlRuntime {
+impl WithInternal for BamlRuntime {
     fn features(&self) -> IrFeatures {
         let ir = self.ir();
 

--- a/engine/baml-runtime/src/runtime/mod.rs
+++ b/engine/baml-runtime/src/runtime/mod.rs
@@ -1,6 +1,5 @@
 mod ir_features;
 mod publisher;
-pub(crate) mod runtime_interface;
 
 use std::{
     collections::HashMap,
@@ -50,75 +49,4 @@ impl CachedClient {
     }
 }
 
-#[derive(Clone)]
-pub struct InternalBamlRuntime {
-    pub ir: Arc<IntermediateRepr>,
-    pub db: ParserDatabase,
-    pub diagnostics: Diagnostics,
-    clients: DashMap<String, CachedClient>,
-    retry_policies: DashMap<String, CallablePolicy>,
-    source_files: Vec<SourceFile>,
-}
-
-impl InternalBamlRuntime {
-    pub(super) fn from_file_content<T: AsRef<str>>(
-        directory: &str,
-        files: &HashMap<T, T>,
-        feature_flags: internal_baml_core::feature_flags::FeatureFlags,
-    ) -> Result<Self> {
-        let contents = files
-            .iter()
-            .map(|(path, contents)| {
-                Ok(SourceFile::from((
-                    PathBuf::from(path.as_ref()),
-                    contents.as_ref().to_string(),
-                )))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let mut schema = validate(&PathBuf::from(directory), contents.clone(), feature_flags);
-        schema.diagnostics.to_result()?;
-
-        let ir = IntermediateRepr::from_parser_database(&schema.db, schema.configuration)?;
-        ir.validate_test_args(&mut schema.diagnostics);
-        schema.diagnostics.to_result()?;
-
-        Ok(InternalBamlRuntime {
-            ir: Arc::new(ir),
-            db: schema.db,
-            diagnostics: schema.diagnostics,
-            clients: Default::default(),
-            retry_policies: Default::default(),
-            source_files: contents,
-        })
-    }
-
-    pub(super) fn from_files(
-        directory: &Path,
-        files: Vec<PathBuf>,
-        feature_flags: internal_baml_core::feature_flags::FeatureFlags,
-    ) -> Result<Self> {
-        let contents: Vec<SourceFile> = files
-            .iter()
-            .map(|path| match std::fs::read_to_string(path) {
-                Ok(contents) => Ok(SourceFile::from((path.clone(), contents))),
-                Err(e) => Err(e),
-            })
-            .filter_map(|res| res.ok())
-            .collect();
-        let mut schema = validate(directory, contents.clone(), feature_flags);
-        schema.diagnostics.to_result()?;
-
-        let ir = IntermediateRepr::from_parser_database(&schema.db, schema.configuration)?;
-        ir.validate_test_args(&mut schema.diagnostics);
-        schema.diagnostics.to_result()?;
-
-        Ok(Self {
-            ir: Arc::new(ir),
-            db: schema.db,
-            diagnostics: schema.diagnostics,
-            clients: Default::default(),
-            retry_policies: Default::default(),
-            source_files: contents,
-        })
-    }
-}
+// InternalBamlRuntime has been merged into BamlRuntime in lib.rs

--- a/engine/baml-runtime/src/runtime/publisher/mod.rs
+++ b/engine/baml-runtime/src/runtime/publisher/mod.rs
@@ -14,7 +14,6 @@ use cowstr::CowStr;
 use internal_baml_core::ir::ir_hasher;
 use serde::Serialize;
 
-use super::InternalBamlRuntime;
 use crate::{
     internal::ir_features::WithInternal, tracingv2::publisher::rpc_converters::TypeLookup,
 };
@@ -84,13 +83,13 @@ impl TypeLookup for AstSignatureWrapper {
     }
 }
 
-impl TryFrom<(Arc<InternalBamlRuntime>, HashMap<String, String>)> for AstSignatureWrapper {
+impl TryFrom<(Arc<crate::BamlRuntime>, HashMap<String, String>)> for AstSignatureWrapper {
     type Error = anyhow::Error;
 
     fn try_from(
-        (ir_runtime, env_vars): (Arc<InternalBamlRuntime>, HashMap<String, String>),
+        (runtime, env_vars): (Arc<crate::BamlRuntime>, HashMap<String, String>),
     ) -> Result<Self, Self::Error> {
-        let ir_signature = ir_hasher::IRSignature::new_from_ir(&ir_runtime.ir)?;
+        let ir_signature = ir_hasher::IRSignature::new_from_ir(runtime.ir())?;
 
         let name_to_baml_type_id_map: HashMap<String, Arc<BamlTypeId>> = ir_signature
             .classes
@@ -226,7 +225,7 @@ impl TryFrom<(Arc<InternalBamlRuntime>, HashMap<String, String>)> for AstSignatu
             )
             .collect();
 
-        let source_code = ir_runtime
+        let source_code = runtime
             .source_files
             .iter()
             .map(|file| (file.path_buf().clone(), CowStr::from(file.as_str())))

--- a/engine/baml-runtime/src/runtime_interface.rs
+++ b/engine/baml-runtime/src/runtime_interface.rs
@@ -18,7 +18,6 @@ use crate::{
             retry_policy::CallablePolicy,
         },
     },
-    runtime::InternalBamlRuntime,
     tracing::{BamlTracer, TracingCall},
     tracingv2::storage::storage::Collector,
     type_builder::TypeBuilder,
@@ -26,18 +25,18 @@ use crate::{
     FunctionResult, RenderCurlSettings, RuntimeContext, RuntimeContextManager,
 };
 
-pub(crate) trait RuntimeConstructor {
+pub(crate) trait RuntimeConstructor: Sized {
     #[cfg(not(target_arch = "wasm32"))]
     fn from_directory(
         dir: &std::path::Path,
         feature_flags: internal_baml_core::feature_flags::FeatureFlags,
-    ) -> Result<InternalBamlRuntime>;
+    ) -> Result<Self>;
 
     fn from_file_content<T: AsRef<str>>(
         root_path: &str,
         files: &HashMap<T, T>,
         feature_flags: internal_baml_core::feature_flags::FeatureFlags,
-    ) -> Result<InternalBamlRuntime>;
+    ) -> Result<Self>;
 }
 
 // These are UNSTABLE, and should be considered as a work in progress

--- a/engine/baml-runtime/src/runtime_methods/call_function.rs
+++ b/engine/baml-runtime/src/runtime_methods/call_function.rs
@@ -33,16 +33,15 @@ use crate::{
         },
         prompt_renderer::PromptRenderer,
     },
-    runtime::InternalBamlRuntime,
-    runtime_interface::{InternalClientLookup, RuntimeConstructor},
+    runtime_interface::RuntimeConstructor,
     tracing::BamlTracer,
     tracingv2::storage::storage::{Collector, BAML_TRACER},
     type_builder::TypeBuilder,
-    FunctionResult, FunctionResultStream, InternalRuntimeInterface, RenderCurlSettings,
-    RuntimeContext, RuntimeContextManager, TripWire,
+    BamlRuntime, FunctionResult, FunctionResultStream, InternalRuntimeInterface,
+    RenderCurlSettings, RuntimeContext, RuntimeContextManager, TripWire,
 };
 
-impl InternalBamlRuntime {
+impl BamlRuntime {
     pub(crate) async fn call_function_impl<'ir>(
         &'ir self,
         prepared_func_call: PreparedFunction<'ir>,

--- a/engine/baml-runtime/src/runtime_methods/prepare_function.rs
+++ b/engine/baml-runtime/src/runtime_methods/prepare_function.rs
@@ -33,13 +33,12 @@ use crate::{
         },
         prompt_renderer::PromptRenderer,
     },
-    runtime::InternalBamlRuntime,
-    runtime_interface::{InternalClientLookup, RuntimeConstructor},
+    runtime_interface::RuntimeConstructor,
     tracing::BamlTracer,
     tracingv2::storage::storage::{Collector, BAML_TRACER},
     type_builder::TypeBuilder,
-    FunctionResult, FunctionResultStream, InternalRuntimeInterface, RenderCurlSettings,
-    RuntimeContext, RuntimeContextManager,
+    BamlRuntime, FunctionResult, FunctionResultStream, InternalRuntimeInterface,
+    RenderCurlSettings, RuntimeContext, RuntimeContextManager,
 };
 
 pub(crate) struct PreparedFunction<'ir> {
@@ -99,7 +98,7 @@ impl From<PrepareFunctionError> for Result<FunctionResult> {
     }
 }
 
-impl InternalBamlRuntime {
+impl BamlRuntime {
     // TODO: this is introduced so that tracing can hook into function calls
     // _after_ prepare_function but before call_function_impl, which is why
     // `prepare_function` is not used in `FunctionResultStream`.  We should try

--- a/engine/baml-runtime/src/runtime_methods/stream_function.rs
+++ b/engine/baml-runtime/src/runtime_methods/stream_function.rs
@@ -33,15 +33,15 @@ use crate::{
         },
         prompt_renderer::PromptRenderer,
     },
-    runtime_interface::{InternalClientLookup, RuntimeConstructor},
+    runtime_interface::RuntimeConstructor,
     tracing::BamlTracer,
     tracingv2::storage::storage::{Collector, BAML_TRACER},
     type_builder::TypeBuilder,
-    FunctionResult, FunctionResultStream, InternalBamlRuntime, InternalRuntimeInterface,
+    BamlRuntime, FunctionResult, FunctionResultStream, InternalRuntimeInterface,
     RenderCurlSettings, RuntimeContext, RuntimeContextManager, TripWire,
 };
 
-impl InternalBamlRuntime {
+impl BamlRuntime {
     pub(crate) fn stream_function_impl(
         &self,
         function_name: String,

--- a/engine/baml-runtime/src/test_executor/mod.rs
+++ b/engine/baml-runtime/src/test_executor/mod.rs
@@ -147,7 +147,7 @@ fn file_reader_pinned(
 impl TestExecutor for BamlRuntime {
     fn cli_list_tests(&self, args: &TestFilter) -> Result<()> {
         let func_test_pairs = {
-            let ir = &self.inner.ir;
+            let ir = &self.ir;
             // Regular LLM function tests
             let from_fn_tests = ir.walk_function_test_pairs().filter_map(|node_pair| {
                 let (function_name, test_name) = node_pair.name();
@@ -208,7 +208,7 @@ impl TestExecutor for BamlRuntime {
     ) -> TestRunStatus {
         let renderer = AggregateRenderer::new(output_format, junit_path);
         let selected_tests: BTreeMap<(String, String), (String, FunctionType)> = {
-            let ir = &self.inner.ir;
+            let ir = &self.ir;
             // Regular LLM function tests
             let from_fn_tests = ir.walk_function_test_pairs().filter_map(|node_pair| {
                 let (function_name, test_name) = node_pair.name();

--- a/engine/baml-runtime/src/tests.rs
+++ b/engine/baml-runtime/src/tests.rs
@@ -32,7 +32,7 @@ fn test_graph_test() -> Result<()> {
 
     let ctx = runtime.create_ctx_manager(BamlValue::String("none".to_string()));
     let ctx = ctx.create_ctx();
-    let graph = runtime.inner.orchestration_graph("GPT4Turbo", &ctx)?;
+    let graph = runtime.orchestration_graph("GPT4Turbo", &ctx)?;
     for node in graph.iter() {
         log::info!("Node: {:#}", node);
     }
@@ -45,7 +45,7 @@ fn test_graph_test() -> Result<()> {
     .iter()
     {
         log::info!("Graph: {}", name);
-        let graph = runtime.inner.orchestration_graph(name, &ctx)?;
+        let graph = runtime.orchestration_graph(name, &ctx)?;
         for node in graph.iter() {
             log::info!("Node: {:#}", node);
         }

--- a/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
@@ -37,10 +37,7 @@ use wasmtimer::tokio::*;
 use super::rpc_converters::{
     to_rpc_event, BlobRefCache, BlobStorage, IRRpcState, IntoRpcEvent, TypeLookup,
 };
-use crate::{
-    runtime::{AstSignatureWrapper, InternalBamlRuntime},
-    tracingv2::storage::interface::TraceEventWithMeta,
-};
+use crate::{runtime::AstSignatureWrapper, tracingv2::storage::interface::TraceEventWithMeta};
 
 enum PublisherMessage {
     Trace(Arc<TraceEventWithMeta>),

--- a/engine/baml-runtime/src/type_builder/mod.rs
+++ b/engine/baml-runtime/src/type_builder/mod.rs
@@ -11,8 +11,8 @@ use internal_baml_core::{
 };
 
 use crate::{
-    runtime::InternalBamlRuntime,
     runtime_context::{PropertyAttributes, RuntimeClassOverride, RuntimeEnumOverride},
+    BamlRuntime,
 };
 
 type MetaData = Arc<Mutex<IndexMap<String, BamlValue>>>;
@@ -669,7 +669,7 @@ impl TypeBuilder {
     ///
     /// Python, TS and Ruby wrappers will call this function when the user runs
     /// `type_builder.add_baml("BAML CODE")`
-    pub fn add_baml(&self, baml: &str, rt: &InternalBamlRuntime) -> anyhow::Result<()> {
+    pub fn add_baml(&self, baml: &str, rt: &BamlRuntime) -> anyhow::Result<()> {
         use internal_baml_core::{
             internal_baml_ast::parse_type_builder_contents_from_str,
             internal_baml_diagnostics::{Diagnostics, SourceFile},
@@ -1221,7 +1221,7 @@ mod tests {
             }
         "##;
 
-        builder.add_baml(baml, runtime.inner.as_ref())?;
+        builder.add_baml(baml, &runtime)?;
         println!("{builder}");
         builder.to_overrides();
         Ok(())

--- a/engine/baml-runtime/tests/test_log_collector.rs
+++ b/engine/baml-runtime/tests/test_log_collector.rs
@@ -75,7 +75,7 @@ mod internal_tests {
         )?;
         log::info!("Runtime:");
 
-        let missing_env_vars = runtime.internal().ir().required_env_vars();
+        let missing_env_vars = runtime.ir.required_env_vars();
 
         let ctx_manager = runtime.create_ctx_manager(BamlValue::String("test".to_string()), None);
         let ctx = ctx_manager.create_ctx_with_default();

--- a/engine/baml-runtime/tests/test_runtime.rs
+++ b/engine/baml-runtime/tests/test_runtime.rs
@@ -179,7 +179,7 @@ mod internal_tests {
         )?;
         log::info!("Runtime:");
 
-        let missing_env_vars = runtime.internal().ir().required_env_vars();
+        let missing_env_vars = runtime.ir.required_env_vars();
 
         let ctx = runtime
             .create_ctx_manager(BamlValue::String("test".to_string()), None)

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -231,7 +231,7 @@ impl WasmProject {
         hm.extend(self.unsaved_files.iter());
 
         WasmDiagnosticError {
-            errors: rt.runtime.internal().diagnostics().clone(),
+            errors: rt.runtime.diagnostics().clone(),
             all_files: hm.keys().map(|s| s.to_string()).collect(),
         }
     }
@@ -944,7 +944,7 @@ impl WasmRuntime {
 impl WasmRuntime {
     #[wasm_bindgen]
     pub fn check_if_in_prompt(&self, cursor_idx: usize) -> bool {
-        self.runtime.internal().ir().walk_functions().any(|f| {
+        self.runtime.ir().walk_functions().any(|f| {
             f.elem().configs().expect("configs").iter().any(|config| {
                 let span = &config.prompt_span;
                 cursor_idx >= span.start && cursor_idx <= span.end
@@ -961,7 +961,6 @@ impl WasmRuntime {
         let ctx = ctx.eval_ctx(false);
 
         self.runtime
-            .internal()
             .ir()
             .walk_functions()
             .map(|f| {
@@ -983,10 +982,7 @@ impl WasmRuntime {
                             .collect::<indexmap::IndexMap<String, _>>();
 
                         // Use the IR's get_dummy_args method
-                        self.runtime
-                            .internal()
-                            .ir()
-                            .get_dummy_args(2, true, &params)
+                        self.runtime.ir().get_dummy_args(2, true, &params)
                     }
                 );
 
@@ -1007,7 +1003,6 @@ impl WasmRuntime {
                                 .collect::<indexmap::IndexMap<String, _>>();
 
                             self.runtime
-                                .internal()
                                 .ir()
                                 .get_dummy_args(2, false, &params)
                                 .split('\n')
@@ -1113,7 +1108,6 @@ impl WasmRuntime {
         let ctx = ctx.eval_ctx(false);
 
         self.runtime
-            .internal()
             .ir()
             .walk_expr_fns()
             .map(|f| {
@@ -1135,10 +1129,7 @@ impl WasmRuntime {
                             .collect::<indexmap::IndexMap<String, _>>();
 
                         // Use the IR's get_dummy_args method
-                        self.runtime
-                            .internal()
-                            .ir()
-                            .get_dummy_args(2, true, &params)
+                        self.runtime.ir().get_dummy_args(2, true, &params)
                     }
                 );
 
@@ -1159,7 +1150,6 @@ impl WasmRuntime {
                                 .collect::<indexmap::IndexMap<String, _>>();
 
                             self.runtime
-                                .internal()
                                 .ir()
                                 .get_dummy_args(2, false, &params)
                                 .split('\n')
@@ -1319,7 +1309,6 @@ impl WasmRuntime {
     #[wasm_bindgen]
     pub fn required_env_vars(&self) -> Vec<String> {
         self.runtime
-            .internal()
             .ir()
             .required_env_vars()
             .into_iter()
@@ -1329,7 +1318,7 @@ impl WasmRuntime {
 
     #[wasm_bindgen]
     pub fn search_for_symbol(&self, symbol: &str) -> Option<SymbolLocation> {
-        let runtime = self.runtime.internal().ir();
+        let runtime = self.runtime.ir();
 
         if let Ok(walker) = runtime.find_enum(symbol) {
             let elem = walker.span().unwrap();
@@ -1431,29 +1420,28 @@ impl WasmRuntime {
 
     #[wasm_bindgen]
     pub fn is_valid_class(&self, symbol: &str) -> bool {
-        self.runtime.internal().ir().find_class(symbol).is_ok()
+        self.runtime.ir().find_class(symbol).is_ok()
     }
 
     #[wasm_bindgen]
     pub fn is_valid_enum(&self, symbol: &str) -> bool {
-        self.runtime.internal().ir().find_enum(symbol).is_ok()
+        self.runtime.ir().find_enum(symbol).is_ok()
     }
 
     #[wasm_bindgen]
     pub fn is_valid_type_alias(&self, symbol: &str) -> bool {
-        self.runtime.internal().ir().find_type_alias(symbol).is_ok()
+        self.runtime.ir().find_type_alias(symbol).is_ok()
     }
 
     #[wasm_bindgen]
     pub fn is_valid_function(&self, symbol: &str) -> bool {
-        let ir = self.runtime.internal().ir();
+        let ir = self.runtime.ir();
         ir.find_function(symbol).is_ok() || ir.find_expr_fn(symbol).is_ok()
     }
 
     #[wasm_bindgen]
     pub fn search_for_class_locations(&self, symbol: &str) -> Vec<SymbolLocation> {
         self.runtime
-            .internal()
             .ir()
             .find_class_locations(symbol)
             .into_iter()
@@ -1474,7 +1462,6 @@ impl WasmRuntime {
     #[wasm_bindgen]
     pub fn search_for_enum_locations(&self, symbol: &str) -> Vec<SymbolLocation> {
         self.runtime
-            .internal()
             .ir()
             .find_enum_locations(symbol)
             .into_iter()
@@ -1495,7 +1482,6 @@ impl WasmRuntime {
     #[wasm_bindgen]
     pub fn search_for_type_alias_locations(&self, symbol: &str) -> Vec<SymbolLocation> {
         self.runtime
-            .internal()
             .ir()
             .find_type_alias_locations(symbol)
             .into_iter()
@@ -1577,7 +1563,7 @@ impl WasmRuntime {
         let ctx = ctx.create_ctx_with_default();
         let ctx = ctx.eval_ctx(true);
 
-        let ir = self.runtime.internal().ir();
+        let ir = self.runtime.ir();
 
         // Combine both LLM function test pairs and expr function test pairs
         let llm_tests = ir.walk_function_test_pairs().map(|tc| {
@@ -2048,7 +2034,7 @@ impl WasmFunction {
         let rt = &rt.runtime;
         let ctx_manager = rt.create_ctx_manager(BamlValue::String("wasm".to_string()), None);
         let ctx = ctx_manager.create_ctx_with_default();
-        let ir = rt.internal().ir();
+        let ir = rt.ir();
 
         // Try to find as LLM function first, if not found check if it's an expr function
         let walker = match ir.find_function(&self.name) {
@@ -2342,7 +2328,7 @@ impl WasmFunction {
             .create_ctx_manager(BamlValue::String("wasm".to_string()), None)
             .create_ctx_with_default();
 
-        let ir = rt.internal().ir();
+        let ir = rt.ir();
 
         // Try to find as LLM function first, if not found try expr function
         let walker = match ir.find_function(&self.name) {

--- a/engine/language_client_cffi/src/ffi/callbacks.rs
+++ b/engine/language_client_cffi/src/ffi/callbacks.rs
@@ -57,26 +57,20 @@ pub fn send_result_to_callback(
     let buf_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         if is_done {
             let meta = content.0.map_meta(|f| EncodeMeta {
-                field_type: f.3.to_non_streaming_type(runtime.inner.ir.as_ref()),
+                field_type: f.3.to_non_streaming_type(runtime.ir.as_ref()),
                 checks: &f.1,
             });
 
-            meta.encode_to_c_buffer(
-                runtime.inner.ir.as_ref(),
-                baml_types::StreamingMode::NonStreaming,
-            )
+            meta.encode_to_c_buffer(runtime.ir.as_ref(), baml_types::StreamingMode::NonStreaming)
         } else {
             // Top level types in streaming always have `not_null` set to true.
             let mut content = content.0.clone();
             content.meta_mut().3.meta_mut().streaming_behavior.needed = true;
             let meta = content.map_meta(|f| EncodeMeta {
-                field_type: f.3.to_streaming_type(runtime.inner.ir.as_ref()),
+                field_type: f.3.to_streaming_type(runtime.ir.as_ref()),
                 checks: &f.1,
             });
-            meta.encode_to_c_buffer(
-                runtime.inner.ir.as_ref(),
-                baml_types::StreamingMode::Streaming,
-            )
+            meta.encode_to_c_buffer(runtime.ir.as_ref(), baml_types::StreamingMode::Streaming)
         }
     }));
 

--- a/engine/language_client_cffi/src/raw_ptr_wrapper/type_builder/objects.rs
+++ b/engine/language_client_cffi/src/raw_ptr_wrapper/type_builder/objects.rs
@@ -56,7 +56,7 @@ pub struct TypeBuilder {
 
 impl TypeBuilder {
     pub fn add_enum(&self, rt: &BamlRuntime, name: &str) -> anyhow::Result<EnumBuilder> {
-        match rt.internal().ir().find_enum(name) {
+        match rt.ir.find_enum(name) {
             Ok(_) => {
                 anyhow::bail!("Enum with name {name} already exists");
             }
@@ -69,7 +69,7 @@ impl TypeBuilder {
     }
 
     pub fn add_class(&self, rt: &BamlRuntime, name: &str) -> anyhow::Result<ClassBuilder> {
-        match rt.internal().ir().find_class(name) {
+        match rt.ir.find_class(name) {
             Ok(_) => {
                 anyhow::bail!("Class with name {name} already exists");
             }
@@ -82,7 +82,7 @@ impl TypeBuilder {
     }
 
     pub fn class(&self, rt: &BamlRuntime, name: &str) -> anyhow::Result<ClassBuilder> {
-        match rt.internal().ir().find_class(name) {
+        match rt.ir.find_class(name) {
             Ok(cls) => {
                 let _ = self.type_builder.upsert_class(name);
                 let builder = ClassBuilder::new(self.type_builder.clone(), name.to_string());
@@ -105,7 +105,7 @@ impl TypeBuilder {
     }
 
     pub fn r#enum(&self, rt: &BamlRuntime, name: &str) -> anyhow::Result<EnumBuilder> {
-        match rt.internal().ir().find_enum(name) {
+        match rt.ir.find_enum(name) {
             Ok(enm) => {
                 let _ = self.type_builder.upsert_enum(name);
                 let builder = EnumBuilder::new(self.type_builder.clone(), name.to_string());
@@ -127,11 +127,11 @@ impl TypeBuilder {
     }
 
     pub fn add_baml(&self, baml: &str, rt: &BamlRuntime) -> anyhow::Result<()> {
-        self.type_builder.add_baml(baml, &rt.inner)
+        self.type_builder.add_baml(baml, rt)
     }
 
     pub fn list_enums(&self, rt: &BamlRuntime) -> Vec<EnumBuilder> {
-        let ir = rt.internal().ir();
+        let ir = &rt.ir;
         let enums = ir.walk_enums();
         enums
             .map(|enm| enm.name().to_string())
@@ -143,7 +143,7 @@ impl TypeBuilder {
     }
 
     pub fn list_classes(&self, rt: &BamlRuntime) -> Vec<ClassBuilder> {
-        let ir = rt.internal().ir();
+        let ir = &rt.ir;
         let classes = ir.walk_classes();
         classes
             .map(|cls| cls.name().to_string())
@@ -186,7 +186,7 @@ impl ClassBuilder {
             NodeRW::ReadOnly => NodeRW::ReadOnly,
             NodeRW::LLMOnly => NodeRW::LLMOnly,
             NodeRW::ReadWrite => {
-                if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+                if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
                     if cls.find_field(name).is_some() {
                         NodeRW::LLMOnly
                     } else {
@@ -206,12 +206,7 @@ impl ClassBuilder {
         rt: &BamlRuntime,
     ) -> anyhow::Result<std::sync::Arc<std::sync::Mutex<type_builder::ClassBuilder>>> {
         // if the IR defines the class, then its always valid
-        if rt
-            .internal()
-            .ir()
-            .find_class(self.class_name.as_str())
-            .is_ok()
-        {
+        if rt.ir.find_class(self.class_name.as_str()).is_ok() {
             let cls = self.type_builder.upsert_class(self.class_name.as_str());
             return Ok(cls);
         }
@@ -235,7 +230,7 @@ impl ClassBuilder {
         let lock = self.cls(rt)?;
         let builder = lock.lock().unwrap();
 
-        let ir_properties = match rt.internal().ir().find_class(self.class_name.as_str()) {
+        let ir_properties = match rt.ir.find_class(self.class_name.as_str()) {
             Ok(ir_cls) => ir_cls
                 .item
                 .elem
@@ -281,7 +276,7 @@ impl ClassBuilder {
         self.mode.at_least(NodeRW::ReadOnly)?;
 
         let ast_alias = || {
-            if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+            if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
                 cls.alias(&Default::default()).ok().flatten()
             } else {
                 None
@@ -302,7 +297,7 @@ impl ClassBuilder {
 
         // ast does not support description
         let ast_description = || {
-            if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+            if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
                 cls.description(&Default::default()).ok().flatten()
             } else {
                 None
@@ -328,7 +323,7 @@ impl ClassBuilder {
         let cls = self.cls(rt)?;
 
         // if the IR already has the property, then its not valid to add it again
-        if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+        if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
             if cls.find_field(name).is_some() {
                 anyhow::bail!(
                     "Property already exists: {} in class {}",
@@ -353,7 +348,7 @@ impl ClassBuilder {
             Some(_) => Ok(self.create_property(name, rt)),
             None => {
                 // if the IR has the property, then its valid to add it again
-                if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+                if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
                     if cls.find_field(name).is_some() {
                         let _ = builder.upsert_property(name);
                         Ok(self.create_property(name, rt))
@@ -369,11 +364,7 @@ impl ClassBuilder {
 
     pub fn is_from_ast(&self, rt: &BamlRuntime) -> anyhow::Result<bool> {
         self.mode.at_least(NodeRW::ReadOnly)?;
-        Ok(rt
-            .internal()
-            .ir()
-            .find_class(self.class_name.as_str())
-            .is_ok())
+        Ok(rt.ir.find_class(self.class_name.as_str()).is_ok())
     }
 }
 
@@ -404,7 +395,7 @@ impl ClassPropertyBuilder {
         rt: &BamlRuntime,
     ) -> anyhow::Result<std::sync::Arc<std::sync::Mutex<type_builder::ClassPropertyBuilder>>> {
         // if the class is defined in the IR, then its always valid
-        if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+        if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
             if cls.find_field(&self.property_name).is_some() {
                 let cls = self.type_builder.upsert_class(self.class_name.as_str());
                 let builder = cls.lock().unwrap();
@@ -435,7 +426,7 @@ impl ClassPropertyBuilder {
         let prop = self.prop(rt)?;
 
         let ast_description = || {
-            if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+            if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
                 if let Some(field) = cls.find_field(&self.property_name) {
                     field.description(&Default::default()).ok().flatten()
                 } else {
@@ -459,7 +450,7 @@ impl ClassPropertyBuilder {
         let prop = self.prop(rt)?;
 
         let ast_alias = || {
-            if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+            if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
                 if let Some(field) = cls.find_field(&self.property_name) {
                     field.description(&Default::default()).ok().flatten()
                 } else {
@@ -481,7 +472,7 @@ impl ClassPropertyBuilder {
         self.mode.at_least(NodeRW::ReadOnly)?;
 
         let ast_type = || {
-            if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+            if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
                 cls.find_field(&self.property_name)
                     .map(|field| field.r#type().clone())
             } else {
@@ -530,7 +521,7 @@ impl ClassPropertyBuilder {
 
     pub fn is_from_ast(&self, rt: &BamlRuntime) -> anyhow::Result<bool> {
         self.mode.at_least(NodeRW::ReadOnly)?;
-        if let Ok(cls) = rt.internal().ir().find_class(self.class_name.as_str()) {
+        if let Ok(cls) = rt.ir.find_class(self.class_name.as_str()) {
             if cls.find_field(&self.property_name).is_some() {
                 return Ok(true);
             }
@@ -564,12 +555,7 @@ impl EnumBuilder {
         rt: &BamlRuntime,
     ) -> anyhow::Result<std::sync::Arc<std::sync::Mutex<type_builder::EnumBuilder>>> {
         // if the IR defines the enum, then its always valid
-        if rt
-            .internal()
-            .ir()
-            .find_enum(self.enum_name.as_str())
-            .is_ok()
-        {
+        if rt.ir.find_enum(self.enum_name.as_str()).is_ok() {
             return Ok(self.type_builder.upsert_enum(self.enum_name.as_str()));
         }
 
@@ -584,7 +570,7 @@ impl EnumBuilder {
             NodeRW::ReadOnly => NodeRW::ReadOnly,
             NodeRW::LLMOnly => NodeRW::LLMOnly,
             NodeRW::ReadWrite => {
-                if let Ok(enm) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+                if let Ok(enm) = rt.ir.find_enum(self.enum_name.as_str()) {
                     if enm.find_value(name).is_some() {
                         NodeRW::LLMOnly
                     } else {
@@ -609,7 +595,7 @@ impl EnumBuilder {
         let enm = self.enm(rt)?;
 
         // if the IR already has the value, then its not valid to add it again
-        if let Ok(enm_ir) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+        if let Ok(enm_ir) = rt.ir.find_enum(self.enum_name.as_str()) {
             if enm_ir.find_value(value).is_some() {
                 anyhow::bail!(
                     "Enum value already exists: {} in enum {}",
@@ -644,7 +630,7 @@ impl EnumBuilder {
 
     pub fn alias(&self, rt: &BamlRuntime) -> Result<Option<String>, anyhow::Error> {
         let ast_alias = || {
-            if let Ok(enm) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+            if let Ok(enm) = rt.ir.find_enum(self.enum_name.as_str()) {
                 enm.alias(&Default::default()).ok().flatten()
             } else {
                 None
@@ -662,7 +648,7 @@ impl EnumBuilder {
 
     pub fn description(&self, rt: &BamlRuntime) -> Result<Option<String>, anyhow::Error> {
         let ast_description = || {
-            if let Ok(enm) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+            if let Ok(enm) = rt.ir.find_enum(self.enum_name.as_str()) {
                 enm.description(&Default::default()).ok().flatten()
             } else {
                 None
@@ -690,7 +676,7 @@ impl EnumBuilder {
 
         let enm = self.enm(rt)?;
 
-        let ir_values = match rt.internal().ir().find_enum(self.enum_name.as_str()) {
+        let ir_values = match rt.ir.find_enum(self.enum_name.as_str()) {
             Ok(ir_enm) => ir_enm
                 .item
                 .elem
@@ -725,7 +711,7 @@ impl EnumBuilder {
             Ok(self.create_value(name, rt))
         } else {
             // if the IR has the value, then its valid to add it again
-            if let Ok(enm_ir) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+            if let Ok(enm_ir) = rt.ir.find_enum(self.enum_name.as_str()) {
                 if enm_ir.find_value(name).is_some() {
                     let _ = builder.upsert_value(name);
                     Ok(self.create_value(name, rt))
@@ -740,11 +726,7 @@ impl EnumBuilder {
 
     pub fn is_from_ast(&self, rt: &BamlRuntime) -> anyhow::Result<bool> {
         self.mode.at_least(NodeRW::ReadOnly)?;
-        Ok(rt
-            .internal()
-            .ir()
-            .find_enum(self.enum_name.as_str())
-            .is_ok())
+        Ok(rt.ir.find_enum(self.enum_name.as_str()).is_ok())
     }
 }
 
@@ -775,7 +757,7 @@ impl EnumValueBuilder {
         rt: &BamlRuntime,
     ) -> anyhow::Result<std::sync::Arc<std::sync::Mutex<type_builder::EnumValueBuilder>>> {
         // if the enum is defined in the IR, then its always valid
-        if let Ok(enm) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+        if let Ok(enm) = rt.ir.find_enum(self.enum_name.as_str()) {
             if enm.find_value(self.value_name.as_str()).is_some() {
                 let enm = self.type_builder.upsert_enum(self.enum_name.as_str());
                 let builder = enm.lock().unwrap();
@@ -820,7 +802,7 @@ impl EnumValueBuilder {
 
     pub fn description(&self, rt: &BamlRuntime) -> Result<Option<String>, anyhow::Error> {
         let ast_description = || {
-            if let Ok(enm) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+            if let Ok(enm) = rt.ir.find_enum(self.enum_name.as_str()) {
                 if let Some(value) = enm.find_value(&self.value_name) {
                     value.description(&Default::default()).ok().flatten()
                 } else {
@@ -842,7 +824,7 @@ impl EnumValueBuilder {
 
     pub fn alias(&self, rt: &BamlRuntime) -> Result<Option<String>, anyhow::Error> {
         let ast_alias = || {
-            if let Ok(enm) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+            if let Ok(enm) = rt.ir.find_enum(self.enum_name.as_str()) {
                 if let Some(value) = enm.find_value(&self.value_name) {
                     value.alias(&Default::default()).ok().flatten()
                 } else {
@@ -875,7 +857,7 @@ impl EnumValueBuilder {
         self.mode.at_least(NodeRW::ReadOnly)?;
 
         let ast_skip = || {
-            if let Ok(enm) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+            if let Ok(enm) = rt.ir.find_enum(self.enum_name.as_str()) {
                 if let Some(value) = enm.find_value(&self.value_name) {
                     value.skip(&Default::default()).ok()
                 } else {
@@ -898,7 +880,7 @@ impl EnumValueBuilder {
 
     pub fn is_from_ast(&self, rt: &BamlRuntime) -> anyhow::Result<bool> {
         self.mode.at_least(NodeRW::ReadOnly)?;
-        if let Ok(enm) = rt.internal().ir().find_enum(self.enum_name.as_str()) {
+        if let Ok(enm) = rt.ir.find_enum(self.enum_name.as_str()) {
             if enm.find_value(&self.value_name).is_some() {
                 return Ok(true);
             }

--- a/engine/language_client_ruby/ext/ruby_ffi/src/types/type_builder.rs
+++ b/engine/language_client_ruby/ext/ruby_ffi/src/types/type_builder.rs
@@ -126,7 +126,7 @@ impl TypeBuilder {
     ) -> Result<()> {
         rb_self
             .inner
-            .add_baml(&baml, runtime.inner.internal())
+            .add_baml(&baml, &runtime.inner)
             .map_err(|e| magnus::Error::new(ruby.exception_runtime_error(), e.to_string()))
     }
 

--- a/engine/language_server/src/baml_project/mod.rs
+++ b/engine/language_server/src/baml_project/mod.rs
@@ -497,24 +497,23 @@ impl BamlRuntimeExt for BamlRuntime {
     }
 
     fn is_valid_class(&self, symbol: &str) -> bool {
-        self.inner.ir.find_class(symbol).is_ok()
+        self.ir.find_class(symbol).is_ok()
     }
 
     fn is_valid_enum(&self, symbol: &str) -> bool {
-        self.inner.ir.find_enum(symbol).is_ok()
+        self.ir.find_enum(symbol).is_ok()
     }
 
     fn is_valid_type_alias(&self, symbol: &str) -> bool {
-        self.inner.ir.find_type_alias(symbol).is_ok()
+        self.ir.find_type_alias(symbol).is_ok()
     }
 
     fn is_valid_function(&self, symbol: &str) -> bool {
-        self.inner.ir.find_function(symbol).is_ok()
+        self.ir.find_function(symbol).is_ok()
     }
 
     fn search_for_class_locations(&self, symbol: &str) -> Vec<SymbolLocation> {
-        self.inner
-            .ir
+        self.ir
             .find_class_locations(symbol)
             .into_iter()
             .map(|span| {
@@ -532,8 +531,7 @@ impl BamlRuntimeExt for BamlRuntime {
     }
 
     fn search_for_enum_locations(&self, symbol: &str) -> Vec<SymbolLocation> {
-        self.inner
-            .ir
+        self.ir
             .find_enum_locations(symbol)
             .into_iter()
             .map(|span| {
@@ -551,8 +549,7 @@ impl BamlRuntimeExt for BamlRuntime {
     }
 
     fn search_for_type_alias_locations(&self, symbol: &str) -> Vec<SymbolLocation> {
-        self.inner
-            .ir
+        self.ir
             .find_type_alias_locations(symbol)
             .into_iter()
             .map(|span| {
@@ -574,8 +571,7 @@ impl BamlRuntimeExt for BamlRuntime {
         let ctx = ctx.create_ctx_with_default();
         let ctx = ctx.eval_ctx(false);
 
-        self.inner
-            .ir
+        self.ir
             .walk_functions()
             .map(|f| {
                 let snippet = format!(
@@ -599,7 +595,7 @@ impl BamlRuntimeExt for BamlRuntime {
                             .collect::<indexmap::IndexMap<String, _>>();
 
                         // Use the IR's get_dummy_args method
-                        self.inner.ir.get_dummy_args(2, true, &params)
+                        self.ir.get_dummy_args(2, true, &params)
                     }
                 );
 
@@ -619,8 +615,7 @@ impl BamlRuntimeExt for BamlRuntime {
                                 .map(|(k, runtime_type)| (k.clone(), runtime_type.clone()))
                                 .collect::<indexmap::IndexMap<String, _>>();
 
-                            self.inner
-                                .ir
+                            self.ir
                                 .get_dummy_args(2, false, &params)
                                 .split('\n')
                                 .map(|line| line.trim().to_string())
@@ -722,8 +717,7 @@ impl BamlRuntimeExt for BamlRuntime {
         let ctx = ctx.create_ctx_with_default();
         let ctx = ctx.eval_ctx(false);
 
-        self.inner
-            .ir
+        self.ir
             .walk_expr_fns()
             .map(|f| {
                 let snippet = format!(
@@ -742,7 +736,7 @@ impl BamlRuntimeExt for BamlRuntime {
                             .map(|(k, runtime_type)| (k.clone(), runtime_type.clone()))
                             .collect::<indexmap::IndexMap<String, _>>();
 
-                        self.inner.ir.get_dummy_args(2, true, &params)
+                        self.ir.get_dummy_args(2, true, &params)
                     }
                 );
 
@@ -762,8 +756,7 @@ impl BamlRuntimeExt for BamlRuntime {
                                 .map(|(k, runtime_type)| (k.clone(), runtime_type.clone()))
                                 .collect::<indexmap::IndexMap<String, _>>();
 
-                            self.inner
-                                .ir
+                            self.ir
                                 .get_dummy_args(2, false, &params)
                                 .split('\n')
                                 .map(|line| line.trim().to_string())
@@ -860,7 +853,7 @@ impl BamlRuntimeExt for BamlRuntime {
     }
 
     fn search_for_symbol(&self, symbol: &str) -> Option<SymbolLocation> {
-        let runtime = self.inner.ir.clone();
+        let runtime = self.ir.clone();
 
         if let Ok(walker) = runtime.find_enum(symbol) {
             let elem = walker.span().unwrap();
@@ -965,8 +958,7 @@ impl BamlRuntimeExt for BamlRuntime {
         let ctx = ctx.create_ctx_with_default();
         let ctx = ctx.eval_ctx(true);
 
-        self.inner
-            .ir
+        self.ir
             .walk_function_test_pairs()
             .map(|tc| {
                 let params = match tc.test_case_params(&ctx) {
@@ -1050,8 +1042,7 @@ impl BamlRuntimeExt for BamlRuntime {
         let ctx = ctx.create_ctx_with_default();
         let ctx = ctx.eval_ctx(true);
 
-        self.inner
-            .ir
+        self.ir
             .walk_expr_fn_test_pairs()
             .map(|tc| {
                 let params = match tc.test_case_params(&ctx) {

--- a/engine/language_server/src/server/api/diagnostics.rs
+++ b/engine/language_server/src/server/api/diagnostics.rs
@@ -141,7 +141,7 @@ pub fn project_diagnostics(
     let fake_env = HashMap::new();
     let baml_diagnostics = match guard.baml_project.runtime(fake_env, feature_flags) {
         Ok(runtime) => {
-            runtime.internal().diagnostics().clone()
+            runtime.diagnostics().clone()
             // Diagnostics::new(PathBuf::from("/fake1"))
         }
         Err(err) => err,
@@ -326,7 +326,7 @@ pub fn file_diagnostics(
     let root_path = PathBuf::from(guard.root_path());
     let fake_env = HashMap::new();
     let baml_diagnostics = match guard.baml_project.runtime(fake_env, feature_flags) {
-        Ok(runtime) => runtime.internal().diagnostics().clone(),
+        Ok(runtime) => runtime.diagnostics().clone(),
         Err(err) => err,
     };
 

--- a/engine/language_server/src/server/api/requests/code_lens.rs
+++ b/engine/language_server/src/server/api/requests/code_lens.rs
@@ -50,7 +50,7 @@ impl SyncRequestHandler for CodeLens {
                 .as_ref()
                 .unwrap_or(&default_flags),
         ) {
-            Ok(runtime) => runtime.internal().diagnostics().clone(),
+            Ok(runtime) => runtime.diagnostics().clone(),
             Err(err) => err,
         };
 


### PR DESCRIPTION
The API boundary originally established between `BamlRuntime` and `InternalBamlRuntime` hasn't been followed, and so the internal runtime is now used in many non-internal places. The split between these two APIs became confusing.

So this PR just removes `InternalBamlRuntime` and make `BamlRuntime` the main entrypoint to the runtime.

In the future, we may want to rename this to `LLMRuntime`, to highlight the fact that it only serves LLM functions, not more general expression functions. Expression functions need their own runtime, which is often aliased to `CoreBamlRuntime`. Renaming `BamlRuntime` to `LLMRuntime` would remove this additional confusing name.