### PR TITLE
reduce amount of version report publishing

### DIFF
--- a/typescript/apps/vscode-ext/src/extension.ts
+++ b/typescript/apps/vscode-ext/src/extension.ts
@@ -378,11 +378,6 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.executeCommand('baml.openBamlPanel')
   }
 
-  setInterval(() => {
-    console.log('requesting baml cli version')
-    publishBamlVersionReport()
-  }, 30_000)
-
   // TODO: Reactivate linter.
   // runDiagnostics()
 }

--- a/typescript/apps/vscode-ext/src/plugins/language-server-client/index.ts
+++ b/typescript/apps/vscode-ext/src/plugins/language-server-client/index.ts
@@ -174,6 +174,8 @@ let bamlOutputChannel: OutputChannel;
 let currentExecutingCliPath: string | null = null;
 // Flag to prevent concurrent LSP restarts
 let isRestarting = false;
+// Flag to ensure periodic version report interval is only set once
+let periodicVersionReportScheduled = false;
 
 // Track last known CLI version and generator info for telemetry
 let lastKnownCliVersion: string | null = null;
@@ -751,7 +753,8 @@ const activateClient = (
         client.outputChannel.show(true);
       }
 
-      if (intervalTimers.length === 0) {
+      if (!periodicVersionReportScheduled) {
+        periodicVersionReportScheduled = true;
         console.log('Setting up periodic update checks.');
         // Publish the first version report after 5 min of extension activation.
         setTimeout(() => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reduces telemetry noise and avoids duplicate scheduling by consolidating version reporting logic.
> 
> - Removes 30s `publishBamlVersionReport` interval from `extension.ts`
> - Adds `periodicVersionReportScheduled` flag and uses it (instead of `intervalTimers.length`) to ensure scheduling happens exactly once in `plugins/language-server-client/index.ts`
> - Keeps first report after 5 minutes, then every 2 hours
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5dddd8d91277ebd12067c8595e45be7aa8b4dfda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->