### PR TITLE
Symbol tuning documentation clarification

### DIFF
--- a/fern/01-guide/06-prompt-engineering/symbol-tuning.mdx
+++ b/fern/01-guide/06-prompt-engineering/symbol-tuning.mdx
@@ -4,7 +4,43 @@ title: Creating a Classification Function with Symbol Tuning
 
 Aliasing field names to abstract symbols like "k1", "k2", etc. can improve classification results. This technique, known as symbol tuning, helps the LLM focus on your descriptions rather than being biased by the enum or property names themselves.
 
-See the paper [Symbol Tuning Improves In-Context Learning in Language Models](https://arxiv.org/abs/2305.08298) for more details.
+## Why does this help in prompt engineering?
+
+You might wonder: if I'm providing descriptions anyway, why would hiding the variable name matter? The key insight is that **LLMs have preconceived notions about what words like "Refund" or "CancelOrder" mean** based on their training data.
+
+When you use meaningful names like:
+```
+Refund: <your custom description>
+CancelOrder: <your custom description>
+```
+
+The model must reconcile its existing understanding of these terms with your custom descriptions. This can cause conflicts—especially when your definitions differ from common usage.
+
+With symbol tuning:
+```
+k1: <your custom description>
+k2: <your custom description>
+```
+
+The model's attention is spent **100% on understanding your descriptions** rather than trying to forget or override its biases about what the category names mean. The abstract symbols have no semantic weight, so your descriptions become the sole source of meaning.
+
+<Note>
+The original [Symbol Tuning paper](https://arxiv.org/abs/2305.08298) demonstrated this technique in fine-tuning, but the same principle applies to prompt engineering: removing semantic bias from labels helps the model focus on what you actually want it to learn from context.
+</Note>
+
+## Related: Using IDs in prompts
+
+A similar principle applies when dealing with entity identifiers. Using long UUIDs like `550e8400-e29b-41d4-a716-446655440000` in prompts is inefficient—they consume many tokens and carry no semantic meaning. Instead, alias them to simple integers (1, 2, 3) within your prompt. See our blog post [Using UUIDs in prompts is bad](https://boundaryml.com/blog/uuid-swap) for detailed guidance.
+
+The general principle: **use the best representation for the model**, which may differ from the best representation in your code.
+
+## Try it yourself
+
+As with all prompt engineering techniques, results vary by model and use case. We recommend testing with and without symbol tuning to see what works best for your specific task.
+
+## Example
+
+Here's a complete classification function using symbol tuning:
 
 ```baml
 enum MyClass {


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]
    - This PR addresses a conceptual gap identified in a Slack conversation regarding the benefits of symbol tuning in prompt engineering, particularly for meaningful labels.

## Changes
Please describe the changes proposed in this pull request

This PR enhances the `symbol-tuning.mdx` documentation by:
- Adding a "Why does this help in prompt engineering?" section to explain how symbol tuning reduces LLM bias from meaningful labels (e.g., "Refund" vs. "k1"), allowing the model to focus solely on custom descriptions.
- Including a "Related: Using IDs in prompts" section, linking to the UUID blog post and emphasizing the principle of using the best representation for the model.
- Adding a "Try it yourself" section to encourage experimentation.
- Improving document structure with an "Example" header.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed (reviewed the updated markdown content for clarity and accuracy)
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The primary goal of these changes is to clarify the conceptual benefits of symbol tuning in prompt engineering, especially when dealing with meaningful classification labels, based on direct user feedback.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1765583237923579?thread_ts=1765583237.923579&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-f3c9095c-17ed-4488-845a-32dd6349b14c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3c9095c-17ed-4488-845a-32dd6349b14c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

