### PR TITLE
Fix `baml.fetch_as` typechecker bug

### DIFF
--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -1542,9 +1542,9 @@ pub fn typecheck_expression(
             // TODO: Handle generics uniformly, not with this kind of one-off handler.
             if (func_name == crate::builtin::functions::FETCH_AS) && type_args.is_empty() {
                 diagnostics.push_error(DatamodelError::new_validation_error(
-                        &format!("Generic function {func_name} must have a type argument. Try adding a type argument like this: {func_name}<Type>"),
-                        function.span().clone(),
-                    ));
+                    &format!("Generic function {func_name} must have a type argument. Try adding a type argument like this: {func_name}<Type>"),
+                    function.span().clone(),
+                ));
             }
 
             let (param_types, return_type, is_known_function) = match &func_type {
@@ -1729,6 +1729,8 @@ pub fn typecheck_expression(
                         }
 
                         "baml.fetch_as" => {
+                            let has_type_args = !type_args.is_empty();
+
                             return_type = match type_args.first() {
                                 Some(hir::TypeArg::Type(t)) => Some(t.to_owned()),
                                 Some(hir::TypeArg::TypeName(n)) => context
@@ -1749,10 +1751,19 @@ pub fn typecheck_expression(
                                 }
 
                                 None => {
-                                    diagnostics.push_error(DatamodelError::new_validation_error(
-                                        "could not infer return type of baml.fetch_as",
-                                        span.clone(),
-                                    ));
+                                    if has_type_args {
+                                        diagnostics.push_error(
+                                            DatamodelError::new_validation_error(
+                                                "could not infer return type of baml.fetch_as",
+                                                span.clone(),
+                                            ),
+                                        );
+                                    } else {
+                                        diagnostics.push_error(DatamodelError::new_validation_error(
+                                            &format!("Generic function {full_name} must have a type argument. Try adding a type argument like this: {full_name}<Type>"),
+                                            span.clone(),
+                                        ));
+                                    }
                                 }
                             }
                         }

--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -1651,6 +1651,11 @@ pub fn typecheck_expression(
             type_args,
             span,
         } => {
+            eprintln!("receiver: {receiver:?}");
+            eprintln!("method: {method:?}");
+            eprintln!("args: {args:?}");
+            eprintln!("type_args: {type_args:?}");
+            eprintln!("span: {span:?}");
             // Special case for namespace method calls (e.g., env.get, baml.fetch_as)
             // We need to check this before typechecking the receiver to avoid "unknown variable" errors
             if let hir::Expression::Identifier(name, id_span) = receiver.as_ref() {
@@ -1659,7 +1664,6 @@ pub fn typecheck_expression(
                     ("baml", "deep_copy") => Some("baml.deep_copy"),
                     ("baml", "deep_equals") => Some("baml.deep_equals"),
                     ("baml", "fetch_as") => Some("baml.fetch_as"),
-                    ("baml", "fetch_value") => Some("baml.fetch_value"),
                     ("image", "from_url") => Some("baml.media.image.from_url"),
                     ("audio", "from_url") => Some("baml.media.audio.from_url"),
                     ("video", "from_url") => Some("baml.media.video.from_url"),
@@ -1682,17 +1686,9 @@ pub fn typecheck_expression(
                     let mut return_type = None;
 
                     // Validate type arguments for generic functions
-                    if (full_name == crate::builtin::functions::FETCH_AS
-                        || full_name == crate::builtin::functions::FETCH_VALUE)
-                        && type_args.is_empty()
-                    {
-                        let fn_name_display = if full_name == crate::builtin::functions::FETCH_AS {
-                            "baml.fetch_as"
-                        } else {
-                            "baml.fetch_value"
-                        };
+                    if (full_name == crate::builtin::functions::FETCH_AS) && type_args.is_empty() {
                         diagnostics.push_error(DatamodelError::new_validation_error(
-                            &format!("Generic function {fn_name_display} must have a type argument. Try adding a type argument like this: {fn_name_display}<Type>"),
+                            &format!("Generic function {full_name} must have a type argument. Try adding a type argument like this: {full_name}<Type>"),
                             span.clone(),
                         ));
                     }
@@ -1747,6 +1743,35 @@ pub fn typecheck_expression(
                                         TypeIR::string(),
                                     ));
                                     return_type = Some(TypeIR::string());
+                                }
+                            }
+                        }
+
+                        "baml.fetch_as" => {
+                            return_type = match type_args.first() {
+                                Some(hir::TypeArg::Type(t)) => Some(t.to_owned()),
+                                Some(hir::TypeArg::TypeName(n)) => context
+                                    .classes
+                                    .get(n)
+                                    .map(|c| TypeIR::class(c.name.clone()))
+                                    .or_else(|| {
+                                        context.enums.get(n).map(|e| TypeIR::r#enum(&e.name))
+                                    })
+                                    .or_else(|| context.get_type(n).map(|t| t.to_owned())),
+                                None => None,
+                            };
+
+                            match &return_type {
+                                Some(t) => {
+                                    func_type =
+                                        Some(TypeIR::arrow(vec![TypeIR::string()], t.clone()));
+                                }
+
+                                None => {
+                                    diagnostics.push_error(DatamodelError::new_validation_error(
+                                        "could not infer return type of baml.fetch_as",
+                                        span.clone(),
+                                    ));
                                 }
                             }
                         }
@@ -1920,7 +1945,6 @@ pub fn typecheck_expression(
                             ("baml", "deep_equals") => Some("baml.deep_equals".to_string()),
 
                             ("baml", "fetch_as") => Some("baml.fetch_as".to_string()),
-                            ("baml", "fetch_value") => Some("baml.fetch_value".to_string()),
 
                             ("baml.unstable", "string") => Some("baml.unstable.string".to_string()),
 
@@ -1985,17 +2009,9 @@ pub fn typecheck_expression(
             };
 
             // Validate type arguments for generic functions
-            if (full_name == crate::builtin::functions::FETCH_AS
-                || full_name == crate::builtin::functions::FETCH_VALUE)
-                && type_args.is_empty()
-            {
-                let fn_name_display = if full_name == crate::builtin::functions::FETCH_AS {
-                    "baml.fetch_as"
-                } else {
-                    "baml.fetch_value"
-                };
+            if (full_name == crate::builtin::functions::FETCH_AS) && type_args.is_empty() {
                 diagnostics.push_error(DatamodelError::new_validation_error(
-                    &format!("Generic function {fn_name_display} must have a type argument. Try adding a type argument like this: {fn_name_display}<Type>"),
+                    &format!("Generic function {full_name} must have a type argument. Try adding a type argument like this: {full_name}<Type>"),
                     span.clone(),
                 ));
             }
@@ -2100,47 +2116,6 @@ pub fn typecheck_expression(
                                         }
                                     }
                                 }
-                                "baml.fetch_value" => {
-                                    generic_return_type_inferred = if !type_args.is_empty() {
-                                        match &type_args[0] {
-                                            hir::TypeArg::Type(t) => Some(t.to_owned()),
-                                            hir::TypeArg::TypeName(n) => context
-                                                .classes
-                                                .get(n)
-                                                .map(|c| TypeIR::class(c.name.clone()))
-                                                .or_else(|| {
-                                                    context
-                                                        .enums
-                                                        .get(n)
-                                                        .map(|e| TypeIR::r#enum(&e.name))
-                                                })
-                                                .or_else(|| {
-                                                    context.get_type(n).map(|t| t.to_owned())
-                                                }),
-                                        }
-                                    } else {
-                                        None
-                                    };
-
-                                    match &generic_return_type_inferred {
-                                        Some(t) => {
-                                            func_type = Some(TypeIR::arrow(
-                                                vec![TypeIR::class(
-                                                    crate::builtin::classes::HTTP_REQUEST,
-                                                )],
-                                                t.clone(),
-                                            ));
-                                        }
-
-                                        None => {
-                                            diagnostics
-                                                .push_error(DatamodelError::new_validation_error(
-                                                "could not infer return type of baml.fetch_value",
-                                                arg.span(),
-                                            ));
-                                        }
-                                    }
-                                }
                                 _ => {
                                     if !types_compatible(arg_type, expected_type) {
                                         diagnostics.push_error(
@@ -2210,7 +2185,7 @@ pub fn typecheck_expression(
                         full_name.clone(),
                         (span.clone(), func_type.clone()),
                     )),
-                    type_args: if (full_name == "baml.fetch_as" || full_name == "baml.fetch_value")
+                    type_args: if (full_name == "baml.fetch_as")
                         && generic_return_type_inferred.is_some()
                     {
                         vec![generic_return_type_inferred.clone().unwrap()]
@@ -2603,8 +2578,6 @@ pub fn typecheck_expression(
                     }
 
                     if !is_namespace {
-                        eprintln!("This shit aint working add err");
-
                         diagnostics.push_error(DatamodelError::new_validation_error(
                             "Can only access fields on class instances",
                             base.span(),

--- a/engine/baml-compiler/src/thir/typecheck.rs
+++ b/engine/baml-compiler/src/thir/typecheck.rs
@@ -93,18 +93,12 @@ pub fn typecheck_returning_context<'a>(
 
     // Add builtin functions to typing context
     // baml.fetch_as<T>(url: string) -> T
-    // baml.fetch_value<T>(request: baml.Request) -> T
     // These are generic functions. For now, we'll add a placeholder with a Top type.
     let generic_return_type = TypeIR::Top(Default::default()); // Placeholder for generic T
     let fetch_as_type = crate::builtin::baml_fetch_as_signature(generic_return_type.clone());
     typing_context.symbols.insert(
         crate::builtin::functions::FETCH_AS.to_string(),
         fetch_as_type,
-    );
-    let fetch_value_type = crate::builtin::baml_fetch_as_signature(generic_return_type);
-    typing_context.symbols.insert(
-        crate::builtin::functions::FETCH_VALUE.to_string(),
-        fetch_value_type,
     );
 
     // Add native functions to typing context
@@ -1546,17 +1540,9 @@ pub fn typecheck_expression(
             let func_type = context.get_type(&func_name).cloned();
 
             // TODO: Handle generics uniformly, not with this kind of one-off handler.
-            if (func_name == crate::builtin::functions::FETCH_AS
-                || func_name == crate::builtin::functions::FETCH_VALUE)
-                && type_args.is_empty()
-            {
-                let fn_name_display = if func_name == crate::builtin::functions::FETCH_AS {
-                    "baml.fetch_as"
-                } else {
-                    "baml.fetch_value"
-                };
+            if (func_name == crate::builtin::functions::FETCH_AS) && type_args.is_empty() {
                 diagnostics.push_error(DatamodelError::new_validation_error(
-                        &format!("Generic function {fn_name_display} must have a type argument. Try adding a type argument like this: {fn_name_display}<Type>"),
+                        &format!("Generic function {func_name} must have a type argument. Try adding a type argument like this: {func_name}<Type>"),
                         function.span().clone(),
                     ));
             }
@@ -1651,11 +1637,6 @@ pub fn typecheck_expression(
             type_args,
             span,
         } => {
-            eprintln!("receiver: {receiver:?}");
-            eprintln!("method: {method:?}");
-            eprintln!("args: {args:?}");
-            eprintln!("type_args: {type_args:?}");
-            eprintln!("span: {span:?}");
             // Special case for namespace method calls (e.g., env.get, baml.fetch_as)
             // We need to check this before typechecking the receiver to avoid "unknown variable" errors
             if let hir::Expression::Identifier(name, id_span) = receiver.as_ref() {

--- a/engine/baml-compiler/tests/builtins.rs
+++ b/engine/baml-compiler/tests/builtins.rs
@@ -1,6 +1,6 @@
 //! Compiler tests for built-in method calls.
 
-use baml_vm::{GlobalIndex, Instruction, ObjectIndex};
+use baml_vm::{BinOp, GlobalIndex, Instruction, ObjectIndex};
 
 mod common;
 use common::{assert_compiles, Program};
@@ -54,6 +54,49 @@ fn fetch_as() -> anyhow::Result<()> {
                 Instruction::LoadConst(1),
                 Instruction::DispatchFuture(2),
                 Instruction::Await,
+                Instruction::Return,
+            ],
+        )],
+    })
+}
+
+#[test]
+fn fetch_as_let_binding() -> anyhow::Result<()> {
+    assert_compiles(Program {
+        source: r#"
+            class StockApiData {
+                date string
+                prices map<string, string>
+            }
+
+            function get_stock_price(symbol: string) -> string {
+                let url = "https://mastra-stock-data.vercel.app/api/stock-data?symbol=" + symbol;
+                let data = baml.fetch_as<StockApiData>(url);
+                let price = data.prices["4. close"];
+
+                price
+            }
+
+            function main() -> string {
+                get_stock_price("AAPL")
+            }
+        "#,
+        expected: vec![(
+            "get_stock_price",
+            vec![
+                Instruction::LoadConst(0),
+                Instruction::LoadVar(1),
+                Instruction::BinOp(BinOp::Add),
+                Instruction::LoadGlobal(GlobalIndex::from_raw(42)),
+                Instruction::LoadVar(2),
+                Instruction::LoadConst(1),
+                Instruction::DispatchFuture(2),
+                Instruction::Await,
+                Instruction::LoadVar(3),
+                Instruction::LoadField(1),
+                Instruction::LoadConst(2),
+                Instruction::LoadMapElement,
+                Instruction::LoadVar(4),
                 Instruction::Return,
             ],
         )],

--- a/engine/baml-lib/baml/tests/validation_files/expr/builtin.baml
+++ b/engine/baml-lib/baml/tests/validation_files/expr/builtin.baml
@@ -28,3 +28,12 @@ function GetTodoMissingTypeArg() -> Todo {
 // 18 |     url: "https://dummyjson.com/todos/1",
 // 19 |   })
 //    | 
+// error: Error validating: Generic function baml.fetch_as must have a type argument. Try adding a type argument like this: baml.fetch_as<Type>
+//   -->  expr/builtin.baml:16
+//    | 
+// 15 | function GetTodoMissingTypeArg() -> Todo {
+// 16 |   baml.fetch_as(baml.HttpRequest {
+// 17 |     method: baml.HttpMethod.Get,
+// 18 |     url: "https://dummyjson.com/todos/1",
+// 19 |   })
+//    | 


### PR DESCRIPTION
Let bindings were untyped:

```ts
let data = baml.fetch_as<Type>(url);
let x = data.x;
```
Error:

```
Can only access fields on class instances
```
