### PR TITLE
Add search functionality to prompt

### DIFF
--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/prompt-preview-curl.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/prompt-preview-curl.tsx
@@ -1,9 +1,9 @@
 import { CopyButton } from '@baml/ui/custom/copy-button';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { atom } from 'jotai';
 import { loadable } from 'jotai/utils';
 import { useTheme } from 'next-themes';
-import { useEffect, useState, memo } from 'react';
+import { useEffect, useState, memo, useRef, useCallback } from 'react';
 import type React from 'react';
 import { useMemo } from 'react';
 import { apiKeysAtom } from '../../../../components/api-keys-dialog/atoms';
@@ -14,6 +14,14 @@ import { Loader } from './components';
 import { vscode } from '../../vscode';
 import { EnhancedErrorRenderer } from './test-panel/components/EnhancedErrorRenderer';
 import { runtimeInstanceAtom } from '../../../../sdk/atoms/core.atoms';
+import {
+  promptSearchQueryAtom,
+  promptSearchCurrentMatchAtom,
+  registerMatchCountAtom,
+  unregisterMatchCountAtom,
+  matchOffsetsAtom,
+} from './search-atoms';
+import { cn } from '@baml/ui/lib/utils';
 
 type CurlResult =
   | {
@@ -90,11 +98,95 @@ const baseCurlAtom = atom<Promise<CurlResult>>(async (get) => {
 
 export const curlAtom = loadable(baseCurlAtom);
 
+// Helper function to escape HTML entities
+const escapeHtml = (text: string): string => {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+};
+
+// Helper function to apply search highlighting to HTML content
+const applySearchHighlightToHtml = (
+  html: string,
+  searchQuery: string,
+  currentMatch: number
+): { html: string; matchCount: number } => {
+  if (!searchQuery || searchQuery.trim() === '') {
+    return { html, matchCount: 0 };
+  }
+
+  // We need to find and highlight text content while preserving HTML tags
+  // Strategy: Extract text nodes, find matches, and wrap them with highlight spans
+
+  const searchLower = searchQuery.toLowerCase();
+  let matchCount = 0;
+  let currentMatchIndex = 0;
+
+  // Split HTML into tags and text content
+  const parts = html.split(/(<[^>]+>)/g);
+
+  const processedParts = parts.map((part) => {
+    // If it's an HTML tag, keep it as is
+    if (part.startsWith('<')) {
+      return part;
+    }
+
+    // It's text content - apply search highlighting
+    const textLower = part.toLowerCase();
+    let result = '';
+    let lastIndex = 0;
+    let searchIndex = textLower.indexOf(searchLower, lastIndex);
+
+    while (searchIndex !== -1) {
+      // Add text before the match
+      if (searchIndex > lastIndex) {
+        result += part.slice(lastIndex, searchIndex);
+      }
+
+      // Add the search match with highlight
+      const matchText = part.slice(searchIndex, searchIndex + searchQuery.length);
+      const isCurrentMatch = currentMatchIndex === currentMatch;
+      const highlightClass = isCurrentMatch
+        ? 'search-match search-match-current'
+        : 'search-match';
+
+      result += `<mark class="${highlightClass}" data-match-index="${currentMatchIndex}">${matchText}</mark>`;
+
+      matchCount++;
+      currentMatchIndex++;
+      lastIndex = searchIndex + searchQuery.length;
+      searchIndex = textLower.indexOf(searchLower, lastIndex);
+    }
+
+    // Add remaining text
+    if (lastIndex < part.length) {
+      result += part.slice(lastIndex);
+    }
+
+    return result || part;
+  });
+
+  return { html: processedParts.join(''), matchCount };
+};
+
 // Syntax highlighting component for curl commands
 const SyntaxHighlightedCurl = memo(({ text }: { text: string }) => {
   const [highlightedHtml, setHighlightedHtml] = useState<string>('');
   const [highlighter, setHighlighter] = useState<any | undefined>(undefined);
   const { theme } = useTheme();
+  const searchQuery = useAtomValue(promptSearchQueryAtom);
+  const currentSearchMatch = useAtomValue(promptSearchCurrentMatchAtom);
+  const matchOffsets = useAtomValue(matchOffsetsAtom);
+  const registerMatchCount = useSetAtom(registerMatchCountAtom);
+  const unregisterMatchCount = useSetAtom(unregisterMatchCountAtom);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const componentId = 'curl-highlight';
+
+  // Get the global offset for this component's matches
+  const globalOffset = matchOffsets.get(componentId) ?? 0;
 
   useEffect(() => {
     if (highlighter) return;
@@ -135,6 +227,47 @@ const SyntaxHighlightedCurl = memo(({ text }: { text: string }) => {
     })();
   }, [highlighter, text, theme]);
 
+  // Compute the local match index (which match within this component is current)
+  const currentLocalMatch = currentSearchMatch - globalOffset;
+
+  // Apply search highlighting on top of syntax highlighting
+  const { finalHtml, matchCount } = useMemo(() => {
+    if (!highlightedHtml) {
+      return { finalHtml: '', matchCount: 0 };
+    }
+    // Pass local match index instead of global
+    const { html, matchCount } = applySearchHighlightToHtml(
+      highlightedHtml,
+      searchQuery,
+      currentLocalMatch
+    );
+    return { finalHtml: html, matchCount };
+  }, [highlightedHtml, searchQuery, currentLocalMatch]);
+
+  // Register match count with global registry
+  useEffect(() => {
+    registerMatchCount({ id: componentId, count: matchCount });
+  }, [matchCount, registerMatchCount]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      unregisterMatchCount(componentId);
+    };
+  }, [unregisterMatchCount]);
+
+  // Scroll current match into view (only if current match is within this component)
+  useEffect(() => {
+    if (containerRef.current && searchQuery && currentLocalMatch >= 0 && currentLocalMatch < matchCount) {
+      const currentMatchElement = containerRef.current.querySelector(
+        '.search-match-current'
+      );
+      if (currentMatchElement) {
+        currentMatchElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+  }, [currentLocalMatch, searchQuery, finalHtml, matchCount]);
+
   if (!highlightedHtml) {
     return (
       <div className="w-full rounded-lg border bg-accent p-4 font-mono">
@@ -151,6 +284,7 @@ const SyntaxHighlightedCurl = memo(({ text }: { text: string }) => {
 
   return (
     <div
+      ref={containerRef}
       className="w-full rounded-lg border bg-accent p-4 font-mono overflow-auto text-xs"
       style={
         {
@@ -216,7 +350,7 @@ const SyntaxHighlightedCurl = memo(({ text }: { text: string }) => {
         .curl-highlight .shiki * {
           background: transparent !important;
         }
-        .curl-highlight .shiki span {
+        .curl-highlight .shiki span:not(.search-match) {
           background: transparent !important;
         }
         .curl-highlight .shiki .line {
@@ -225,11 +359,23 @@ const SyntaxHighlightedCurl = memo(({ text }: { text: string }) => {
           word-wrap: break-word !important;
           overflow-wrap: break-word !important;
         }
+        .curl-highlight .search-match {
+          background-color: rgba(250, 204, 21, 0.7) !important;
+          color: black !important;
+          border-radius: 2px;
+          padding: 0 2px;
+        }
+        .curl-highlight .search-match-current {
+          background-color: rgb(250, 204, 21) !important;
+          color: black !important;
+          outline: 2px solid rgb(202, 138, 4);
+          outline-offset: -1px;
+        }
       `}</style>
       <div
         className="curl-highlight"
         // biome-ignore lint/security/noDangerouslySetInnerHtml: <explanation>
-        dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+        dangerouslySetInnerHTML={{ __html: finalHtml }}
       />
     </div>
   );

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/prompt-search-bar.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/prompt-search-bar.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { Input } from '@baml/ui/input';
+import { Button } from '@baml/ui/button';
+import { cn } from '@baml/ui/lib/utils';
+import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { ChevronUp, ChevronDown, X, Search } from 'lucide-react';
+import { useEffect, useRef, useCallback } from 'react';
+import {
+  promptSearchQueryAtom,
+  promptSearchVisibleAtom,
+  promptSearchCurrentMatchAtom,
+  promptSearchTotalMatchesAtom,
+  clearMatchCountsAtom,
+} from './search-atoms';
+
+interface PromptSearchBarProps {
+  className?: string;
+}
+
+export const PromptSearchBar: React.FC<PromptSearchBarProps> = ({ className }) => {
+  const [searchQuery, setSearchQuery] = useAtom(promptSearchQueryAtom);
+  const [isVisible, setIsVisible] = useAtom(promptSearchVisibleAtom);
+  const [currentMatch, setCurrentMatch] = useAtom(promptSearchCurrentMatchAtom);
+  const totalMatches = useAtomValue(promptSearchTotalMatchesAtom);
+  const clearMatchCounts = useSetAtom(clearMatchCountsAtom);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Handle keyboard shortcuts (Ctrl+F / Cmd+F)
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Ctrl+F or Cmd+F to open search
+      if ((e.ctrlKey || e.metaKey) && e.key === 'f') {
+        e.preventDefault();
+        setIsVisible(true);
+        // Focus input after a short delay to ensure it's rendered
+        setTimeout(() => inputRef.current?.focus(), 0);
+      }
+      // Escape to close search
+      if (e.key === 'Escape' && isVisible) {
+        e.preventDefault();
+        handleClose();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isVisible, setIsVisible]);
+
+  // Focus input when search becomes visible
+  useEffect(() => {
+    if (isVisible) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isVisible]);
+
+  const handleClose = useCallback(() => {
+    setIsVisible(false);
+    setSearchQuery('');
+    setCurrentMatch(0);
+    clearMatchCounts();
+  }, [setIsVisible, setSearchQuery, setCurrentMatch, clearMatchCounts]);
+
+  const handlePrevMatch = useCallback(() => {
+    if (totalMatches > 0) {
+      setCurrentMatch((prev) => (prev > 0 ? prev - 1 : totalMatches - 1));
+    }
+  }, [totalMatches, setCurrentMatch]);
+
+  const handleNextMatch = useCallback(() => {
+    if (totalMatches > 0) {
+      setCurrentMatch((prev) => (prev < totalMatches - 1 ? prev + 1 : 0));
+    }
+  }, [totalMatches, setCurrentMatch]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (e.shiftKey) {
+        handlePrevMatch();
+      } else {
+        handleNextMatch();
+      }
+    }
+  };
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-1 px-2 py-1 bg-background border rounded-md shadow-sm',
+        className
+      )}
+    >
+      <Search className="size-4 text-muted-foreground flex-shrink-0" />
+      <Input
+        ref={inputRef}
+        type="text"
+        placeholder="Search in prompt..."
+        value={searchQuery}
+        onChange={(e) => {
+          setSearchQuery(e.target.value);
+          setCurrentMatch(0);
+        }}
+        onKeyDown={handleKeyDown}
+        className="h-7 text-xs border-0 focus-visible:ring-0 focus-visible:ring-offset-0 px-1 min-w-[150px]"
+      />
+      {searchQuery && (
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          {totalMatches > 0 ? `${currentMatch + 1}/${totalMatches}` : 'No results'}
+        </span>
+      )}
+      <div className="flex items-center gap-0.5">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          onClick={handlePrevMatch}
+          disabled={totalMatches === 0}
+          title="Previous match (Shift+Enter)"
+        >
+          <ChevronUp className="size-3" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          onClick={handleNextMatch}
+          disabled={totalMatches === 0}
+          title="Next match (Enter)"
+        >
+          <ChevronDown className="size-3" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 w-6 p-0"
+          onClick={handleClose}
+          title="Close (Escape)"
+        >
+          <X className="size-3" />
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-text.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/render-text.tsx
@@ -1,41 +1,164 @@
 import { cn } from '@baml/ui/lib/utils';
-import { atom, useAtomValue } from 'jotai';
-import { useMemo, useState, useEffect } from 'react';
+import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useMemo, useState, useEffect, useRef, useId } from 'react';
 import React from 'react';
 import { displaySettingsAtom } from '../preview-toolbar';
 import { getHighlightedParts } from './highlight-utils';
 import { TokenEncoderCache } from './render-tokens';
 import type { Tiktoken } from 'js-tiktoken/lite';
+import {
+  promptSearchQueryAtom,
+  promptSearchCurrentMatchAtom,
+  registerMatchCountAtom,
+  unregisterMatchCountAtom,
+  matchOffsetsAtom,
+} from './search-atoms';
 
 export const showTokensAtom = atom(
   (get) => get(displaySettingsAtom).showTokens,
 );
 
+// Global counter for tracking matches across all HighlightedText instances
+let globalMatchCounter = 0;
+let globalMatchCounterResetKey = '';
+
 const HighlightedText: React.FC<{
   text: string;
   highlightChunks: string[];
-}> = ({ text, highlightChunks }) => {
-  const parts = getHighlightedParts(text, highlightChunks);
+  searchQuery?: string;
+  currentSearchMatch?: number;
+  globalOffset?: number; // Global offset for this component's matches
+  onMatchCount?: (count: number) => void;
+}> = ({ text, highlightChunks, searchQuery, currentSearchMatch = 0, globalOffset = 0, onMatchCount }) => {
+  const matchRefs = useRef<(HTMLElement | null)[]>([]);
+
+  // First apply regular highlighting
+  const baseParts = getHighlightedParts(text, highlightChunks);
+
+  // Then apply search highlighting on top
+  const partsWithSearch = useMemo(() => {
+    if (!searchQuery || searchQuery.trim() === '') {
+      return baseParts.map(part => ({ ...part, isSearchMatch: false, localMatchIndex: -1 }));
+    }
+
+    const searchLower = searchQuery.toLowerCase();
+    let localMatchIndex = 0;
+
+    return baseParts.flatMap(part => {
+      const text = part.text;
+      const textLower = text.toLowerCase();
+
+      // Find all occurrences of search term in this part
+      const segments: Array<{ text: string; highlight: boolean; isSearchMatch: boolean; localMatchIndex: number }> = [];
+      let lastIndex = 0;
+      let searchIndex = textLower.indexOf(searchLower, lastIndex);
+
+      while (searchIndex !== -1) {
+        // Add text before the match
+        if (searchIndex > lastIndex) {
+          segments.push({
+            text: text.slice(lastIndex, searchIndex),
+            highlight: part.highlight,
+            isSearchMatch: false,
+            localMatchIndex: -1,
+          });
+        }
+
+        // Add the search match
+        segments.push({
+          text: text.slice(searchIndex, searchIndex + searchQuery.length),
+          highlight: part.highlight,
+          isSearchMatch: true,
+          localMatchIndex: localMatchIndex++,
+        });
+
+        lastIndex = searchIndex + searchQuery.length;
+        searchIndex = textLower.indexOf(searchLower, lastIndex);
+      }
+
+      // Add remaining text
+      if (lastIndex < text.length) {
+        segments.push({
+          text: text.slice(lastIndex),
+          highlight: part.highlight,
+          isSearchMatch: false,
+          localMatchIndex: -1,
+        });
+      }
+
+      return segments.length > 0 ? segments : [{ ...part, isSearchMatch: false, localMatchIndex: -1 }];
+    });
+  }, [baseParts, searchQuery]);
+
+  // Count matches and report
+  useEffect(() => {
+    const matchCount = partsWithSearch.filter(p => p.isSearchMatch).length;
+    onMatchCount?.(matchCount);
+  }, [partsWithSearch, onMatchCount]);
+
+  // Find which local match index corresponds to the current global match
+  const currentLocalMatch = currentSearchMatch - globalOffset;
+
+  // Get the local match count
+  const localMatchCount = partsWithSearch.filter(p => p.isSearchMatch).length;
+
+  // Scroll current match into view (only if current match is within this component)
+  useEffect(() => {
+    if (currentLocalMatch >= 0 && currentLocalMatch < localMatchCount) {
+      const currentMatchElement = matchRefs.current[currentLocalMatch];
+      if (currentMatchElement) {
+        currentMatchElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+  }, [currentLocalMatch, localMatchCount]);
 
   return (
     <>
-      {parts.map((part, i) =>
-        part.highlight ? (
-          <mark
-            key={`${i}-${part.highlight}-${part.text.length}`}
-            className={cn(
-              'inline whitespace-pre-wrap break-words rounded px-1 py-0.5 font-normal text-xs text-primary-foreground',
-              part.text.trim() === '' ? 'bg-chart-5/30' : 'bg-chart-1/40',
-            )}
-          >
-            {part.text}
-          </mark>
-        ) : (
+      {partsWithSearch.map((part, i) => {
+        // Check if this match is the current global match
+        const isCurrentMatch = part.isSearchMatch && part.localMatchIndex === currentLocalMatch;
+
+        if (part.isSearchMatch) {
+          return (
+            <mark
+              key={`${i}-search-${part.localMatchIndex}`}
+              ref={(el) => {
+                if (part.localMatchIndex >= 0) {
+                  matchRefs.current[part.localMatchIndex] = el;
+                }
+              }}
+              className={cn(
+                'inline whitespace-pre-wrap break-words rounded px-0.5 font-normal text-xs',
+                isCurrentMatch
+                  ? 'bg-yellow-400 text-black ring-2 ring-yellow-600'
+                  : 'bg-yellow-300/70 text-black',
+              )}
+            >
+              {part.text}
+            </mark>
+          );
+        }
+
+        if (part.highlight) {
+          return (
+            <mark
+              key={`${i}-${part.highlight}-${part.text.length}`}
+              className={cn(
+                'inline whitespace-pre-wrap break-words rounded px-1 py-0.5 font-normal text-xs text-primary-foreground',
+                part.text.trim() === '' ? 'bg-chart-5/30' : 'bg-chart-1/40',
+              )}
+            >
+              {part.text}
+            </mark>
+          );
+        }
+
+        return (
           <React.Fragment key={`${i}-normal-${part.text.length}`}>
             {part.text}
           </React.Fragment>
-        ),
-      )}
+        );
+      })}
     </>
   );
 };
@@ -46,9 +169,31 @@ export const RenderPromptPart: React.FC<{
   model?: string;
   provider?: string;
 }> = ({ text, highlightChunks = [], model, provider }) => {
+  const componentId = useId();
   const showTokens = useAtomValue(showTokensAtom);
+  const searchQuery = useAtomValue(promptSearchQueryAtom);
+  const currentSearchMatch = useAtomValue(promptSearchCurrentMatchAtom);
+  const matchOffsets = useAtomValue(matchOffsetsAtom);
+  const registerMatchCount = useSetAtom(registerMatchCountAtom);
+  const unregisterMatchCount = useSetAtom(unregisterMatchCountAtom);
   const [encoder, setEncoder] = useState<Tiktoken | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [localMatchCount, setLocalMatchCount] = useState(0);
+
+  // Get the global offset for this component's matches
+  const globalOffset = matchOffsets.get(componentId) ?? 0;
+
+  // Register/update match count with the global registry
+  useEffect(() => {
+    registerMatchCount({ id: componentId, count: localMatchCount });
+  }, [localMatchCount, componentId, registerMatchCount]);
+
+  // Cleanup on unmount
+  useEffect(() => {
+    return () => {
+      unregisterMatchCount(componentId);
+    };
+  }, [componentId, unregisterMatchCount]);
 
   // Load encoder asynchronously when needed
   useEffect(() => {
@@ -124,8 +269,17 @@ export const RenderPromptPart: React.FC<{
     }
 
     // Only do highlighting if we're not tokenizing
-    return <HighlightedText text={text} highlightChunks={highlightChunks} />;
-  }, [text, highlightChunks, tokenizer, showTokens, isLoading]);
+    return (
+      <HighlightedText
+        text={text}
+        highlightChunks={highlightChunks}
+        searchQuery={searchQuery}
+        currentSearchMatch={currentSearchMatch}
+        globalOffset={globalOffset}
+        onMatchCount={setLocalMatchCount}
+      />
+    );
+  }, [text, highlightChunks, tokenizer, showTokens, isLoading, searchQuery, currentSearchMatch, globalOffset]);
 
   return (
     <div className="flex flex-col min-w-0">

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/search-atoms.ts
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/search-atoms.ts
@@ -1,0 +1,125 @@
+import { atom } from 'jotai';
+
+/**
+ * Atom to store the current search query for prompt preview
+ */
+export const promptSearchQueryAtom = atom<string>('');
+
+/**
+ * Atom to control whether the search bar is visible
+ */
+export const promptSearchVisibleAtom = atom<boolean>(false);
+
+/**
+ * Atom to store the current match index (for navigation between matches)
+ */
+export const promptSearchCurrentMatchAtom = atom<number>(0);
+
+/**
+ * Match registration entry with count and order for computing global offsets
+ */
+interface MatchRegistration {
+  count: number;
+  order: number; // Used to sort components and compute offsets
+}
+
+/**
+ * Atom to store match counts from individual components
+ * Key is a unique component ID, value includes count and order
+ */
+export const promptSearchMatchCountsAtom = atom<Map<string, MatchRegistration>>(new Map());
+
+/**
+ * Derived atom to compute total matches from all components
+ */
+export const promptSearchTotalMatchesAtom = atom(
+  (get) => {
+    const matchCounts = get(promptSearchMatchCountsAtom);
+    let total = 0;
+    matchCounts.forEach((reg) => {
+      total += reg.count;
+    });
+    return total;
+  }
+);
+
+/**
+ * Derived atom to get sorted entries for computing offsets
+ */
+export const sortedMatchEntriesAtom = atom(
+  (get) => {
+    const matchCounts = get(promptSearchMatchCountsAtom);
+    const entries = Array.from(matchCounts.entries());
+    // Sort by order to ensure consistent global indices
+    entries.sort((a, b) => a[1].order - b[1].order);
+    return entries;
+  }
+);
+
+/**
+ * Derived atom to compute the global offset for each component
+ * Returns a map of component ID -> global offset (start index for that component's matches)
+ */
+export const matchOffsetsAtom = atom(
+  (get) => {
+    const sortedEntries = get(sortedMatchEntriesAtom);
+    const offsets = new Map<string, number>();
+    let cumulativeOffset = 0;
+
+    for (const [id, reg] of sortedEntries) {
+      offsets.set(id, cumulativeOffset);
+      cumulativeOffset += reg.count;
+    }
+
+    return offsets;
+  }
+);
+
+// Global counter for registration order
+let registrationCounter = 0;
+
+/**
+ * Write-only atom to register a component's match count
+ */
+export const registerMatchCountAtom = atom(
+  null,
+  (get, set, { id, count, order }: { id: string; count: number; order?: number }) => {
+    const current = get(promptSearchMatchCountsAtom);
+    const next = new Map(current);
+
+    // If component already registered, preserve its order
+    const existing = current.get(id);
+    const finalOrder = order ?? existing?.order ?? registrationCounter++;
+
+    if (count > 0) {
+      next.set(id, { count, order: finalOrder });
+    } else {
+      next.delete(id);
+    }
+    set(promptSearchMatchCountsAtom, next);
+  }
+);
+
+/**
+ * Write-only atom to unregister a component's match count
+ */
+export const unregisterMatchCountAtom = atom(
+  null,
+  (get, set, id: string) => {
+    const current = get(promptSearchMatchCountsAtom);
+    const next = new Map(current);
+    next.delete(id);
+    set(promptSearchMatchCountsAtom, next);
+  }
+);
+
+/**
+ * Write-only atom to clear all match counts (useful when switching tabs)
+ */
+export const clearMatchCountsAtom = atom(
+  null,
+  (_get, set) => {
+    set(promptSearchMatchCountsAtom, new Map());
+    registrationCounter = 0; // Reset counter when clearing
+  }
+);

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/unified-prompt-preview.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/unified-prompt-preview.tsx
@@ -16,6 +16,7 @@ import { renderedPromptAtom } from './prompt-preview-content';
 import { PromptPreviewCurl, curlAtom } from './prompt-preview-curl';
 import { GraphView } from './graph-view';
 import { ReactFlowProvider } from '@xyflow/react';
+import { PromptSearchBar } from './prompt-search-bar';
 
 const GraphHost = () => (
   <div className="h-full">
@@ -199,6 +200,9 @@ export const UnifiedPromptPreview = () => {
               )}
             </div>
             <div className="flex items-center gap-2">
+              {(activeTab === 'preview' || activeTab === 'curl') && (
+                <PromptSearchBar />
+              )}
               {activeTab === 'preview' && (
                 <Button
                   variant="ghost"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a searchable prompt preview (and cURL view) with match highlighting, navigation, and keyboard shortcuts, backed by shared Jotai state.
> 
> - **Search UI**
>   - Add `PromptSearchBar` with Ctrl/Cmd+F to open, Esc to close, Enter/Shift+Enter to navigate matches in `prompt-search-bar.tsx`.
> - **Search State/Plumbing**
>   - Introduce shared atoms in `prompt-preview/search-atoms.ts` for `query`, visibility, current/total matches, per-component match registration, and computed global `matchOffsets`.
> - **Prompt Preview Rendering**
>   - Update `render-text.tsx` to highlight search matches over existing highlights, track per-component match counts, compute local vs global indices, and auto-scroll current match into view.
> - **cURL Rendering**
>   - Enhance `prompt-preview-curl.tsx` to overlay search highlights on Shiki HTML, register match counts, compute local/global indices, and auto-scroll current match; add styles for `.search-match` and `.search-match-current`.
> - **Integration**
>   - Show `PromptSearchBar` in `unified-prompt-preview.tsx` when `preview` or `curl` tab is active.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93f788e7f6a4a966494fda35045de3ee8533a00b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->