### PR TITLE
default request timeout is too low

### DIFF
--- a/engine/baml-lib/llm-client/src/clients/helpers.rs
+++ b/engine/baml-lib/llm-client/src/clients/helpers.rs
@@ -749,7 +749,7 @@ impl<Meta: Clone> PropertyHandler<Meta> {
                     let mut http_config = HttpConfig::default();
                     if provider_type != "fallback" && provider_type != "round-robin" {
                         http_config.connect_timeout_ms = Some(10_000);
-                        http_config.request_timeout_ms = Some(30_000);
+                        http_config.request_timeout_ms = Some(60_000 * 5); // 5 minutes
                     }
                     http_config
                 }
@@ -759,7 +759,7 @@ impl<Meta: Clone> PropertyHandler<Meta> {
             let mut http_config = HttpConfig::default();
             if provider_type != "fallback" && provider_type != "round-robin" {
                 http_config.connect_timeout_ms = Some(10_000);
-                http_config.request_timeout_ms = Some(30_000);
+                http_config.request_timeout_ms = Some(60_000 * 5); // 5 minutes
             }
             http_config
         }

--- a/engine/baml-lib/llm-client/src/clients/helpers.rs
+++ b/engine/baml-lib/llm-client/src/clients/helpers.rs
@@ -732,7 +732,7 @@ impl<Meta: Clone> PropertyHandler<Meta> {
                             http_config.connect_timeout_ms = Some(10_000); // 10s default
                         }
                         if http_config.request_timeout_ms.is_none() {
-                            http_config.request_timeout_ms = Some(30_000); // 30s default
+                            http_config.request_timeout_ms = Some(60_000 * 5); // 5 minutes default
                         }
                         // Streaming timeouts have no defaults - they're opt-in
                     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Raise default `request_timeout_ms` from 30s to 5m for regular (non-composite) clients; composite clients unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e60ae788421451f958cf9c5b76dd88bc672085b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->