### PR TITLE
docs: clarify set_primary behavior has no fallback

### DIFF
--- a/fern/01-guide/05-baml-advanced/client-registry.mdx
+++ b/fern/01-guide/05-baml-advanced/client-registry.mdx
@@ -35,10 +35,10 @@ async def run():
         "api_key": os.environ.get('OPENAI_API_KEY')
     })
     
-    # Sets MyAmazingClient as the primary client
+    # Sets MyAmazingClient as the client to use (no fallback to other clients)
     cr.set_primary('MyAmazingClient')
 
-    # ExtractResume will now use MyAmazingClient as the calling client
+    # ExtractResume will now use only MyAmazingClient
     res = await b.ExtractResume("...", { "client_registry": cr })
 ```
 
@@ -63,10 +63,10 @@ async function run() {
         api_key: process.env.OPENAI_API_KEY
     })
     
-    // Sets MyAmazingClient as the primary client
+    // Sets MyAmazingClient as the client to use (no fallback to other clients)
     cr.setPrimary('MyAmazingClient')
 
-    // ExtractResume will now use MyAmazingClient as the calling client
+    // ExtractResume will now use only MyAmazingClient
     const res = await b.ExtractResume("...", { clientRegistry: cr })
 }
 ```
@@ -101,10 +101,10 @@ def run
     }
   )
 
-  # Sets MyAmazingClient as the primary client
+  # Sets MyAmazingClient as the client to use (no fallback to other clients)
   cr.set_primary('MyAmazingClient')
 
-  # ExtractResume will now use MyAmazingClient as the calling client
+  # ExtractResume will now use only MyAmazingClient
   res = Baml.Client.extract_resume(input: '...', baml_options: { client_registry: cr })
 end
 
@@ -151,10 +151,10 @@ func main() {
         panic(fmt.Sprintf("Failed to add responses client: %v", err))
     }
     
-    // Sets MyAmazingClient as the primary client
+    // Sets MyAmazingClient as the client to use (no fallback to other clients)
     cr.SetPrimary("MyAmazingClient")
-    
-    // ExtractResume will now use MyAmazingClient as the calling client
+
+    // ExtractResume will now use only MyAmazingClient
     res, err := baml.ExtractResume(ctx, "...", b.WithClientRegistry(cr))
     if err != nil {
         panic(fmt.Sprintf("Failed to extract resume: %v", err))
@@ -243,7 +243,11 @@ The name of a retry policy that is already defined in a .baml file. See [Retry P
 </ParamField>
 
 ### set_primary / setPrimary
-This sets the client for the function to use. (i.e. replaces the `client` property in a function)
+This sets the **only** client that the function will use, completely replacing the `client` property defined in the .baml function.
+
+<Note>
+Despite the name "primary", there is **no fallback** to a secondary client. The function will use only the specified client. If the client fails, the function call fails - there is no automatic retry with a different client.
+</Note>
 
 <ParamField
     path="name"

--- a/fern/03-reference/baml_client/client-option.mdx
+++ b/fern/03-reference/baml_client/client-option.mdx
@@ -6,7 +6,7 @@ title: client Option
 Added in 0.216.0
 </Info>
 
-The `client` option provides a simple way to override which LLM client a function uses at runtime. It's a shorthand for creating a `ClientRegistry` and calling `set_primary()`.
+The `client` option provides a simple way to override which LLM client a function uses at runtime. It's a shorthand for creating a `ClientRegistry` and calling `set_primary()`. The specified client will be the **only** client used (no fallback to other clients).
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Fixes #2827

This PR clarifies the documentation for the `set_primary` / `setPrimary` function to address user confusion about whether there's fallback behavior to a "secondary" client.

## Problem

The issue reporter noted that the term "primary" in `set_primary` was confusing because:
- "Primary" suggests there could be a silent fallback "secondary" client
- Users wanted clarity on whether it effectively acts as `set_only` or simply `set_client`
- The documentation didn't explicitly state whether there's any fallback behavior

After reviewing the implementation in `engine/baml-runtime/src/client_registry/mod.rs`, I confirmed that `set_primary` simply stores the client name with **no fallback logic**.

## Changes

Updated documentation in two files:

### 1. `fern/01-guide/05-baml-advanced/client-registry.mdx`
- Added a prominent `<Note>` block explaining there is **no fallback** to a secondary client
- Changed function description from "sets the client for the function to use" to "sets the **only** client that the function will use"
- Updated all code example comments (Python, TypeScript, Ruby, Go) to clarify "no fallback to other clients"
- Changed comments from "will now use MyAmazingClient as the calling client" to "will now use **only** MyAmazingClient"

### 2. `fern/03-reference/baml_client/client-option.mdx`
- Added clarification that the specified client will be "the **only** client used (no fallback to other clients)"

## Impact

This makes it crystal clear to users that:
- `set_primary` sets the **only** client that will be used
- If that client fails, the function call fails
- There is **no automatic retry** with a different client
- No silent fallback behavior exists

Users can now confidently use `set_primary` knowing exactly what to expect in terms of behavior.