### PR TITLE
feat(cli): hide internal subcommands by default

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -21,4 +21,7 @@ else
     export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
 fi
 
+# we hide subcommands like baml-cli login, baml-cli dump-hir from our users by default
+export BAML_INTERNAL=1
+
 git config --local include.path ../.gitconfig

--- a/engine/cli/src/commands.rs
+++ b/engine/cli/src/commands.rs
@@ -286,39 +286,3 @@ fn baml_internal_env_is_truthy() -> bool {
         .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true"))
         .unwrap_or(false)
 }
-
-// const INTERNAL_ONLY_SUBCOMMANDS: &[&str] = &["dump-hir", "dump-bytecode", "repl"];
-
-// fn unhide_all_subcommands(command: &mut clap::Command) {
-//     for subcommand in command.get_subcommands_mut() {
-//         let mut visible_subcommand = std::mem::take(subcommand).hide(false);
-//         prepend_internal_only_tag_if_needed(&mut visible_subcommand);
-//         unhide_all_subcommands(&mut visible_subcommand);
-//         *subcommand = visible_subcommand;
-//     }
-// }
-
-// fn prepend_internal_only_tag_if_needed(command: &mut clap::Command) {
-//     if !INTERNAL_ONLY_SUBCOMMANDS.contains(&command.get_name()) {
-//         return;
-//     }
-
-//     let about_text = command.get_about().map(|styled| styled.to_string());
-//     let needs_prefix = match &about_text {
-//         Some(text) => !text.trim_start().starts_with("(internal-only)"),
-//         None => true,
-//     };
-
-//     if !needs_prefix {
-//         return;
-//     }
-
-//     let new_about = match about_text {
-//         Some(text) if !text.trim().is_empty() => format!("(internal-only) {text}"),
-//         _ => "(internal-only)".to_string(),
-//     };
-
-//     let mut command_owned = std::mem::take(command);
-//     command_owned = command_owned.about(new_about);
-//     *command = command_owned;
-// }

--- a/engine/cli/src/commands.rs
+++ b/engine/cli/src/commands.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use baml_runtime::{cli::RuntimeCliDefaults, BamlRuntime};
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
 #[command(author, version, about = "A CLI tool for working with BAML. Learn more at https://docs.boundaryml.com.", long_about = None)]
@@ -55,20 +55,49 @@ pub(crate) enum Commands {
     #[command(about = "Run BAML tests")]
     Test(baml_runtime::cli::testing::TestArgs),
 
-    #[command(about = "Print HIR from BAML files")]
+    #[command(about = "(internal-only) Print HIR from BAML files", hide = true)]
     DumpHIR(baml_runtime::cli::dump_intermediate::DumpIntermediateArgs),
 
-    #[command(about = "Print Bytecode from BAML files")]
+    #[command(about = "(internal-only) Print Bytecode from BAML files", hide = true)]
     DumpBytecode(baml_runtime::cli::dump_intermediate::DumpIntermediateArgs),
 
     #[command(about = "Starts a language server", name = "lsp")]
     LanguageServer(crate::lsp::LanguageServerArgs),
 
-    #[command(about = "Start an interactive REPL for BAML expressions")]
+    #[command(about = "(internal-only) Start an interactive REPL for BAML expressions", hide = true)]
     Repl(baml_runtime::cli::repl::ReplArgs),
 }
 
 impl RuntimeCli {
+    /// Parse CLI arguments, unhiding all subcommands if the BAML_INTERNAL environment variable is set.
+    ///
+    /// This should be used for CLI invocations instead of `RuntimeCli::parse_from`.
+    pub fn smart_parse_from(argv: Vec<String>) -> Self {
+        use clap::FromArgMatches;
+
+        let mut command = RuntimeCli::command();
+
+        if baml_internal_env_is_truthy() {
+            unhide_all_subcommands(&mut command);
+        }
+
+        let mut matches = match command.try_get_matches_from_mut(argv) {
+            Ok(matches) => matches,
+            Err(err) => err.exit(),
+        };
+
+        let mut cli = match RuntimeCli::from_arg_matches(&mut matches) {
+            Ok(cli) => cli,
+            Err(err) => err.exit(),
+        };
+
+        if let Err(err) = RuntimeCli::update_from_arg_matches(&mut cli, &matches) {
+            err.exit();
+        }
+
+        cli
+    }
+
     pub fn run(&mut self, defaults: RuntimeCliDefaults) -> Result<crate::ExitCode> {
         use internal_baml_core::feature_flags::FeatureFlags;
 
@@ -238,5 +267,19 @@ impl RuntimeCli {
                 }
             },
         }
+    }
+}
+
+fn baml_internal_env_is_truthy() -> bool {
+    std::env::var("BAML_INTERNAL")
+        .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true"))
+        .unwrap_or(false)
+}
+
+fn unhide_all_subcommands(command: &mut clap::Command) {
+    for subcommand in command.get_subcommands_mut() {
+        let mut visible_subcommand = std::mem::take(subcommand).hide(false);
+        unhide_all_subcommands(&mut visible_subcommand);
+        *subcommand = visible_subcommand;
     }
 }

