### PR TITLE
fix(aws-bedrock): Pass region to DefaultCredentialsChain for IRSA support

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/primitive/aws/aws_client.rs
+++ b/engine/baml-runtime/src/internal/llm_client/primitive/aws/aws_client.rs
@@ -582,6 +582,12 @@ impl AwsClient {
                     if let Some(profile) = self.properties.profile.as_ref() {
                         builder = builder.profile_name(profile);
                     }
+                    // Add region to DefaultCredentialsChain for IRSA support.
+                    // IRSA (IAM Roles for Service Accounts) uses STS AssumeRoleWithWebIdentity
+                    // which requires a region to make the STS API call.
+                    if let Some(region) = self.properties.region.as_ref() {
+                        builder = builder.region(Region::new(region.clone()));
+                    }
                     loader.credentials_provider(builder.build().await)
                 }
             }


### PR DESCRIPTION
Fixes IRSA (IAM Roles for Service Accounts) credential resolution for the `aws-bedrock` client in EKS environments.

## Problem

When using BAML's `aws-bedrock` client in EKS with IRSA configured and no explicit credentials, the client fails with "credentials not found" — even though the IRSA environment variables are present:

```
AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
AWS_ROLE_ARN=arn:aws:iam::xxx:role/xxx
AWS_REGION=us-west-2
```

## Root Cause

The `DefaultCredentialsChain::builder()` was built without a region. IRSA uses STS `AssumeRoleWithWebIdentity` which requires a region to determine the STS endpoint. The region was being set on the loader *after* credentials were already resolved.

## End-to-End Validation

Built a 2-stage Docker image with the patched BAML (Rust build → Node.js runtime) and deployed it to an EKS cluster using the **exact same IRSA service account and IAM role** that was originally failing in production.

| Test | Result | Time |
|------|--------|------|
| IRSA credentials without explicit creds | ✅ Pass | 484ms |
| Streaming with IRSA | ✅ Pass | 512ms |
| Region inheritance from `AWS_REGION` | ✅ Pass | 426ms |
| IRSA availability diagnostic | ✅ Pass | 7ms |

## Related

Fixes #2849; see [Discord discussion thread](https://discord.com/channels/1119368998161752075/1451662811477311638)