### PR TITLE
feat: trim tests from inlined baml files

### DIFF
--- a/engine/baml-runtime/src/async_interpreter_runtime.rs
+++ b/engine/baml-runtime/src/async_interpreter_runtime.rs
@@ -655,9 +655,10 @@ impl BamlAsyncInterpreterRuntime {
         input_files: &indexmap::IndexMap<std::path::PathBuf, String>,
         no_version_check: bool,
         generator_type: generators_lib::version_check::GeneratorType,
+        strip_tests: bool,
     ) -> anyhow::Result<Vec<generators_lib::GenerateOutput>> {
         self.llm_runtime
-            .run_codegen(input_files, no_version_check, generator_type)
+            .run_codegen(input_files, no_version_check, generator_type, strip_tests)
     }
 
     pub fn codegen_generators(

--- a/engine/baml-runtime/src/async_vm_runtime.rs
+++ b/engine/baml-runtime/src/async_vm_runtime.rs
@@ -961,9 +961,10 @@ impl BamlAsyncVmRuntime {
         input_files: &indexmap::IndexMap<std::path::PathBuf, String>,
         no_version_check: bool,
         generator_type: generators_lib::version_check::GeneratorType,
+        strip_tests: bool,
     ) -> anyhow::Result<Vec<generators_lib::GenerateOutput>> {
         self.llm_runtime
-            .run_codegen(input_files, no_version_check, generator_type)
+            .run_codegen(input_files, no_version_check, generator_type, strip_tests)
     }
 
     pub fn codegen_generators(

--- a/engine/baml-runtime/src/cli/dev.rs
+++ b/engine/baml-runtime/src/cli/dev.rs
@@ -55,6 +55,7 @@ impl DevArgs {
         let _ = GenerateArgs {
             from: self.from.clone(),
             no_version_check: false,
+            no_tests: false,
         }
         .run(defaults, feature_flags.clone());
         t.spawn(server.clone().serve(tcp_listener));
@@ -82,6 +83,7 @@ impl DevArgs {
                                 let _ = GenerateArgs {
                                     from: self.from.clone(),
                                     no_version_check: false,
+                                    no_tests: false,
                                 }
                                 .run(defaults, feature_flags.clone());
 

--- a/engine/baml-runtime/src/cli/generate.rs
+++ b/engine/baml-runtime/src/cli/generate.rs
@@ -16,6 +16,12 @@ pub struct GenerateArgs {
         default_value_t = false
     )]
     pub(super) no_version_check: bool,
+    #[arg(
+        long,
+        help = "Strip test blocks from inlined BAML to reduce generated file size",
+        default_value_t = false
+    )]
+    pub no_tests: bool,
 }
 
 impl GenerateArgs {
@@ -73,7 +79,12 @@ impl GenerateArgs {
             .collect::<Result<_>>()
             .context("Failed while reading .baml files in baml_src/")?;
         let generated = runtime
-            .run_codegen(&all_files, self.no_version_check, GeneratorType::CLI)
+            .run_codegen(
+                &all_files,
+                self.no_version_check,
+                GeneratorType::CLI,
+                self.no_tests,
+            )
             .context("Client generation failed")?;
 
         // give the user a working config to copy-paste (so we need to run it through generator again)

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -1691,12 +1691,72 @@ impl BamlRuntime {
             })
     }
 
+    /// Strip test blocks from the input files using the parser database
+    /// This is safe because it uses the actual parsed spans from the AST
+    fn strip_tests_from_files(
+        &self,
+        input_files: &IndexMap<PathBuf, String>,
+    ) -> Result<IndexMap<PathBuf, String>> {
+        use internal_baml_ast::ast::WithSpan;
+
+        // Collect all test block spans grouped by file
+        let mut test_spans_by_file: std::collections::HashMap<PathBuf, Vec<Span>> =
+            std::collections::HashMap::new();
+
+        for test_walker in self.db.walk_test_cases() {
+            let span = test_walker.span();
+            let file_path = span.file.path_buf().clone();
+            test_spans_by_file
+                .entry(file_path)
+                .or_default()
+                .push(span.clone());
+        }
+
+        // Process each file, removing test blocks
+        let mut result = IndexMap::new();
+        for (path, content) in input_files.iter() {
+            let processed_content = if let Some(spans) = test_spans_by_file.get(path) {
+                // Sort spans by start position in reverse order so we can remove from end to start
+                let mut sorted_spans = spans.clone();
+                sorted_spans.sort_by(|a, b| b.start.cmp(&a.start));
+
+                // Remove each test block from the content
+                let mut new_content = content.clone();
+                for span in sorted_spans {
+                    let start = span.start;
+                    let end = span.end;
+
+                    // Replace the span with empty string
+                    // We need to work with byte offsets
+                    if start <= end && end <= new_content.len() {
+                        new_content.replace_range(start..end, "");
+                    }
+                }
+                new_content
+            } else {
+                content.clone()
+            };
+
+            result.insert(path.clone(), processed_content);
+        }
+
+        Ok(result)
+    }
+
     pub fn run_codegen(
         &self,
         input_files: &IndexMap<PathBuf, String>,
         no_version_check: bool,
         generator_type: GeneratorType,
+        strip_tests: bool,
     ) -> Result<Vec<GenerateOutput>> {
+        // If strip_tests is enabled, remove test blocks using the parser database
+        let processed_files = if strip_tests {
+            self.strip_tests_from_files(input_files)?
+        } else {
+            input_files.clone()
+        };
+
         let client_types: Vec<(&CodegenGenerator, GeneratorArgs)> = self
             .codegen_generators()
             .map(|generator| {
@@ -1705,7 +1765,7 @@ impl BamlRuntime {
                     GeneratorArgs::new(
                         generator.output_dir(),
                         generator.baml_src.clone(),
-                        input_files.iter(),
+                        processed_files.iter(),
                         generator.version.clone(),
                         no_version_check,
                         generator.default_client_mode(),

--- a/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
+++ b/engine/baml-schema-wasm/src/runtime_wasm/mod.rs
@@ -1154,6 +1154,7 @@ impl WasmRuntime {
                     .collect(),
                 no_version_check,
                 GeneratorType::VSCodeCLI,
+                false, // strip_tests - not applicable for WASM runtime
             )
             .map_err(|e| JsError::new(format!("{e:#}").as_str()))?
             .into_iter()

--- a/engine/language_server/src/baml_project/mod.rs
+++ b/engine/language_server/src/baml_project/mod.rs
@@ -178,6 +178,7 @@ impl BamlProject {
             &all_files,
             no_version_check.unwrap_or(false),
             GeneratorType::VSCode,
+            false, // strip_tests - not applicable for VSCode extension
         ) {
             Ok(gen) => {
                 let elapsed = start_time.elapsed();


### PR DESCRIPTION
Add a flag: `baml-cli generate --no-tests`, which strips tests from the inlinedbaml.* files.

For some users, the tests are very large because we are interested in the LLM's performance with large inputs. For production deployments, the source code of the tests is generally not needed  in the inline clients.