### PR TITLE
Fix emit ts codegen bug

### DIFF
--- a/engine/generators/languages/typescript/src/events.rs
+++ b/engine/generators/languages/typescript/src/events.rs
@@ -214,14 +214,6 @@ pub fn build_event_collectors(
         }
     }
 
-    let has_any_events = builders
-        .values()
-        .any(|builder| builder.has_markdown || !builder.var_channels.is_empty());
-
-    if !has_any_events {
-        return Ok(Vec::new());
-    }
-
     let mut names: Vec<String> = builders.keys().cloned().collect();
     names.sort();
 

--- a/engine/generators/languages/typescript/src/lib.rs
+++ b/engine/generators/languages/typescript/src/lib.rs
@@ -119,9 +119,7 @@ $ pnpm add @boundaryml/baml
             &render_sync_request(&functions, &types, &pkg)?,
         )?;
 
-        if !event_collectors.is_empty() {
-            collector.add_file("events.ts", events::render_events(&event_collectors)?)?;
-        }
+        collector.add_file("events.ts", events::render_events(&event_collectors)?)?;
 
         // Generate type files
         let classes = ir.walk_classes().collect::<Vec<_>>();


### PR DESCRIPTION
This fixes a bug in the 0.211.1 release in which events.ts is generated conditionally on the existence of an `@emit` in the user's baml source, but importing `event.ts` is unconditional (causing a module lookup error).