### PR TITLE
Use zigbuild for cross-compilation to x86 musl targets

### DIFF
--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -68,13 +68,15 @@ jobs:
               tar -xzf x86_64-linux-musl-cross.tgz
               echo "$PWD/x86_64-linux-musl-cross/bin" >> $GITHUB_PATH
 
+              apt-get update && apt-get install -y zig
+
               cat >>$GITHUB_ENV <<EOF
               CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
               CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
               AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar
               RUSTFLAGS=-C target-feature=-crt-static --cfg tracing_unstable
               EOF
-            node_build: pnpm build:napi-release --target x86_64-unknown-linux-musl --use-napi-cross
+            node_build: pnpm build:napi-release --target x86_64-unknown-linux-musl -x
 
           - target: aarch64-unknown-linux-musl
             host: ubuntu-22.04

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -68,8 +68,6 @@ jobs:
               tar -xzf x86_64-linux-musl-cross.tgz
               echo "$PWD/x86_64-linux-musl-cross/bin" >> $GITHUB_PATH
 
-              apt-get update && apt-get install -y zig
-
               cat >>$GITHUB_ENV <<EOF
               CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
               CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
@@ -77,6 +75,7 @@ jobs:
               RUSTFLAGS=-C target-feature=-crt-static --cfg tracing_unstable
               EOF
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-musl -x
+            setup_zig: true
 
           - target: aarch64-unknown-linux-musl
             host: ubuntu-22.04
@@ -117,6 +116,11 @@ jobs:
           targets: ${{ matrix._.target }}
           prefix-key: v5-rust-${{ matrix._.target }}
           cache-on-failure: true
+
+      # Setup Zig for targets that need it (e.g. musl cross-compilation)
+      - name: Setup Zig
+        if: matrix._.setup_zig
+        uses: mlugg/setup-zig@v2
 
       # per-matrix-entry dependency setup
       - name: Build tools setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
       - gofix2
       - cursor/implement-collector-clear-and-update-docs-7c67
       - greg/bedrock-pdf-citations
+      - zig-compilation-for-x86-musl
 concurrency:
   # No suffix specified - in reusable workflows we need a statically-defined suffix
   # to prevent workflow_call workflows from triggering a concurrency deadlock
@@ -154,11 +155,11 @@ jobs:
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
-        
+
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
         with:
-          node-action-version: 'v6'
+          node-action-version: "v6"
           node-version: latest
 
       - name: Ensure npm CLI supports trusted publishing
@@ -223,7 +224,7 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
         with:
-          node-action-version: 'v6'
+          node-action-version: "v6"
           install_dependencies: false
           npm-token: ${{ secrets.NPM_TOKEN }}
       - name: Download VSIX artifacts
@@ -251,7 +252,7 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
         with:
-          node-action-version: 'v6'
+          node-action-version: "v6"
           install_dependencies: false
           npm-token: ${{ secrets.NPM_TOKEN }}
       - name: Download VSIX artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
       - cursor/implement-collector-clear-and-update-docs-7c67
       - greg/bedrock-pdf-citations
       - zig-compilation-for-x86-musl
+      - OscarCornish:zig-compilation-for-x86-musl
 concurrency:
   # No suffix specified - in reusable workflows we need a statically-defined suffix
   # to prevent workflow_call workflows from triggering a concurrency deadlock


### PR DESCRIPTION
# Pull Request Template

See my post on the [discord](https://discord.com/channels/1119368998161752075/1453544600211034294) for a bit of background

## Issue Reference
Fixes:
- #1270
- #1466

## Changes
tldr: Fix baml on x86 musl platforms (like Alpine)

Use the `-x` option when building x86 musl target, which uses zig instead of napi-rs's cross-toolchain builder (this is how it is done in the napi-rs cross-build example [repo](https://github.com/napi-rs/cross-build/blob/77d4d8cd22fff4d27588a35d8cd2f26be9b39bd4/.github/workflows/pure-rust-build-on-linux.yml#L33))

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed (Built locally and loaded via `require` inside an alpine x86 container)
- [ ] Tested in [environment]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Haven't changed the aarch64 musl target, as it works at the moment - doesn't seem like much point fixing something that isn't broken?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Switch `x86_64-unknown-linux-musl` build to Zig**
> 
> - Replaces `--use-napi-cross` with `-x` for `pnpm build:napi-release` on `x86_64-unknown-linux-musl`, and adds `setup_zig: true` with a conditional Zig install step in `build-typescript-release.reusable.yaml`.
> - Keeps `aarch64-unknown-linux-musl` using `--use-napi-cross`.
> 
> **Release workflow updates**
> 
> - Adds branches `zig-compilation-for-x86-musl` and `OscarCornish:zig-compilation-for-x86-musl` to `release.yml` triggers.
> - Normalizes `node-action-version` quoting to "v6" in publish jobs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5937797ec96e7682cc636021b7bb06f43bb34b29. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->