### PR TITLE
fix(onionskin): restore terminal on panic

### DIFF
--- a/baml_language/crates/baml_onionskin/src/main.rs
+++ b/baml_language/crates/baml_onionskin/src/main.rs
@@ -50,6 +50,20 @@ fn main() -> Result<()> {
                 anyhow::bail!("Path does not exist: {}", path.display());
             }
 
+            // Set up panic hook to restore terminal
+            let original_hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(move |panic_info| {
+                // Restore terminal before showing panic
+                let _ = crossterm::terminal::disable_raw_mode();
+                let _ = crossterm::execute!(
+                    std::io::stdout(),
+                    crossterm::terminal::LeaveAlternateScreen,
+                    crossterm::event::DisableMouseCapture
+                );
+                // Then call the original panic handler
+                original_hook(panic_info);
+            }));
+
             // Initialize terminal
             let mut terminal = ui::init_terminal()?;
 

--- a/beps/docs/README.md
+++ b/beps/docs/README.md
@@ -29,7 +29,7 @@ Below is an auto-generated index of all BEPs.
       <td><a href="./proposals/BEP-001-exceptions/"><strong>BEP-001</strong>: Exception Handling</a> &nbsp; <img src="https://img.shields.io/badge/Status-Proposed-yellow" alt="Proposed"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): Vaibhav Gupta <vbv@boundaryml.com></span></td>
     </tr>
     <tr>
-      <td><a href="./proposals/BEP-002-match/"><strong>BEP-002</strong>: match</a> &nbsp; <img src="https://img.shields.io/badge/Status-Accepted-brightgreen" alt="Accepted"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): hellovai <vbv@boundaryml.com></span></td>
+      <td><a href="./proposals/BEP-002-match/"><strong>BEP-002</strong>: match</a> &nbsp; <img src="https://img.shields.io/badge/Status-Draft-lightgrey" alt="Draft"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): hellovai <vbv@boundaryml.com>, rossirpaulo <rossir.paulo@gmail.com></span></td>
     </tr>
     <tr>
       <td><a href="./proposals/BEP-005-prompt-optimization/"><strong>BEP-005</strong>: Prompt Optimization</a> &nbsp; <img src="https://img.shields.io/badge/Status-Accepted-brightgreen" alt="Accepted"><br><br>- `baml-cli` supports a new command called `optimize` that writes and improves prompts for you, similar to [DSPy](https://dspy.ai/). - Prompt optimization attempts to maximize the number of passing BAML test cases, and optionally minimize tokens and latency. - The optimizer is based on the [GEPA algorithm](https://arxiv.org/abs/2507.19457), which is partially encoded as BAML functions that you can tweak.<br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): Greg Hale <imalsogreg@gmail.com></span></td>

--- a/beps/docs/README.md
+++ b/beps/docs/README.md
@@ -29,7 +29,7 @@ Below is an auto-generated index of all BEPs.
       <td><a href="./proposals/BEP-001-exceptions/"><strong>BEP-001</strong>: Exception Handling</a> &nbsp; <img src="https://img.shields.io/badge/Status-Proposed-yellow" alt="Proposed"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): Vaibhav Gupta <vbv@boundaryml.com></span></td>
     </tr>
     <tr>
