### PR TITLE
Fix react chatbot documentation and implementation

### DIFF
--- a/fern/01-guide/08-frameworks/01-react-nextjs/02-chatbot.mdx
+++ b/fern/01-guide/08-frameworks/01-react-nextjs/02-chatbot.mdx
@@ -145,7 +145,7 @@ export function ChatInterface() {
 You can use the hook's callbacks for more control over streaming events. This is useful for logging, analytics, or custom state management. The highlighted lines show the additions to the base example:
 
 <CodeBlocks>
-```tsx {9, 11-28} title="app/components/chat-interface.tsx"
+```tsx {9, 12-29, 54} title="app/components/chat-interface.tsx"
 'use client'
 
 import { useChat } from "@/baml_client/react/hooks";

--- a/fern/01-guide/08-frameworks/01-react-nextjs/02-chatbot.mdx
+++ b/fern/01-guide/08-frameworks/01-react-nextjs/02-chatbot.mdx
@@ -68,11 +68,7 @@ baml-cli generate
 
 ## Step 2: Implement the Chat Interface
 
-You can implement the chat interface in two ways:
-
-### Option A: Using the Generated Hook Directly
-
-The simplest approach is to use the generated hook directly. Note that the hook's `data` property contains the assistant's response (a `string`), not the messages array. You need to maintain your own message state:
+The `useChat` hook's `data` property contains the assistant's streaming response (a `string`), not the messages array. You need to maintain your own message state:
 
 <CodeBlocks>
 ```tsx title="app/components/chat-interface.tsx"
@@ -144,12 +140,12 @@ export function ChatInterface() {
 ```
 </CodeBlocks>
 
-### Option B: Using Callbacks for Fine-Grained Control
+### Using Callbacks for Fine-Grained Control
 
-You can use the hook's callbacks for more control over streaming events. This is useful for logging, analytics, or custom state management:
+You can use the hook's callbacks for more control over streaming events. This is useful for logging, analytics, or custom state management. The highlighted lines show the additions to the base example:
 
 <CodeBlocks>
-```tsx title="app/components/chat-interface-with-callbacks.tsx"
+```tsx {9, 11-28} title="app/components/chat-interface.tsx"
 'use client'
 
 import { useChat } from "@/baml_client/react/hooks";
@@ -158,8 +154,8 @@ import type { Message } from "@/baml_client/types";
 
 export function ChatInterface() {
   const [messages, setMessages] = useState<Message[]>([]);
-  const [input, setInput] = useState("");
   const [streamingContent, setStreamingContent] = useState("");
+  const [input, setInput] = useState("");
 
   const chat = useChat({
     // Called on each streaming partial update
@@ -177,11 +173,6 @@ export function ChatInterface() {
         ]);
         setStreamingContent("");
       }
-    },
-    // Called on any error
-    onError: (error) => {
-      console.error("Chat error:", error);
-      setStreamingContent("");
     },
   });
 
@@ -208,11 +199,8 @@ export function ChatInterface() {
         ))}
         {chat.isLoading && (
           <div>
-            <strong>assistant:</strong> {streamingContent || "Thinking..."}
+            <strong>assistant:</strong> {streamingContent || "Generating..."}
           </div>
-        )}
-        {chat.isError && (
-          <div style={{ color: 'red' }}>Error: {chat.error?.message}</div>
         )}
       </div>
 