--- a/engine/cli/src/commands.rs
+++ b/engine/cli/src/commands.rs
@@ -55,16 +55,16 @@ pub(crate) enum Commands {
     #[command(about = "Run BAML tests")]
     Test(baml_runtime::cli::testing::TestArgs),
 
-    #[command(about = "(internal-only) Print HIR from BAML files", hide = true)]
+    #[command(about = "Print HIR from BAML files", hide = true)]
     DumpHIR(baml_runtime::cli::dump_intermediate::DumpIntermediateArgs),
 
-    #[command(about = "(internal-only) Print Bytecode from BAML files", hide = true)]
+    #[command(about = "Print Bytecode from BAML files", hide = true)]
     DumpBytecode(baml_runtime::cli::dump_intermediate::DumpIntermediateArgs),
 
     #[command(about = "Starts a language server", name = "lsp")]
     LanguageServer(crate::lsp::LanguageServerArgs),
 
-    #[command(about = "(internal-only) Start an interactive REPL for BAML expressions", hide = true)]
+    #[command(about = "Start an interactive REPL for BAML expressions", hide = true)]
     Repl(baml_runtime::cli::repl::ReplArgs),
 }
 
@@ -72,13 +72,24 @@ impl RuntimeCli {
     /// Parse CLI arguments, unhiding all subcommands if the BAML_INTERNAL environment variable is set.
     ///
     /// This should be used for CLI invocations instead of `RuntimeCli::parse_from`.
-    pub fn smart_parse_from(argv: Vec<String>) -> Self {
+    pub fn parse_from_smart(argv: Vec<String>) -> Self {
         use clap::FromArgMatches;
 
         let mut command = RuntimeCli::command();
 
         if baml_internal_env_is_truthy() {
-            unhide_all_subcommands(&mut command);
+            for subcommand in command
+                .get_subcommands_mut()
+                .filter(|subcommand| subcommand.is_hide_set())
+            {
+                let mut new_subcommand = std::mem::take(subcommand);
+                new_subcommand = new_subcommand.hide(false);
+                if let Some(about) = new_subcommand.get_about() {
+                    let new_about = format!("(internal-only) {about}");
+                    new_subcommand = new_subcommand.about(new_about);
+                }
+                *subcommand = new_subcommand;
+            }
         }
 
         let mut matches = match command.try_get_matches_from_mut(argv) {
@@ -276,10 +287,38 @@ fn baml_internal_env_is_truthy() -> bool {
         .unwrap_or(false)
 }
 
-fn unhide_all_subcommands(command: &mut clap::Command) {
-    for subcommand in command.get_subcommands_mut() {
-        let mut visible_subcommand = std::mem::take(subcommand).hide(false);
-        unhide_all_subcommands(&mut visible_subcommand);
-        *subcommand = visible_subcommand;
-    }
-}
+// const INTERNAL_ONLY_SUBCOMMANDS: &[&str] = &["dump-hir", "dump-bytecode", "repl"];
+
+// fn unhide_all_subcommands(command: &mut clap::Command) {
+//     for subcommand in command.get_subcommands_mut() {
+//         let mut visible_subcommand = std::mem::take(subcommand).hide(false);
+//         prepend_internal_only_tag_if_needed(&mut visible_subcommand);
+//         unhide_all_subcommands(&mut visible_subcommand);
+//         *subcommand = visible_subcommand;
+//     }
+// }
+
+// fn prepend_internal_only_tag_if_needed(command: &mut clap::Command) {
+//     if !INTERNAL_ONLY_SUBCOMMANDS.contains(&command.get_name()) {
+//         return;
+//     }
+
+//     let about_text = command.get_about().map(|styled| styled.to_string());
+//     let needs_prefix = match &about_text {
+//         Some(text) => !text.trim_start().starts_with("(internal-only)"),
+//         None => true,
+//     };
+
+//     if !needs_prefix {
+//         return;
+//     }
+
+//     let new_about = match about_text {
+//         Some(text) if !text.trim().is_empty() => format!("(internal-only) {text}"),
+//         _ => "(internal-only)".to_string(),
+//     };
+
+//     let mut command_owned = std::mem::take(command);
+//     command_owned = command_owned.about(new_about);
+//     *command = command_owned;
+// }

--- a/engine/cli/src/commands.rs
+++ b/engine/cli/src/commands.rs
@@ -97,7 +97,7 @@ impl RuntimeCli {
             Err(err) => err.exit(),
         };
 
-        let mut cli = match RuntimeCli::from_arg_matches(&mut matches) {
+        let mut cli = match RuntimeCli::from_arg_matches(&matches) {
             Ok(cli) => cli,
             Err(err) => err.exit(),
         };

--- a/engine/cli/src/lib.rs
+++ b/engine/cli/src/lib.rs
@@ -62,7 +62,7 @@ pub fn run_cli(
     argv: Vec<String>,
     caller_type: baml_runtime::RuntimeCliDefaults,
 ) -> Result<ExitCode> {
-    let mut cli = commands::RuntimeCli::smart_parse_from(argv);
+    let mut cli = commands::RuntimeCli::parse_from_smart(argv);
     if !matches!(cli.command, commands::Commands::Test(_)) {
         // We only need to set the exit handlers if we're not running tests
         // and the caller is Python.

--- a/engine/cli/src/lib.rs
+++ b/engine/cli/src/lib.rs
@@ -8,7 +8,6 @@ pub(crate) mod lsp;
 pub(crate) mod propelauth;
 pub(crate) mod tui;
 use anyhow::Result;
-use clap::Parser;
 
 #[derive(Debug, Clone)]
 pub enum ExitCode {
@@ -63,7 +62,7 @@ pub fn run_cli(
     argv: Vec<String>,
     caller_type: baml_runtime::RuntimeCliDefaults,
 ) -> Result<ExitCode> {
-    let mut cli = commands::RuntimeCli::parse_from(argv);
+    let mut cli = commands::RuntimeCli::smart_parse_from(argv);
     if !matches!(cli.command, commands::Commands::Test(_)) {
         // We only need to set the exit handlers if we're not running tests
         // and the caller is Python.


### PR DESCRIPTION
By default, `hide=true` subcommands will be hidden from the user. They will be exposed when `BAML_INTERNAL=1`.