-      <td><a href="./proposals/BEP-002-match/"><strong>BEP-002</strong>: match</a> &nbsp; <img src="https://img.shields.io/badge/Status-Draft-lightgrey" alt="Draft"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): hellovai <vbv@boundaryml.com>, rossirpaulo <rossir.paulo@gmail.com></span></td>
+      <td><a href="./proposals/BEP-002-match/"><strong>BEP-002</strong>: match</a> &nbsp; <img src="https://img.shields.io/badge/Status-Accepted-brightgreen" alt="Accepted"><br><br><br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): hellovai <vbv@boundaryml.com>, rossirpaulo <rossir.paulo@gmail.com></span></td>
     </tr>
     <tr>
       <td><a href="./proposals/BEP-005-prompt-optimization/"><strong>BEP-005</strong>: Prompt Optimization</a> &nbsp; <img src="https://img.shields.io/badge/Status-Accepted-brightgreen" alt="Accepted"><br><br>- `baml-cli` supports a new command called `optimize` that writes and improves prompts for you, similar to [DSPy](https://dspy.ai/). - Prompt optimization attempts to maximize the number of passing BAML test cases, and optionally minimize tokens and latency. - The optimizer is based on the [GEPA algorithm](https://arxiv.org/abs/2507.19457), which is partially encoded as BAML functions that you can tweak.<br><br><span style='font-size:0.8em; color:gray'>Shepherd(s): Greg Hale <imalsogreg@gmail.com></span></td>

--- a/beps/docs/proposals/BEP-002-match/README.md
+++ b/beps/docs/proposals/BEP-002-match/README.md
@@ -439,32 +439,6 @@ match (x) {
 
 The following features are explicitly **deferred** for future consideration:
 
-### Enum Variants as Types
-
-Enum variants are **values**, not types. You cannot use them after `:` in a binding pattern:
-
-```baml
-enum Status { Active, Inactive, Pending }
-
-// NOT SUPPORTED — enum variants are not types:
-match (s) {
-  x: Status.Active => ...              // ERROR
-  x: Status.Active | Status.Pending => ...  // ERROR
-}
-
-// CORRECT — match variants as values directly:
-match (s) {
-  Status.Active => "active"
-  Status.Active | Status.Pending => "actionable"
-  Status.Inactive => "inactive"
-}
-
-// CORRECT — or bind the whole enum type:
-match (s) {
-  x: Status => "got status: " + x
-}
-```
-
 ### Destructuring (Phase 3 - Future)
 
 ```baml

--- a/beps/docs/proposals/BEP-002-match/README.md
+++ b/beps/docs/proposals/BEP-002-match/README.md
@@ -566,7 +566,7 @@ Status.Active => "active"
 Status.Active | Status.Pending => "actionable"
 
 // INCORRECT: Cannot use enum variant after `:` — it's not a type!
-// x: Status.Active => ...  // ✗ ERROR: Status.Active is a value, not a type
+// x: Status.Active => ...  // ERROR: Status.Active is a value, not a type
 ```
 
 To match an enum with binding, match the entire enum type and use guards:

--- a/beps/docs/proposals/BEP-002-match/README.md
+++ b/beps/docs/proposals/BEP-002-match/README.md
@@ -446,20 +446,20 @@ Enum variants are **values**, not types. You cannot use them after `:` in a bind
 ```baml
 enum Status { Active, Inactive, Pending }
 
-// ✗ NOT SUPPORTED — enum variants are not types:
+// NOT SUPPORTED — enum variants are not types:
 match (s) {
   x: Status.Active => ...              // ERROR
   x: Status.Active | Status.Pending => ...  // ERROR
 }
 
-// ✓ CORRECT — match variants as values directly:
+// CORRECT — match variants as values directly:
 match (s) {
   Status.Active => "active"
   Status.Active | Status.Pending => "actionable"
   Status.Inactive => "inactive"
 }
 
-// ✓ CORRECT — or bind the whole enum type:
+// CORRECT — or bind the whole enum type:
 match (s) {
   x: Status => "got status: " + x
 }

--- a/beps/docs/proposals/BEP-002-match/README.md
+++ b/beps/docs/proposals/BEP-002-match/README.md
@@ -106,18 +106,20 @@ cmd: "start" | "stop"
 When binding a union pattern, the bound variable retains the **exact union type**, not a collapsed/widened type:
 
 ```baml
-enum Status { Active, Inactive, Pending }
+class Success { data string }
+class Failure { reason string }
+class Pending { eta int }
 
-match (s) {
-  x: Status.Active | Status.Inactive => {
-    // x has type `Status.Active | Status.Inactive`, NOT `Status`
+match (result) {
+  x: Success | Failure => {
+    // x has type `Success | Failure`, NOT some supertype
     handle(x)
   }
-  _: Status.Pending => "pending"
+  _: Pending => "pending"
 }
 ```
 
-This preserves precision: you know exactly which variants `x` could be.
+This preserves precision: you know exactly which types `x` could be.
 
 ### Decision 6: Exhaustiveness via Untyped Binding
 
@@ -168,19 +170,21 @@ type_expr      := ... (existing type expression grammar)
 
 ### Pattern Forms
 
-| Pattern          | Matches                         | Binding                   | Example                     |
-| ---------------- | ------------------------------- | ------------------------- | --------------------------- |
-| `name`           | Anything                        | `name` bound to scrutinee | `other => use(other)`       |
-| `_`              | Anything                        | Discarded                 | `_ => "fallback"`           |
-| `name: Type`     | Values of type `T`              | `name` bound (narrowed)   | `s: Success => s.data`      |
-| `_: Type`        | Values of `T`                   | Discarded                 | `_: Failure => "failed"`    |
-| `null`           | `null` value                    | None                      | `null => "nothing"`         |
-| `true` / `false` | Boolean literal                 | None                      | `true => "yes"`             |
-| `42` / `3.14`    | Numeric literal                 | None                      | `200 => "OK"`               |
-| `"foo"`          | String literal                  | None                      | `"start" => "starting"`     |
-| `Enum.Variant`   | Enum variant (value equality)   | None                      | `Status.Active => "active"` |
-| `A \| B`         | Union of literals/enum variants | None                      | `200 \| 201 => "success"`   |
-| `x: A \| B`      | Union of types                  | `x` bound                 | `x: int \| bool => use(x)`  |
+| Pattern          | Matches                         | Binding                   | Example                                  |
+| ---------------- | ------------------------------- | ------------------------- | ---------------------------------------- |
+| `name`           | Anything                        | `name` bound to scrutinee | `other => use(other)`                    |
+| `_`              | Anything                        | Discarded                 | `_ => "fallback"`                        |
+| `name: Type`     | Values of type `T`              | `name` bound (narrowed)   | `s: Success => s.data`                   |
+| `_: Type`        | Values of type `T`              | Discarded                 | `_: Failure => "failed"`                 |
+| `null`           | `null` value                    | None                      | `null => "nothing"`                      |
+| `true` / `false` | Boolean literal                 | None                      | `true => "yes"`                          |
+| `42` / `3.14`    | Numeric literal                 | None                      | `200 => "OK"`                            |
+| `"foo"`          | String literal                  | None                      | `"start" => "starting"`                  |
+| `Enum.Variant`   | Enum variant (value equality)   | None                      | `Status.Active => "active"`              |
+| `A \| B`         | Union of literals/enum variants | None                      | `Status.Active \| Status.Pending => ...` |
+| `x: A \| B`      | Union of **types** (not values) | `x` bound                 | `x: Success \| Failure => ...`           |
+
+> **Note:** The `Type` after `:` must be an actual type (class, primitive, type alias), not an enum variant. Enum variants are values and must be matched directly without `:` binding.
 
 ### Precedence
 
@@ -435,6 +439,32 @@ match (x) {
 
 The following features are explicitly **deferred** for future consideration:
 
+### Enum Variants as Types
+
+Enum variants are **values**, not types. You cannot use them after `:` in a binding pattern:
+
+```baml
+enum Status { Active, Inactive, Pending }
+
+// ✗ NOT SUPPORTED — enum variants are not types:
+match (s) {
+  x: Status.Active => ...              // ERROR
+  x: Status.Active | Status.Pending => ...  // ERROR
+}
+
+// ✓ CORRECT — match variants as values directly:
+match (s) {
+  Status.Active => "active"
+  Status.Active | Status.Pending => "actionable"
+  Status.Inactive => "inactive"
+}
+
+// ✓ CORRECT — or bind the whole enum type:
+match (s) {
+  x: Status => "got status: " + x
+}
+```
+
 ### Destructuring (Phase 3 - Future)
 
 ```baml
@@ -543,28 +573,46 @@ other => "fallback"
 ### 2. Type Expressions vs Value Expressions
 
 After `:`, we parse a **type expression**, not a value expression. This means:
-- `s: Success` — `Success` is resolved as a type
-- `s: 200 | 201` — `200` and `201` are literal types (not values)
-- `s: Status.Active | Status.Inactive` — these are enum variant types
+- `s: Success` — `Success` is resolved as a type (class name)
+- `s: 200 | 201` — `200` and `201` are literal types
+- `s: Success | Failure` — union of class types
 
 Without the `:`, we have value patterns:
 - `200` — matches the integer value 200
 - `Status.Active` — matches the enum variant (via value equality)
 - `other` — binds to any value
 
-### 3. Enum Variants in Patterns
+### 3. Enum Variants Are Values, Not Types
 
-Enum variants can appear in two contexts:
+**Important distinction:** Enum variants like `Status.Active` are **values**, not types. You match them directly as value patterns:
 
 ```baml
-// As a bare pattern (value equality):
+// CORRECT: Enum variant as value pattern (no binding needed)
 Status.Active => "active"
+Status.Active | Status.Pending => "actionable"
 
-// As a type after `:` (type matching):
-s: Status.Active | Status.Inactive => use(s)
+// INCORRECT: Cannot use enum variant after `:` — it's not a type!
+// x: Status.Active => ...  // ✗ ERROR: Status.Active is a value, not a type
 ```
 
-Both are valid. The first checks value equality; the second does type narrowing and binding.
+To match an enum with binding, match the entire enum type and use guards:
+
+```baml
+enum Status { Active, Inactive, Pending }
+
+match (s) {
+  // Match specific variants as values (no binding):
+  Status.Active => "active"
+  Status.Inactive => "inactive"
+  Status.Pending => "pending"
+}
+
+// Or match the enum type with binding and use guards:
+match (s) {
+  x: Status if x == Status.Active => "active: " + x
+  _: Status => "other status"
+}
+```
 
 ### 4. Guards Don't Affect Exhaustiveness
 
@@ -603,13 +651,16 @@ if (expensiveCall() instanceof A) { ... }  // Wrong: multiple calls!
 When `x: A | B` matches, `x` has type `A | B`, not a supertype:
 
 ```baml
-enum Status { Active, Inactive, Pending }
+class Success { data string }
+class Failure { reason string }
+class Pending { eta int }
 
-match (s) {
-  x: Status.Active | Status.Inactive => {
-    // x: Status.Active | Status.Inactive
-    // NOT x: Status
+match (result) {
+  x: Success | Failure => {
+    // x has type: Success | Failure
+    // NOT some broader type
   }
+  _: Pending => "pending"
 }
 ```
 

--- a/beps/docs/proposals/BEP-002-match/README.md
+++ b/beps/docs/proposals/BEP-002-match/README.md
@@ -168,19 +168,19 @@ type_expr      := ... (existing type expression grammar)
 
 ### Pattern Forms
 
-| Pattern          | Matches                       | Binding                   | Example                     |
-| ---------------- | ----------------------------- | ------------------------- | --------------------------- |
-| `name`           | Anything                      | `name` bound to scrutinee | `other => use(other)`       |
-| `_`              | Anything                      | Discarded                 | `_ => "fallback"`           |
-| `name: Type`     | Values of `Type`              | `name` bound (narrowed)   | `s: Success => s.data`      |
-| `_: Type`        | Values of `Type`              | Discarded                 | `_: Failure => "failed"`    |
-| `null`           | `null` value                  | None                      | `null => "nothing"`         |
-| `true` / `false` | Boolean literal               | None                      | `true => "yes"`             |
-| `42` / `3.14`    | Numeric literal               | None                      | `200 => "OK"`               |
-| `"foo"`          | String literal                | None                      | `"start" => "starting"`     |
-| `Enum.Variant`   | Enum variant (value equality) | None                      | `Status.Active => "active"` |
-| `A \| B`         | Union of literals/variants    | None                      | `200 \| 201 => "success"`   |
-| `x: A \| B`      | Union of types                | `x` bound                 | `x: int \| bool => use(x)`  |
+| Pattern          | Matches                         | Binding                   | Example                     |
+| ---------------- | ------------------------------- | ------------------------- | --------------------------- |
+| `name`           | Anything                        | `name` bound to scrutinee | `other => use(other)`       |
+| `_`              | Anything                        | Discarded                 | `_ => "fallback"`           |
+| `name: Type`     | Values of type `T`              | `name` bound (narrowed)   | `s: Success => s.data`      |
+| `_: Type`        | Values of `T`                   | Discarded                 | `_: Failure => "failed"`    |
+| `null`           | `null` value                    | None                      | `null => "nothing"`         |
+| `true` / `false` | Boolean literal                 | None                      | `true => "yes"`             |
+| `42` / `3.14`    | Numeric literal                 | None                      | `200 => "OK"`               |
+| `"foo"`          | String literal                  | None                      | `"start" => "starting"`     |
+| `Enum.Variant`   | Enum variant (value equality)   | None                      | `Status.Active => "active"` |
+| `A \| B`         | Union of literals/enum variants | None                      | `200 \| 201 => "success"`   |
+| `x: A \| B`      | Union of types                  | `x` bound                 | `x: int \| bool => use(x)`  |
 
 ### Precedence
 
@@ -230,6 +230,8 @@ function Classify(result: Result) -> string {
 ```
 
 **Important:** Guards do not contribute to exhaustiveness. A guarded pattern `s: Success if cond` does not cover all `Success` values. You must have an unguarded fallback.
+
+> **Scope note:** This is a simplification for the current proposal. Future versions may support smarter exhaustiveness analysis that recognizes complementary guards (e.g., `if x > 0` and `if x <= 0`) as covering all cases.
 
 ### Example 3: Enum Matching
 
@@ -338,7 +340,7 @@ The compiler performs exhaustiveness analysis to ensure all possible values are 
 1. **All cases must be covered** — either explicitly or via catch-all
 2. **Guarded arms don't guarantee coverage** — `s: T if cond` covers only a subset of `T`
 3. **Catch-all covers remaining cases** — an untyped binding (`_` or `name`) covers everything not yet matched
-4. **Order matters** — first matching arm wins; unreachable arms should warn
+4. **Order matters** — first matching arm wins; unreachable arms are a compile error
 
 ### Examples
 
@@ -364,7 +366,7 @@ match (x) {
   _: B => "b"
 }
 
-// WARNING: unreachable arm (B already covered by catch-all)
+// ERROR: unreachable arm (B already covered by catch-all)
 match (x) {
   _: A => "a"
   _ => "other"
@@ -489,7 +491,7 @@ Each `MATCH_ARM` contains:
 
 1. **Pattern type inference** — determine what type each pattern matches
 2. **Exhaustiveness analysis** — compute coverage, error on gaps
-3. **Unreachable arm detection** — warn on arms that can never match
+3. **Unreachable arm detection** — error on arms that can never match
 4. **Type narrowing** — narrow bound variable types within arms
 
 ### Codegen Changes
@@ -615,12 +617,12 @@ This requires the type checker to construct the exact union type from the patter
 
 ### 7. First-Match Semantics and Warnings
 
-Order matters. The compiler should warn on unreachable arms:
+Order matters. The compiler should error on unreachable arms:
 
 ```baml
 match (x) {
   _ => "catch all"
-  _: Success => "never reached"  // WARNING: unreachable
+  _: Success => "never reached"  // ERROR: unreachable
 }
 ```
 

--- a/beps/docs/proposals/BEP-002-match/README.md
+++ b/beps/docs/proposals/BEP-002-match/README.md
@@ -2,9 +2,8 @@
 id: BEP-002
 title: "match"
 shepherds: hellovai <vbv@boundaryml.com>, rossirpaulo <rossir.paulo@gmail.com>
-status: Draft
+status: Accepted
 created: 2025-12-15
-feedback:
 ---
 
 The `match` expression in BAML provides exhaustive, type-safe pattern matching over union types, enums, and literal values. It enables declarative handling of different data shapes while ensuring at compile time that all cases are covered.

--- a/beps/docs/proposals/BEP-002-match/README.md
+++ b/beps/docs/proposals/BEP-002-match/README.md
@@ -1,210 +1,645 @@
 ---
 id: BEP-002
 title: "match"
-shepherds: hellovai <vbv@boundaryml.com>
-status: Accepted
-created: 2025-12-01
-feedback: https://gloo-global.slack.com/docs/T03KV1PH19P/F0A1715PM52
+shepherds: hellovai <vbv@boundaryml.com>, rossirpaulo <rossir.paulo@gmail.com>
+status: Draft
+created: 2025-12-15
+feedback:
 ---
 
-The `match` expression in BAML provides a powerful way to handle different data shapes, particularly useful for working with union types and structured LLM outputs. It lets you write declarative, type-safe code that is easier to read and maintain than complex `if-else` chains.
+The `match` expression in BAML provides exhaustive, type-safe pattern matching over union types, enums, and literal values. It enables declarative handling of different data shapes while ensuring at compile time that all cases are covered.
 
-## Quick Start
+## Motivation
 
-Use `match` to handle all possible values of an enum or union type:
+LLM responses in BAML frequently use union types and nullable fields. Currently, handling these requires verbose `if-else` chains that are error-prone and don't guarantee exhaustiveness:
 
 ```baml
-enum Status {
-  Active
-  Inactive
-  Pending
-}
-
-function GetMessage(s: Status) -> string {
-  return match (s) {
-    Status.Active => "User is active"
-    Status.Inactive => "User is inactive"
-    Status.Pending => "User is pending"
+function Process(result: LlmResult) -> string {
+  if (result == null) {
+    return "No result"
   }
-}
-```
-
-The compiler ensures you handle every case. If you add a `Status.Archived` variant later, BAML will tell you exactly where you need to update your code.
-
-## Core Concepts
-
-### How Match Works
-
-A `match` expression compares a value against a series of **patterns**. The first pattern that matches determines the result.
-
-```baml
-match (value) {
-  Pattern1 => Result1
-  Pattern2 => Result2
-}
-```
-
-Because `match` is an **expression**, it evaluates to a value that you can assign to a variable or return directly.
-
-### Type Patterns
-
-When working with Union types (like `string | Image`), use the `variable: Type` syntax to narrow the type:
-
-```baml
-class Image { url string }
-
-function GetContent(input: string | Image) -> string {
-  return match (input) {
-    // Matches if input is a string, binding it to 's'
-    s: string => s
-    
-    // Matches if input is an Image, binding it to 'img'
-    img: Image => img.url
+  if (result instanceof Success) {
+    if (result.score >= 0.9) {
+      return "High confidence"
+    }
+    return "Low confidence"
   }
+  if (result instanceof Failure) {
+    return "Failed: " + result.reason
+  }
+  // What if we forget a case? No compiler help.
 }
 ```
 
-This is syntactically sugar for:
-```javascript
-if (input instanceof string) { ... }
-else if (input instanceof Image) { ... }
-```
+Pattern matching solves this with:
+1. **Exhaustiveness checking** — the compiler ensures all cases are handled
+2. **Cleaner syntax** — flat, declarative case enumeration
+3. **Type narrowing** — bound variables have their type narrowed within each arm
 
-### Wildcards
+## Core Design Decisions
 
-Use `_` (underscore) or a named variable to catch "everything else":
+### Decision 1: Type Patterns Require Explicit Binding
+
+**Problem:** In a bare pattern like `match(x) { Type1 => ... }`, it's ambiguous whether `Type1` is a type name or a variable/value.
+
+**Solution:** Type patterns always use the `name: TypeExpr` syntax:
 
 ```baml
 match (x) {
-  1 => "One"
-  other => "Something else: " + other
+  s: Success => "got success: " + s.data   // s is bound, type is Success
+  _: Failure => "got failure"              // _ is bound but discarded
+  value1 => "literal match"                // value1 is a literal or catch-all
 }
 ```
 
-If you don't care about the value, you can just use `_`:
+This makes parsing unambiguous and aligns with TypeScript's type annotation syntax.
+
+### Decision 2: `_` is a Binding, Not a Special Keyword
+
+The underscore `_` is a valid binding name. Like any other binding, it captures the matched value. However, the value is **dropped later in the pipeline** (not accessible in the arm body).
 
 ```baml
-match (status) {
-  Status.Active => "Active"
-  _ => "Not active" 
+match (result) {
+  _: Success => "success"     // _ bound to Success, but dropped
+  other => "other: " + other  // other bound and usable
 }
 ```
 
-## Common Patterns
+**Important:** There is no special `default` keyword. Any untyped binding (including `_` or any identifier) acts as a catch-all because it matches any value.
 
-### Handling LLM Outputs
+### Decision 3: Catch-All via Untyped Binding
 
-BAML functions often return unions when the LLM might return different structures (e.g., a valid result or an error explanation).
+A pattern without `: TypeExpr` matches anything and binds the scrutinee:
 
 ```baml
-class Success { data string }
-class Failure { reason string }
+match (x) {
+  _: int => "integer"
+  _: string => "string"
+  other => "something else: " + other  // catch-all, binds to 'other'
+}
 
-function Process(result: Success | Failure) -> string {
+// Or using _ as catch-all (value discarded):
+match (x) {
+  _: int => "integer"
+  _ => "not an integer"  // catch-all, value discarded
+}
+```
+
+### Decision 4: Full Type Expression Generality
+
+The type expression after `:` supports full generality — unions, type aliases, parenthesized groups:
+
+```baml
+// All equivalent:
+x: int | bool
+x: (int | bool)
+x: (int) | (bool)
+
+// Complex unions:
+result: Success | Failure
+code: 200 | 201 | 204
+cmd: "start" | "stop"
+```
+
+### Decision 5: Union Types Don't Collapse
+
+When binding a union pattern, the bound variable retains the **exact union type**, not a collapsed/widened type:
+
+```baml
+enum Status { Active, Inactive, Pending }
+
+match (s) {
+  x: Status.Active | Status.Inactive => {
+    // x has type `Status.Active | Status.Inactive`, NOT `Status`
+    handle(x)
+  }
+  _: Status.Pending => "pending"
+}
+```
+
+This preserves precision: you know exactly which variants `x` could be.
+
+### Decision 6: Exhaustiveness via Untyped Binding
+
+Exhaustiveness is required. An untyped binding (catch-all) satisfies exhaustiveness for all remaining cases:
+
+```baml
+type Result = Success | Failure | null
+
+// Exhaustive via explicit patterns:
+match (result) {
+  _: Success => "ok"
+  _: Failure => "error"
+  null => "nothing"
+}
+
+// Exhaustive via catch-all:
+match (result) {
+  _: Success => "ok"
+  _ => "not success"  // covers Failure and null
+}
+
+// NOT exhaustive — compile error:
+match (result) {
+  _: Success => "ok"
+  _: Failure => "error"
+  // Error: 'null' not handled
+}
+```
+
+**Future enhancement:** Warn when a catch-all covers multiple cases, to encourage explicit handling.
+
+## Syntax Specification
+
+### Grammar
+
+```
+match_expr     := 'match' '(' expr ')' '{' match_arm+ '}'
+match_arm      := pattern guard? '=>' arm_body
+pattern        := binding_pattern | literal_pattern | union_pattern
+binding_pattern := IDENT (':' type_expr)?
+literal_pattern := 'null' | 'true' | 'false' | INTEGER | FLOAT | STRING
+union_pattern  := (literal_pattern | enum_variant) ('|' (literal_pattern | enum_variant))*
+enum_variant   := IDENT '.' IDENT
+guard          := 'if' expr
+arm_body       := expr | block_expr
+type_expr      := ... (existing type expression grammar)
+```
+
+### Pattern Forms
+
+| Pattern          | Matches                       | Binding                   | Example                     |
+| ---------------- | ----------------------------- | ------------------------- | --------------------------- |
+| `name`           | Anything                      | `name` bound to scrutinee | `other => use(other)`       |
+| `_`              | Anything                      | Discarded                 | `_ => "fallback"`           |
+| `name: Type`     | Values of `Type`              | `name` bound (narrowed)   | `s: Success => s.data`      |
+| `_: Type`        | Values of `Type`              | Discarded                 | `_: Failure => "failed"`    |
+| `null`           | `null` value                  | None                      | `null => "nothing"`         |
+| `true` / `false` | Boolean literal               | None                      | `true => "yes"`             |
+| `42` / `3.14`    | Numeric literal               | None                      | `200 => "OK"`               |
+| `"foo"`          | String literal                | None                      | `"start" => "starting"`     |
+| `Enum.Variant`   | Enum variant (value equality) | None                      | `Status.Active => "active"` |
+| `A \| B`         | Union of literals/variants    | None                      | `200 \| 201 => "success"`   |
+| `x: A \| B`      | Union of types                | `x` bound                 | `x: int \| bool => use(x)`  |
+
+### Precedence
+
+The `:` in `name: TypeExpr` binds tighter than `|`:
+
+```baml
+x: int | bool    // parsed as x: (int | bool)
+x: (int | bool)  // same as above
+x: (int) | (bool) // same as above
+```
+
+## Detailed Examples
+
+### Example 1: Basic Union Discrimination
+
+```baml
+class Success { data string, score float }
+class Failure { reason string, code int }
+type Result = Success | Failure | null
+
+function Process(result: Result) -> string {
   return match (result) {
-    s: Success => "Computed: " + s.data
-    f: Failure => "Failed: " + f.reason
+    null => "No result"
+    s: Success => "Got: " + s.data
+    f: Failure => "Error: " + f.reason
   }
 }
 ```
 
-### Literal Matching
+### Example 2: Guards for Conditional Matching
 
-You can match exact values (strings, numbers, booleans) directly:
-
-```baml
-type Command = "start" | "stop" | int
-
-match (cmd) {
-  "start" => "Starting engine..."
-  "stop" => "Stopping engine..."
-  
-  // Catch all integers
-  seconds: int => "Sleeping for " + seconds + " seconds"
-}
-```
-
-### Destructuring
-
-You can unpack classes and objects directly in the pattern to access their fields:
+Guards add conditions that must be true for the arm to match:
 
 ```baml
-class User {
-  name string
-  age int
-}
+function Classify(result: Result) -> string {
+  return match (result) {
+    null => "none"
 
-function Greet(u: User) -> string {
-  return match (u) {
-    // Match specific field value
-    User { name: "Admin" } => "Welcome, Administrator"
-    
-    // Bind 'name' variable
-    User { name } => "Hello, " + name
+    s: Success if s.score >= 0.9 => "excellent: " + s.data
+    s: Success if s.score >= 0.7 => "good: " + s.data
+    s: Success => "marginal: " + s.data
+
+    f: Failure if f.code >= 500 => "server error: " + f.reason
+    f: Failure => "client error: " + f.reason
   }
 }
 ```
 
-## Advanced Features
+**Important:** Guards do not contribute to exhaustiveness. A guarded pattern `s: Success if cond` does not cover all `Success` values. You must have an unguarded fallback.
 
-### Guards
-
-Add conditions to patterns using `if`. The pattern matches only if the condition is true.
+### Example 3: Enum Matching
 
 ```baml
-match (response) {
-  // Pattern + Guard
-  s: Success if s.score > 0.9 => "High confidence"
-  
-  // Fallback for same type
-  s: Success => "Low confidence"
-  
-  Failure => "Failed"
+enum Status { Active, Inactive, Pending, Archived }
+
+function Describe(s: Status) -> string {
+  return match (s) {
+    Status.Active => "User is active"
+    Status.Inactive => "User is inactive"
+    Status.Pending => "Awaiting approval"
+    Status.Archived => "User archived"
+  }
 }
 ```
 
-### Complex Unions
+If you later add `Status.Deleted`, the compiler will error on this match — forcing you to handle the new case.
 
-You can match against subsets of a union.
+### Example 4: Literal Unions
 
 ```baml
-type Primitive = string | int
+type HttpSuccess = 200 | 201 | 204
+type HttpError = 400 | 404 | 500
+
+function DescribeStatus(code: int) -> string {
+  return match (code) {
+    200 | 201 => "Success with content"
+    204 => "Success, no content"
+    400 | 404 => "Client error"
+    500 => "Server error"
+    _ => "Unknown status: " + code
+  }
+}
+```
+
+### Example 5: Variant Unions
+
+```baml
+enum Status { Active, Inactive, Pending }
+
+function IsActionable(s: Status) -> bool {
+  return match (s) {
+    Status.Active | Status.Pending => true
+    Status.Inactive => false
+  }
+}
+```
+
+### Example 6: Type Unions with Binding
+
+```baml
+type Primitive = string | int | bool
 type Complex = User | Image
-type Any = Primitive | Complex
+type Any = Primitive | Complex | null
 
-function Handle(val: Any) -> string {
+function Categorize(val: Any) -> string {
   return match (val) {
-    // Matches if val is string OR int
-    p: Primitive => "Got a primitive"
-    
-    // Matches if val is User OR Image
-    c: Complex => "Got an object"
+    null => "nothing"
+    p: Primitive => "primitive value"  // p has type string | int | bool
+    c: Complex => "complex object"     // c has type User | Image
   }
 }
 ```
 
-### Blocks
+### Example 7: Nested Match
 
-If you need to perform multiple actions in a match arm, use a block `{ ... }`. The last expression in the block is the result.
+```baml
+class Request { auth: ApiKey | OAuth | null, endpoint: string }
+
+function Authorize(req: Request) -> string {
+  return match (req.auth) {
+    null => "No auth for " + req.endpoint
+
+    a: ApiKey => match (a.key) {
+      k: string if k.startsWith("prod_") => "Production key"
+      _ => "Dev key"
+    }
+
+    o: OAuth if o.expires > now() => "Valid OAuth"
+    _: OAuth => "Expired OAuth"
+  }
+}
+```
+
+### Example 8: Block Bodies
+
+When an arm needs multiple statements, use a block. The last expression is the result:
 
 ```baml
 match (status) {
-  Status.Error => {
+  _: Error => {
     log("Error occurred")
     metrics.increment("errors")
-    "Failed" // Return value
+    "Failed"  // return value
   }
   _ => "OK"
 }
 ```
 
-## Why `match`?
+## Exhaustiveness Checking
 
-### 1. Type Safety (Exhaustiveness)
-The biggest benefit is **exhaustiveness checking**. When you use `if/else`, it's easy to miss a case, especially when a type definition changes (e.g., adding a new Enum variant). With `match`, the BAML compiler guarantees you've handled every possible case.
+The compiler performs exhaustiveness analysis to ensure all possible values are handled.
 
-### 2. Expressiveness
-Parsing LLM outputs often involves checking for many different structures ("Did it return the answer? Did it return a clarification request? Did it return an error?"). `match` flattens what would be a deep nested `if` structure into a linear, readable list of cases.
+### Rules
 
-### 3. Declaration vs Control Flow
-`match` encourages a "parse, don't validate" mindset. Instead of checking conditions imperatively (`if x.is_valid()`), you declare the shapes of data you expect to handle. This aligns well with BAML's philosophy of treating data structures as first-class schemas.
+1. **All cases must be covered** — either explicitly or via catch-all
+2. **Guarded arms don't guarantee coverage** — `s: T if cond` covers only a subset of `T`
+3. **Catch-all covers remaining cases** — an untyped binding (`_` or `name`) covers everything not yet matched
+4. **Order matters** — first matching arm wins; unreachable arms should warn
+
+### Examples
+
+```baml
+type T = A | B | C
+
+// OK: all explicit
+match (x) {
+  _: A => "a"
+  _: B => "b"
+  _: C => "c"
+}
+
+// OK: catch-all covers B and C
+match (x) {
+  _: A => "a"
+  _ => "not a"
+}
+
+// ERROR: C not covered
+match (x) {
+  _: A => "a"
+  _: B => "b"
+}
+
+// WARNING: unreachable arm (B already covered by catch-all)
+match (x) {
+  _: A => "a"
+  _ => "other"
+  _: B => "b"  // unreachable!
+}
+```
+
+## Semantics
+
+### Evaluation Order
+
+1. Evaluate the scrutinee expression **once**
+2. Test arms **top-to-bottom**
+3. For each arm:
+   - Check if pattern matches
+   - If pattern has a guard, evaluate guard
+   - If both match, bind variables and evaluate arm body
+4. First matching arm's body is the result
+
+### Type Narrowing
+
+Within a matched arm, bound variables have their type narrowed:
+
+```baml
+type T = string | int | null
+
+match (x) {
+  s: string => s.length()    // s is string, not string | int | null
+  n: int => n + 1            // n is int
+  null => 0
+}
+```
+
+### Binding Scope
+
+- Bound variables are in scope in the guard and arm body
+- Bound variables do **not** leak outside the arm
+- The same binding name can be reused across arms
+
+```baml
+match (x) {
+  a: A => use(a)   // a is A
+  a: B => use(a)   // a is B (different a, shadows previous)
+}
+// a is not accessible here
+```
+
+## Comparison to Other Languages
+
+| Feature            | Rust              | Python 3.10+        | TypeScript | BAML                |
+| ------------------ | ----------------- | ------------------- | ---------- | ------------------- |
+| **Syntax**         | `match x { ... }` | `match x: case ...` | N/A        | `match (x) { ... }` |
+| **Type patterns**  | `Some(x)`         | `case Some(x)`      | N/A        | `x: Type`           |
+| **Binding**        | `x @ pattern`     | `case x`            | N/A        | `x: Type` or `x`    |
+| **Guards**         | `if cond`         | `if cond`           | N/A        | `if cond`           |
+| **Exhaustiveness** | Enforced          | Optional            | N/A        | Enforced            |
+| **Literal unions** | `1 \| 2 \| 3`     | `case 1 \| 2 \| 3`  | N/A        | `1 \| 2 \| 3`       |
+
+**Key BAML choices:**
+- `:` for type binding (familiar to TS/JS developers)
+- Parentheses around scrutinee (familiar to C-family)
+- `=>` for arm bodies (familiar to JS arrow functions)
+- No special `default` keyword; catch-all is just an untyped binding
+
+## What's NOT in This Proposal
+
+The following features are explicitly **deferred** for future consideration:
+
+### Destructuring (Phase 3 - Future)
+
+```baml
+// NOT YET SUPPORTED:
+match (user) {
+  User { name: "Admin" } => "admin"
+  User { name, age } => name + " is " + age
+}
+```
+
+Destructuring introduces complexity around:
+- Nullable field handling (`{ field }` vs `{ field? }`)
+- Literal vs variable disambiguation in field patterns
+- Nesting depth limits
+
+### Multiple Patterns Per Arm
+
+```baml
+// NOT SUPPORTED:
+match (x) {
+  _: A | _: B => "a or b"  // can't have multiple binding patterns
+}
+
+// INSTEAD, use type union:
+match (x) {
+  _: A | B => "a or b"  // A | B is a type expression
+}
+```
+
+### `@` Binding (Bind Whole + Destructure)
+
+```baml
+// NOT SUPPORTED:
+match (x) {
+  s @ Success { data } => use(s, data)
+}
+```
+
+## Implementation Notes
+
+### Parser Changes
+
+Add `parse_match_expr` to the parser, producing:
+- `MATCH_EXPR` node containing:
+  - Scrutinee expression
+  - One or more `MATCH_ARM` nodes
+
+Each `MATCH_ARM` contains:
+- Pattern (binding, literal, or union)
+- Optional guard expression
+- Arm body expression
+
+### Type Checker Changes
+
+1. **Pattern type inference** — determine what type each pattern matches
+2. **Exhaustiveness analysis** — compute coverage, error on gaps
+3. **Unreachable arm detection** — warn on arms that can never match
+4. **Type narrowing** — narrow bound variable types within arms
+
+### Codegen Changes
+
+Desugar `match` to equivalent `if-else` chain with `instanceof` checks:
+
+```baml
+// Source:
+match (x) {
+  s: Success if s.score > 0.9 => "high"
+  s: Success => "low"
+  _: Failure => "failed"
+}
+
+// Desugared (conceptually):
+{
+  let $scrut = x
+  if ($scrut instanceof Success) {
+    let s = $scrut
+    if (s.score > 0.9) {
+      "high"
+    } else {
+      "low"
+    }
+  } else if ($scrut instanceof Failure) {
+    "failed"
+  } else {
+    // unreachable if exhaustive
+  }
+}
+```
+
+## Key Implementation Caveats
+
+These are subtle points that implementers must handle correctly:
+
+### 1. `_` is NOT a Keyword
+
+Unlike Rust where `_` is a special pattern, in BAML `_` is just an identifier that happens to be dropped. The lexer should emit it as a `WORD` token, not a special token. The "drop" behavior is handled later in the pipeline (name resolution or codegen), not in parsing.
+
+```baml
+// These are parsed identically at the syntax level:
+_ => "fallback"
+other => "fallback"
+
+// The difference is semantic: _ is dropped, other is usable
+```
+
+### 2. Type Expressions vs Value Expressions
+
+After `:`, we parse a **type expression**, not a value expression. This means:
+- `s: Success` — `Success` is resolved as a type
+- `s: 200 | 201` — `200` and `201` are literal types (not values)
+- `s: Status.Active | Status.Inactive` — these are enum variant types
+
+Without the `:`, we have value patterns:
+- `200` — matches the integer value 200
+- `Status.Active` — matches the enum variant (via value equality)
+- `other` — binds to any value
+
+### 3. Enum Variants in Patterns
+
+Enum variants can appear in two contexts:
+
+```baml
+// As a bare pattern (value equality):
+Status.Active => "active"
+
+// As a type after `:` (type matching):
+s: Status.Active | Status.Inactive => use(s)
+```
+
+Both are valid. The first checks value equality; the second does type narrowing and binding.
+
+### 4. Guards Don't Affect Exhaustiveness
+
+This is critical for the exhaustiveness checker:
+
+```baml
+match (x) {
+  s: Success if s.score > 0.9 => "high"
+  // ERROR: Success not exhaustively covered!
+}
+```
+
+Even though `s: Success` appears, the guard makes it partial. The checker must track "guarded coverage" separately from "total coverage."
+
+### 5. Scrutinee Evaluation
+
+The scrutinee must be evaluated exactly once and stored:
+
+```baml
+match (expensiveCall()) {
+  _: A => ...
+  _: B => ...
+}
+
+// Must compile to:
+let $scrut = expensiveCall()
+if ($scrut instanceof A) { ... }
+else if ($scrut instanceof B) { ... }
+
+// NOT:
+if (expensiveCall() instanceof A) { ... }  // Wrong: multiple calls!
+```
+
+### 6. Union Type Precision
+
+When `x: A | B` matches, `x` has type `A | B`, not a supertype:
+
+```baml
+enum Status { Active, Inactive, Pending }
+
+match (s) {
+  x: Status.Active | Status.Inactive => {
+    // x: Status.Active | Status.Inactive
+    // NOT x: Status
+  }
+}
+```
+
+This requires the type checker to construct the exact union type from the pattern.
+
+### 7. First-Match Semantics and Warnings
+
+Order matters. The compiler should warn on unreachable arms:
+
+```baml
+match (x) {
+  _ => "catch all"
+  _: Success => "never reached"  // WARNING: unreachable
+}
+```
+
+But overlapping typed patterns are fine (first wins):
+
+```baml
+match (x) {
+  _: A => "a"      // matches A
+  _: A | B => "ab" // only matches B (A already handled)
+}
+```
+
+## Open Questions (Resolved)
+
+These questions from earlier drafts have been resolved:
+
+| Question                             | Resolution                                               |
+| ------------------------------------ | -------------------------------------------------------- |
+| `default` vs `_` for catch-all?      | No special keyword; any untyped binding is catch-all     |
+| Guard keyword: `if` or `when`?       | `if` — familiar to all                                   |
+| Should `\|` allow multiple patterns? | No; `\|` is always a type/value union within one pattern |
+| Require parens in type unions?       | No; precedence is clear (`x: A \| B` = `x: (A \| B)`)    |


### PR DESCRIPTION
When the compiler panics (e.g., "undefined class: t"), the terminal is left in raw mode with mouse capture enabled. This causes escape sequences to flood stdout on every mouse movement, making the terminal unusable.

The fix adds a panic hook before `init_terminal()` that restores the terminal state before the panic handler runs.

**Before:**
Panic leaves terminal in broken state, mouse movements print garbage like `M35;41;19M35;42;...`

**After:**
Panic cleanly exits, terminal returns to normal

### Changes
In `crates/baml_onionskin/src/main.rs`, I've Set up panic hook to call `disable_raw_mode()`, `LeaveAlternateScreen`, and `DisableMouseCapture` before the default panic handler

### Reference