### PR TITLE
typescript x86 musl

### DIFF
--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -68,13 +68,15 @@ jobs:
               tar -xzf x86_64-linux-musl-cross.tgz
               echo "$PWD/x86_64-linux-musl-cross/bin" >> $GITHUB_PATH
 
+              apt-get update && apt-get install -y zig
+
               cat >>$GITHUB_ENV <<EOF
               CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
               CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
               AR_x86_64_unknown_linux_musl=x86_64-linux-musl-ar
               RUSTFLAGS=-C target-feature=-crt-static --cfg tracing_unstable
               EOF
-            node_build: pnpm build:napi-release --target x86_64-unknown-linux-musl --use-napi-cross
+            node_build: pnpm build:napi-release --target x86_64-unknown-linux-musl -x
 
           - target: aarch64-unknown-linux-musl
             host: ubuntu-22.04

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -68,8 +68,6 @@ jobs:
               tar -xzf x86_64-linux-musl-cross.tgz
               echo "$PWD/x86_64-linux-musl-cross/bin" >> $GITHUB_PATH
 
-              apt-get update && apt-get install -y zig
-
               cat >>$GITHUB_ENV <<EOF
               CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc
               CXX_x86_64_unknown_linux_musl=x86_64-linux-musl-g++
@@ -77,6 +75,7 @@ jobs:
               RUSTFLAGS=-C target-feature=-crt-static --cfg tracing_unstable
               EOF
             node_build: pnpm build:napi-release --target x86_64-unknown-linux-musl -x
+            setup_zig: true
 
           - target: aarch64-unknown-linux-musl
             host: ubuntu-22.04
@@ -117,6 +116,11 @@ jobs:
           targets: ${{ matrix._.target }}
           prefix-key: v5-rust-${{ matrix._.target }}
           cache-on-failure: true
+
+      # Setup Zig for targets that need it (e.g. musl cross-compilation)
+      - name: Setup Zig
+        if: matrix._.setup_zig
+        uses: mlugg/setup-zig@v2
 
       # per-matrix-entry dependency setup
       - name: Build tools setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ on:
       - gofix2
       - cursor/implement-collector-clear-and-update-docs-7c67
       - greg/bedrock-pdf-citations
+      - zig-compilation-for-x86-musl
 concurrency:
   # No suffix specified - in reusable workflows we need a statically-defined suffix
   # to prevent workflow_call workflows from triggering a concurrency deadlock
@@ -154,11 +155,11 @@ jobs:
 
       - name: Setup Tools
         uses: ./.github/actions/setup-tools
-        
+
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
         with:
-          node-action-version: 'v6'
+          node-action-version: "v6"
           node-version: latest
 
       - name: Ensure npm CLI supports trusted publishing
@@ -223,7 +224,7 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
         with:
-          node-action-version: 'v6'
+          node-action-version: "v6"
           install_dependencies: false
           npm-token: ${{ secrets.NPM_TOKEN }}
       - name: Download VSIX artifacts
@@ -251,7 +252,7 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
         with:
-          node-action-version: 'v6'
+          node-action-version: "v6"
           install_dependencies: false
           npm-token: ${{ secrets.NPM_TOKEN }}
       - name: Download VSIX artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,7 @@ on:
       - gofix2
       - cursor/implement-collector-clear-and-update-docs-7c67
       - greg/bedrock-pdf-citations
-      - zig-compilation-for-x86-musl
-      - OscarCornish:zig-compilation-for-x86-musl
+      - typescript-x86-musl
 concurrency:
   # No suffix specified - in reusable workflows we need a statically-defined suffix
   # to prevent workflow_call workflows from triggering a concurrency deadlock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
       - cursor/implement-collector-clear-and-update-docs-7c67
       - greg/bedrock-pdf-citations
       - zig-compilation-for-x86-musl
+      - OscarCornish:zig-compilation-for-x86-musl
 concurrency:
   # No suffix specified - in reusable workflows we need a statically-defined suffix
   # to prevent workflow_call workflows from triggering a concurrency deadlock


### PR DESCRIPTION
- **use zig-based cross compilation for x86 musl**
- **dryrun build**
- **setup zig**
- **run release**
- **new branch**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches the TypeScript x86_64 musl build to Zig-based cross-compilation and wires it into release workflows.
> 
> - In `build-typescript-release.reusable.yaml`, updates `x86_64-unknown-linux-musl` to use `pnpm build:napi-release --target x86_64-unknown-linux-musl -x` and conditionally sets up Zig via `mlugg/setup-zig@v2`
> - Adds a `Setup Zig` step gated by `matrix._.setup_zig`
> - `release.yml`: adds `typescript-x86-musl` branch to triggers; normalizes `node-action-version` quoting to `"v6"`; minor whitespace cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b342a800976d1af8a93300550e359c5bd0cfe8f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->