### PR TITLE
feat: Add placeholder API keys for new VSCode playground users

### DIFF
--- a/typescript/packages/playground-common/src/components/api-keys-dialog/api-key-list-item.tsx
+++ b/typescript/packages/playground-common/src/components/api-keys-dialog/api-key-list-item.tsx
@@ -104,7 +104,7 @@ export const ApiKeyListItem: React.FC<ApiKeyListItemProps> = ({
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
             <Input
-              type={apiKey.hidden ? 'password' : 'text'}
+              type={apiKey.hidden && !isPlaceholderApiKey(localValue) ? 'password' : 'text'}
               value={localValue}
               onChange={handleChange}
               className={`h-8 text-sm font-mono placeholder:font-sans ${
@@ -119,12 +119,7 @@ export const ApiKeyListItem: React.FC<ApiKeyListItemProps> = ({
                 <TooltipProvider delayDuration={300}>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <div className="flex items-center gap-1">
-                        <AlertTriangle className="h-4 w-4 text-yellow-500" />
-                        {isPlaceholderApiKey(apiKey.value) && (
-                          <span className="text-xs text-muted-foreground">(placeholder)</span>
-                        )}
-                      </div>
+                      <AlertTriangle className="h-4 w-4 text-yellow-500" />
                     </TooltipTrigger>
                     <TooltipContent side="top" className="text-xs">
                       {isPlaceholderApiKey(apiKey.value)

--- a/typescript/packages/playground-common/src/components/api-keys-dialog/api-key-list-item.tsx
+++ b/typescript/packages/playground-common/src/components/api-keys-dialog/api-key-list-item.tsx
@@ -19,7 +19,7 @@ import {
   AlertDialogTrigger,
 } from '@baml/ui/alert-dialog';
 import { AlertTriangle, Eye, EyeOff, Trash2, Loader2 } from 'lucide-react';
-import { escapeValue, unescapeValue, REQUIRED_ENV_VAR_UNSET_WARNING } from './utils';
+import { escapeValue, unescapeValue, REQUIRED_ENV_VAR_UNSET_WARNING, isPlaceholderApiKey, PLACEHOLDER_ENV_VAR_MESSAGE } from './utils';
 import type { ApiKeyEntry } from './atoms';
 import { useSetAtom } from 'jotai';
 import { updateApiKeyAtom, deleteApiKeyAtom, apiKeyVisibilityAtom, saveApiKeyChangesAtom } from './atoms';
@@ -107,20 +107,29 @@ export const ApiKeyListItem: React.FC<ApiKeyListItemProps> = ({
               type={apiKey.hidden ? 'password' : 'text'}
               value={localValue}
               onChange={handleChange}
-              className="h-8 text-sm font-mono placeholder:font-sans"
-              placeholder=""
+              className={`h-8 text-sm font-mono placeholder:font-sans ${
+                isPlaceholderApiKey(localValue) ? 'text-muted-foreground italic' : ''
+              }`}
+              placeholder={isPlaceholderApiKey(localValue) ? "Replace with your API key" : ""}
               autoComplete="off"
               data-1p-ignore
             />
-            {apiKey.required && (!apiKey.value || apiKey.value === '') && (
+            {apiKey.required && (!apiKey.value || apiKey.value === '' || isPlaceholderApiKey(apiKey.value)) && (
               <div className="absolute right-2 top-1/2 -translate-y-1/2">
                 <TooltipProvider delayDuration={300}>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                      <div className="flex items-center gap-1">
+                        <AlertTriangle className="h-4 w-4 text-yellow-500" />
+                        {isPlaceholderApiKey(apiKey.value) && (
+                          <span className="text-xs text-muted-foreground">(placeholder)</span>
+                        )}
+                      </div>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="text-xs">
-                      {REQUIRED_ENV_VAR_UNSET_WARNING}
+                      {isPlaceholderApiKey(apiKey.value)
+                        ? PLACEHOLDER_ENV_VAR_MESSAGE
+                        : REQUIRED_ENV_VAR_UNSET_WARNING}
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>

--- a/typescript/packages/playground-common/src/components/api-keys-dialog/api-key-status.tsx
+++ b/typescript/packages/playground-common/src/components/api-keys-dialog/api-key-status.tsx
@@ -5,14 +5,16 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@baml/ui/tooltip';
-import { AlertTriangle, Check } from 'lucide-react';
-import { REQUIRED_ENV_VAR_UNSET_WARNING } from './utils';
+import { AlertTriangle, Check, Info } from 'lucide-react';
+import { REQUIRED_ENV_VAR_UNSET_WARNING, isPlaceholderApiKey, PLACEHOLDER_ENV_VAR_MESSAGE } from './utils';
 
 export function ApiKeyStatus({
   value,
   required,
 }: { value?: string; required: boolean }) {
-  if (!value || value === '') {
+  const isPlaceholder = isPlaceholderApiKey(value);
+
+  if ((!value || value === '') && required) {
     return (
       <TooltipProvider delayDuration={300}>
         <Tooltip>
@@ -27,7 +29,25 @@ export function ApiKeyStatus({
     );
   }
 
-  if (required) {
+  if (isPlaceholder) {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div className="flex items-center gap-1">
+              <Info className="h-4 w-4 text-blue-500 flex-shrink-0" />
+              <span className="text-xs text-muted-foreground">(placeholder)</span>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="text-xs">
+            {PLACEHOLDER_ENV_VAR_MESSAGE}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  if (required && value) {
     return (
       <TooltipProvider delayDuration={300}>
         <Tooltip>

--- a/typescript/packages/playground-common/src/components/api-keys-dialog/atoms.ts
+++ b/typescript/packages/playground-common/src/components/api-keys-dialog/atoms.ts
@@ -215,18 +215,37 @@ const defaultEnvKeyValues: [string, string][] = (() => {
   if (typeof window === 'undefined') {
     return [];
   }
-  if ((window as any).next?.version) {
 
+  const baseDefaults: [string, string][] = [];
+
+  // Add proxy URL defaults based on environment
+  if ((window as any).next?.version) {
     const domain = window?.location?.origin || '';
     if (domain.includes('localhost')) {
       // we can do somehting fancier here later if we want to test locally.
-      return [['BOUNDARY_PROXY_URL', 'https://fiddle-proxy.fly.dev']];
+      baseDefaults.push(['BOUNDARY_PROXY_URL', 'https://fiddle-proxy.fly.dev']);
+    } else {
+      baseDefaults.push(['BOUNDARY_PROXY_URL', 'https://fiddle-proxy.fly.dev']);
     }
-    return [['BOUNDARY_PROXY_URL', 'https://fiddle-proxy.fly.dev']];
+  } else {
+    // VSCode environment
+    baseDefaults.push(['BOUNDARY_PROXY_URL', 'http://localhost:0000']);
+
+    // Add placeholder API keys for new VSCode users
+    // Check if this is a new user (no existing storage)
+    if (typeof window !== 'undefined' && window.localStorage) {
+      const storedValue = window.localStorage.getItem('env-key-values');
+      if (!storedValue || storedValue === '[]') {
+        // New user - add placeholder keys
+        baseDefaults.push(['OPENAI_API_KEY', 'PLACEHOLDER_OPENAI_KEY']);
+        baseDefaults.push(['ANTHROPIC_API_KEY', 'PLACEHOLDER_ANTHROPIC_KEY']);
+        console.debug('New VSCode user detected - adding placeholder API keys');
+      }
+    }
   }
-  console.debug('Not running in a Next.js environment, set default value');
-  // Not running in a Next.js environment, set default value
-  return [['BOUNDARY_PROXY_URL', 'http://localhost:0000']];
+
+  console.debug('Default environment values:', baseDefaults);
+  return baseDefaults;
 })();
 
 

--- a/typescript/packages/playground-common/src/components/api-keys-dialog/dialog-content.tsx
+++ b/typescript/packages/playground-common/src/components/api-keys-dialog/dialog-content.tsx
@@ -1,22 +1,45 @@
 'use client';
 
-import { useSetAtom } from 'jotai';
+import { useSetAtom, useAtomValue } from 'jotai';
 import React from 'react';
 import { AddApiKeyForm } from './add-api-key-form';
 import { ApiKeysList } from './api-keys-list';
-import { syncLocalApiKeysAtom } from './atoms';
+import { syncLocalApiKeysAtom, renderedApiKeysAtom } from './atoms';
 import { ImportApiKeyDialog } from './import-api-key-dialog';
 import { SaveActionsFooter } from './save-actions-footer';
+import { Alert, AlertDescription } from '@baml/ui/alert';
+import { Info } from 'lucide-react';
+import { isPlaceholderApiKey } from './utils';
 
 export const ApiKeysDialogContent: React.FC = () => {
   const syncLocalApiKeys = useSetAtom(syncLocalApiKeysAtom);
+  const apiKeys = useAtomValue(renderedApiKeysAtom);
 
   // Initialize local API keys on mount
   React.useEffect(() => {
     syncLocalApiKeys();
   }, [syncLocalApiKeys]);
+
+  const hasPlaceholderKeys = apiKeys.some(key => isPlaceholderApiKey(key.value));
+
   return (
     <div className="space-y-2 max-h-[70vh] overflow-y-auto">
+      {/* Welcome message for users with placeholder keys */}
+      {hasPlaceholderKeys && (
+        <Alert className="mb-4">
+          <Info className="h-4 w-4" />
+          <AlertDescription>
+            <div className="space-y-2">
+              <p>Welcome to BAML Playground! We've added placeholder API keys to help you get started.</p>
+              <p className="text-sm text-muted-foreground">
+                You can explore the playground features immediately. When you're ready to make real LLM calls,
+                replace the placeholder values with your actual API keys from OpenAI or Anthropic.
+              </p>
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
       {/* Add New Api Key Form */}
       <div className="mb-4 p-4 rounded-md border border-border flex flex-col gap-2">
         <AddApiKeyForm />

--- a/typescript/packages/playground-common/src/components/api-keys-dialog/utils.ts
+++ b/typescript/packages/playground-common/src/components/api-keys-dialog/utils.ts
@@ -30,3 +30,16 @@ export const unescapeValue = (value: string): string => {
 
 export const REQUIRED_ENV_VAR_UNSET_WARNING =
   'Your BAML clients may fail if this is not set';
+
+export const PLACEHOLDER_VALUES = {
+  OPENAI_API_KEY: 'PLACEHOLDER_OPENAI_KEY',
+  ANTHROPIC_API_KEY: 'PLACEHOLDER_ANTHROPIC_KEY',
+} as const;
+
+export const PLACEHOLDER_ENV_VAR_MESSAGE =
+  'This is a placeholder value. Replace with your actual API key when available.';
+
+export const isPlaceholderApiKey = (value: string | undefined): boolean => {
+  return value === PLACEHOLDER_VALUES.OPENAI_API_KEY ||
+         value === PLACEHOLDER_VALUES.ANTHROPIC_API_KEY;
+};


### PR DESCRIPTION
- Automatically populate PLACEHOLDER_OPENAI_KEY and PLACEHOLDER_ANTHROPIC_KEY for new users
- Add visual indicators (blue info icon, italic text, "(placeholder)" label) for placeholder keys
- Show welcome message explaining placeholders when detected
- Only applies to VSCode environment with empty localStorage (new users)
- Existing users with saved keys are unaffected
- Placeholders are clearly distinguished from real API keys in the UI

This improves the first-run experience by allowing new users to explore the playground
immediately without needing real API keys upfront.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces placeholder OpenAI/Anthropic keys for new VSCode users, adds placeholder-aware UI/validation, and refactors default proxy/env initialization.
> 
> - **UI/UX**:
>   - `api-key-list-item.tsx`: Treat placeholders as visible text with italic muted style and hint; consider placeholders as unset for required warnings with specific tooltip message.
>   - `api-key-status.tsx`: Add blue info indicator and "(placeholder)" label with tooltip for placeholder values; keep existing unset and in-use states.
>   - `dialog-content.tsx`: Show a welcome alert explaining placeholders when detected.
> - **State/Logic**:
>   - `utils.ts`: Add `PLACEHOLDER_VALUES`, `PLACEHOLDER_ENV_VAR_MESSAGE`, and `isPlaceholderApiKey` helpers.
>   - `atoms.ts`: Build `defaultEnvKeyValues` dynamically; in VSCode with empty storage, prefill `OPENAI_API_KEY` and `ANTHROPIC_API_KEY` with placeholders; set `BOUNDARY_PROXY_URL` defaults based on environment and log defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24e75099bab392d64b186b81b0c2153c805217f0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->