@@ -232,11 +220,11 @@ export function ChatInterface() {
 ```
 </CodeBlocks>
 
-The callback approach is useful when you need to:
+With callbacks, you can:
 - Track streaming progress with `onStreamData`
 - Handle completion with `onFinalData`
-- Implement custom error handling with `onError`
-- Add analytics or logging on each event
+- Add error handling with `onError`
+- Integrate analytics or logging on each event
 
 ## Next Steps
 

--- a/fern/01-guide/08-frameworks/01-react-nextjs/02-chatbot.mdx
+++ b/fern/01-guide/08-frameworks/01-react-nextjs/02-chatbot.mdx
@@ -72,40 +72,60 @@ You can implement the chat interface in two ways:
 
 ### Option A: Using the Generated Hook Directly
 
-The simplest approach is to use the generated hook directly:
+The simplest approach is to use the generated hook directly. Note that the hook's `data` property contains the assistant's response (a `string`), not the messages array. You need to maintain your own message state:
 
 <CodeBlocks>
 ```tsx title="app/components/chat-interface.tsx"
 'use client'
 
 import { useChat } from "@/baml_client/react/hooks";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import type { Message } from "@/baml_client/types";
 
 export function ChatInterface() {
+  const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
 
   const chat = useChat();
 
-  const handleSubmit = async () => {
-    const newMessages = [
-      ...chat.data?.messages,
-      { role: "user", content: input }
-    ];
+  // When the assistant responds, add the response to the message history
+  useEffect(() => {
+    if (chat.isSuccess && chat.finalData) {
+      setMessages((prev) => [
+        ...prev,
+        { role: "assistant", content: chat.finalData! }
+      ]);
+    }
+  }, [chat.isSuccess, chat.finalData]);
 
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || chat.isLoading) return;
+
+    const userMessage: Message = { role: "user", content: input };
+    const newMessages = [...messages, userMessage];
+
+    // Update local state immediately
+    setMessages(newMessages);
     setInput("");
 
-    await chat.mutate({ messages: newMessages });
+    // Send the full message history to the Chat function
+    await chat.mutate(newMessages);
   };
 
   return (
     <div>
       <div>
-        {chat.data?.messages.map((message, i) => (
+        {messages.map((message, i) => (
           <div key={i}>
-            {message.content}
+            <strong>{message.role}:</strong> {message.content}
           </div>
         ))}
-        {chat.isLoading && <div>Generating...</div>}
+        {chat.isLoading && (
+          <div>
+            <strong>assistant:</strong> {chat.data ?? "Generating..."}
+          </div>
+        )}
       </div>
 
       <form onSubmit={handleSubmit}>
@@ -124,61 +144,58 @@ export function ChatInterface() {
 ```
 </CodeBlocks>
 
-### Option B: Using a Custom Server Action
+### Option B: Using Callbacks for Fine-Grained Control
 
-Alternatively, you can create a custom server action for more control over the server-side implementation:
+You can use the hook's callbacks for more control over streaming events. This is useful for logging, analytics, or custom state management:
 
 <CodeBlocks>
-```ts title="app/actions/chat.ts"
-'use server'
-
-import { b } from "@/baml_client";
-import { Message } from "@/baml_client/types";
-
-export async function streamChat(messages: Message[]) {
-  const user = await authUser();
-
-  if (!user) {
-    throw new Error("User not authenticated");
-  }
-
-  return b.stream.Chat(messages).toStreamable();
-}
-```
-
-```tsx title="app/components/chat-interface-with-action.tsx"
+```tsx title="app/components/chat-interface-with-callbacks.tsx"
 'use client'
 
 import { useChat } from "@/baml_client/react/hooks";
-import { streamChat } from "../actions/chat";
 import { useState } from "react";
+import type { Message } from "@/baml_client/types";
 
 export function ChatInterface() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
+  const [streamingContent, setStreamingContent] = useState("");
 
-  const handleSubmit = async () => {
-    const newMessages = [
-      ...messages,
-      { role: "user", content: input }
-    ];
-    setInput("");
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const stream = await streamChat(newMessages);
-
-      for await (const message of stream) {
-        setMessages((prev) => [...prev, message]);
+  const chat = useChat({
+    // Called on each streaming partial update
+    onStreamData: (partial) => {
+      if (partial) {
+        setStreamingContent(partial);
       }
-    } catch (error) {
-      setError(error as Error);
-    } finally {
-      setIsLoading(false);
-    }
+    },
+    // Called when streaming completes with the final response
+    onFinalData: (final) => {
+      if (final) {
+        setMessages((prev) => [
+          ...prev,
+          { role: "assistant", content: final }
+        ]);
+        setStreamingContent("");
+      }
+    },
+    // Called on any error
+    onError: (error) => {
+      console.error("Chat error:", error);
+      setStreamingContent("");
+    },
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!input.trim() || chat.isLoading) return;
+
+    const userMessage: Message = { role: "user", content: input };
+    const newMessages = [...messages, userMessage];
+
+    setMessages(newMessages);
+    setInput("");
+
+    await chat.mutate(newMessages);
   };
 
   return (
@@ -186,23 +203,28 @@ export function ChatInterface() {
       <div>
         {messages.map((message, i) => (
           <div key={i}>
-            {message.content}
+            <strong>{message.role}:</strong> {message.content}
           </div>
         ))}
-        {isLoading && <div>Typing...</div>}
+        {chat.isLoading && (
+          <div>
+            <strong>assistant:</strong> {streamingContent || "Thinking..."}
+          </div>
+        )}
+        {chat.isError && (
+          <div style={{ color: 'red' }}>Error: {chat.error?.message}</div>
+        )}
       </div>
 
       <form onSubmit={handleSubmit}>
-        <div>
-          <input
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Type your message..."
-          />
-          <button type="submit" disabled={isLoading}>
-            Send
-          </button>
-        </div>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Type your message..."
+        />
+        <button type="submit" disabled={chat.isLoading}>
+          Send
+        </button>
       </form>
     </div>
   );
@@ -210,12 +232,11 @@ export function ChatInterface() {
 ```
 </CodeBlocks>
 
-The server action approach is useful when you need to:
-- Add custom server-side logic
-- Handle authentication
-- Add logging or monitoring
-- Implement rate limiting
-- Add custom error handling
+The callback approach is useful when you need to:
+- Track streaming progress with `onStreamData`
+- Handle completion with `onFinalData`
+- Implement custom error handling with `onError`
+- Add analytics or logging on each event
 
 ## Next Steps
 


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes # (Documentation fix for `useChat` hook)

## Changes
Please describe the changes proposed in this pull request

The previous documentation for building a React chatbot with `useChat` incorrectly assumed that `chat.data` contained a `messages` array. In reality, `chat.data` directly returns the string response from the BAML `Chat` function.

This PR updates the documentation to:
*   **Option A (Direct Hook Usage):** Correctly manage chat message history in local React state (`useState`). It now uses `useEffect` to append the assistant's `finalData` to the message history and displays `chat.data` for streaming updates.
*   **Option B (Callbacks for Control):** Replaced the flawed "Custom Server Action" example with a robust demonstration of `useChat`'s `onStreamData`, `onFinalData`, and `onError` callbacks. This provides a clear pattern for handling streaming responses, final data, and errors, managing separate `streamingContent` state for better UX.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed (Verified the examples now correctly manage chat state and display streaming responses as intended by the `useChat` hook's actual behavior.)
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [ ] I have read and followed the contributing guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The primary goal was to correct the fundamental misunderstanding of the `useChat` hook's `data` return type, ensuring the documentation provides accurate and functional examples for building a chatbot UI.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1764972872554809?thread_ts=1764972872.554809&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-e487d74e-eb15-4831-b6c8-460290a581f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e487d74e-eb15-4831-b6c8-460290a581f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the React chatbot guide to manage local message history with `useChat`’s streaming string data and introduces a callbacks-based pattern for fine-grained control.
> 
> - **Docs — React/Next.js Chatbot Guide** (`fern/01-guide/08-frameworks/01-react-nextjs/02-chatbot.mdx`):
>   - Clarifies `useChat.data` is a streaming `string`; maintain `messages` locally and append assistant `finalData` via `useEffect`; send full history to `chat.mutate(newMessages)`.
>   - Updates example UI to render `role`-prefixed messages and display streaming content during `isLoading` (using `chat.data`).
>   - Replaces server action example with a callbacks-based approach using `onStreamData` and `onFinalData` (mention `onError`), managing `streamingContent` state.
>   - Adds reference links to generated hooks and error handling docs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf76cbf31f1321d88b23191020b95475003312f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->