### PR TITLE
Don't optimize WASM binaries on CI during `"typecheck"`

### DIFF
--- a/engine/baml-schema-wasm/web/package.json
+++ b/engine/baml-schema-wasm/web/package.json
@@ -7,6 +7,7 @@
     "clean": "git clean -xdf ./dist .turbo node_modules",
     "comment": "don't use 'wasm pack --dev' below or it will be too big of a bundle and playground will be slow to load.",
     "build": "pnpm run release",
+    "typecheck": "pnpm run pack --dev",
     "release": "pnpm run pack --release",
     "pack": "wasm-pack build ../ --target bundler --out-dir ./web/dist"
   },

--- a/engine/package.json
+++ b/engine/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "cargo clean && git clean -xdf .turbo node_modules target",
 		"build": "cargo build --workspace",
-    "check": "cargo check --workspace",
+    "typecheck": "cargo check --workspace",
 		"release": "cargo build --release --workspace",
 		"dev": "cargo build --workspace",
 		"format": "cargo fmt --workspace -- --config imports_granularity=Crate --config group_imports=StdExternalCrate",

--- a/engine/package.json
+++ b/engine/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "cargo clean && git clean -xdf .turbo node_modules target",
 		"build": "cargo build --workspace",
-    "typecheck": "cargo check --workspace",
+    "check": "cargo check --workspace",
 		"release": "cargo build --release --workspace",
 		"dev": "cargo build --workspace",
 		"format": "cargo fmt --workspace -- --config imports_granularity=Crate --config group_imports=StdExternalCrate",

--- a/turbo.json
+++ b/turbo.json
@@ -69,7 +69,7 @@
       "env": ["SKIP_BAML_SRC_CHECK"]
     },
     "@baml/playground-common#typecheck": {
-      "dependsOn": ["@gloo-ai/baml-schema-wasm-web#build"]
+      "dependsOn": ["@gloo-ai/baml-schema-wasm-web#typecheck"]
     },
     "@baml/playground-common#dev": {
       "dependsOn": ["@gloo-ai/baml-schema-wasm-web#build"],


### PR DESCRIPTION
The `typecheck` step for playground-common depended on wasm-web build:

```json
"@baml/playground-common#typecheck": {
  "dependsOn": ["@gloo-ai/baml-schema-wasm-web#build"]
}
```

The build scripts called another script that ended up running `wasm-pack --release`, which has a very time-consuming optimization stage:

```
[INFO]: ⬇️ Installing wasm-bindgen...
[INFO]: Optimizing wasm binaries with `wasm-opt`...
[INFO]: ✨ Done in 4m 37s
[INFO]: 📦 Your wasm pkg is ready to publish at ../web/dist.
```

This is not necessary for _typechecking_, we can run `--dev` instead of `--release`.