### PR TITLE
Update Fern CLI to configure settings from docs.yml

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -967,6 +967,9 @@ layout:
   searchbar-placement: header
   header-height: 54px
   tabs-placement: header
+settings:
+  dark-mode-code: true
+  http-snippets: false
 
 typography:
   bodyFont:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "boundary",
-  "version": "0.65.45"
+  "version": "0.88.4"
 }


### PR DESCRIPTION
These settings were previously controlled in an internal configuration. Now, we have transferred these settings to be controllable from the `docs.yml`. This PR adds the settings currently enabled in the internal configuration for Boundary to the `docs.yml` file.

We will be deprecating the internal configuration in the coming weeks. Please merge to avoid any disruption in these settings.