### PR TITLE
Fixing doc - invalid options for gpt-4.1 model

### DIFF
--- a/fern/03-reference/baml/clients/providers/openai-responses.mdx
+++ b/fern/03-reference/baml/clients/providers/openai-responses.mdx
@@ -21,7 +21,7 @@ client<llm> MyResponsesClient {
   provider "openai-responses"
   options {
     api_key env.MY_OPENAI_KEY
-    model "gpt-4.1"
+    model "gpt-5"
     reasoning {
       effort "medium"
     }


### PR DESCRIPTION
The original doc when used produces the following error:
```
 ---ERROR (Unspecified error code: 400)---
    Request failed with status code: 400 Bad Request, 
    {
      "error": {
        "message": "Unsupported parameter: 'reasoning.effort' is not supported with this model.",
        "type": "invalid_request_error",
        "param": "reasoning.effort",
        "code": "unsupported_parameter"
      }
    }
```
`gpt-4.1` is not a reasoning model and does not support reasoning and effort options. Can use `gpt-5`instead