### PR TITLE
Debug playground slugishness

### DIFF
--- a/engine/baml-lib/jsonish/src/lib.rs
+++ b/engine/baml-lib/jsonish/src/lib.rs
@@ -28,7 +28,20 @@ use serde::{
 use crate::deserializer::score::WithScore;
 
 #[derive(Clone, Debug)]
-pub struct ResponseBamlValue(pub BamlValueWithMeta<ResponseValueMeta>);
+pub struct ResponseBamlValue(BamlValueWithMeta<ResponseValueMeta>);
+
+impl ResponseBamlValue {
+    /// Smart constructor that clears deserialization flags.
+    pub fn new_with_cleared_flags(mut value: BamlValueWithMeta<ResponseValueMeta>) -> Self {
+        value.meta_mut().0 = vec![];
+        Self(value)
+    }
+
+    /// Read-only view of the contents.
+    pub fn inner(&self) -> &BamlValueWithMeta<ResponseValueMeta> {
+        &self.0
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct ResponseValueMeta(

--- a/engine/baml-runtime/src/async_interpreter_runtime.rs
+++ b/engine/baml-runtime/src/async_interpreter_runtime.rs
@@ -331,7 +331,7 @@ impl BamlAsyncInterpreterRuntime {
                                 if let Ok(response_value) = parsed.as_ref() {
                                     // Convert ResponseBamlValue to BamlValueWithMeta<WatchValueMetadata>
                                     let baml_value_with_watch_meta =
-                                        response_value.0.clone().map_meta(|meta| {
+                                        response_value.inner().clone().map_meta(|meta| {
                                             baml_compiler::watch::WatchValueMetadata {
                                                 // Constraints come from the TypeIR, not from the flags
                                                 // Flags only contain ConstraintResults (the evaluation results)
@@ -386,8 +386,8 @@ impl BamlAsyncInterpreterRuntime {
                                     .unwrap()
                                     .as_ref()
                                     .unwrap()
+                                    .inner()
                                     .clone()
-                                    .0
                                     .value();
 
                                 Ok(baml_value_to_baml_value_with_meta(baml_value))
@@ -418,8 +418,8 @@ impl BamlAsyncInterpreterRuntime {
                                     .unwrap()
                                     .as_ref()
                                     .unwrap()
+                                    .inner()
                                     .clone()
-                                    .0
                                     .value();
 
                                 Ok(baml_value_to_baml_value_with_meta(baml_value))
@@ -493,10 +493,11 @@ impl BamlAsyncInterpreterRuntime {
             }
         };
 
-        let response_baml_value = ResponseBamlValue(BamlValueWithMeta::with_const_meta(
-            &baml_value,
-            ResponseValueMeta(vec![], vec![], Completion::default(), output_type),
-        ));
+        let response_baml_value =
+            ResponseBamlValue::new_with_cleared_flags(BamlValueWithMeta::with_const_meta(
+                &baml_value,
+                ResponseValueMeta(vec![], vec![], Completion::default(), output_type),
+            ));
 
         let final_result = Ok(FunctionResult::new(
             OrchestrationScope { scope: vec![] },

--- a/engine/baml-runtime/src/async_vm_runtime.rs
+++ b/engine/baml-runtime/src/async_vm_runtime.rs
@@ -708,7 +708,7 @@ impl BamlAsyncVmRuntime {
                                     };
 
                                     let response_baml_value = response.map(|r| {
-                                        ResponseBamlValue(
+                                        ResponseBamlValue::new_with_cleared_flags(
                                             BamlValueWithMeta::<Vec<Flag>>::from(r).map_meta(
                                                 |_| {
                                                     ResponseValueMeta(
@@ -791,10 +791,11 @@ impl BamlAsyncVmRuntime {
             }
         };
 
-        let response_baml_value = ResponseBamlValue(BamlValueWithMeta::with_const_meta(
-            &baml_value,
-            ResponseValueMeta(vec![], vec![], Completion::default(), output_type),
-        ));
+        let response_baml_value =
+            ResponseBamlValue::new_with_cleared_flags(BamlValueWithMeta::with_const_meta(
+                &baml_value,
+                ResponseValueMeta(vec![], vec![], Completion::default(), output_type),
+            ));
 
         let final_result = Ok(FunctionResult::new(
             OrchestrationScope { scope: vec![] },
@@ -1341,8 +1342,8 @@ fn try_vm_value_from_function_result(
         .ok_or_else(|| anyhow!("no parsed result available from function call"))?
         .as_ref()
         .map_err(|e| anyhow!("error parsing function result: {e}"))?
+        .inner()
         .clone()
-        .0
         .value();
 
     try_vm_value_from_baml_value(vm, resolved_class_names, resolved_enums_names, &baml_value)

--- a/engine/baml-runtime/src/cli/repl.rs
+++ b/engine/baml-runtime/src/cli/repl.rs
@@ -592,8 +592,8 @@ impl ReplState {
                         }
                         match function_result.parsed() {
                             Some(Ok(response_baml_value)) => Ok(response_baml_value
+                                .inner()
                                 .clone()
-                                .0
                                 .map_meta_owned(|_| (Span::fake(), None))),
                             Some(Err(e)) => Err(anyhow!("Failed to parse function result: {}", e)),
                             None => Err(anyhow!("No parsed result available from function call")),

--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -669,7 +669,7 @@ impl Stream for EventStream {
         match self.receiver.poll_recv(cx) {
             Poll::Ready(Some(item)) => match item.result_with_constraints_content() {
                 // TODO: not sure if this is the correct way to implement this.
-                Ok(parsed) => Poll::Ready(Some(parsed.0.clone().into())),
+                Ok(parsed) => Poll::Ready(Some(parsed.inner().clone().into())),
                 Err(_) => Poll::Pending,
             },
             Poll::Ready(None) => Poll::Ready(None),

--- a/engine/baml-runtime/src/internal/llm_client/mod.rs
+++ b/engine/baml-runtime/src/internal/llm_client/mod.rs
@@ -67,7 +67,7 @@ pub fn parsed_value_to_response(
         .map_meta(|(((x, y), z), ft)| {
             jsonish::ResponseValueMeta(z.clone(), y.clone(), x.clone(), ft.clone())
         });
-    Ok(ResponseBamlValue(response_value))
+    Ok(ResponseBamlValue::new_with_cleared_flags(response_value))
 }
 
 // Whether we should download a url into a base64 (resolving it if necessary), as well as

--- a/engine/baml-runtime/src/internal/llm_client/orchestrator/stream.rs
+++ b/engine/baml-runtime/src/internal/llm_client/orchestrator/stream.rs
@@ -105,12 +105,7 @@ async fn process_latest_snapshot<'a, ParseFn, EventFn>(
 
     match partial_parse_fn(&snapshot.content) {
         Ok(baml_value) => {
-            let parsed = ResponseBamlValue(
-                baml_value
-                    .0
-                    .map_meta_owned(|m| jsonish::ResponseValueMeta(vec![], m.1, m.2, m.3)),
-            );
-            let partial = parsed.serialize_partial();
+            let partial = baml_value.serialize_partial();
             let serialized = serde_json::to_string(&partial).ok();
 
             let should_emit = {
@@ -135,7 +130,7 @@ async fn process_latest_snapshot<'a, ParseFn, EventFn>(
                 on_event(FunctionResult::new(
                     scope.clone(),
                     LLMResponse::Success((*snapshot).clone()),
-                    Some(Ok(parsed)),
+                    Some(Ok(baml_value)),
                 ));
             }
         }
@@ -470,7 +465,7 @@ where
                 // figure out how to reduce memory usage.
                 let response_value_without_flags = match response_value {
                     Some(Ok(baml_value)) => {
-                        Some(Ok(ResponseBamlValue(baml_value.0.map_meta_owned(|m| {
+                        Some(Ok(ResponseBamlValue::new_with_cleared_flags(baml_value.inner().clone().map_meta_owned(|m| {
                             jsonish::ResponseValueMeta(vec![], m.1, m.2, m.3)
                         }))))
                     }

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -281,7 +281,9 @@ impl<'a> TracingCallGuard<'a> {
                 self.call_id_stack.clone(),
                 match result {
                     Ok(func_result) => match func_result.result_with_constraints_content() {
-                        Ok(value) => Ok(value.0.map_meta(|f| f.3.to_non_streaming_type(self.ir))),
+                        Ok(value) => Ok(value
+                            .inner()
+                            .map_meta(|f| f.3.to_non_streaming_type(self.ir))),
                         Err(e) => Err((&e).to_baml_error()),
                     },
                     Err(e) => Err(e.to_baml_error()),
@@ -314,7 +316,9 @@ impl<'a> TracingCallGuard<'a> {
                 self.call_id_stack.clone(),
                 match result {
                     Ok(func_result) => match func_result.result_with_constraints_content() {
-                        Ok(value) => Ok(value.0.map_meta(|f| f.3.to_non_streaming_type(self.ir))),
+                        Ok(value) => Ok(value
+                            .inner()
+                            .map_meta(|f| f.3.to_non_streaming_type(self.ir))),
                         Err(e) => Err((&e).to_baml_error()),
                     },
                     Err(e) => Err(e.to_baml_error()),
@@ -1059,7 +1063,7 @@ impl BamlRuntime {
             } else {
                 match val {
                     Some(Ok(value)) => {
-                        let value_with_constraints = value.0.map_meta(|m| m.1.clone());
+                        let value_with_constraints = value.inner().map_meta(|m| m.1.clone());
                         evaluate_test_constraints(
                             &params,
                             &value_with_constraints,
@@ -1230,7 +1234,7 @@ impl BamlRuntime {
         } else {
             match &expr_response {
                 Some(Ok(val)) => {
-                    let value_with_constraints = val.0.map_meta(|m| m.1.clone());
+                    let value_with_constraints = val.inner().map_meta(|m| m.1.clone());
                     evaluate_test_constraints(
                         &params,
                         &value_with_constraints,

--- a/engine/baml-runtime/src/tracing/mod.rs
+++ b/engine/baml-runtime/src/tracing/mod.rs
@@ -155,7 +155,7 @@ impl Visualize for FunctionResult {
                 if matches!(self.llm_response(), LLMResponse::Success(_)) {
                     s.push(format!(
                         "{}",
-                        format!("---Parsed Response ({})---", val.0.r#type()).blue()
+                        format!("---Parsed Response ({})---", val.inner().r#type()).blue()
                     ));
                     let json_str = serde_json::to_string_pretty(&val.serialize_final()).unwrap();
 
@@ -280,7 +280,7 @@ impl BamlEventLoggable<'_> {
                             .result_with_constraints()
                             .as_ref()
                             .and_then(|r| r.as_ref().ok())
-                            .map(|v| v.0.r#type().to_string()),
+                            .map(|v| v.inner().r#type().to_string()),
                         parsed_response: response
                             .result_with_constraints()
                             .as_ref()
@@ -1032,7 +1032,7 @@ impl ToLogSchema for TestResponse {
                         .as_ref()
                         .and_then(|r| r.as_ref().ok())
                         .map(|r| {
-                            let v: BamlValue = r.0.clone().into();
+                            let v: BamlValue = r.inner().clone().into();
                             IOValue::from(&v)
                         }),
                 },
@@ -1081,7 +1081,7 @@ impl ToLogSchema for FunctionResult {
                     .as_ref()
                     .and_then(|r| r.as_ref().ok())
                     .map(|r| {
-                        let v: BamlValue = r.0.clone().into();
+                        let v: BamlValue = r.inner().clone().into();
                         IOValue::from(&v)
                     }),
             },

--- a/engine/baml-runtime/src/types/response.rs
+++ b/engine/baml-runtime/src/types/response.rs
@@ -37,7 +37,7 @@ impl std::fmt::Display for FunctionResult {
                 writeln!(
                     f,
                     "{}",
-                    format!("---Parsed Response ({})---", val.0.r#type()).blue()
+                    format!("---Parsed Response ({})---", val.inner().r#type()).blue()
                 )?;
                 write!(f, "{:#}", serde_json::json!(val.serialize_partial()))
             }
@@ -317,7 +317,7 @@ impl std::fmt::Display for TestResponse {
                     writeln!(
                         f,
                         "{}",
-                        format!("---Parsed Response ({})---", val.0.r#type()).blue()
+                        format!("---Parsed Response ({})---", val.inner().r#type()).blue()
                     )?;
                     write!(f, "{:#}", serde_json::json!(val.serialize_partial()))
                 }

--- a/engine/baml-runtime/src/types/stream.rs
+++ b/engine/baml-runtime/src/types/stream.rs
@@ -155,7 +155,7 @@ impl FunctionResultStream {
             match &res {
                 Ok(result) => match result.result_with_constraints_content() {
                     Ok(value) => Ok(value
-                        .0
+                        .inner()
                         .map_meta(|f| f.3.to_non_streaming_type(self.ir.as_ref()))),
                     Err(e) => Err((&e).to_baml_error()),
                 },

--- a/engine/baml-schema-wasm/src/lib.rs
+++ b/engine/baml-schema-wasm/src/lib.rs
@@ -16,7 +16,9 @@ pub fn enable_logs() {
     #[cfg(target_arch = "wasm32")]
     {
         console_error_panic_hook::set_once();
-        wasm_logger::init(wasm_logger::Config::default());
+        // Set log level to Info to filter out debug/trace logs from jsonish
+        // This significantly improves performance in the playground
+        wasm_logger::init(wasm_logger::Config::new(log::Level::Warn));
     }
 }
 

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -58,13 +58,13 @@ type JsResult<T> = core::result::Result<T, JsError>;
 use std::panic;
 #[wasm_bindgen(start)]
 pub fn on_wasm_init() {
-    // TODO: set LOG_LEVEL to ::Debug if you wish to see logs.
-    // this is disabled by default because its slows down release mode builds.
+    // Set log level to Info for release builds to avoid performance issues from debug logs
+    // Debug builds keep Debug level for development
     cfg_if::cfg_if! {
         if #[cfg(debug_assertions)] {
-            const LOG_LEVEL: log::Level = log::Level::Debug;
+            const LOG_LEVEL: log::Level = log::Level::Warn;
         } else {
-            const LOG_LEVEL: log::Level = log::Level::Debug;
+            const LOG_LEVEL: log::Level = log::Level::Warn;
         }
     };
     // I dont think we need this line anymore -- seems to break logging if you add it.

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -560,7 +560,7 @@ impl WasmLLMResponse {
 
     pub fn prompt(&self) -> WasmPrompt {
         // TODO: This is a hack. We shouldn't hardcode AllowedRoleMetadata::All
-        // here, but instead plumb it through the LLMErrors
+        // here, but instead plumb it through the LLMErrors.
         (&self.prompt, &self.scope, &AllowedRoleMetadata::All).into()
     }
 }
@@ -599,14 +599,14 @@ impl WasmFunctionResponse {
 
 fn serialize_value_counting_checks(value: &ResponseBamlValue) -> (serde_json::Value, usize) {
     let checks = value
-        .0
+        .inner()
         .meta()
         .1
         .iter()
         .map(|ResponseCheck { name, status, .. }| (name.clone(), status.clone()))
         .collect::<IndexMap<String, String>>();
 
-    let sub_check_count: usize = value.0.iter().map(|node| node.meta().1.len()).sum();
+    let sub_check_count: usize = value.inner().iter().map(|node| node.meta().1.len()).sum();
     let json_value: serde_json::Value = serde_json::to_value(value.serialize_final())
         .unwrap_or("Error converting value to JSON".into());
 

--- a/engine/language_client_cffi/src/ffi/callbacks.rs
+++ b/engine/language_client_cffi/src/ffi/callbacks.rs
@@ -56,7 +56,7 @@ pub fn send_result_to_callback(
 
     let buf_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         if is_done {
-            let meta = content.0.map_meta(|f| EncodeMeta {
+            let meta = content.inner().map_meta(|f| EncodeMeta {
                 field_type: f.3.to_non_streaming_type(runtime.ir.as_ref()),
                 checks: &f.1,
             });
@@ -64,7 +64,7 @@ pub fn send_result_to_callback(
             meta.encode_to_c_buffer(runtime.ir.as_ref(), baml_types::StreamingMode::NonStreaming)
         } else {
             // Top level types in streaming always have `not_null` set to true.
-            let mut content = content.0.clone();
+            let mut content = content.inner().clone();
             content.meta_mut().3.meta_mut().streaming_behavior.needed = true;
             let meta = content.map_meta(|f| EncodeMeta {
                 field_type: f.3.to_streaming_type(runtime.ir.as_ref()),

--- a/engine/language_client_python/src/types/function_results.rs
+++ b/engine/language_client_python/src/types/function_results.rs
@@ -102,9 +102,9 @@ pub(crate) fn pythonize_strict(
     allow_partials: bool, //if true, use the stream type
     runtime: &BamlRuntime,
 ) -> PyResult<PyObject> {
-    let allow_partials = allow_partials && !parsed.0.meta().2.required_done;
+    let allow_partials = allow_partials && !parsed.inner().meta().2.required_done;
 
-    let _stream_type_metadata = parsed.0.map_meta(|f| {
+    let _stream_type_metadata = parsed.inner().map_meta(|f| {
         let meta = f.3.to_streaming_type(runtime.inner.internal().ir.as_ref());
         Meta {
             _field_type: meta,
@@ -112,7 +112,7 @@ pub(crate) fn pythonize_strict(
         }
     });
 
-    let meta = parsed.0.meta().clone();
+    let meta = parsed.inner().meta().clone();
 
     let is_pydantic_2 = {
         let pydantic = py.import("pydantic")?;
@@ -128,7 +128,7 @@ pub(crate) fn pythonize_strict(
         "parse_obj"
     };
 
-    let py_value_without_constraints = match parsed.0 {
+    let py_value_without_constraints = match parsed.inner() {
         BamlValueWithMeta::String(val, _) => val.into_py_any(py),
         BamlValueWithMeta::Int(val, _) => val.into_py_any(py),
         BamlValueWithMeta::Float(val, _) => val.into_py_any(py),
@@ -139,7 +139,7 @@ pub(crate) fn pythonize_strict(
                 let key = key.into_pyobject(py)?;
                 let value = pythonize_strict(
                     py,
-                    ResponseBamlValue(value),
+                    ResponseBamlValue::new_with_cleared_flags(value.clone()),
                     enum_module,
                     cls_module,
                     partial_cls_module,
@@ -156,7 +156,7 @@ pub(crate) fn pythonize_strict(
                 .map(|v| {
                     pythonize_strict(
                         py,
-                        ResponseBamlValue(v),
+                        ResponseBamlValue::new_with_cleared_flags(v.clone()),
                         enum_module,
                         cls_module,
                         partial_cls_module,
@@ -212,7 +212,7 @@ pub(crate) fn pythonize_strict(
                     let subvalue_allow_partials = allow_partials && !value.meta().2.required_done;
                     let value = pythonize_strict(
                         py,
-                        ResponseBamlValue(value),
+                        ResponseBamlValue::new_with_cleared_flags(value.clone()),
                         enum_module,
                         cls_module,
                         partial_cls_module,

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "generate": "turbo run generate",
     "typecheck": "turbo run typecheck",
     "lint:ws": "pnpm dlx sherif@latest",
+    "package:vscode": "pnpm run build:vscode && cd typescript/apps/vscode-ext && pnpm run vscode:package",
     "postinstall.skip": "pnpm lint:ws",
     "setup-dev": "./scripts/setup-dev.sh",
     "format": "biome check",


### PR DESCRIPTION
 - Hide the `ResponseBamlValue` constructor, the only way to construct one is with the deserializer_flags scrubbing function
 - Set WASM logging to Warn unconditionally (just to test if this helps)

The second change made all the difference for our example BAML code.