### PR TITLE
ban println to prevent lsp crashes, since it uses stdio to communicate

### DIFF
--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Run Rust lint (Clippy)
         if: matrix.check == 'rust-lint'
-        run: RUSTFLAGS="-A unused -D warnings" cargo clippy
+        run: RUSTFLAGS="-A unused -D warnings" cargo clippy --workspace -- -D clippy::print_stdout
         working-directory: engine
 
       - name: Run Rust lint WASM (Clippy)

--- a/engine/baml-compiler/src/hir/lowering.rs
+++ b/engine/baml-compiler/src/hir/lowering.rs
@@ -414,7 +414,7 @@ impl Block {
             .map(Box::new);
 
         if !block.expr_headers.is_empty() {
-            println!(
+            eprintln!(
                 "Annotated!: {}",
                 trailing_expr
                     .as_ref()
@@ -446,7 +446,7 @@ fn maybe_annotated_statement(
     if annotated_comments.is_empty() {
         stmt
     } else {
-        println!("Annotated!: {}", stmt.to_doc().pretty(80));
+        eprintln!("Annotated!: {}", stmt.to_doc().pretty(80));
         Statement::AnnotatedStatement {
             headers: annotated_comments
                 .iter()

--- a/engine/baml-lib/baml-log/src/logger.rs
+++ b/engine/baml-lib/baml-log/src/logger.rs
@@ -468,6 +468,7 @@ impl ConfigSetting<Level> for LogLevel {
         }
     }
 
+    #[allow(clippy::print_stdout)]
     fn set(value: Level) -> Result<(), LogError> {
         match CONFIG.write() {
             Ok(mut config) => {

--- a/engine/baml-lib/llm-client/src/clients/helpers.rs
+++ b/engine/baml-lib/llm-client/src/clients/helpers.rs
@@ -72,7 +72,7 @@ impl<Meta: Clone> PropertyHandler<Meta> {
     }
 
     pub fn print_options(&self) {
-        println!(
+        eprintln!(
             "options: {:#?}",
             self.options
                 .iter()

--- a/engine/baml-runtime/src/async_interpreter_runtime.rs
+++ b/engine/baml-runtime/src/async_interpreter_runtime.rs
@@ -102,10 +102,10 @@ impl BamlAsyncInterpreterRuntime {
             .iter()
             .find(|f| f.name == function_name)
         {
-            println!("THIR for expression function '{function_name}':");
-            println!("{}", expr_fn.body.dump_str());
+            eprintln!("THIR for expression function '{function_name}':");
+            eprintln!("{}", expr_fn.body.dump_str());
         } else {
-            println!("Function '{function_name}' not found or is not an expression function");
+            eprintln!("Function '{function_name}' not found or is not an expression function");
         }
     }
 

--- a/engine/baml-runtime/src/async_vm_runtime.rs
+++ b/engine/baml-runtime/src/async_vm_runtime.rs
@@ -92,11 +92,11 @@ impl BamlAsyncVmRuntime {
             .get(function_name)
             .map(|(index, _)| *index)
         else {
-            return println!("function not found: {function_name}");
+            return eprintln!("function not found: {function_name}");
         };
 
         let baml_vm::Object::Function(function) = &self.program.objects[index] else {
-            return println!("not a function: {function_name}");
+            return eprintln!("not a function: {function_name}");
         };
 
         baml_vm::debug::disassemble(

--- a/engine/baml-runtime/src/cli/check.rs
+++ b/engine/baml-runtime/src/cli/check.rs
@@ -40,6 +40,7 @@ impl CheckArgs {
         Ok(())
     }
 
+    #[allow(clippy::print_stdout)]
     fn check(
         &self,
         defaults: super::RuntimeCliDefaults,

--- a/engine/baml-runtime/src/cli/dump_intermediate.rs
+++ b/engine/baml-runtime/src/cli/dump_intermediate.rs
@@ -33,16 +33,16 @@ impl DumpIntermediateArgs {
 
         match dump_type {
             DumpType::HIR => {
-                println!("=== HIGH-LEVEL INTERMEDIATE REPRESENTATION (HIR) ===");
-                println!("Source directory: {:?}", self.from);
-                println!();
+                eprintln!("=== HIGH-LEVEL INTERMEDIATE REPRESENTATION (HIR) ===");
+                eprintln!("Source directory: {:?}", self.from);
+                eprintln!();
 
                 self.dump_hir(&validated_schema)?;
             }
             DumpType::Bytecode => {
-                println!("=== BYTECODE ===");
-                println!("Source directory: {:?}", self.from);
-                println!();
+                eprintln!("=== BYTECODE ===");
+                eprintln!("Source directory: {:?}", self.from);
+                eprintln!();
 
                 self.dump_bytecode(&validated_schema)?;
             }
@@ -98,7 +98,7 @@ impl DumpIntermediateArgs {
         hir.to_doc()
             .render(78, &mut w)
             .expect("Rendering should succeed");
-        println!(
+        eprintln!(
             "{}",
             String::from_utf8(w).expect("UTF-8 conversion should succeed")
         );
@@ -117,8 +117,8 @@ impl DumpIntermediateArgs {
                     if baml_compiler::builtin::is_builtin_identifier(&f.name) {
                         continue;
                     }
-                    println!("{}", f.name);
-                    println!(
+                    eprintln!("{}", f.name);
+                    eprintln!(
                         "{}",
                         baml_vm::debug::display_bytecode(
                             f,
@@ -131,12 +131,12 @@ impl DumpIntermediateArgs {
                 }
                 Object::Class(c) => {
                     if !baml_compiler::builtin::is_builtin_class(&c.name) {
-                        println!("Class: {} with {} fields", c.name, c.field_names.len());
+                        eprintln!("Class: {} with {} fields", c.name, c.field_names.len());
                     }
                 }
                 Object::Enum(e) => {
                     if !baml_compiler::builtin::is_builtin_enum(&e.name) {
-                        println!("Enum {}", e.name);
+                        eprintln!("Enum {}", e.name);
                     }
                 }
                 _ => {

--- a/engine/baml-runtime/src/cli/init_ui.rs
+++ b/engine/baml-runtime/src/cli/init_ui.rs
@@ -285,6 +285,7 @@ impl InitUIContext {
         }
     }
 
+    #[allow(clippy::print_stdout)]
     pub fn finish(self) -> Result<()> {
         if let Some(ui) = self.ui {
             // Show final state for a moment

--- a/engine/baml-runtime/src/cli/repl.rs
+++ b/engine/baml-runtime/src/cli/repl.rs
@@ -256,6 +256,7 @@ impl ReplState {
         }
     }
 
+    #[allow(clippy::print_stdout)]
     fn load_baml_sources(&mut self, path: PathBuf) -> Result<()> {
         let runtime =
             BamlRuntime::from_directory(&path, self.env_vars.clone(), Default::default()).context(
@@ -395,6 +396,7 @@ impl ReplState {
         Ok(output)
     }
 
+    #[allow(clippy::print_stdout)]
     fn reset(&mut self) {
         self.variables.clear();
         println!("✓ Reset interpreter environment");
@@ -842,6 +844,7 @@ impl ReplState {
 }
 
 impl ReplArgs {
+    #[allow(clippy::print_stdout)]
     pub async fn run(&self) -> Result<()> {
         // Suppress logging while TUI is active so logs don't corrupt the UI
         let _ = baml_log::set_log_level(baml_log::Level::Off);
@@ -1629,6 +1632,7 @@ impl ReplArgs {
         Ok(())
     }
 
+    #[allow(clippy::print_stdout)]
     fn handle_command(&self, state: &mut ReplState, input: &str) -> Result<Option<String>> {
         let parts: Vec<&str> = input[1..].split_whitespace().collect();
         if parts.is_empty() {

--- a/engine/baml-runtime/src/test_executor/mod.rs
+++ b/engine/baml-runtime/src/test_executor/mod.rs
@@ -145,6 +145,7 @@ fn file_reader_pinned(
 }
 
 impl TestExecutor for BamlRuntime {
+    #[allow(clippy::print_stdout)]
     fn cli_list_tests(&self, args: &TestFilter) -> Result<()> {
         let func_test_pairs = {
             let ir = &self.ir;
@@ -198,6 +199,7 @@ impl TestExecutor for BamlRuntime {
         Ok(())
     }
 
+    #[allow(clippy::print_stdout)]
     async fn cli_run_tests(
         self: std::sync::Arc<Self>,
         args: &TestFilter,

--- a/engine/baml-runtime/src/test_executor/output_github.rs
+++ b/engine/baml-runtime/src/test_executor/output_github.rs
@@ -14,6 +14,7 @@ use crate::TestStatus;
 impl RenderTestExecutionStatus for GithubTestExecutionStatusRenderer {
     fn render_progress(&self, test_status_map: &TestExecutionStatusMap) {}
 
+    #[allow(clippy::print_stdout)]
     fn render_final(
         &self,
         test_status_map: &TestExecutionStatusMap,

--- a/engine/baml-runtime/src/test_executor/output_pretty.rs
+++ b/engine/baml-runtime/src/test_executor/output_pretty.rs
@@ -284,6 +284,7 @@ impl PrettyTestExecutionStatusRenderer {
         }
     }
 
+    #[allow(clippy::print_stdout)]
     pub fn print_final_results(
         &self,
         test_status_map: &TestExecutionStatusMap,

--- a/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
@@ -660,7 +660,7 @@ impl TracePublisher {
         #[cfg(not(target_arch = "wasm32"))]
         {
             if let Ok(trace_file_path) = std::env::var("BAML_TRACE_FILE") {
-                println!("Writing trace events to file: {trace_file_path}");
+                eprintln!("Writing trace events to file: {trace_file_path}");
                 use tokio::fs::OpenOptions;
                 if let Ok(mut file) = OpenOptions::new()
                     .create(true)

--- a/engine/baml-vm/src/debug.rs
+++ b/engine/baml-vm/src/debug.rs
@@ -370,5 +370,5 @@ pub fn disassemble(
 
     let disassembly = display_bytecode(function, stack, objects, globals, use_colors);
 
-    println!("{disassembly}");
+    eprintln!("{disassembly}");
 }

--- a/engine/boundary-udf/src/lib.rs
+++ b/engine/boundary-udf/src/lib.rs
@@ -51,6 +51,7 @@ impl<T: ?Sized> Ord for HashByPtr<'_, T> {
 impl<T: ?Sized> Eq for HashByPtr<'_, T> {}
 
 impl<'a, T: ?Sized> PartialOrd for HashByPtr<'a, T> {
+    #[allow(clippy::non_canonical_partial_ord_impl)]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         // NOTE: (Jesus) cast to *const () removes metadata so that we're sure that we're only
         // comparing raw addresses.

--- a/engine/cli/src/auth.rs
+++ b/engine/cli/src/auth.rs
@@ -26,6 +26,7 @@ impl AuthCommands {
 pub struct LoginArgs {}
 
 impl LoginArgs {
+    #[allow(clippy::print_stdout)]
     pub async fn run_async(&self) -> Result<()> {
         let propel_auth_client = super::propelauth::PropelAuthClient::new()?;
         let mut token_data = propel_auth_client.run_authorization_code_flow().await?;
@@ -50,6 +51,7 @@ impl LoginArgs {
 pub struct TokenArgs {}
 
 impl TokenArgs {
+    #[allow(clippy::print_stdout)]
     pub async fn run_async(&self) -> Result<()> {
         let mut token_data = PersistedTokenData::read_from_storage()?;
         let token = token_data.access_token().await?;

--- a/engine/cli/src/colordiff.rs
+++ b/engine/cli/src/colordiff.rs
@@ -13,6 +13,7 @@ impl std::fmt::Display for Line {
 }
 
 /// Taken from https://github.com/mitsuhiko/similar/blob/main/examples/terminal-inline.rs
+#[allow(clippy::print_stdout)]
 pub(crate) fn print_diff(prev: &str, new: &str) {
     let diff = TextDiff::from_lines(prev, new);
 

--- a/engine/cli/src/deploy.rs
+++ b/engine/cli/src/deploy.rs
@@ -225,6 +225,7 @@ impl Deployer {
         }
     }
 
+    #[allow(clippy::print_stdout)]
     async fn deploy_new_project(&self) -> Result<CreateDeploymentResponse> {
         let api_client = ApiClient {
             base_url: self.api_url.clone(),

--- a/engine/cli/src/format.rs
+++ b/engine/cli/src/format.rs
@@ -26,6 +26,7 @@ pub struct FormatArgs {
 }
 
 impl FormatArgs {
+    #[allow(clippy::print_stdout)]
     pub fn run(&self) -> Result<()> {
         let paths = if self.paths.is_empty() {
             // Usually this is done in commands.rs, but fmt is a special case

--- a/engine/cli/src/lib.rs
+++ b/engine/cli/src/lib.rs
@@ -110,7 +110,7 @@ fn set_exit_handlers() {
     // Install our custom Ctrl+C handler
     // This will run in a separate thread when SIGINT is received
     ctrlc::set_handler(move || {
-        println!("\nShutting Down BAML...");
+        eprintln!("\nShutting Down BAML...");
         // Notify the main thread through the channel
         // Using ok() to ignore send errors if the receiver is already dropped
         interrupt_send.send(()).ok();

--- a/engine/cli/src/propelauth.rs
+++ b/engine/cli/src/propelauth.rs
@@ -102,6 +102,7 @@ impl PropelAuthClient {
         ))
     }
 
+    #[allow(clippy::print_stdout)]
     pub(crate) async fn request_authorization_code(
         &self,
         code_verifier: &str,

--- a/engine/generators/utils/test_harness/src/lib.rs
+++ b/engine/generators/utils/test_harness/src/lib.rs
@@ -233,7 +233,7 @@ impl<L: TestLanguageFeatures> TestStructure<L> {
                 run_and_stream(&mut cmd)?;
             }
         } else {
-            println!("Not running! Set RUN_GENERATOR_TESTS=1 to run tests");
+            eprintln!("Not running! Set RUN_GENERATOR_TESTS=1 to run tests");
         }
 
         Ok(())
@@ -246,6 +246,7 @@ use std::{
     thread,
 };
 
+#[allow(clippy::print_stdout)]
 fn run_and_stream(cmd: &mut Command) -> anyhow::Result<()> {
     // Pipe both streams before we spawn.
     let mut child = cmd.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn()?;

--- a/engine/language_client_python/src/lib.rs
+++ b/engine/language_client_python/src/lib.rs
@@ -104,6 +104,6 @@ fn init_debug_logger() {
     if let Err(e) =
         env_logger::try_init_from_env(env_logger::Env::new().filter("BAML_INTERNAL_LOG"))
     {
-        println!("Failed to initialize BAML DEBUG logger: {e:#}");
+        eprintln!("Failed to initialize BAML DEBUG logger: {e:#}");
     }
 }

--- a/engine/language_client_python/src/types/log_collector.rs
+++ b/engine/language_client_python/src/types/log_collector.rs
@@ -93,7 +93,7 @@ impl Collector {
     #[staticmethod]
     pub fn __print_storage() {
         let tracer = BAML_TRACER.lock().unwrap();
-        println!("Storage: {tracer:#?}");
+        eprintln!("Storage: {tracer:#?}");
     }
 }
 

--- a/engine/language_client_ruby/ext/ruby_ffi/src/types/log_collector.rs
+++ b/engine/language_client_ruby/ext/ruby_ffi/src/types/log_collector.rs
@@ -138,7 +138,7 @@ impl Collector {
 
     pub fn __print_storage() {
         let tracer = BAML_TRACER.lock().unwrap();
-        println!("Storage: {tracer:#?}");
+        eprintln!("Storage: {tracer:#?}");
     }
 
     pub fn define_in_ruby(module: &RModule) -> Result<()> {

--- a/engine/language_client_typescript/src/types/log_collector.rs
+++ b/engine/language_client_typescript/src/types/log_collector.rs
@@ -96,7 +96,7 @@ impl Collector {
     #[napi(js_name = "__printStorage")]
     pub fn print_storage() {
         let tracer = BAML_TRACER.lock().unwrap();
-        println!("Storage: {tracer:#?}");
+        eprintln!("Storage: {tracer:#?}");
     }
 }
 

--- a/engine/language_server/src/baml_project/mod.rs
+++ b/engine/language_server/src/baml_project/mod.rs
@@ -369,7 +369,7 @@ impl BamlProject {
             match internal_baml_core::FeatureFlags::from_vec(feature_flags.to_vec()) {
                 Ok(flags) => {
                     tracing::info!(
-                        "Successfully converted feature flags to FeatureFlags struct: {:?}",
+                        "Successfully converted feature flags to FeatureFlags struct: {:?}.",
                         flags
                     );
                     flags

--- a/engine/language_server/src/lib.rs
+++ b/engine/language_server/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(clippy::print_stdout)]
 use std::num::NonZeroUsize;
 
 use anyhow::Context;

--- a/engine/language_server/src/server.rs
+++ b/engine/language_server/src/server.rs
@@ -546,13 +546,13 @@ impl Server {
             code_lens_provider: Some(CodeLensOptions {
                 resolve_provider: Some(true),
             }),
-            code_action_provider: Some(lsp_types::CodeActionProviderCapability::Simple(true)),
+            code_action_provider: None,
             execute_command_provider: Some(lsp_types::ExecuteCommandOptions {
                 commands: vec![api::OPEN_IN_BROWSER_COMMAND.to_string()],
                 work_done_progress_options: Default::default(),
             }),
             definition_provider: Some(lsp_types::OneOf::Left(true)),
-            document_formatting_provider: Some(lsp_types::OneOf::Left(true)),
+            document_formatting_provider: None,
             hover_provider: Some(HoverProviderCapability::Simple(true)),
             rename_provider: Some(lsp_types::OneOf::Left(true)),
             text_document_sync: Some(TextDocumentSyncCapability::Options(

--- a/engine/llm-response-parser/src/provider.rs
+++ b/engine/llm-response-parser/src/provider.rs
@@ -31,7 +31,7 @@ impl LLMProvider {
         }
     }
 
-    pub fn from_str(s: &str) -> Option<Self> {
+    pub fn try_from_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "openai" => Some(LLMProvider::OpenAI),
             "anthropic" => Some(LLMProvider::Anthropic),

--- a/engine/playground-server/src/bin/playground_barebones.rs
+++ b/engine/playground-server/src/bin/playground_barebones.rs
@@ -9,7 +9,7 @@ use walkdir::WalkDir;
 
 // const PROJECT_DIR: &'static str = "/Users/sam/baml4/c2/baml_src";
 // const PROJECT_DIR: &'static str = "/Users/sam/baml/engine/playground-server/tests/codelens-bugs";
-const PROJECT_DIR: &'static str = "/Users/sam/baml/integ-tests/baml_src";
+const PROJECT_DIR: &str = "/Users/sam/baml/integ-tests/baml_src";
 
 #[derive(Debug)]
 pub struct Playground2Server {
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn load_project_from_directory(dir_path: &'static str) -> BamlNotification {
+fn load_project_from_directory(dir_path: &str) -> BamlNotification {
     let mut files = HashMap::new();
     let base_path = Path::new(dir_path);
 
@@ -103,7 +103,7 @@ pub async fn run_server() -> anyhow::Result<()> {
     let server = Playground2Server {
         app_state: AppState {
             webview_router_to_websocket_rx_provider: webview_router_to_websocket_tx.clone().into(),
-            to_webview_router_tx: to_webview_router_tx,
+            to_webview_router_tx,
             playground_port: port_picks.playground_port,
             proxy_port: port_picks.proxy_port,
             editor_config: std::sync::Arc::new(std::sync::RwLock::new(

--- a/engine/tools/src/bin/language-server-hot-reload.rs
+++ b/engine/tools/src/bin/language-server-hot-reload.rs
@@ -67,11 +67,14 @@ impl HotReloader {
 
     async fn replay_stdin(&self, process: &mut TokioChild) -> Result<()> {
         if let Some(stdin) = process.stdin.as_mut() {
-            let buffer = self.stdin_buffer.lock().unwrap();
+            // Clone messages to avoid holding lock across await
+            let messages: Vec<StdinMessage> = {
+                let buffer = self.stdin_buffer.lock().unwrap();
+                info!("Replaying {} stdin messages", buffer.len());
+                buffer.iter().cloned().collect()
+            };
 
-            info!("Replaying {} stdin messages", buffer.len());
-
-            for message in buffer.iter() {
+            for message in messages.iter() {
                 if let Err(e) = stdin.write_all(&message.data).await {
                     warn!("Failed to replay stdin message: {}", e);
                     break;
@@ -221,15 +224,12 @@ impl HotReloader {
             }
 
             if let Some(ref mut child) = self.current_process {
-                match child.try_wait()? {
-                    Some(status) => {
-                        info!("Process exited with status: {}", status);
-                        if !status.success() {
-                            info!("Process failed, waiting for binary update...");
-                            self.current_process = None;
-                        }
+                if let Some(status) = child.try_wait()? {
+                    info!("Process exited with status: {}", status);
+                    if !status.success() {
+                        info!("Process failed, waiting for binary update...");
+                        self.current_process = None;
                     }
-                    None => {}
                 }
             }
         }

--- a/mise.toml
+++ b/mise.toml
@@ -2,11 +2,10 @@
 
 [tools]
 # Core languages
-rust = "1.88.0"
 go = "1.23.11"
-python = "3.13"  # Will use uv for Python package management
+python = "3.13"     # Will use uv for Python package management
 ruby = "3.2.2"
-node = "lts"     # For pnpm
+node = "lts"        # For pnpm
 java = "temurin-23"
 
 # Rust tools
@@ -14,6 +13,7 @@ java = "temurin-23"
 "cargo:cross" = "latest"
 "cargo:cargo-watch" = "latest"
 "cargo:wasm-pack" = "0.13.1"
+"cargo:ripgrep" = "latest"
 
 # Go tools
 # locked to match the version in .github/actions/setup-go/action.yml

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,6 @@ importers:
 
   engine/language_server: {}
 
-  examples/internal/vaibhav/my-wf: {}
-
   fern:
     devDependencies:
       fern-api:
@@ -475,7 +473,7 @@ importers:
         version: 5.8.3
       webpack:
         specifier: ^5.88.0
-        version: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
+        version: 5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.99.9)
@@ -20140,17 +20138,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.99.9)':
     dependencies:
-      webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
+      webpack: 5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.99.9)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.99.9)':
     dependencies:
-      webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
+      webpack: 5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.99.9)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.99.9)':
     dependencies:
-      webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
+      webpack: 5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.99.9)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -21124,7 +21122,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
+      webpack: 5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4)
 
   css-select@5.1.0:
     dependencies:
@@ -26877,7 +26875,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.99.9):
     dependencies:
-      webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
+      webpack: 5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4)
 
   style-mod@4.1.2: {}
 
@@ -27037,18 +27035,6 @@ snapshots:
       ansi-escapes: 4.3.2
       supports-hyperlinks: 2.3.0
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.12.7)(esbuild@0.25.2)(webpack@5.99.9):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
-      jest-worker: 27.5.1
-      schema-utils: 4.3.2
-      serialize-javascript: 6.0.2
-      terser: 5.43.1
-      webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@swc/core': 1.12.7
-      esbuild: 0.25.2
-
   terser-webpack-plugin@5.3.14(@swc/core@1.12.7)(webpack@5.99.9(@swc/core@1.12.7)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
@@ -27057,6 +27043,17 @@ snapshots:
       serialize-javascript: 6.0.2
       terser: 5.43.1
       webpack: 5.99.9(@swc/core@1.12.7)
+    optionalDependencies:
+      '@swc/core': 1.12.7
+
+  terser-webpack-plugin@5.3.14(@swc/core@1.12.7)(webpack@5.99.9):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      jest-worker: 27.5.1
+      schema-utils: 4.3.2
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.12.7
 
@@ -27241,7 +27238,7 @@ snapshots:
       semver: 7.7.2
       source-map: 0.7.4
       typescript: 5.8.3
-      webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
+      webpack: 5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4)
 
   ts-morph@12.0.0:
     dependencies:
@@ -28147,7 +28144,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4)
+      webpack: 5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
 
   webpack-merge@5.10.0:
@@ -28192,7 +28189,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.99.9(@swc/core@1.12.7)(esbuild@0.25.2)(webpack-cli@5.1.4):
+  webpack@5.99.9(@swc/core@1.12.7)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -28215,7 +28212,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(@swc/core@1.12.7)(esbuild@0.25.2)(webpack@5.99.9)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.12.7)(webpack@5.99.9)
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     optionalDependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enforces no-stdout across the workspace (Clippy + stderr), updates LSP capabilities, and includes minor refactors and tooling tweaks.
> 
> - **Lint/CI**:
>   - Enforce `clippy::print_stdout` across the workspace in CI (`cargo clippy --workspace -- -D clippy::print_stdout`).
>   - Add `#![deny(clippy::print_stdout)]` to `engine/language_server`.
> - **Stdout → Stderr changes**:
>   - Replace `println!` with `eprintln!` in numerous modules (compiler lowering, runtimes, VM debug, CLI tools, tracing publisher, language clients) to avoid polluting stdio.
>   - Add targeted `#[allow(clippy::print_stdout)]` on intentional user-facing stdout paths (CLI outputs, REPL, formatter, test renderer, auth, etc.).
> - **Language Server**:
>   - Disable `codeActionProvider` and `documentFormattingProvider` (set to `None`).
>   - Misc logging tweaks and startup messages moved to stderr.
> - **Tools/Dev UX**:
>   - Hot-reload utility: replay stdin without holding locks across awaits; simplify child status polling.
>   - Playground: minor type signature cleanups (`&'static str` → `&str`).
> - **Core/Lib changes**:
>   - Rename `LLMProvider::from_str` to `try_from_str`.
>   - Minor log message punctuation and additional allowances.
> - **Env/Tooling**:
>   - Update `mise.toml` (add cargo ripgrep, node/python tool notes and settings).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abb4a012a28db1225a1a5054b179351248f82261. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->