### PR TITLE
nix flake: llvm 17 is retired

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -777,7 +777,7 @@
             BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin then
               "" # Rely on default includes provided by stdenv.cc + libclang
             else
-              "-isystem ${pkgs.llvmPackages_17.libclang.lib}/lib/clang/17/include -isystem ${pkgs.llvmPackages_17.libclang.lib}/include -isystem ${pkgs.glibc.dev}/include";
+              "-isystem ${pkgs.llvmPackages.libclang.lib}/lib/clang/${pkgs.llvmPackages.libclang.version}/include -isystem ${pkgs.llvmPackages.libclang.lib}/include -isystem ${pkgs.glibc.dev}/include";
 
             # Prevent SDK conflicts on macOS
             shellHook = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''


### PR DESCRIPTION
# context

Onboarding for folks running NixOS is not smooth. Here's the default experience.

```
$ cd ~/work/boundaryml/baml
$ direnv allow .

direnv: loading ~/code/boundaryml/baml/.envrc
direnv: using flake
error:
       … while calling the 'derivationStrict' builtin
         at <nix/derivation-internal.nix>:37:12:
           36|
           37|   strict = derivationStrict drvAttrs;
             |            ^
           38|

       … while evaluating derivation 'nix-shell'
         whose name attribute is located at /nix/store/9v6qa656sq3xc58vkxslqy646p0ajj61-source/pkgs/stdenv/generic/make-derivation.nix:544:13

       … while evaluating attribute 'BINDGEN_EXTRA_CLANG_ARGS' of derivation 'nix-shell'
         at /nix/store/rgdhxcm6fzf2hjyc73cq3i6n1pd5rbka-source/flake.nix:777:13:
          776|             # UV_PYTHON = "${pythonEnv}/bin/python3"; // This doesn't work with maturin.
          777|             BINDGEN_EXTRA_CLANG_ARGS = if pkgs.stdenv.isDarwin then
             |             ^
          778|               "" # Rely on default includes provided by stdenv.cc + libclang

       (stack trace truncated; use '--show-trace' to show the full, detailed trace)

       error: llvmPackages_17 has been removed, as it is unmaintained and obsolete
direnv: nix-direnv: Evaluating current devShell failed. Falling back to previous environment!
```

# thoughts

- Is unpinned LLVM acceptable or should we move to 19 (or 19+)
- I note CONTRIBUTING.md references mise ala scripts/*.sh to bootstrap (bootstrapping rn so no feedback yet)

# notes

- This is a simple version bump/unpin which hasn't been tested (raising and slapping CI with the change instead) generated via a low-effort Claude Code 'fix it' prompt.
