### PR TITLE
Cursor beps permabanner

### DIFF
--- a/beps/bep_hooks.py
+++ b/beps/bep_hooks.py
@@ -11,6 +11,37 @@ DOCS_DIR = Path(__file__).resolve().parent / "docs"
 _DIFF_CACHE = {}
 
 
+def _get_current_branch() -> str:
+    """Get the current git branch name."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return "unknown"
+
+
+def on_config(config, **kwargs):
+    """
+    MkDocs hook: runs when config is loaded.
+    - Injects current git branch name into config.extra for the permabanner.
+    """
+    if "extra" not in config:
+        config["extra"] = {}
+    
+    branch = _get_current_branch()
+    config["extra"]["git_branch"] = branch
+    
+    return config
+
+
 def _generate_toc(markdown: str) -> str:
     """
     Replace <!-- TOC_PLACEHOLDER --> placeholder with auto-generated table of contents.

--- a/beps/mkdocs.yml
+++ b/beps/mkdocs.yml
@@ -4,6 +4,7 @@ site_description: BAML Language Proposals
 
 theme:
   name: material
+  custom_dir: overrides
   features:
     - navigation.instant
     - navigation.tracking

--- a/beps/overrides/main.html
+++ b/beps/overrides/main.html
@@ -1,0 +1,31 @@
+{% extends "base.html" %}
+
+{% block announce %}
+<style>
+  .md-banner {
+    background-color: #7c4dff;
+    color: white;
+  }
+  .md-banner__inner {
+    font-size: 0.8rem;
+    font-weight: 600;
+    padding: 0.4rem 0;
+  }
+  .md-banner__inner code {
+    background-color: rgba(255, 255, 255, 0.2);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    font-family: var(--md-code-font-family);
+    font-size: 0.85em;
+  }
+  .branch-icon {
+    margin-right: 0.3rem;
+  }
+</style>
+<div class="md-banner">
+  <div class="md-banner__inner md-grid md-typeset">
+    <span class="branch-icon">🌿</span>
+    Branch: <code id="branch-name">{{ config.extra.git_branch | default('unknown') }}</code>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

Adds a highly visible, permanent banner to the top of all BEP documentation pages, displaying the current Git branch name. This is achieved by:
- Creating a custom `main.html` override to render the banner in the MkDocs Material `announce` block.
- Updating `mkdocs.yml` to reference the new `overrides` directory.
- Implementing a `bep_hooks.py` function to dynamically fetch the Git branch name and inject it into the MkDocs template context.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [x] Tested in local build environment

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The banner features a prominent purple background and a branch icon to ensure high visibility, fulfilling the requirement for a "permabanner" that clearly indicates the current branch.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1766021339313329?thread_ts=1766021339.313329&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-415a1627-05d1-46c7-9114-48d0f9f3a109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-415a1627-05d1-46c7-9114-48d0f9f3a109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

