### PR TITLE
fix windows cli build

### DIFF
--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -146,13 +146,13 @@ jobs:
           echo "target dir is: ${{ env.TARGET_DIR }}"
 
       # Build the CLI - Always use static-ssl features
-      - name: Build CLI Binary
-        # This single step now handles all builds
-        run: >
-          ${{ env.CARGO }} build --release --bin baml-cli ${{ env.TARGET_FLAGS }}
-          --features static-ssl
-          --no-default-features
-        working-directory: engine
+      # - name: Build CLI Binary
+      #   # This single step now handles all builds
+      #   run: >
+      #     ${{ env.CARGO }} build --release --bin baml-cli ${{ env.TARGET_FLAGS }}
+      #     --features static-ssl
+      #     --no-default-features
+      #   working-directory: engine
 
       - name: Build CFFI Library (Unix)
         if: ${{ !contains(matrix._.os, 'windows') }}

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
       - sam/mise-protoc-gen-go
+      - aaron/fix-windows
 env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
   # Turbo remote caching
@@ -82,10 +83,17 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
 
-
       - uses: jdx/mise-action@v2
+        if: matrix._.os != 'windows-2022'
         with:
           install_args: "protoc-gen-go"
+
+      - name: Install protoc-gen-go (Windows)
+        if: matrix._.os == 'windows-2022'
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.34.1
+          echo "$HOME/go/bin" >> $GITHUB_PATH
+        shell: bash
 
       - name: Test protoc-gen-go availability
         id: protoc_gen_go_setup

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -146,13 +146,13 @@ jobs:
           echo "target dir is: ${{ env.TARGET_DIR }}"
 
       # Build the CLI - Always use static-ssl features
-      # - name: Build CLI Binary
-      #   # This single step now handles all builds
-      #   run: >
-      #     ${{ env.CARGO }} build --release --bin baml-cli ${{ env.TARGET_FLAGS }}
-      #     --features static-ssl
-      #     --no-default-features
-      #   working-directory: engine
+      - name: Build CLI Binary
+        # This single step now handles all builds
+        run: >
+          ${{ env.CARGO }} build --release --bin baml-cli ${{ env.TARGET_FLAGS }}
+          --features static-ssl
+          --no-default-features
+        working-directory: engine
 
       - name: Build CFFI Library (Unix)
         if: ${{ !contains(matrix._.os, 'windows') }}

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -88,6 +88,17 @@ jobs:
         with:
           install_args: "protoc-gen-go"
 
+      - name: Setup Protoc (Windows)
+        if: matrix._.os == 'windows-2022'
+        shell: bash
+        run: |
+          # Download protoc directly to avoid rate limiting
+          PROTOC_VERSION="27.1"
+          curl -LO "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-win64.zip"
+          unzip -q protoc-${PROTOC_VERSION}-win64.zip -d $HOME/.local
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          rm protoc-${PROTOC_VERSION}-win64.zip
+
       - name: Install protoc-gen-go (Windows)
         if: matrix._.os == 'windows-2022'
         run: |
@@ -143,7 +154,8 @@ jobs:
           --no-default-features
         working-directory: engine
 
-      - name: Build CFFI Library
+      - name: Build CFFI Library (Unix)
+        if: ${{ !contains(matrix._.os, 'windows') }}
         shell: bash
         run: |
           # Set the correct protoc-gen-go path based on whether we're using cross (Linux) or native build
@@ -163,6 +175,13 @@ jobs:
           export PATH=$PATH:$GOROOT:$GOPATH:$GOBIN
 
           ${{ env.CARGO }} build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
+        working-directory: engine
+
+      - name: Build CFFI Library (Windows)
+        if: ${{ contains(matrix._.os, 'windows') }}
+        shell: bash
+        run: |
+          cargo build --release -p baml_cffi ${{ env.TARGET_FLAGS }}
         working-directory: engine
 
       # Determine CFFI library name and artifact suffix based on OS

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -237,10 +237,13 @@ jobs:
           export LD_LIBRARY_PATH="${RUBY_LIB_PATH}:${LD_LIBRARY_PATH}"
           # Build baml_cffi shared library
           cargo build --package baml_cffi
+          echo "Listing release directory:"
+          ls -la engine/target/release/libbaml_cffi.* || true
+          ls -la engine/target/release/baml_cffi.* || true
 
           export BAML_LIBRARY_PATH=${{ github.workspace }}/engine/target/debug/libbaml_cffi.so
           # Run tests
-          echo "BAML_LIBRARY_PATH=${{ github.workspace }}/engine/target/debug/libbaml_cffi.so" >> $GITHUB_ENV"
+          echo "BAML_LIBRARY_PATH=${{ github.workspace }}/engine/target/debug/libbaml_cffi.so" >> $GITHUB_ENV
           cargo test --features skip-integ-tests --verbose -- --nocapture
         working-directory: engine
 

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -237,6 +237,8 @@ jobs:
           export LD_LIBRARY_PATH="${RUBY_LIB_PATH}:${LD_LIBRARY_PATH}"
           # Build baml_cffi shared library
           cargo build --package baml_cffi
+
+          BAML_LIBRARY_PATH=${{ github.workspace }}/engine/target/debug/baml_cffi.so
           # Run tests
           cargo test --features skip-integ-tests
         working-directory: engine

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -240,7 +240,8 @@ jobs:
 
           export BAML_LIBRARY_PATH=${{ github.workspace }}/engine/target/debug/libbaml_cffi.so
           # Run tests
-          cargo test --features skip-integ-tests
+          echo "BAML_LIBRARY_PATH=${{ github.workspace }}/engine/target/debug/libbaml_cffi.so" >> $GITHUB_ENV"
+          cargo test --features skip-integ-tests --verbose -- --nocapture
         working-directory: engine
 
       - name: Run Python integration tests

--- a/.github/workflows/primary.yml
+++ b/.github/workflows/primary.yml
@@ -238,7 +238,7 @@ jobs:
           # Build baml_cffi shared library
           cargo build --package baml_cffi
 
-          BAML_LIBRARY_PATH=${{ github.workspace }}/engine/target/debug/baml_cffi.so
+          export BAML_LIBRARY_PATH=${{ github.workspace }}/engine/target/debug/libbaml_cffi.so
           # Run tests
           cargo test --features skip-integ-tests
         working-directory: engine

--- a/engine/generators/languages/python/generated_tests/array_types/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/array_types/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/array_types/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/array_types/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/array_types/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/array_types/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/asserts/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/asserts/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/asserts/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/asserts/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/asserts/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/asserts/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/classes/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/classes/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/classes/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/classes/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/classes/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/classes/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/edge_cases/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/edge_cases/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/edge_cases/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/edge_cases/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/edge_cases/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/edge_cases/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/enums/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/enums/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/enums/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/enums/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/enums/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/enums/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/literal_types/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/literal_types/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/literal_types/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/literal_types/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/literal_types/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/literal_types/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/map_types/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/map_types/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/map_types/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/map_types/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/map_types/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/map_types/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/media_types/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/media_types/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/media_types/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/media_types/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/media_types/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/media_types/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/nested_structures/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/nested_structures/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/nested_structures/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/nested_structures/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/nested_structures/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/nested_structures/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/primitive_types/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/primitive_types/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/primitive_types/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/primitive_types/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/primitive_types/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/primitive_types/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/recursive_types/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/recursive_types/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/recursive_types/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/recursive_types/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/recursive_types/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/recursive_types/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/sample/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/sample/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/sample/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/sample/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/sample/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/sample/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/python/generated_tests/unions/baml_client/__init__.py
+++ b/engine/generators/languages/python/generated_tests/unions/baml_client/__init__.py
@@ -10,7 +10,7 @@
 # BAML files and re-generate this code using: baml-cli generate
 # baml-cli is available with the baml package.
 
-__version__ = "0.208.5"
+__version__ = "0.212.0"
 
 try:
   from baml_py.safe_import import EnsureBamlPyImport
@@ -41,6 +41,7 @@ with EnsureBamlPyImport(__version__) as e:
   
   from .async_client import b
   
+  from . import watchers
 
 
 # FOR LEGACY COMPATIBILITY, expose "partial_types" as an alias for "stream_types"
@@ -55,4 +56,5 @@ __all__ = [
   "types",
   "reset_baml_env_vars",
   "config",
+  "watchers",
 ]

--- a/engine/generators/languages/python/generated_tests/unions/baml_client/config.py
+++ b/engine/generators/languages/python/generated_tests/unions/baml_client/config.py
@@ -85,10 +85,18 @@ def set_log_max_chunk_length():
     os.environ["BAML_LOG_MAX_CHUNK_LENGTH"] = "1000"
 
 
+def set_log_max_message_length(*args, **kwargs):
+    """
+    Alias for set_log_max_chunk_length for compatibility with docs.
+    """
+    return set_log_max_chunk_length(*args, **kwargs)
+
+
 __all__ = [
     "set_log_level",
     "get_log_level",
     "set_log_json_mode",
     "reset_baml_env_vars",
+    "set_log_max_message_length",
     "set_log_max_chunk_length",
 ]

--- a/engine/generators/languages/python/generated_tests/unions/baml_client/runtime.py
+++ b/engine/generators/languages/python/generated_tests/unions/baml_client/runtime.py
@@ -30,6 +30,7 @@ class BamlCallOptions(typing.TypedDict, total=False):
     ]
     abort_controller: typing_extensions.NotRequired[baml_py.baml_py.AbortController]
     on_tick: typing_extensions.NotRequired[typing.Callable[[str, baml_py.baml_py.FunctionLog], None]]
+    watchers: typing_extensions.NotRequired[typing.Any]  # EventCollector type, will be overridden in generated clients
 
 
 class _ResolvedBamlOptions:
@@ -40,6 +41,7 @@ class _ResolvedBamlOptions:
     tags: typing.Dict[str, str]
     abort_controller: typing.Optional[baml_py.baml_py.AbortController]
     on_tick: typing.Optional[typing.Callable[[], None]]
