### PR TITLE
Update bep readme script to remove dates

### DIFF
--- a/beps/docs/README.md
+++ b/beps/docs/README.md
@@ -26,10 +26,10 @@ Below is an auto-generated index of all BEPs.
   </thead>
   <tbody>
     <tr>
-      <td><a href="./proposals/BEP-001-exceptions/"><strong>BEP-001</strong>: Exception Handling</a> &nbsp; <img src="https://img.shields.io/badge/Status-Proposed-yellow" alt="Proposed"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): Vaibhav Gupta <vbv@boundaryml.com> | Created: 2025-11-20 | Updated: 2025-12-04</span></td>
+      <td><a href="./proposals/BEP-001-exceptions/"><strong>BEP-001</strong>: Exception Handling</a> &nbsp; <img src="https://img.shields.io/badge/Status-Proposed-yellow" alt="Proposed"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): Vaibhav Gupta <vbv@boundaryml.com></span></td>
     </tr>
     <tr>
-      <td><a href="./proposals/BEP-002-match/"><strong>BEP-002</strong>: match</a> &nbsp; <img src="https://img.shields.io/badge/Status-Accepted-brightgreen" alt="Accepted"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): hellovai <vbv@boundaryml.com> | Created: TBD | Updated: TBD</span></td>
+      <td><a href="./proposals/BEP-002-match/"><strong>BEP-002</strong>: match</a> &nbsp; <img src="https://img.shields.io/badge/Status-Accepted-brightgreen" alt="Accepted"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): hellovai <vbv@boundaryml.com></span></td>
     </tr>
   </tbody>
 </table>

--- a/beps/scripts/update_bep_readme.py
+++ b/beps/scripts/update_bep_readme.py
@@ -279,8 +279,6 @@ def generate_table(entries):
         desc = e["summary"] or ""
         status = e["status"]
         shepherds = e.get("shepherds", "TBD")
-        created = e.get("created", "Unknown")
-        last_modified = e.get("last_modified", "Unknown")
         
         if shepherds == "TBD" and status not in ["Superseded", "Rejected"]:
              raise ValueError(f"BEP {e['id']} ({status}) must have a shepherd assigned (currently 'TBD').")
@@ -297,7 +295,7 @@ def generate_table(entries):
         shepherd_display = ", ".join(shepherd_list)
         
         lines.append("    <tr>")
-        lines.append(f"      <td>{link} &nbsp; {status_badge}<br><br>{desc}<br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): {shepherd_display} | Created: {created} | Updated: {last_modified}</span></td>")
+        lines.append(f"      <td>{link} &nbsp; {status_badge}<br><br>{desc}<br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): {shepherd_display}</span></td>")
         lines.append("    </tr>")
 
     lines.append("  </tbody>")


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]
This PR resolves a recurring CI failure where `beps/scripts/update_bep_readme.py --check` would fail due to date discrepancies.

## Changes
This PR updates the `beps/scripts/update_bep_readme.py` script to:
- Remove the "Created" and "Updated" date fields from the generated `beps/docs/README.md`.
- Remove the corresponding unused `created` and `last_modified` variables from the script.

The `beps/docs/README.md` has been updated to reflect these changes, no longer displaying dates for BEP entries.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Tested in [environment]

Manual testing involved:
- Running `./beps/scripts/update_bep_readme.py` to regenerate the README.
- Running `./beps/scripts/update_bep_readme.py --check` to verify the check now passes without errors.
- Verifying that `beps/docs/README.md` no longer contains date information for BEPs.

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [ ] I have read and followed the contributing guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The dates were removed because they were dynamically generated from git history, leading to inconsistent values across different environments and causing the `--check` command to frequently fail in CI. Removing them simplifies the README generation and resolves these CI issues.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1765047308818129?thread_ts=1765047308.818129&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-1e1e7c2d-bf01-4760-aa3b-ec6f3b7cc799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1e1e7c2d-bf01-4760-aa3b-ec6f3b7cc799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove Created/Updated dates from the generated BEP README table and corresponding script output, leaving only shepherd info.
> 
> - **Docs**:
>   - `beps/docs/README.md`: Remove "Created" and "Updated" date fields from BEP table entries; keep only shepherd info.
> - **Script** (`beps/scripts/update_bep_readme.py`):
>   - Stop using `created`/`last_modified` in table generation and omit dates from output.
>   - Retain shepherd validation and status badge rendering.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 341ae4ae0f81b9d49a8bc7663e902d49c5f78755. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->