### PR TITLE
Documentation seniority format correction

### DIFF
--- a/fern/01-guide/07-observability/studio.mdx
+++ b/fern/01-guide/07-observability/studio.mdx
@@ -74,7 +74,7 @@ async def test_book1():
 ```
 
 ```typescript TypeScript
-import { baml } from 'baml_client';
+import { b } from 'baml_client';
 import { Book, AuthorInfo } from 'baml_client/types';
 import { traceSync, traceAsync } from 'baml_client/tracing';
 
@@ -83,10 +83,10 @@ const preProcessText = traceSync('preProcessText', function(text: string): Promi
 });
 
 const fullAnalysis = traceAsync('fullAnalysis', async function(book: Book): Promise<any> {
-    const sentiment = await baml.ClassifySentiment(
+    const sentiment = await b.ClassifySentiment(
         preProcessText(book.content)
     );
-    const bookAnalysis = await baml.AnalyzeBook(book);
+    const bookAnalysis = await b.AnalyzeBook(book);
     return bookAnalysis;
 });
 

--- a/fern/01-guide/09-comparisons/ai-sdk.mdx
+++ b/fern/01-guide/09-comparisons/ai-sdk.mdx
@@ -252,9 +252,6 @@ function ExtractResume(resume_text: string) -> Resume {
   prompt #"
     Extract the following information from the resume.
     
-    Pay attention to the seniority descriptions:
-    {{ ctx.output_format.seniority }}
-    
     Resume:
     ---
     {{ resume_text }}
@@ -313,14 +310,14 @@ function ExtractResume(resume_text: string) -> Resume {
 
 Use it in TypeScript:
 ```typescript
-import { baml } from '@/baml_client';
+import { b } from '@/baml_client';
 
 // Use default model
-const resume = await baml.ExtractResume(resumeText);
+const resume = await b.ExtractResume(resumeText);
 
 // Switch models based on your needs
-const complexResume = await baml.ExtractResume(complexText, { client: "Claude" });
-const simpleResume = await baml.ExtractResume(simpleText, { client: "Llama" });
+const complexResume = await b.ExtractResume(complexText, { client: "Claude" });
+const simpleResume = await b.ExtractResume(simpleText, { client: "Llama" });
 
 // Everything is fully typed!
 console.log(resume.seniority); // TypeScript knows this is SeniorityLevel

--- a/fern/01-guide/09-comparisons/ai-sdk.mdx
+++ b/fern/01-guide/09-comparisons/ai-sdk.mdx
@@ -358,8 +358,8 @@ AI SDK is fantastic for building streaming AI applications in Next.js. But for s
 - **Model flexibility** - Never get locked into one provider
 - **Cleaner code** - No wrapper classes or infrastructure code needed
 
-**AI SDK is great for:** Streaming UI, Next.js integration, rapid prototyping
-**BAML is great for:** Production structured extraction, multi-model apps, cost optimization
+**AI SDK is great for:** Rapid prototyping, simple use cases
+**BAML is great for:** Production structured extraction, multi-model apps, cost optimization, streaming UIs with [semantic streaming](/guide/baml-basics/streaming#semantic-streaming)
 
 We built BAML because we were tired of elegant APIs that fall apart when you need production reliability and control.
 
@@ -368,6 +368,5 @@ We built BAML because we were tired of elegant APIs that fall apart when you nee
 BAML does have some limitations:
 1. It's a new language (but learning takes < 10 minutes)
 2. Best experience requires VSCode
-3. Focused on structured extraction, not general AI features
 
-If you're building a Next.js app with streaming UI, use AI SDK. If you want bulletproof structured extraction with full control, [try BAML](https://docs.boundaryml.com).
+Ready for bulletproof structured extraction with full control? [Try BAML](https://docs.boundaryml.com).

--- a/fern/01-guide/09-comparisons/langchain.mdx
+++ b/fern/01-guide/09-comparisons/langchain.mdx
@@ -203,9 +203,6 @@ function ExtractResume(resume_text: string) -> Resume {
   prompt #"
     Extract information from this resume.
     
-    For seniority level, consider:
-    {{ ctx.output_format.seniority }}
-    
     Resume:
     ---
     {{ resume_text }}

--- a/fern/01-guide/09-comparisons/openai-sdk.mdx
+++ b/fern/01-guide/09-comparisons/openai-sdk.mdx
@@ -271,15 +271,11 @@ function ExtractResume(resume_text: string) -> Resume {
   prompt #"
     Extract structured information from this resume.
     
-    When determining seniority, use these guidelines:
-    {{ ctx.output_format.seniority }}
-    
     Resume:
     ---
     {{ resume_text }}
     ---
     
-    Output format:
     {{ ctx.output_format }}
   "#
 }

--- a/fern/01-guide/why-baml.mdx
+++ b/fern/01-guide/why-baml.mdx
@@ -282,9 +282,6 @@ function ExtractResume(resume_text: string) -> Resume {
   prompt #"
     Extract information from this resume.
     
-    For seniority level, consider:
-    {{ ctx.output_format.seniority }}
-    
     Resume:
     ---
     {{ resume_text }}


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

This PR addresses several documentation inaccuracies and improvements:
- Removed incorrect `{{ ctx.output_format.seniority }}` references from prompt examples, as enum descriptions are automatically included with `{{ ctx.output_format }}`.
- Updated TypeScript code snippets to use `import { b }` instead of `import { baml }` and adjusted corresponding `baml.FunctionName` calls to `b.FunctionName`.
- Revised the AI SDK comparison page (`ai-sdk.mdx`) to accurately reflect BAML's capabilities, especially regarding streaming UI with semantic streaming, and removed misleading statements about BAML's focus.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed (verified rendered documentation and code snippets)
- [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [ ] I have read and followed the contributing guidelines
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

**Summary of Documentation Corrections:**
- **Fixed `{{ ctx.output_format.seniority }}` (doesn't exist)** in `fern/01-guide/why-baml.mdx`, `fern/01-guide/09-comparisons/openai-sdk.mdx`, `fern/01-guide/09-comparisons/ai-sdk.mdx`, and `fern/01-guide/09-comparisons/langchain.mdx`. The `@description` annotations on enum values are automatically included when using `{{ ctx.output_format }}`, making the explicit field accessor unnecessary.
- **Fixed `import { baml }` → `import { b }`** in `fern/01-guide/07-observability/studio.mdx` and `fern/01-guide/09-comparisons/ai-sdk.mdx`. Corresponding usages from `baml.FunctionName` to `b.FunctionName` were also updated.
- **Fixed the AI SDK comparison** in `fern/01-guide/09-comparisons/ai-sdk.mdx` to highlight BAML's semantic streaming capabilities for building UIs, removing the incorrect suggestion to "use AI SDK" for streaming UI and clarifying BAML's feature set.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1766220697365979?thread_ts=1766220697.365979&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-a3e9e506-b158-4e35-ad38-cbf77c794530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a3e9e506-b158-4e35-ad38-cbf77c794530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

