### PR TITLE
Document baml generate no tests

### DIFF
--- a/fern/01-guide/03-development/deploying/docker.mdx
+++ b/fern/01-guide/03-development/deploying/docker.mdx
@@ -35,6 +35,13 @@ RUN baml-cli generate --from path-to-baml_src
 ```
 </CodeBlocks>
 
+<Tip>
+For production builds, add the `--no-tests` flag to reduce the generated client size by excluding test blocks:
+```bash
+baml-cli generate --from path-to-baml_src --no-tests
+```
+</Tip>
+
 ## Go: Multi-stage Docker builds
 
 When using Go, the `baml-cli generate` command downloads the `libbaml-cffi` native library that BAML needs at runtime. This library is cached to avoid downloading it every time your container runs.

--- a/fern/01-guide/04-baml-basics/testing-functions.mdx
+++ b/fern/01-guide/04-baml-basics/testing-functions.mdx
@@ -590,3 +590,15 @@ baml-cli test --list
 ```
 
 See the [CLI Test Reference](/ref/baml-cli/test) for complete documentation of all available options, filtering capabilities, and output formats.
+
+## Production Builds
+
+When deploying to production, you may want to reduce the size of your generated `baml_client` by excluding test blocks. Use the `--no-tests` flag with the `generate` command:
+
+```bash
+baml-cli generate --no-tests
+```
+
+This strips test blocks from the inlined BAML code in the generated client, reducing bundle size without affecting runtime functionality. Your BAML functions will continue to work normally; only the embedded test definitions are removed.
+
+See the [CLI Generate Reference](/ref/baml-cli/generate) for more details.

--- a/fern/03-reference/baml-cli/generate.mdx
+++ b/fern/03-reference/baml-cli/generate.mdx
@@ -12,6 +12,7 @@ baml-cli generate [OPTIONS]
 |--------|-------------|---------|
 | `--from <PATH>` | Path to the `baml_src` directory | `./baml_src` |
 | `--no-version-check` | Generate `baml_client` without checking for version mismatch | `false` |
+| `--no-tests` | Strip test blocks from inlined BAML to reduce generated file size | `false` |
 
 ## Description
 
@@ -38,6 +39,11 @@ The `generate` command performs the following actions:
    baml-cli generate --no-version-check
    ```
 
+4. Generate clients without test blocks (reduces file size):
+   ```
+   baml-cli generate --no-tests
+   ```
+
 ## Output
 
 The command provides informative output about the generation process:
@@ -51,3 +57,4 @@ The command provides informative output about the generation process:
 - If no generator configurations are found in the BAML files, the command will generate a default client based on the CLI defaults and provide instructions on how to add a generator configuration to your BAML files.
 - If generator configurations are found, the command will generate clients according to those configurations.
 - If one of the generators fails, the command will stop at that point and report the error.
+- The `--no-tests` flag is useful for production builds where you want to minimize the generated client size. When enabled, test blocks defined in your BAML files are not included in the generated `baml_client`, reducing bundle size without affecting runtime functionality.


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

This PR adds comprehensive documentation for the new `baml generate --no-tests` flag. This flag allows users to strip test blocks from the generated `baml_client`, reducing its size for production deployments without affecting runtime functionality.

Documentation was added in the following locations:
-   **CLI Reference (`fern/03-reference/baml-cli/generate.mdx`)**: Added the flag to the options table, included an example, and provided a detailed note on its purpose.
-   **Testing Functions Guide (`fern/01-guide/04-baml-basics/testing-functions.mdx`)**: Introduced a new "Production Builds" section explaining the flag's benefits for bundle size reduction.
-   **Docker Deployment Guide (`fern/01-guide/03-development/deploying/docker.mdx`)**: Added a tip demonstrating how to use the flag in Docker builds.

## Testing
Please describe how you tested these changes

-   [ ] Unit tests added/updated
-   [X] Manual testing performed (Verified documentation rendering and content accuracy)
-   [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

-   [X] I have read and followed the contributing guidelines
-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [X] I have commented my code, particularly in hard-to-understand areas
-   [X] I have made corresponding changes to the documentation
-   [X] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The `--no-tests` flag is crucial for optimizing `baml_client` size in production environments, and this PR ensures it is well-documented across relevant guides and references.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1765320127807829?thread_ts=1765320127.807829&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-3a367db7-7dd1-490a-8512-c5f3b512267e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3a367db7-7dd1-490a-8512-c5f3b512267e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

