### PR TITLE
Document baml-cffi docker build caching

### DIFF
--- a/fern/01-guide/03-development/deploying/docker.mdx
+++ b/fern/01-guide/03-development/deploying/docker.mdx
@@ -28,8 +28,8 @@ RUN bundle exec baml-cli generate --from path/to/baml_src
 ```
 
 ```dockerfile Go Dockerfile
-# Install Go and BAML CLI
-RUN go install github.com/boundaryml/baml/baml-cli@latest
+# baml-cli is installed when you add BAML as a dependency
+RUN go get github.com/boundaryml/baml
 # Generate BAML client
 RUN baml-cli generate --from path-to-baml_src
 ```
@@ -56,8 +56,9 @@ Set the `BAML_CACHE_DIR` environment variable in both stages and copy it to your
 FROM golang:1.21 AS builder
 ENV BAML_CACHE_DIR=/baml-cache
 WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN go install github.com/boundaryml/baml/baml-cli@latest
 RUN baml-cli generate --from baml_src
 RUN go build -o myapp
 
@@ -77,8 +78,9 @@ Install `baml-cli` in your final image and run `baml-cli --version` (or `baml-cl
 # Build stage
 FROM golang:1.21 AS builder
 WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN go install github.com/boundaryml/baml/baml-cli@latest
 RUN baml-cli generate --from baml_src
 RUN go build -o myapp
 

--- a/fern/01-guide/03-development/deploying/docker.mdx
+++ b/fern/01-guide/03-development/deploying/docker.mdx
@@ -28,8 +28,8 @@ RUN bundle exec baml-cli generate --from path/to/baml_src
 ```
 
 ```dockerfile Go Dockerfile
-# baml-cli is installed when you add BAML as a dependency
-RUN go get github.com/boundaryml/baml
+# Install BAML CLI
+RUN go install github.com/boundaryml/baml/baml-cli@latest
 # Generate BAML client
 RUN baml-cli generate --from path-to-baml_src
 ```
@@ -59,6 +59,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+RUN go install github.com/boundaryml/baml/baml-cli@latest
 RUN baml-cli generate --from baml_src
 RUN go build -o myapp
 
@@ -81,6 +82,7 @@ WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+RUN go install github.com/boundaryml/baml/baml-cli@latest
 RUN baml-cli generate --from baml_src
 RUN go build -o myapp
 

--- a/fern/01-guide/03-development/deploying/docker.mdx
+++ b/fern/01-guide/03-development/deploying/docker.mdx
@@ -35,3 +35,70 @@ RUN baml-cli generate --from path-to-baml_src
 ```
 </CodeBlocks>
 
+## Go: Multi-stage Docker builds
+
+When using Go, the `baml-cli generate` command downloads the `libbaml-cffi` native library that BAML needs at runtime. This library is cached to avoid downloading it every time your container runs.
+
+### Single-stage builds
+
+For single-stage builds, running `baml-cli generate` (as shown above) will automatically download and cache `libbaml-cffi` in your Docker image.
+
+### Multi-stage builds
+
+For multi-stage Docker builds, you need to ensure `libbaml-cffi` is available in your final image. You have two options:
+
+**Option 1: Copy the cache directory**
+
+Set the `BAML_CACHE_DIR` environment variable in both stages and copy it to your final image:
+
+```dockerfile
+# Build stage
+FROM golang:1.21 AS builder
+ENV BAML_CACHE_DIR=/baml-cache
+WORKDIR /app
+COPY . .
+RUN go install github.com/boundaryml/baml/baml-cli@latest
+RUN baml-cli generate --from baml_src
+RUN go build -o myapp
+
+# Runtime stage
+FROM debian:bookworm-slim
+ENV BAML_CACHE_DIR=/baml-cache
+COPY --from=builder /app/myapp /myapp
+COPY --from=builder /baml-cache /baml-cache
+CMD ["/myapp"]
+```
+
+**Option 2: Regenerate in the final stage**
+
+Install `baml-cli` in your final image and run `baml-cli --version` (or `baml-cli generate`) to download `libbaml-cffi`:
+
+```dockerfile
+# Build stage
+FROM golang:1.21 AS builder
+WORKDIR /app
+COPY . .
+RUN go install github.com/boundaryml/baml/baml-cli@latest
+RUN baml-cli generate --from baml_src
+RUN go build -o myapp
+
+# Runtime stage
+FROM debian:bookworm-slim
+WORKDIR /app
+COPY --from=builder /app/myapp /myapp
+COPY --from=builder /go/bin/baml-cli /usr/local/bin/baml-cli
+# Download libbaml-cffi into the runtime image
+RUN baml-cli --version
+CMD ["/myapp"]
+```
+
+### Customizing the cache directory
+
+By default, BAML downloads `libbaml-cffi` to a system-specific cache directory. You can control this location using the `BAML_CACHE_DIR` environment variable:
+
+```dockerfile
+ENV BAML_CACHE_DIR=/custom/cache/path
+```
+
+This is particularly useful when you want to explicitly control where the native library is stored in your container.
+


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

Adds comprehensive documentation to `fern/01-guide/03-development/deploying/docker.mdx` for Go projects, detailing how to efficiently manage the `libbaml-cffi` native library in Docker builds, especially for multi-stage scenarios. This includes strategies for copying the `BAML_CACHE_DIR` and regenerating the library in the final stage, along with Dockerfile examples.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed (reviewed the generated markdown and Dockerfile examples)
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [ ] I have read and followed the contributing guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

This update directly addresses a user pain point identified in a recent conversation regarding `libbaml-cffi` not being carried over in multi-stage Go Docker builds, improving clarity and providing practical solutions.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1764359146798479?thread_ts=1764359146.798479&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-942f6e94-dcc5-4e68-a62e-7ddcefaa736f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-942f6e94-dcc5-4e68-a62e-7ddcefaa736f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