+    watchers: typing.Optional[typing.Any]
 
     def __init__(
         self,
@@ -50,6 +52,7 @@ class _ResolvedBamlOptions:
         tags: typing.Dict[str, str],
         abort_controller: typing.Optional[baml_py.baml_py.AbortController],
         on_tick: typing.Optional[typing.Callable[[], None]],
+        watchers: typing.Optional[typing.Any],
     ):
         self.tb = tb
         self.client_registry = client_registry
@@ -58,6 +61,7 @@ class _ResolvedBamlOptions:
         self.tags = tags
         self.abort_controller = abort_controller
         self.on_tick = on_tick
+        self.watchers = watchers
 
 
 
@@ -109,6 +113,8 @@ class DoNotUseDirectlyCallManager:
         else:
             on_tick_wrapper = None
 
+        watchers = self.__baml_options.get("watchers")
+
         return _ResolvedBamlOptions(
             baml_tb,
             client_registry,
@@ -117,6 +123,7 @@ class DoNotUseDirectlyCallManager:
             tags,
             abort_controller,
             on_tick_wrapper,
+            watchers,
         )
 
     def merge_options(self, options: BamlCallOptions) -> "DoNotUseDirectlyCallManager":
@@ -148,6 +155,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def call_function_sync(
@@ -177,6 +186,8 @@ class DoNotUseDirectlyCallManager:
             resolved_options.tags,
             # abort_controller
             resolved_options.abort_controller,
+            # watchers
+            resolved_options.watchers,
         )
 
     def create_async_stream(

--- a/engine/generators/languages/typescript/generated_tests/array_types/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/array_types/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestEmptyArrays(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SimpleArrays> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SimpleArrays
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestLargeArrays(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SimpleArrays> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SimpleArrays
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestMixedArrays(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.MixedArrays> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.MixedArrays
             } catch (error) {
@@ -237,7 +242,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestNestedArrays(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.NestedArrays> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -275,6 +280,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.NestedArrays
             } catch (error) {
@@ -284,7 +290,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestObjectArrays(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.ObjectArrays> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -322,6 +328,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.ObjectArrays
             } catch (error) {
@@ -331,7 +338,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestSimpleArrays(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SimpleArrays> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -369,6 +376,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SimpleArrays
             } catch (error) {
@@ -378,7 +386,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevel3DArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<string[][][]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -416,6 +424,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as string[][][]
             } catch (error) {
@@ -425,7 +434,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelArrayOfMaps(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, number>[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -463,6 +472,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, number>[]
             } catch (error) {
@@ -472,7 +482,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelBoolArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<boolean[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -510,6 +520,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as boolean[]
             } catch (error) {
@@ -519,7 +530,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelEmptyArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<string[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -557,6 +568,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as string[]
             } catch (error) {
@@ -566,7 +578,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelFloatArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<number[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -604,6 +616,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as number[]
             } catch (error) {
@@ -613,7 +626,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelIntArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<number[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -651,6 +664,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as number[]
             } catch (error) {
@@ -660,7 +674,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelMixedArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<(string | number | boolean)[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -698,6 +712,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as (string | number | boolean)[]
             } catch (error) {
@@ -707,7 +722,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelNestedArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<number[][]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -745,6 +760,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as number[][]
             } catch (error) {
@@ -754,7 +770,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelNullableArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<(string | null)[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -792,6 +808,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as (string | null)[]
             } catch (error) {
@@ -801,7 +818,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelObjectArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.User[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -839,6 +856,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.User[]
             } catch (error) {
@@ -848,7 +866,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelStringArray(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<string[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -886,6 +904,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as string[]
             } catch (error) {
@@ -909,7 +928,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestEmptyArrays(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SimpleArrays, types.SimpleArrays>
               {
               try {
@@ -975,7 +994,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestLargeArrays(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SimpleArrays, types.SimpleArrays>
               {
               try {
@@ -1041,7 +1060,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestMixedArrays(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.MixedArrays, types.MixedArrays>
               {
               try {
@@ -1107,7 +1126,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestNestedArrays(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.NestedArrays, types.NestedArrays>
               {
               try {
@@ -1173,7 +1192,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestObjectArrays(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.ObjectArrays, types.ObjectArrays>
               {
               try {
@@ -1239,7 +1258,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestSimpleArrays(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SimpleArrays, types.SimpleArrays>
               {
               try {
@@ -1305,7 +1324,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevel3DArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<string[][][], string[][][]>
               {
               try {
@@ -1371,7 +1390,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelArrayOfMaps(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, number>[], Record<string, number>[]>
               {
               try {
@@ -1437,7 +1456,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelBoolArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<boolean[], boolean[]>
               {
               try {
@@ -1503,7 +1522,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelEmptyArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<string[], string[]>
               {
               try {
@@ -1569,7 +1588,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelFloatArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<number[], number[]>
               {
               try {
@@ -1635,7 +1654,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelIntArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<number[], number[]>
               {
               try {
@@ -1701,7 +1720,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelMixedArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<(string | number | boolean)[], (string | number | boolean)[]>
               {
               try {
@@ -1767,7 +1786,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelNestedArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<number[][], number[][]>
               {
               try {
@@ -1833,7 +1852,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelNullableArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<(string | null)[], (string | null)[]>
               {
               try {
@@ -1899,7 +1918,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelObjectArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.User[], types.User[]>
               {
               try {
@@ -1965,7 +1984,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelStringArray(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<string[], string[]>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/array_types/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/array_types/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ArrayWithConstraints, MixedArrays, NestedArrays, ObjectArrays, Product, SimpleArrays, Tag, User} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestEmptyArrays(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestLargeArrays(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async TestMixedArrays(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -116,7 +118,7 @@ env?: Record<string, string | undefined>
       
   async TestNestedArrays(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -141,7 +143,7 @@ env?: Record<string, string | undefined>
       
   async TestObjectArrays(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -166,7 +168,7 @@ env?: Record<string, string | undefined>
       
   async TestSimpleArrays(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -191,7 +193,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevel3DArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -216,7 +218,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelArrayOfMaps(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -241,7 +243,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelBoolArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -266,7 +268,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelEmptyArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -291,7 +293,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelFloatArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -316,7 +318,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelIntArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -341,7 +343,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelMixedArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -366,7 +368,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelNestedArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -391,7 +393,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelNullableArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -416,7 +418,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelObjectArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -441,7 +443,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelStringArray(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -472,7 +474,7 @@ env?: Record<string, string | undefined>
       
       async TestEmptyArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -497,7 +499,7 @@ env?: Record<string, string | undefined>
           
       async TestLargeArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -522,7 +524,7 @@ env?: Record<string, string | undefined>
           
       async TestMixedArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -547,7 +549,7 @@ env?: Record<string, string | undefined>
           
       async TestNestedArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -572,7 +574,7 @@ env?: Record<string, string | undefined>
           
       async TestObjectArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -597,7 +599,7 @@ env?: Record<string, string | undefined>
           
       async TestSimpleArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -622,7 +624,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevel3DArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -647,7 +649,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelArrayOfMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -672,7 +674,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelBoolArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -697,7 +699,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelEmptyArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -722,7 +724,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelFloatArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -747,7 +749,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelIntArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -772,7 +774,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelMixedArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -797,7 +799,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelNestedArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -822,7 +824,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelNullableArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -847,7 +849,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelObjectArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -872,7 +874,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelStringArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/array_types/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/array_types/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/array_types/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/array_types/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestEmptyArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SimpleArrays {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SimpleArrays
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestLargeArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SimpleArrays {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SimpleArrays
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   TestMixedArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.MixedArrays {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.MixedArrays
     } catch (error: any) {
@@ -219,21 +224,21 @@ export class BamlSyncClient {
   
   TestNestedArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.NestedArrays {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -251,6 +256,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.NestedArrays
     } catch (error: any) {
@@ -260,21 +266,21 @@ export class BamlSyncClient {
   
   TestObjectArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.ObjectArrays {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -292,6 +298,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.ObjectArrays
     } catch (error: any) {
@@ -301,21 +308,21 @@ export class BamlSyncClient {
   
   TestSimpleArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SimpleArrays {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -333,6 +340,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SimpleArrays
     } catch (error: any) {
@@ -342,21 +350,21 @@ export class BamlSyncClient {
   
   TestTopLevel3DArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): string[][][] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -374,6 +382,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as string[][][]
     } catch (error: any) {
@@ -383,21 +392,21 @@ export class BamlSyncClient {
   
   TestTopLevelArrayOfMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, number>[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -415,6 +424,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, number>[]
     } catch (error: any) {
@@ -424,21 +434,21 @@ export class BamlSyncClient {
   
   TestTopLevelBoolArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): boolean[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -456,6 +466,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as boolean[]
     } catch (error: any) {
@@ -465,21 +476,21 @@ export class BamlSyncClient {
   
   TestTopLevelEmptyArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): string[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -497,6 +508,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as string[]
     } catch (error: any) {
@@ -506,21 +518,21 @@ export class BamlSyncClient {
   
   TestTopLevelFloatArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): number[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -538,6 +550,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as number[]
     } catch (error: any) {
@@ -547,21 +560,21 @@ export class BamlSyncClient {
   
   TestTopLevelIntArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): number[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -579,6 +592,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as number[]
     } catch (error: any) {
@@ -588,21 +602,21 @@ export class BamlSyncClient {
   
   TestTopLevelMixedArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): (string | number | boolean)[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -620,6 +634,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as (string | number | boolean)[]
     } catch (error: any) {
@@ -629,21 +644,21 @@ export class BamlSyncClient {
   
   TestTopLevelNestedArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): number[][] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -661,6 +676,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as number[][]
     } catch (error: any) {
@@ -670,21 +686,21 @@ export class BamlSyncClient {
   
   TestTopLevelNullableArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): (string | null)[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -702,6 +718,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as (string | null)[]
     } catch (error: any) {
@@ -711,21 +728,21 @@ export class BamlSyncClient {
   
   TestTopLevelObjectArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.User[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -743,6 +760,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.User[]
     } catch (error: any) {
@@ -752,21 +770,21 @@ export class BamlSyncClient {
   
   TestTopLevelStringArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): string[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -784,6 +802,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as string[]
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/array_types/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/array_types/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ArrayWithConstraints, MixedArrays, NestedArrays, ObjectArrays, Product, SimpleArrays, Tag, User} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestEmptyArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestLargeArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   TestMixedArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -112,7 +114,7 @@ export class HttpRequest {
   
   TestNestedArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -137,7 +139,7 @@ export class HttpRequest {
   
   TestObjectArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -162,7 +164,7 @@ export class HttpRequest {
   
   TestSimpleArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -187,7 +189,7 @@ export class HttpRequest {
   
   TestTopLevel3DArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -212,7 +214,7 @@ export class HttpRequest {
   
   TestTopLevelArrayOfMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -237,7 +239,7 @@ export class HttpRequest {
   
   TestTopLevelBoolArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -262,7 +264,7 @@ export class HttpRequest {
   
   TestTopLevelEmptyArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -287,7 +289,7 @@ export class HttpRequest {
   
   TestTopLevelFloatArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -312,7 +314,7 @@ export class HttpRequest {
   
   TestTopLevelIntArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -337,7 +339,7 @@ export class HttpRequest {
   
   TestTopLevelMixedArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -362,7 +364,7 @@ export class HttpRequest {
   
   TestTopLevelNestedArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -387,7 +389,7 @@ export class HttpRequest {
   
   TestTopLevelNullableArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -412,7 +414,7 @@ export class HttpRequest {
   
   TestTopLevelObjectArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -437,7 +439,7 @@ export class HttpRequest {
   
   TestTopLevelStringArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -468,7 +470,7 @@ export class HttpStreamRequest {
   
   TestEmptyArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -493,7 +495,7 @@ export class HttpStreamRequest {
   
   TestLargeArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -518,7 +520,7 @@ export class HttpStreamRequest {
   
   TestMixedArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -543,7 +545,7 @@ export class HttpStreamRequest {
   
   TestNestedArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -568,7 +570,7 @@ export class HttpStreamRequest {
   
   TestObjectArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -593,7 +595,7 @@ export class HttpStreamRequest {
   
   TestSimpleArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -618,7 +620,7 @@ export class HttpStreamRequest {
   
   TestTopLevel3DArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -643,7 +645,7 @@ export class HttpStreamRequest {
   
   TestTopLevelArrayOfMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -668,7 +670,7 @@ export class HttpStreamRequest {
   
   TestTopLevelBoolArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -693,7 +695,7 @@ export class HttpStreamRequest {
   
   TestTopLevelEmptyArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -718,7 +720,7 @@ export class HttpStreamRequest {
   
   TestTopLevelFloatArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -743,7 +745,7 @@ export class HttpStreamRequest {
   
   TestTopLevelIntArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -768,7 +770,7 @@ export class HttpStreamRequest {
   
   TestTopLevelMixedArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -793,7 +795,7 @@ export class HttpStreamRequest {
   
   TestTopLevelNestedArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -818,7 +820,7 @@ export class HttpStreamRequest {
   
   TestTopLevelNullableArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -843,7 +845,7 @@ export class HttpStreamRequest {
   
   TestTopLevelObjectArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -868,7 +870,7 @@ export class HttpStreamRequest {
   
   TestTopLevelStringArray(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/asserts/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/asserts/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async PersonTest(
         
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.Person> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.Person
             } catch (error) {
@@ -157,7 +160,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             PersonTest(
             
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.Person, types.Person>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/asserts/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/asserts/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Person} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async PersonTest(
   
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -72,7 +74,7 @@ env?: Record<string, string | undefined>
       
       async PersonTest(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/asserts/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/asserts/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/asserts/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/asserts/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   PersonTest(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.Person {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.Person
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/asserts/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/asserts/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Person} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   PersonTest(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -68,7 +70,7 @@ export class HttpStreamRequest {
   
   PersonTest(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/classes/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/classes/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async ConsumeSimpleClass(
         item: types.SimpleClass,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SimpleClass> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SimpleClass
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async MakeSimpleClass(
         
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SimpleClass> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SimpleClass
             } catch (error) {
@@ -204,7 +208,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             ConsumeSimpleClass(
             item: types.SimpleClass,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SimpleClass, types.SimpleClass>
               {
               try {
@@ -270,7 +274,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             MakeSimpleClass(
             
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SimpleClass, types.SimpleClass>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/classes/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/classes/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {SimpleClass} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async ConsumeSimpleClass(
   item: types.SimpleClass,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async MakeSimpleClass(
   
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -97,7 +99,7 @@ env?: Record<string, string | undefined>
       
       async ConsumeSimpleClass(
       item: types.SimpleClass,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -122,7 +124,7 @@ env?: Record<string, string | undefined>
           
       async MakeSimpleClass(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/classes/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/classes/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/classes/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/classes/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   ConsumeSimpleClass(
       item: types.SimpleClass,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SimpleClass {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SimpleClass
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   MakeSimpleClass(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SimpleClass {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SimpleClass
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/classes/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/classes/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {SimpleClass} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   ConsumeSimpleClass(
       item: types.SimpleClass,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   MakeSimpleClass(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -93,7 +95,7 @@ export class HttpStreamRequest {
   
   ConsumeSimpleClass(
       item: types.SimpleClass,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -118,7 +120,7 @@ export class HttpStreamRequest {
   
   MakeSimpleClass(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestCircularReference(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.CircularReference> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.CircularReference
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestDeepRecursion(
         depth: number,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.DeepRecursion> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.DeepRecursion
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestEmptyCollections(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.EmptyCollections> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.EmptyCollections
             } catch (error) {
@@ -237,7 +242,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestLargeStructure(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.LargeStructure> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -275,6 +280,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.LargeStructure
             } catch (error) {
@@ -284,7 +290,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestNumberEdgeCases(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.NumberEdgeCases> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -322,6 +328,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.NumberEdgeCases
             } catch (error) {
@@ -331,7 +338,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestSpecialCharacters(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SpecialCharacters> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -369,6 +376,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SpecialCharacters
             } catch (error) {
@@ -392,7 +400,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestCircularReference(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.CircularReference, types.CircularReference>
               {
               try {
@@ -458,7 +466,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestDeepRecursion(
             depth: number,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.DeepRecursion, types.DeepRecursion>
               {
               try {
@@ -524,7 +532,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestEmptyCollections(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.EmptyCollections, types.EmptyCollections>
               {
               try {
@@ -590,7 +598,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestLargeStructure(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.LargeStructure, types.LargeStructure>
               {
               try {
@@ -656,7 +664,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestNumberEdgeCases(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.NumberEdgeCases, types.NumberEdgeCases>
               {
               try {
@@ -722,7 +730,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestSpecialCharacters(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SpecialCharacters, types.SpecialCharacters>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {AllNullable, BooleanEdgeCases, CircularReference, DeepRecursion, EmptyCollections, InnerNullable, LargeStructure, MixedEdgeCases, NestedNullable, NullEdgeCases, NumberEdgeCases, OptionalEverything, OuterNullable, SomeNullable, SpecialCharacters, User, VeryLongStrings} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestCircularReference(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestDeepRecursion(
   depth: number,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async TestEmptyCollections(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -116,7 +118,7 @@ env?: Record<string, string | undefined>
       
   async TestLargeStructure(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -141,7 +143,7 @@ env?: Record<string, string | undefined>
       
   async TestNumberEdgeCases(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -166,7 +168,7 @@ env?: Record<string, string | undefined>
       
   async TestSpecialCharacters(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -197,7 +199,7 @@ env?: Record<string, string | undefined>
       
       async TestCircularReference(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -222,7 +224,7 @@ env?: Record<string, string | undefined>
           
       async TestDeepRecursion(
       depth: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -247,7 +249,7 @@ env?: Record<string, string | undefined>
           
       async TestEmptyCollections(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -272,7 +274,7 @@ env?: Record<string, string | undefined>
           
       async TestLargeStructure(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -297,7 +299,7 @@ env?: Record<string, string | undefined>
           
       async TestNumberEdgeCases(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -322,7 +324,7 @@ env?: Record<string, string | undefined>
           
       async TestSpecialCharacters(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestCircularReference(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.CircularReference {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.CircularReference
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestDeepRecursion(
       depth: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.DeepRecursion {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.DeepRecursion
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   TestEmptyCollections(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.EmptyCollections {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.EmptyCollections
     } catch (error: any) {
@@ -219,21 +224,21 @@ export class BamlSyncClient {
   
   TestLargeStructure(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.LargeStructure {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -251,6 +256,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.LargeStructure
     } catch (error: any) {
@@ -260,21 +266,21 @@ export class BamlSyncClient {
   
   TestNumberEdgeCases(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.NumberEdgeCases {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -292,6 +298,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.NumberEdgeCases
     } catch (error: any) {
@@ -301,21 +308,21 @@ export class BamlSyncClient {
   
   TestSpecialCharacters(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SpecialCharacters {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -333,6 +340,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SpecialCharacters
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/edge_cases/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {AllNullable, BooleanEdgeCases, CircularReference, DeepRecursion, EmptyCollections, InnerNullable, LargeStructure, MixedEdgeCases, NestedNullable, NullEdgeCases, NumberEdgeCases, OptionalEverything, OuterNullable, SomeNullable, SpecialCharacters, User, VeryLongStrings} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestCircularReference(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestDeepRecursion(
       depth: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   TestEmptyCollections(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -112,7 +114,7 @@ export class HttpRequest {
   
   TestLargeStructure(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -137,7 +139,7 @@ export class HttpRequest {
   
   TestNumberEdgeCases(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -162,7 +164,7 @@ export class HttpRequest {
   
   TestSpecialCharacters(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -193,7 +195,7 @@ export class HttpStreamRequest {
   
   TestCircularReference(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -218,7 +220,7 @@ export class HttpStreamRequest {
   
   TestDeepRecursion(
       depth: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -243,7 +245,7 @@ export class HttpStreamRequest {
   
   TestEmptyCollections(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -268,7 +270,7 @@ export class HttpStreamRequest {
   
   TestLargeStructure(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -293,7 +295,7 @@ export class HttpStreamRequest {
   
   TestNumberEdgeCases(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -318,7 +320,7 @@ export class HttpStreamRequest {
   
   TestSpecialCharacters(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/enums/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/enums/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async ConsumeTestEnum(
         input: types.TestEnum,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.TestEnum> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.TestEnum
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async FnTestAliasedEnumOutput(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.TestEnum> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.TestEnum
             } catch (error) {
@@ -204,7 +208,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             ConsumeTestEnum(
             input: types.TestEnum,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<types.TestEnum, types.TestEnum>
               {
               try {
@@ -270,7 +274,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             FnTestAliasedEnumOutput(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<types.TestEnum, types.TestEnum>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/enums/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/enums/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {TestEnum} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async ConsumeTestEnum(
   input: types.TestEnum,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async FnTestAliasedEnumOutput(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -97,7 +99,7 @@ env?: Record<string, string | undefined>
       
       async ConsumeTestEnum(
       input: types.TestEnum,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -122,7 +124,7 @@ env?: Record<string, string | undefined>
           
       async FnTestAliasedEnumOutput(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/enums/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/enums/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/enums/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/enums/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   ConsumeTestEnum(
       input: types.TestEnum,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.TestEnum {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.TestEnum
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   FnTestAliasedEnumOutput(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.TestEnum {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.TestEnum
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/enums/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/enums/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {TestEnum} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   ConsumeTestEnum(
       input: types.TestEnum,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   FnTestAliasedEnumOutput(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -93,7 +95,7 @@ export class HttpStreamRequest {
   
   ConsumeTestEnum(
       input: types.TestEnum,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -118,7 +120,7 @@ export class HttpStreamRequest {
   
   FnTestAliasedEnumOutput(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestBooleanLiterals(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.BooleanLiterals> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.BooleanLiterals
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestComplexLiterals(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.ComplexLiterals> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.ComplexLiterals
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestIntegerLiterals(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.IntegerLiterals> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.IntegerLiterals
             } catch (error) {
@@ -237,7 +242,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestMixedLiterals(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.MixedLiterals> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -275,6 +280,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.MixedLiterals
             } catch (error) {
@@ -284,7 +290,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestStringLiterals(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.StringLiterals> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -322,6 +328,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.StringLiterals
             } catch (error) {
@@ -345,7 +352,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestBooleanLiterals(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.BooleanLiterals, types.BooleanLiterals>
               {
               try {
@@ -411,7 +418,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestComplexLiterals(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.ComplexLiterals, types.ComplexLiterals>
               {
               try {
@@ -477,7 +484,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestIntegerLiterals(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.IntegerLiterals, types.IntegerLiterals>
               {
               try {
@@ -543,7 +550,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestMixedLiterals(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.MixedLiterals, types.MixedLiterals>
               {
               try {
@@ -609,7 +616,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestStringLiterals(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.StringLiterals, types.StringLiterals>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {BooleanLiterals, ComplexLiterals, IntegerLiterals, MixedLiterals, StringLiterals} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestBooleanLiterals(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestComplexLiterals(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async TestIntegerLiterals(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -116,7 +118,7 @@ env?: Record<string, string | undefined>
       
   async TestMixedLiterals(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -141,7 +143,7 @@ env?: Record<string, string | undefined>
       
   async TestStringLiterals(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -172,7 +174,7 @@ env?: Record<string, string | undefined>
       
       async TestBooleanLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -197,7 +199,7 @@ env?: Record<string, string | undefined>
           
       async TestComplexLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -222,7 +224,7 @@ env?: Record<string, string | undefined>
           
       async TestIntegerLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -247,7 +249,7 @@ env?: Record<string, string | undefined>
           
       async TestMixedLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -272,7 +274,7 @@ env?: Record<string, string | undefined>
           
       async TestStringLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestBooleanLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.BooleanLiterals {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.BooleanLiterals
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestComplexLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.ComplexLiterals {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.ComplexLiterals
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   TestIntegerLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.IntegerLiterals {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.IntegerLiterals
     } catch (error: any) {
@@ -219,21 +224,21 @@ export class BamlSyncClient {
   
   TestMixedLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.MixedLiterals {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -251,6 +256,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.MixedLiterals
     } catch (error: any) {
@@ -260,21 +266,21 @@ export class BamlSyncClient {
   
   TestStringLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.StringLiterals {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -292,6 +298,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.StringLiterals
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/literal_types/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {BooleanLiterals, ComplexLiterals, IntegerLiterals, MixedLiterals, StringLiterals} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestBooleanLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestComplexLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   TestIntegerLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -112,7 +114,7 @@ export class HttpRequest {
   
   TestMixedLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -137,7 +139,7 @@ export class HttpRequest {
   
   TestStringLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -168,7 +170,7 @@ export class HttpStreamRequest {
   
   TestBooleanLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -193,7 +195,7 @@ export class HttpStreamRequest {
   
   TestComplexLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -218,7 +220,7 @@ export class HttpStreamRequest {
   
   TestIntegerLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -243,7 +245,7 @@ export class HttpStreamRequest {
   
   TestMixedLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -268,7 +270,7 @@ export class HttpStreamRequest {
   
   TestStringLiterals(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/map_types/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/map_types/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestComplexMaps(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.ComplexMaps> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.ComplexMaps
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestEdgeCaseMaps(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.EdgeCaseMaps> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.EdgeCaseMaps
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestLargeMaps(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SimpleMaps> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SimpleMaps
             } catch (error) {
@@ -237,7 +242,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestNestedMaps(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.NestedMaps> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -275,6 +280,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.NestedMaps
             } catch (error) {
@@ -284,7 +290,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestSimpleMaps(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SimpleMaps> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -322,6 +328,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SimpleMaps
             } catch (error) {
@@ -331,7 +338,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelBoolMap(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, boolean>> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -369,6 +376,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, boolean>
             } catch (error) {
@@ -378,7 +386,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelEmptyMap(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, string>> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -416,6 +424,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, string>
             } catch (error) {
@@ -425,7 +434,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelFloatMap(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, number>> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -463,6 +472,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, number>
             } catch (error) {
@@ -472,7 +482,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelIntMap(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, number>> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -510,6 +520,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, number>
             } catch (error) {
@@ -519,7 +530,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelMapOfArrays(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, number[]>> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -557,6 +568,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, number[]>
             } catch (error) {
@@ -566,7 +578,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelMapOfObjects(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, types.User>> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -604,6 +616,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, types.User>
             } catch (error) {
@@ -613,7 +626,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelMapWithNullable(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, string | null>> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -651,6 +664,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, string | null>
             } catch (error) {
@@ -660,7 +674,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelNestedMap(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, Record<string, string>>> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -698,6 +712,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, Record<string, string>>
             } catch (error) {
@@ -707,7 +722,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelStringMap(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<Record<string, string>> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -745,6 +760,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as Record<string, string>
             } catch (error) {
@@ -768,7 +784,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestComplexMaps(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.ComplexMaps, types.ComplexMaps>
               {
               try {
@@ -834,7 +850,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestEdgeCaseMaps(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.EdgeCaseMaps, types.EdgeCaseMaps>
               {
               try {
@@ -900,7 +916,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestLargeMaps(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SimpleMaps, types.SimpleMaps>
               {
               try {
@@ -966,7 +982,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestNestedMaps(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.NestedMaps, types.NestedMaps>
               {
               try {
@@ -1032,7 +1048,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestSimpleMaps(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SimpleMaps, types.SimpleMaps>
               {
               try {
@@ -1098,7 +1114,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelBoolMap(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, boolean>, Record<string, boolean>>
               {
               try {
@@ -1164,7 +1180,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelEmptyMap(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, string>, Record<string, string>>
               {
               try {
@@ -1230,7 +1246,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelFloatMap(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, number>, Record<string, number>>
               {
               try {
@@ -1296,7 +1312,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelIntMap(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, number>, Record<string, number>>
               {
               try {
@@ -1362,7 +1378,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelMapOfArrays(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, number[]>, Record<string, number[]>>
               {
               try {
@@ -1428,7 +1444,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelMapOfObjects(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, partial_types.User>, Record<string, types.User>>
               {
               try {
@@ -1494,7 +1510,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelMapWithNullable(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, string | null>, Record<string, string | null>>
               {
               try {
@@ -1560,7 +1576,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelNestedMap(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, Record<string, string>>, Record<string, Record<string, string>>>
               {
               try {
@@ -1626,7 +1642,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelStringMap(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<Record<string, string>, Record<string, string>>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/map_types/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/map_types/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ComplexMaps, Config, EdgeCaseMaps, MixedKeyMaps, NestedMaps, Product, SimpleMaps, Status, User} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestComplexMaps(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestEdgeCaseMaps(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async TestLargeMaps(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -116,7 +118,7 @@ env?: Record<string, string | undefined>
       
   async TestNestedMaps(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -141,7 +143,7 @@ env?: Record<string, string | undefined>
       
   async TestSimpleMaps(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -166,7 +168,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelBoolMap(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -191,7 +193,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelEmptyMap(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -216,7 +218,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelFloatMap(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -241,7 +243,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelIntMap(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -266,7 +268,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelMapOfArrays(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -291,7 +293,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelMapOfObjects(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -316,7 +318,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelMapWithNullable(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -341,7 +343,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelNestedMap(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -366,7 +368,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelStringMap(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -397,7 +399,7 @@ env?: Record<string, string | undefined>
       
       async TestComplexMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -422,7 +424,7 @@ env?: Record<string, string | undefined>
           
       async TestEdgeCaseMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -447,7 +449,7 @@ env?: Record<string, string | undefined>
           
       async TestLargeMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -472,7 +474,7 @@ env?: Record<string, string | undefined>
           
       async TestNestedMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -497,7 +499,7 @@ env?: Record<string, string | undefined>
           
       async TestSimpleMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -522,7 +524,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelBoolMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -547,7 +549,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelEmptyMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -572,7 +574,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelFloatMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -597,7 +599,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelIntMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -622,7 +624,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelMapOfArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -647,7 +649,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelMapOfObjects(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -672,7 +674,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelMapWithNullable(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -697,7 +699,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelNestedMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -722,7 +724,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelStringMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/map_types/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/map_types/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/map_types/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/map_types/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestComplexMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.ComplexMaps {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.ComplexMaps
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestEdgeCaseMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.EdgeCaseMaps {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.EdgeCaseMaps
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   TestLargeMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SimpleMaps {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SimpleMaps
     } catch (error: any) {
@@ -219,21 +224,21 @@ export class BamlSyncClient {
   
   TestNestedMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.NestedMaps {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -251,6 +256,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.NestedMaps
     } catch (error: any) {
@@ -260,21 +266,21 @@ export class BamlSyncClient {
   
   TestSimpleMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SimpleMaps {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -292,6 +298,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SimpleMaps
     } catch (error: any) {
@@ -301,21 +308,21 @@ export class BamlSyncClient {
   
   TestTopLevelBoolMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, boolean> {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -333,6 +340,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, boolean>
     } catch (error: any) {
@@ -342,21 +350,21 @@ export class BamlSyncClient {
   
   TestTopLevelEmptyMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, string> {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -374,6 +382,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, string>
     } catch (error: any) {
@@ -383,21 +392,21 @@ export class BamlSyncClient {
   
   TestTopLevelFloatMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, number> {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -415,6 +424,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, number>
     } catch (error: any) {
@@ -424,21 +434,21 @@ export class BamlSyncClient {
   
   TestTopLevelIntMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, number> {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -456,6 +466,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, number>
     } catch (error: any) {
@@ -465,21 +476,21 @@ export class BamlSyncClient {
   
   TestTopLevelMapOfArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, number[]> {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -497,6 +508,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, number[]>
     } catch (error: any) {
@@ -506,21 +518,21 @@ export class BamlSyncClient {
   
   TestTopLevelMapOfObjects(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, types.User> {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -538,6 +550,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, types.User>
     } catch (error: any) {
@@ -547,21 +560,21 @@ export class BamlSyncClient {
   
   TestTopLevelMapWithNullable(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, string | null> {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -579,6 +592,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, string | null>
     } catch (error: any) {
@@ -588,21 +602,21 @@ export class BamlSyncClient {
   
   TestTopLevelNestedMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, Record<string, string>> {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -620,6 +634,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, Record<string, string>>
     } catch (error: any) {
@@ -629,21 +644,21 @@ export class BamlSyncClient {
   
   TestTopLevelStringMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): Record<string, string> {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -661,6 +676,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as Record<string, string>
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/map_types/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/map_types/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ComplexMaps, Config, EdgeCaseMaps, MixedKeyMaps, NestedMaps, Product, SimpleMaps, Status, User} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestComplexMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestEdgeCaseMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   TestLargeMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -112,7 +114,7 @@ export class HttpRequest {
   
   TestNestedMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -137,7 +139,7 @@ export class HttpRequest {
   
   TestSimpleMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -162,7 +164,7 @@ export class HttpRequest {
   
   TestTopLevelBoolMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -187,7 +189,7 @@ export class HttpRequest {
   
   TestTopLevelEmptyMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -212,7 +214,7 @@ export class HttpRequest {
   
   TestTopLevelFloatMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -237,7 +239,7 @@ export class HttpRequest {
   
   TestTopLevelIntMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -262,7 +264,7 @@ export class HttpRequest {
   
   TestTopLevelMapOfArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -287,7 +289,7 @@ export class HttpRequest {
   
   TestTopLevelMapOfObjects(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -312,7 +314,7 @@ export class HttpRequest {
   
   TestTopLevelMapWithNullable(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -337,7 +339,7 @@ export class HttpRequest {
   
   TestTopLevelNestedMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -362,7 +364,7 @@ export class HttpRequest {
   
   TestTopLevelStringMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -393,7 +395,7 @@ export class HttpStreamRequest {
   
   TestComplexMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -418,7 +420,7 @@ export class HttpStreamRequest {
   
   TestEdgeCaseMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -443,7 +445,7 @@ export class HttpStreamRequest {
   
   TestLargeMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -468,7 +470,7 @@ export class HttpStreamRequest {
   
   TestNestedMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -493,7 +495,7 @@ export class HttpStreamRequest {
   
   TestSimpleMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -518,7 +520,7 @@ export class HttpStreamRequest {
   
   TestTopLevelBoolMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -543,7 +545,7 @@ export class HttpStreamRequest {
   
   TestTopLevelEmptyMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -568,7 +570,7 @@ export class HttpStreamRequest {
   
   TestTopLevelFloatMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -593,7 +595,7 @@ export class HttpStreamRequest {
   
   TestTopLevelIntMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -618,7 +620,7 @@ export class HttpStreamRequest {
   
   TestTopLevelMapOfArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -643,7 +645,7 @@ export class HttpStreamRequest {
   
   TestTopLevelMapOfObjects(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -668,7 +670,7 @@ export class HttpStreamRequest {
   
   TestTopLevelMapWithNullable(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -693,7 +695,7 @@ export class HttpStreamRequest {
   
   TestTopLevelNestedMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -718,7 +720,7 @@ export class HttpStreamRequest {
   
   TestTopLevelStringMap(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/media_types/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/media_types/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestMediaArrayInputs(
         imageArray: Image[],textInput: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.MediaArrayAnalysisResult> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.MediaArrayAnalysisResult
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestMediaInput(
         media: Image | Audio | Pdf | Video,textInput: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.MediaAnalysisResult> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.MediaAnalysisResult
             } catch (error) {
@@ -204,7 +208,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestMediaArrayInputs(
             imageArray: Image[],textInput: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.MediaArrayAnalysisResult, types.MediaArrayAnalysisResult>
               {
               try {
@@ -270,7 +274,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestMediaInput(
             media: Image | Audio | Pdf | Video,textInput: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.MediaAnalysisResult, types.MediaAnalysisResult>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/media_types/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/media_types/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {MediaAnalysisResult, MediaArrayAnalysisResult, MediaMapAnalysisResult, MixedMediaAnalysisResult, OptionalMediaAnalysisResult} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestMediaArrayInputs(
   imageArray: Image[],textInput: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestMediaInput(
   media: Image | Audio | Pdf | Video,textInput: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -97,7 +99,7 @@ env?: Record<string, string | undefined>
       
       async TestMediaArrayInputs(
       imageArray: Image[],textInput: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -122,7 +124,7 @@ env?: Record<string, string | undefined>
           
       async TestMediaInput(
       media: Image | Audio | Pdf | Video,textInput: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/media_types/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/media_types/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/media_types/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/media_types/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestMediaArrayInputs(
       imageArray: Image[],textInput: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.MediaArrayAnalysisResult {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.MediaArrayAnalysisResult
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestMediaInput(
       media: Image | Audio | Pdf | Video,textInput: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.MediaAnalysisResult {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.MediaAnalysisResult
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/media_types/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/media_types/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {MediaAnalysisResult, MediaArrayAnalysisResult, MediaMapAnalysisResult, MixedMediaAnalysisResult, OptionalMediaAnalysisResult} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestMediaArrayInputs(
       imageArray: Image[],textInput: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestMediaInput(
       media: Image | Audio | Pdf | Video,textInput: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -93,7 +95,7 @@ export class HttpStreamRequest {
   
   TestMediaArrayInputs(
       imageArray: Image[],textInput: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -118,7 +120,7 @@ export class HttpStreamRequest {
   
   TestMediaInput(
       media: Image | Audio | Pdf | Video,textInput: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestKitchenSink(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.KitchenSink> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.KitchenSink
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestRecursiveComplexity(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.Node> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.Node
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestUltraComplex(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.UltraComplex> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.UltraComplex
             } catch (error) {
@@ -251,7 +256,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestKitchenSink(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.KitchenSink, types.KitchenSink>
               {
               try {
@@ -317,7 +322,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestRecursiveComplexity(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.Node, types.Node>
               {
               try {
@@ -383,7 +388,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestUltraComplex(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.UltraComplex, types.UltraComplex>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Action, Asset, AssetMetadata, ButtonWidget, ComplexData, Condition, Configuration, ContainerWidget, DataObject, Dimensions, Environment, Error, ErrorDetail, Feature, ImageWidget, Item, KitchenSink, Node, NodeMetadata, PrimaryData, Record, ResponseMetadata, Rule, SecondaryData, Setting, SimpleCondition, Success, TertiaryData, TextWidget, UltraComplex, User, UserProfile, UserResponse, Variant, Widget} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestKitchenSink(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestRecursiveComplexity(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async TestUltraComplex(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -122,7 +124,7 @@ env?: Record<string, string | undefined>
       
       async TestKitchenSink(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -147,7 +149,7 @@ env?: Record<string, string | undefined>
           
       async TestRecursiveComplexity(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -172,7 +174,7 @@ env?: Record<string, string | undefined>
           
       async TestUltraComplex(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestKitchenSink(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.KitchenSink {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.KitchenSink
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestRecursiveComplexity(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.Node {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.Node
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   TestUltraComplex(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.UltraComplex {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.UltraComplex
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/mixed_complex_types/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Action, Asset, AssetMetadata, ButtonWidget, ComplexData, Condition, Configuration, ContainerWidget, DataObject, Dimensions, Environment, Error, ErrorDetail, Feature, ImageWidget, Item, KitchenSink, Node, NodeMetadata, PrimaryData, Record, ResponseMetadata, Rule, SecondaryData, Setting, SimpleCondition, Success, TertiaryData, TextWidget, UltraComplex, User, UserProfile, UserResponse, Variant, Widget} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestKitchenSink(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestRecursiveComplexity(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   TestUltraComplex(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -118,7 +120,7 @@ export class HttpStreamRequest {
   
   TestKitchenSink(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -143,7 +145,7 @@ export class HttpStreamRequest {
   
   TestRecursiveComplexity(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -168,7 +170,7 @@ export class HttpStreamRequest {
   
   TestUltraComplex(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestComplexNested(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.ComplexNested> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.ComplexNested
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestDeeplyNested(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.DeeplyNested> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.DeeplyNested
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestRecursiveStructure(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.RecursiveStructure> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.RecursiveStructure
             } catch (error) {
@@ -237,7 +242,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestSimpleNested(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SimpleNested> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -275,6 +280,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SimpleNested
             } catch (error) {
@@ -298,7 +304,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestComplexNested(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.ComplexNested, types.ComplexNested>
               {
               try {
@@ -364,7 +370,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestDeeplyNested(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.DeeplyNested, types.DeeplyNested>
               {
               try {
@@ -430,7 +436,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestRecursiveStructure(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.RecursiveStructure, types.RecursiveStructure>
               {
               try {
@@ -496,7 +502,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestSimpleNested(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SimpleNested, types.SimpleNested>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Address, Approval, Budget, Company, CompanyMetadata, ComplexNested, Contact, Coordinates, DeeplyNested, Department, DisplaySettings, Employee, Level1, Level2, Level3, Level4, Level5, Metadata, Milestone, NotificationSettings, Preferences, PrivacySettings, Profile, Project, RecursiveStructure, SimpleNested, SocialLinks, Task, User, UserSettings} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestComplexNested(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestDeeplyNested(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async TestRecursiveStructure(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -116,7 +118,7 @@ env?: Record<string, string | undefined>
       
   async TestSimpleNested(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -147,7 +149,7 @@ env?: Record<string, string | undefined>
       
       async TestComplexNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -172,7 +174,7 @@ env?: Record<string, string | undefined>
           
       async TestDeeplyNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -197,7 +199,7 @@ env?: Record<string, string | undefined>
           
       async TestRecursiveStructure(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -222,7 +224,7 @@ env?: Record<string, string | undefined>
           
       async TestSimpleNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestComplexNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.ComplexNested {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.ComplexNested
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestDeeplyNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.DeeplyNested {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.DeeplyNested
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   TestRecursiveStructure(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.RecursiveStructure {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.RecursiveStructure
     } catch (error: any) {
@@ -219,21 +224,21 @@ export class BamlSyncClient {
   
   TestSimpleNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SimpleNested {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -251,6 +256,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SimpleNested
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/nested_structures/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Address, Approval, Budget, Company, CompanyMetadata, ComplexNested, Contact, Coordinates, DeeplyNested, Department, DisplaySettings, Employee, Level1, Level2, Level3, Level4, Level5, Metadata, Milestone, NotificationSettings, Preferences, PrivacySettings, Profile, Project, RecursiveStructure, SimpleNested, SocialLinks, Task, User, UserSettings} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestComplexNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestDeeplyNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   TestRecursiveStructure(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -112,7 +114,7 @@ export class HttpRequest {
   
   TestSimpleNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -143,7 +145,7 @@ export class HttpStreamRequest {
   
   TestComplexNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -168,7 +170,7 @@ export class HttpStreamRequest {
   
   TestDeeplyNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -193,7 +195,7 @@ export class HttpStreamRequest {
   
   TestRecursiveStructure(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -218,7 +220,7 @@ export class HttpStreamRequest {
   
   TestSimpleNested(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestAllNull(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.NullableTypes> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.NullableTypes
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestAllOptionalOmitted(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.OptionalFields> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.OptionalFields
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestMixedOptionalNullable(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.MixedOptionalNullable> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.MixedOptionalNullable
             } catch (error) {
@@ -237,7 +242,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestNullableTypes(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.NullableTypes> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -275,6 +280,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.NullableTypes
             } catch (error) {
@@ -284,7 +290,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestOptionalFields(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.OptionalFields> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -322,6 +328,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.OptionalFields
             } catch (error) {
@@ -345,7 +352,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestAllNull(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.NullableTypes, types.NullableTypes>
               {
               try {
@@ -411,7 +418,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestAllOptionalOmitted(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.OptionalFields, types.OptionalFields>
               {
               try {
@@ -477,7 +484,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestMixedOptionalNullable(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.MixedOptionalNullable, types.MixedOptionalNullable>
               {
               try {
@@ -543,7 +550,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestNullableTypes(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.NullableTypes, types.NullableTypes>
               {
               try {
@@ -609,7 +616,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestOptionalFields(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.OptionalFields, types.OptionalFields>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ComplexOptional, MixedOptionalNullable, NullableTypes, OptionalData, OptionalFields, OptionalItem, OptionalValue, Product, UnionWithNull, User} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestAllNull(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestAllOptionalOmitted(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async TestMixedOptionalNullable(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -116,7 +118,7 @@ env?: Record<string, string | undefined>
       
   async TestNullableTypes(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -141,7 +143,7 @@ env?: Record<string, string | undefined>
       
   async TestOptionalFields(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -172,7 +174,7 @@ env?: Record<string, string | undefined>
       
       async TestAllNull(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -197,7 +199,7 @@ env?: Record<string, string | undefined>
           
       async TestAllOptionalOmitted(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -222,7 +224,7 @@ env?: Record<string, string | undefined>
           
       async TestMixedOptionalNullable(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -247,7 +249,7 @@ env?: Record<string, string | undefined>
           
       async TestNullableTypes(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -272,7 +274,7 @@ env?: Record<string, string | undefined>
           
       async TestOptionalFields(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestAllNull(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.NullableTypes {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.NullableTypes
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestAllOptionalOmitted(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.OptionalFields {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.OptionalFields
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   TestMixedOptionalNullable(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.MixedOptionalNullable {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.MixedOptionalNullable
     } catch (error: any) {
@@ -219,21 +224,21 @@ export class BamlSyncClient {
   
   TestNullableTypes(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.NullableTypes {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -251,6 +256,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.NullableTypes
     } catch (error: any) {
@@ -260,21 +266,21 @@ export class BamlSyncClient {
   
   TestOptionalFields(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.OptionalFields {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -292,6 +298,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.OptionalFields
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/optional_nullable/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ComplexOptional, MixedOptionalNullable, NullableTypes, OptionalData, OptionalFields, OptionalItem, OptionalValue, Product, UnionWithNull, User} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestAllNull(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestAllOptionalOmitted(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   TestMixedOptionalNullable(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -112,7 +114,7 @@ export class HttpRequest {
   
   TestNullableTypes(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -137,7 +139,7 @@ export class HttpRequest {
   
   TestOptionalFields(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -168,7 +170,7 @@ export class HttpStreamRequest {
   
   TestAllNull(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -193,7 +195,7 @@ export class HttpStreamRequest {
   
   TestAllOptionalOmitted(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -218,7 +220,7 @@ export class HttpStreamRequest {
   
   TestMixedOptionalNullable(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -243,7 +245,7 @@ export class HttpStreamRequest {
   
   TestNullableTypes(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -268,7 +270,7 @@ export class HttpStreamRequest {
   
   TestOptionalFields(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestEmptyCollections(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.PrimitiveArrays> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.PrimitiveArrays
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestMixedPrimitives(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.MixedPrimitives> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.MixedPrimitives
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestPrimitiveArrays(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.PrimitiveArrays> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.PrimitiveArrays
             } catch (error) {
@@ -237,7 +242,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestPrimitiveMaps(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.PrimitiveMaps> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -275,6 +280,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.PrimitiveMaps
             } catch (error) {
@@ -284,7 +290,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestPrimitiveTypes(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.PrimitiveTypes> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -322,6 +328,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.PrimitiveTypes
             } catch (error) {
@@ -331,7 +338,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelBool(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<boolean> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -369,6 +376,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as boolean
             } catch (error) {
@@ -378,7 +386,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelFloat(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<number> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -416,6 +424,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as number
             } catch (error) {
@@ -425,7 +434,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelInt(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<number> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -463,6 +472,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as number
             } catch (error) {
@@ -472,7 +482,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelNull(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<undefined> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -510,6 +520,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as undefined
             } catch (error) {
@@ -519,7 +530,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestTopLevelString(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<string> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -557,6 +568,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as string
             } catch (error) {
@@ -580,7 +592,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestEmptyCollections(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.PrimitiveArrays, types.PrimitiveArrays>
               {
               try {
@@ -646,7 +658,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestMixedPrimitives(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.MixedPrimitives, types.MixedPrimitives>
               {
               try {
@@ -712,7 +724,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestPrimitiveArrays(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.PrimitiveArrays, types.PrimitiveArrays>
               {
               try {
@@ -778,7 +790,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestPrimitiveMaps(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.PrimitiveMaps, types.PrimitiveMaps>
               {
               try {
@@ -844,7 +856,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestPrimitiveTypes(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.PrimitiveTypes, types.PrimitiveTypes>
               {
               try {
@@ -910,7 +922,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelBool(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<boolean, boolean>
               {
               try {
@@ -976,7 +988,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelFloat(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<number, number>
               {
               try {
@@ -1042,7 +1054,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelInt(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<number, number>
               {
               try {
@@ -1108,7 +1120,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelNull(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<undefined, undefined>
               {
               try {
@@ -1174,7 +1186,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestTopLevelString(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<string, string>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {MixedPrimitives, PrimitiveArrays, PrimitiveMaps, PrimitiveTypes} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestEmptyCollections(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestMixedPrimitives(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async TestPrimitiveArrays(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -116,7 +118,7 @@ env?: Record<string, string | undefined>
       
   async TestPrimitiveMaps(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -141,7 +143,7 @@ env?: Record<string, string | undefined>
       
   async TestPrimitiveTypes(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -166,7 +168,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelBool(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -191,7 +193,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelFloat(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -216,7 +218,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelInt(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -241,7 +243,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelNull(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -266,7 +268,7 @@ env?: Record<string, string | undefined>
       
   async TestTopLevelString(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -297,7 +299,7 @@ env?: Record<string, string | undefined>
       
       async TestEmptyCollections(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -322,7 +324,7 @@ env?: Record<string, string | undefined>
           
       async TestMixedPrimitives(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -347,7 +349,7 @@ env?: Record<string, string | undefined>
           
       async TestPrimitiveArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -372,7 +374,7 @@ env?: Record<string, string | undefined>
           
       async TestPrimitiveMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -397,7 +399,7 @@ env?: Record<string, string | undefined>
           
       async TestPrimitiveTypes(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -422,7 +424,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelBool(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -447,7 +449,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelFloat(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -472,7 +474,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelInt(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -497,7 +499,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelNull(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -522,7 +524,7 @@ env?: Record<string, string | undefined>
           
       async TestTopLevelString(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestEmptyCollections(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.PrimitiveArrays {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.PrimitiveArrays
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestMixedPrimitives(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.MixedPrimitives {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.MixedPrimitives
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   TestPrimitiveArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.PrimitiveArrays {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.PrimitiveArrays
     } catch (error: any) {
@@ -219,21 +224,21 @@ export class BamlSyncClient {
   
   TestPrimitiveMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.PrimitiveMaps {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -251,6 +256,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.PrimitiveMaps
     } catch (error: any) {
@@ -260,21 +266,21 @@ export class BamlSyncClient {
   
   TestPrimitiveTypes(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.PrimitiveTypes {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -292,6 +298,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.PrimitiveTypes
     } catch (error: any) {
@@ -301,21 +308,21 @@ export class BamlSyncClient {
   
   TestTopLevelBool(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): boolean {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -333,6 +340,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as boolean
     } catch (error: any) {
@@ -342,21 +350,21 @@ export class BamlSyncClient {
   
   TestTopLevelFloat(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): number {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -374,6 +382,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as number
     } catch (error: any) {
@@ -383,21 +392,21 @@ export class BamlSyncClient {
   
   TestTopLevelInt(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): number {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -415,6 +424,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as number
     } catch (error: any) {
@@ -424,21 +434,21 @@ export class BamlSyncClient {
   
   TestTopLevelNull(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): undefined {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -456,6 +466,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as undefined
     } catch (error: any) {
@@ -465,21 +476,21 @@ export class BamlSyncClient {
   
   TestTopLevelString(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): string {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -497,6 +508,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as string
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/primitive_types/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {MixedPrimitives, PrimitiveArrays, PrimitiveMaps, PrimitiveTypes} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestEmptyCollections(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestMixedPrimitives(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   TestPrimitiveArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -112,7 +114,7 @@ export class HttpRequest {
   
   TestPrimitiveMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -137,7 +139,7 @@ export class HttpRequest {
   
   TestPrimitiveTypes(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -162,7 +164,7 @@ export class HttpRequest {
   
   TestTopLevelBool(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -187,7 +189,7 @@ export class HttpRequest {
   
   TestTopLevelFloat(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -212,7 +214,7 @@ export class HttpRequest {
   
   TestTopLevelInt(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -237,7 +239,7 @@ export class HttpRequest {
   
   TestTopLevelNull(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -262,7 +264,7 @@ export class HttpRequest {
   
   TestTopLevelString(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -293,7 +295,7 @@ export class HttpStreamRequest {
   
   TestEmptyCollections(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -318,7 +320,7 @@ export class HttpStreamRequest {
   
   TestMixedPrimitives(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -343,7 +345,7 @@ export class HttpStreamRequest {
   
   TestPrimitiveArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -368,7 +370,7 @@ export class HttpStreamRequest {
   
   TestPrimitiveMaps(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -393,7 +395,7 @@ export class HttpStreamRequest {
   
   TestPrimitiveTypes(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -418,7 +420,7 @@ export class HttpStreamRequest {
   
   TestTopLevelBool(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -443,7 +445,7 @@ export class HttpStreamRequest {
   
   TestTopLevelFloat(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -468,7 +470,7 @@ export class HttpStreamRequest {
   
   TestTopLevelInt(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -493,7 +495,7 @@ export class HttpStreamRequest {
   
   TestTopLevelNull(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -518,7 +520,7 @@ export class HttpStreamRequest {
   
   TestTopLevelString(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async Foo(
         x: number,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.JSON> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.JSON
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async JsonInput(
         x: types.JSON,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.JSON> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.JSON
             } catch (error) {
@@ -204,7 +208,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             Foo(
             x: number,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.JSON, types.JSON>
               {
               try {
@@ -270,7 +274,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             JsonInput(
             x: types.JSON,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.JSON, types.JSON>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {JSON, Recursive1, UseMyUnion} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async Foo(
   x: number,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async JsonInput(
   x: types.JSON,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -97,7 +99,7 @@ env?: Record<string, string | undefined>
       
       async Foo(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -122,7 +124,7 @@ env?: Record<string, string | undefined>
           
       async JsonInput(
       x: types.JSON,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   Foo(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.JSON {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.JSON
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   JsonInput(
       x: types.JSON,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.JSON {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.JSON
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/recursive_types/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {JSON, Recursive1, UseMyUnion} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   Foo(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   JsonInput(
       x: types.JSON,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -93,7 +95,7 @@ export class HttpStreamRequest {
   
   Foo(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -118,7 +120,7 @@ export class HttpStreamRequest {
   
   JsonInput(
       x: types.JSON,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/sample/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/sample/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async Bar(
         x: number,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.Example | types.Example2> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.Example | types.Example2
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async Foo(
         x: number,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.Example2 | types.Example> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.Example2 | types.Example
             } catch (error) {
@@ -204,7 +208,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             Bar(
             x: number,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.Example | partial_types.Example2, types.Example | types.Example2>
               {
               try {
@@ -270,7 +274,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             Foo(
             x: number,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.Example2 | partial_types.Example, types.Example2 | types.Example>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/sample/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/sample/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Example, Example2} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async Bar(
   x: number,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async Foo(
   x: number,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -97,7 +99,7 @@ env?: Record<string, string | undefined>
       
       async Bar(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -122,7 +124,7 @@ env?: Record<string, string | undefined>
           
       async Foo(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/sample/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/sample/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/sample/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/sample/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   Bar(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.Example | types.Example2 {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.Example | types.Example2
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   Foo(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.Example2 | types.Example {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.Example2 | types.Example
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/sample/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/sample/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Example, Example2} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   Bar(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   Foo(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -93,7 +95,7 @@ export class HttpStreamRequest {
   
   Bar(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -118,7 +120,7 @@ export class HttpStreamRequest {
   
   Foo(
       x: number,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async MakeClassWithBlockDone(
         
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.ClassWithBlockDone> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.ClassWithBlockDone
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async MakeClassWithExternalDone(
         
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.ClassWithoutDone> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.ClassWithoutDone
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async MakeSemanticContainer(
         
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.SemanticContainer> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.SemanticContainer
             } catch (error) {
@@ -251,7 +256,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             MakeClassWithBlockDone(
             
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<types.ClassWithBlockDone, types.ClassWithBlockDone>
               {
               try {
@@ -317,7 +322,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             MakeClassWithExternalDone(
             
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<types.ClassWithoutDone, types.ClassWithoutDone>
               {
               try {
@@ -383,7 +388,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             MakeSemanticContainer(
             
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.SemanticContainer, types.SemanticContainer>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ClassWithBlockDone, ClassWithoutDone, SemanticContainer, SmallThing} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async MakeClassWithBlockDone(
   
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async MakeClassWithExternalDone(
   
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async MakeSemanticContainer(
   
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -122,7 +124,7 @@ env?: Record<string, string | undefined>
       
       async MakeClassWithBlockDone(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -147,7 +149,7 @@ env?: Record<string, string | undefined>
           
       async MakeClassWithExternalDone(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -172,7 +174,7 @@ env?: Record<string, string | undefined>
           
       async MakeSemanticContainer(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   MakeClassWithBlockDone(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.ClassWithBlockDone {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.ClassWithBlockDone
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   MakeClassWithExternalDone(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.ClassWithoutDone {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.ClassWithoutDone
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   MakeSemanticContainer(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.SemanticContainer {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.SemanticContainer
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/semantic_streaming/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ClassWithBlockDone, ClassWithoutDone, SemanticContainer, SmallThing} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   MakeClassWithBlockDone(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   MakeClassWithExternalDone(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   MakeSemanticContainer(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -118,7 +120,7 @@ export class HttpStreamRequest {
   
   MakeClassWithBlockDone(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -143,7 +145,7 @@ export class HttpStreamRequest {
   
   MakeClassWithExternalDone(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -168,7 +170,7 @@ export class HttpStreamRequest {
   
   MakeSemanticContainer(
       
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async TestComplexUnions(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.ComplexUnions> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.ComplexUnions
             } catch (error) {
@@ -143,7 +146,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestDiscriminatedUnions(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.DiscriminatedUnions> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -181,6 +184,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.DiscriminatedUnions
             } catch (error) {
@@ -190,7 +194,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestPrimitiveUnions(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.PrimitiveUnions> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -228,6 +232,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.PrimitiveUnions
             } catch (error) {
@@ -237,7 +242,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
         async TestUnionArrays(
         input: string,
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<types.UnionArrays> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -275,6 +280,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as types.UnionArrays
             } catch (error) {
@@ -298,7 +304,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             TestComplexUnions(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.ComplexUnions, types.ComplexUnions>
               {
               try {
@@ -364,7 +370,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestDiscriminatedUnions(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.DiscriminatedUnions, types.DiscriminatedUnions>
               {
               try {
@@ -430,7 +436,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestPrimitiveUnions(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.PrimitiveUnions, types.PrimitiveUnions>
               {
               try {
@@ -496,7 +502,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
                   
             TestUnionArrays(
             input: string,
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<partial_types.UnionArrays, types.UnionArrays>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Admin, ApiError, ApiPending, ApiSuccess, Bird, Cat, Circle, ComplexUnions, DataResponse, DiscriminatedUnions, Dog, Error, ErrorResponse, PrimitiveUnions, Product, Rectangle, RecursiveUnion, Result, Success, Triangle, UnionArrays, User, Warning} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async TestComplexUnions(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -66,7 +68,7 @@ env?: Record<string, string | undefined>
       
   async TestDiscriminatedUnions(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -91,7 +93,7 @@ env?: Record<string, string | undefined>
       
   async TestPrimitiveUnions(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -116,7 +118,7 @@ env?: Record<string, string | undefined>
       
   async TestUnionArrays(
   input: string,
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -147,7 +149,7 @@ env?: Record<string, string | undefined>
       
       async TestComplexUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -172,7 +174,7 @@ env?: Record<string, string | undefined>
           
       async TestDiscriminatedUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -197,7 +199,7 @@ env?: Record<string, string | undefined>
           
       async TestPrimitiveUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -222,7 +224,7 @@ env?: Record<string, string | undefined>
           
       async TestUnionArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   TestComplexUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.ComplexUnions {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.ComplexUnions
     } catch (error: any) {
@@ -137,21 +140,21 @@ export class BamlSyncClient {
   
   TestDiscriminatedUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.DiscriminatedUnions {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -169,6 +172,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.DiscriminatedUnions
     } catch (error: any) {
@@ -178,21 +182,21 @@ export class BamlSyncClient {
   
   TestPrimitiveUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.PrimitiveUnions {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -210,6 +214,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.PrimitiveUnions
     } catch (error: any) {
@@ -219,21 +224,21 @@ export class BamlSyncClient {
   
   TestUnionArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): types.UnionArrays {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -251,6 +256,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as types.UnionArrays
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/union_types_extended/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {Admin, ApiError, ApiPending, ApiSuccess, Bird, Cat, Circle, ComplexUnions, DataResponse, DiscriminatedUnions, Dog, Error, ErrorResponse, PrimitiveUnions, Product, Rectangle, RecursiveUnion, Result, Success, Triangle, UnionArrays, User, Warning} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   TestComplexUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -62,7 +64,7 @@ export class HttpRequest {
   
   TestDiscriminatedUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -87,7 +89,7 @@ export class HttpRequest {
   
   TestPrimitiveUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -112,7 +114,7 @@ export class HttpRequest {
   
   TestUnionArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -143,7 +145,7 @@ export class HttpStreamRequest {
   
   TestComplexUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -168,7 +170,7 @@ export class HttpStreamRequest {
   
   TestDiscriminatedUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -193,7 +195,7 @@ export class HttpStreamRequest {
   
   TestPrimitiveUnions(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -218,7 +220,7 @@ export class HttpStreamRequest {
   
   TestUnionArrays(
       input: string,
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/unions/baml_client/async_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/unions/baml_client/async_client.ts
@@ -30,6 +30,7 @@ import { AsyncHttpRequest, AsyncHttpStreamRequest } from "./async_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX,
 DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
 * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -38,7 +39,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
 
     type TickReason = "Unknown";
 
-    type BamlCallOptions = {
+    type BamlCallOptions<WatchersT = never> = {
     tb?: TypeBuilder
     clientRegistry?: ClientRegistry
     collector?: Collector | Collector[]
@@ -46,6 +47,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
       tags?: Record<string, string>
         signal?: AbortSignal
         onTick?: (reason: TickReason, log: FunctionLog | null) => void
+        watchers?: WatchersT
         }
 
         export class BamlAsyncClient {
@@ -96,7 +98,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
         
         async JsonInput(
         x: types.ExistingSystemComponent[],
-        __baml_options__?: BamlCallOptions
+        __baml_options__?: BamlCallOptions<never>
         ): Promise<string[]> {
           try {
           const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
@@ -134,6 +136,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             options.tags || {},
             env,
             signal,
+            options.watchers,
             )
             return raw.parsed(false) as string[]
             } catch (error) {
@@ -157,7 +160,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>
             
             JsonInput(
             x: types.ExistingSystemComponent[],
-            __baml_options__?: BamlCallOptions
+            __baml_options__?: BamlCallOptions<never>
             ): BamlStream<string[], string[]>
               {
               try {

--- a/engine/generators/languages/typescript/generated_tests/unions/baml_client/async_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/unions/baml_client/async_request.ts
@@ -25,14 +25,16 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ExistingSystemComponent, Recursive1, UseMyUnion} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
 tb?: TypeBuilder
 clientRegistry?: ClientRegistry
 env?: Record<string, string | undefined>
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  events?: EventsT
   }
 
   export class AsyncHttpRequest {
@@ -41,7 +43,7 @@ env?: Record<string, string | undefined>
   
   async JsonInput(
   x: types.ExistingSystemComponent[],
-  __baml_options__?: BamlCallOptions
+  __baml_options__?: BamlCallOptions<never>
   ): Promise<HTTPRequest> {
     try {
     const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -72,7 +74,7 @@ env?: Record<string, string | undefined>
       
       async JsonInput(
       x: types.ExistingSystemComponent[],
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
       ): Promise<HTTPRequest> {
         try {
         const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };

--- a/engine/generators/languages/typescript/generated_tests/unions/baml_client/index.ts
+++ b/engine/generators/languages/typescript/generated_tests/unions/baml_client/index.ts
@@ -20,22 +20,22 @@ $ pnpm add @boundaryml/baml
 
 /**
  * If this import fails, you may need to upgrade @boundaryml/baml.
- * 
- * Please upgrade @boundaryml/baml to 0.209.0.
- * 
- * $ npm install @boundaryml/baml@0.209.0
- * $ yarn add @boundaryml/baml@0.209.0
- * $ pnpm add @boundaryml/baml@0.209.0
- * 
+ *
+ * Please upgrade @boundaryml/baml to 0.212.0.
+ *
+ * $ npm install @boundaryml/baml@0.212.0
+ * $ yarn add @boundaryml/baml@0.212.0
+ * $ pnpm add @boundaryml/baml@0.212.0
+ *
  * If nothing else works, please ask for help:
- * 
+ *
  * https://github.com/boundaryml/baml/issues
  * https://boundaryml.com/discord
- * 
+ *
  **/
 import { ThrowIfVersionMismatch } from "@boundaryml/baml";
 
-export const version = "0.209.0";
+export const version = "0.212.0";
 
 ThrowIfVersionMismatch(version);
 
@@ -46,6 +46,6 @@ export { b } from "./async_client"
 export * from "./types"
 export type { partial_types } from "./partial_types"
 export * from "./tracing"
-export * as events from "./events"
+export * as watchers from "./watchers"
 export { resetBamlEnvVars } from "./globals"
 export { BamlClientHttpError, BamlValidationError, BamlClientFinishReasonError } from "@boundaryml/baml"

--- a/engine/generators/languages/typescript/generated_tests/unions/baml_client/sync_client.ts
+++ b/engine/generators/languages/typescript/generated_tests/unions/baml_client/sync_client.ts
@@ -27,6 +27,7 @@ import type TypeBuilder from "./type_builder"
 import { HttpRequest, HttpStreamRequest } from "./sync_request"
 import { LlmResponseParser, LlmStreamParser } from "./parser"
 import { DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_CTX, DO_NOT_USE_DIRECTLY_UNLESS_YOU_KNOW_WHAT_YOURE_DOING_RUNTIME } from "./globals"
+import type * as events from "./events"
 
 /**
  * @deprecated Use RecursivePartialNull from 'baml_client/types' instead.
@@ -39,7 +40,7 @@ export type RecursivePartialNull<T> = MovedRecursivePartialNull<T>;
 
 type TickReason = "Unknown";
 
-type BamlCallOptions = {
+type BamlCallOptions<WatchersT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   collector?: Collector | Collector[]
@@ -47,6 +48,7 @@ type BamlCallOptions = {
   tags?: Record<string, string>
   signal?: AbortSignal
   onTick?: (reason: TickReason, log: FunctionLog | null) => void
+  watchers?: WatchersT
 }
 
 export class BamlSyncClient {
@@ -96,21 +98,21 @@ export class BamlSyncClient {
   
   JsonInput(
       x: types.ExistingSystemComponent[],
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): string[] {
     try {
       const options = { ...this.bamlOptions, ...(__baml_options__ || {}) }
       const signal = options.signal;
-      
+
       if (signal?.aborted) {
         throw new BamlAbortError('Operation was aborted', signal.reason);
       }
-      
+
       // Check if onTick is provided and reject for sync operations
       if (options.onTick) {
         throw new Error("onTick is not supported for synchronous functions. Please use the async client instead.");
       }
-      
+
       const collector = options.collector ? (Array.isArray(options.collector) ? options.collector : [options.collector]) : [];
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
       const env: Record<string, string> = Object.fromEntries(
@@ -128,6 +130,7 @@ export class BamlSyncClient {
         options.tags || {},
         env,
         signal,
+        options.watchers,
       )
       return raw.parsed(false) as string[]
     } catch (error: any) {

--- a/engine/generators/languages/typescript/generated_tests/unions/baml_client/sync_request.ts
+++ b/engine/generators/languages/typescript/generated_tests/unions/baml_client/sync_request.ts
@@ -24,11 +24,13 @@ import type { Checked, Check } from "./types"
 import type * as types from "./types"
 import type {ExistingSystemComponent, Recursive1, UseMyUnion} from "./types"
 import type TypeBuilder from "./type_builder"
+import type * as events from "./events"
 
-type BamlCallOptions = {
+type BamlCallOptions<EventsT = never> = {
   tb?: TypeBuilder
   clientRegistry?: ClientRegistry
   env?: Record<string, string | undefined>
+  events?: EventsT
 }
 
 export class HttpRequest {
@@ -37,7 +39,7 @@ export class HttpRequest {
   
   JsonInput(
       x: types.ExistingSystemComponent[],
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };
@@ -68,7 +70,7 @@ export class HttpStreamRequest {
   
   JsonInput(
       x: types.ExistingSystemComponent[],
-      __baml_options__?: BamlCallOptions
+      __baml_options__?: BamlCallOptions<never>
   ): HTTPRequest {
     try {
       const rawEnv = __baml_options__?.env ? { ...process.env, ...__baml_options__.env } : { ...process.env };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable Windows CLI build in CI and update generated Python/TypeScript clients to v0.212.0 with new `watchers` support and minor config tweaks.
> 
> - **CI/CD (CLI Build)**:
>   - Add Windows branch trigger and Windows-specific setup in `.github/workflows/build-cli-release.reusable.yaml` (install `protoc` and `protoc-gen-go`, skip `mise` on Windows).
>   - Split CFFI build into Unix vs Windows steps; adjust artifact naming and PATH handling.
>   - Improve Rust unit test workflow in `primary.yml` (list built libs, set `BAML_LIBRARY_PATH`, run tests verbosely).
> - **Generated Python Client**:
>   - Bump generator version to `0.212.0` and export `watchers`.
>   - Extend `BamlCallOptions` with `watchers` and plumb through runtime calls.
>   - Add `set_log_max_message_length` alias in `config`.
> - **Generated TypeScript Client**:
>   - Bump package version to `0.212.0` and switch exported namespace from `events` to `watchers`.
>   - Make `BamlCallOptions` generic with optional `watchers`; thread through async/sync clients and request builders.
>   - Update method calls to pass `options.watchers` across generated services.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a571ddd344df3bb9249304ef861f3737a8d10e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->