### PR TITLE
Fix boolean literal initialization bug in let statements

### DIFF
--- a/baml_language/crates/baml_codegen/tests/builtins.rs
+++ b/baml_language/crates/baml_codegen/tests/builtins.rs
@@ -6,7 +6,6 @@ use baml_tests::{
 };
 
 #[test]
-#[ignore = "method calls not yet in HIR"]
 fn builtin_method_call() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -17,14 +16,15 @@ fn builtin_method_call() -> anyhow::Result<()> {
         "#,
         expected: vec![(
             "main",
+            // arr is Virtual (single-use), so array stays on stack as argument.
+            // Method call arr.length() desugars to baml.Array.length(arr).
+            // ReturnPhi: call result stays on stack for return.
             vec![
+                Instruction::LoadGlobal(Value::function("baml.Array.length")),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::LoadConst(Value::Int(2)),
                 Instruction::LoadConst(Value::Int(3)),
                 Instruction::AllocArray(3),
-                Instruction::LoadGlobal(Value::function("baml.Array.length")),
-                Instruction::LoadVar("arr".to_string()),
-                // call with one argument (self)
                 Instruction::Call(1),
                 Instruction::Return,
             ],

--- a/baml_language/crates/baml_codegen/tests/functions.rs
+++ b/baml_language/crates/baml_codegen/tests/functions.rs
@@ -126,7 +126,6 @@ fn call_function_assign_to_variable() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "assignment statements not yet in HIR"]
 fn mutable_variables() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -147,16 +146,12 @@ fn mutable_variables() -> anyhow::Result<()> {
         expected: vec![
             (
                 "DeclareMutableInFunction",
-                vec![
-                    Instruction::LoadConst(Value::Int(3)),
-                    Instruction::LoadConst(Value::Int(5)),
-                    Instruction::StoreVar("y".to_string()),
-                    Instruction::LoadVar("y".to_string()),
-                    Instruction::Return,
-                ],
+                // Dead store elimination: y=3 immediately overwritten by y=5, just return 5
+                vec![Instruction::LoadConst(Value::Int(5)), Instruction::Return],
             ),
             (
                 "MutableInArg",
+                // x is a Parameter, so it needs a real slot for the reassignment
                 vec![
                     Instruction::LoadConst(Value::Int(3)),
                     Instruction::StoreVar("x".to_string()),

--- a/baml_language/crates/baml_codegen/tests/match_expr.rs
+++ b/baml_language/crates/baml_codegen/tests/match_expr.rs
@@ -1,10 +1,4 @@
 //! Compiler tests for match expressions.
-//!
-//! NOTE: These tests were written for the old direct THIR->bytecode compiler.
-//! The new MIR-based pipeline produces functionally equivalent but structurally
-//! different bytecode (using explicit locals instead of stack manipulation).
-//! These tests are ignored until they can be rewritten for the MIR format.
-//! Match functionality is tested through snapshot tests in `baml_tests`.
 
 use baml_tests::{
     codegen::{Program, assert_compiles},
@@ -17,7 +11,6 @@ use baml_vm::CmpOp;
 // ============================================================================
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_catch_all_underscore() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: "
@@ -29,10 +22,11 @@ fn match_catch_all_underscore() -> anyhow::Result<()> {
         ",
         expected: vec![(
             "main",
+            // Scrutinee stored to _ (wasteful for wildcard, but correct)
             vec![
-                // Scrutinee stored (but catch-all doesn't need to check it)
+                Instruction::LoadConst(Value::Null), // slot for _
                 Instruction::LoadConst(Value::Int(42)),
-                // Catch-all arm body
+                Instruction::StoreVar("_".to_string()),
                 Instruction::LoadConst(Value::Int(100)),
                 Instruction::Return,
             ],
@@ -41,7 +35,6 @@ fn match_catch_all_underscore() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_catch_all_named_binding() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: "
@@ -53,14 +46,11 @@ fn match_catch_all_named_binding() -> anyhow::Result<()> {
         ",
         expected: vec![(
             "main",
+            // x binds to 42, used once in x+1 -> optimizer inlines to 42+1
             vec![
                 Instruction::LoadConst(Value::Int(42)),
-                // x is bound to scrutinee, then x + 1
-                Instruction::LoadVar("@match_scrut_0".to_string()),
-                Instruction::LoadVar("x".to_string()),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::BinOp(baml_vm::BinOp::Add),
-                Instruction::PopReplace(1),
                 Instruction::Return,
             ],
         )],
@@ -72,7 +62,6 @@ fn match_catch_all_named_binding() -> anyhow::Result<()> {
 // ============================================================================
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_literal_int_with_fallback() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: "
@@ -86,16 +75,20 @@ fn match_literal_int_with_fallback() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                Instruction::LoadConst(Value::Int(1)), // scrutinee
-                Instruction::LoadVar("@match_scrut_0".to_string()),
-                Instruction::LoadConst(Value::Int(1)), // literal 1
+                Instruction::LoadConst(Value::Null),   // slot for _
+                Instruction::LoadConst(Value::Null),   // slot for _1 (scrutinee)
+                Instruction::LoadConst(Value::Int(1)), // scrutinee value
+                Instruction::StoreVar("_1".to_string()),
+                Instruction::LoadVar("_1".to_string()), // load for comparison
+                Instruction::LoadConst(Value::Int(1)),  // literal 1
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(4), // skip to next arm
-                Instruction::Pop(1),            // pop comparison result
-                Instruction::LoadConst(Value::Int(100)), // arm body
-                Instruction::Jump(3),           // jump to end
-                Instruction::Pop(1),            // pop comparison result (false path)
-                Instruction::LoadConst(Value::Int(0)), // catch-all body
+                Instruction::PopJumpIfFalse(2), // if false, skip to catch-all
+                Instruction::Jump(5),           // if true, skip to arm body (100)
+                Instruction::LoadVar("_1".to_string()), // catch-all: load scrutinee
+                Instruction::StoreVar("_".to_string()), // bind to _
+                Instruction::LoadConst(Value::Int(0)), // catch-all result
+                Instruction::Jump(2),           // skip to return
+                Instruction::LoadConst(Value::Int(100)), // first arm result
                 Instruction::Return,
             ],
         )],
@@ -103,7 +96,6 @@ fn match_literal_int_with_fallback() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_literal_bool_exhaustive() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -117,20 +109,23 @@ fn match_literal_bool_exhaustive() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                Instruction::LoadConst(Value::Bool(true)), // scrutinee
-                Instruction::LoadVar("@match_scrut_0".to_string()),
+                Instruction::LoadConst(Value::Null), // slot for _1 (scrutinee)
+                Instruction::LoadConst(Value::Bool(true)), // scrutinee value
+                Instruction::StoreVar("_1".to_string()),
+                Instruction::LoadVar("_1".to_string()), // load for first comparison
                 Instruction::LoadConst(Value::Bool(true)), // literal true
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(4), // skip to next arm
-                Instruction::Pop(1),
-                Instruction::LoadConst(Value::string("yes")),
-                Instruction::Jump(7), // jump to end
-                Instruction::Pop(1),
-                Instruction::LoadVar("@match_scrut_0".to_string()),
+                Instruction::PopJumpIfFalse(2), // if false, try next arm
+                Instruction::Jump(9),           // if true, skip to "yes"
+                Instruction::LoadVar("_1".to_string()), // load for second comparison
                 Instruction::LoadConst(Value::Bool(false)), // literal false
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::Pop(1), // last arm, no jump needed
+                Instruction::PopJumpIfFalse(6), // if false (shouldn't happen)
+                Instruction::Jump(2),           // if true, skip to "no"
+                Instruction::Jump(4),           // unreachable fallthrough
                 Instruction::LoadConst(Value::string("no")),
+                Instruction::Jump(2), // skip to return
+                Instruction::LoadConst(Value::string("yes")),
                 Instruction::Return,
             ],
         )],
@@ -138,7 +133,6 @@ fn match_literal_bool_exhaustive() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_literal_null() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -152,16 +146,20 @@ fn match_literal_null() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                Instruction::LoadConst(Value::Null), // scrutinee
-                Instruction::LoadVar("@match_scrut_0".to_string()),
-                Instruction::LoadConst(Value::Null), // literal null
+                Instruction::LoadConst(Value::Null), // slot for _
+                Instruction::LoadConst(Value::Null), // slot for _1 (scrutinee)
+                Instruction::LoadConst(Value::Null), // scrutinee value
+                Instruction::StoreVar("_1".to_string()),
+                Instruction::LoadVar("_1".to_string()), // load for comparison
+                Instruction::LoadConst(Value::Null),    // literal null
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(4),
-                Instruction::Pop(1),
-                Instruction::LoadConst(Value::string("nothing")),
-                Instruction::Jump(3),
-                Instruction::Pop(1),
-                Instruction::LoadConst(Value::string("something")),
+                Instruction::PopJumpIfFalse(2), // if false, skip to catch-all
+                Instruction::Jump(5),           // if true, skip to "nothing"
+                Instruction::LoadVar("_1".to_string()), // catch-all: load scrutinee
+                Instruction::StoreVar("_".to_string()), // bind to _
+                Instruction::LoadConst(Value::string("something")), // catch-all result
+                Instruction::Jump(2),           // skip to return
+                Instruction::LoadConst(Value::string("nothing")), // first arm result
                 Instruction::Return,
             ],
         )],
@@ -173,7 +171,6 @@ fn match_literal_null() -> anyhow::Result<()> {
 // ============================================================================
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_typed_pattern_single_class() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -192,27 +189,28 @@ fn match_typed_pattern_single_class() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
+                Instruction::LoadConst(Value::Null), // slot for _
+                Instruction::LoadConst(Value::Null), // slot for _3 (scrutinee)
                 // let result = Success { data: "hello" }
                 Instruction::AllocInstance(Value::class("Success")),
                 Instruction::Copy(0),
                 Instruction::LoadConst(Value::string("hello")),
                 Instruction::StoreField(0),
-                // match (result)
-                Instruction::LoadVar("result".to_string()),
-                // s: Success pattern - instanceof check
-                Instruction::LoadVar("@match_scrut_0".to_string()),
+                Instruction::StoreVar("_3".to_string()),
+                // instanceof check
+                Instruction::LoadVar("_3".to_string()),
                 Instruction::LoadConst(Value::class("Success")),
                 Instruction::CmpOp(CmpOp::InstanceOf),
-                Instruction::PopJumpIfFalse(7), // skip to catch-all
-                Instruction::Pop(1),
-                // bind s and access s.data
-                Instruction::LoadVar("@match_scrut_0".to_string()),
-                Instruction::LoadVar("s".to_string()),
-                Instruction::LoadField(0), // field 0 is 'data'
-                Instruction::PopReplace(1),
-                Instruction::Jump(3), // jump past catch-all
-                Instruction::Pop(1),
+                Instruction::PopJumpIfFalse(2), // if false, skip to catch-all
+                Instruction::Jump(5),           // if true, skip to s.data
+                // catch-all arm
+                Instruction::LoadVar("_3".to_string()),
+                Instruction::StoreVar("_".to_string()),
                 Instruction::LoadConst(Value::string("unknown")),
+                Instruction::Jump(3), // skip to return
+                // s: Success arm - access s.data (s is virtual, so use _3 directly)
+                Instruction::LoadVar("_3".to_string()),
+                Instruction::LoadField(0),
                 Instruction::Return,
             ],
         )],
@@ -220,7 +218,6 @@ fn match_typed_pattern_single_class() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_typed_pattern_two_classes() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -243,34 +240,33 @@ fn match_typed_pattern_two_classes() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
+                Instruction::LoadConst(Value::Null), // slot for _3 (scrutinee)
                 // let result = Success { data: "ok" }
                 Instruction::AllocInstance(Value::class("Success")),
                 Instruction::Copy(0),
                 Instruction::LoadConst(Value::string("ok")),
                 Instruction::StoreField(0),
-                // match (result)
-                Instruction::LoadVar("result".to_string()),
-                // s: Success
-                Instruction::LoadVar("@match_scrut_0".to_string()),
+                Instruction::StoreVar("_3".to_string()),
+                // s: Success instanceof check
+                Instruction::LoadVar("_3".to_string()),
                 Instruction::LoadConst(Value::class("Success")),
                 Instruction::CmpOp(CmpOp::InstanceOf),
-                Instruction::PopJumpIfFalse(7),
-                Instruction::Pop(1),
-                Instruction::LoadVar("@match_scrut_0".to_string()),
-                Instruction::LoadVar("s".to_string()),
-                Instruction::LoadField(0),
-                Instruction::PopReplace(1),
-                Instruction::Jump(10), // jump past f: Failure arm
-                // f: Failure
-                Instruction::Pop(1),
-                Instruction::LoadVar("@match_scrut_0".to_string()),
+                Instruction::PopJumpIfFalse(2), // if false, try Failure
+                Instruction::Jump(10),          // if true, skip to s.data
+                // f: Failure instanceof check
+                Instruction::LoadVar("_3".to_string()),
                 Instruction::LoadConst(Value::class("Failure")),
                 Instruction::CmpOp(CmpOp::InstanceOf),
-                Instruction::Pop(1), // last arm
-                Instruction::LoadVar("@match_scrut_0".to_string()),
-                Instruction::LoadVar("f".to_string()),
+                Instruction::PopJumpIfFalse(8), // if false (shouldn't happen)
+                Instruction::Jump(2),           // if true, skip to f.reason
+                Instruction::Jump(6),           // unreachable fallthrough
+                // f: Failure arm - access f.reason
+                Instruction::LoadVar("_3".to_string()),
                 Instruction::LoadField(0),
-                Instruction::PopReplace(1),
+                Instruction::Jump(3), // skip to return
+                // s: Success arm - access s.data
+                Instruction::LoadVar("_3".to_string()),
+                Instruction::LoadField(0),
                 Instruction::Return,
             ],
         )],
@@ -282,7 +278,6 @@ fn match_typed_pattern_two_classes() -> anyhow::Result<()> {
 // ============================================================================
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_union_literal_two_values() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -296,24 +291,29 @@ fn match_union_literal_two_values() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                Instruction::LoadConst(Value::Int(200)), // scrutinee
-                // Union pattern: 200 | 201
-                Instruction::LoadVar("@match_scrut_0".to_string()),
+                Instruction::LoadConst(Value::Null),     // slot for _
+                Instruction::LoadConst(Value::Null),     // slot for _1 (scrutinee)
+                Instruction::LoadConst(Value::Int(200)), // scrutinee value
+                Instruction::StoreVar("_1".to_string()),
+                // First part of union: 200
+                Instruction::LoadVar("_1".to_string()),
                 Instruction::LoadConst(Value::Int(200)),
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(3), // try 201
-                Instruction::Pop(1),
-                Instruction::Jump(7), // matched! jump to arm body
-                Instruction::Pop(1),
-                Instruction::LoadVar("@match_scrut_0".to_string()),
+                Instruction::PopJumpIfFalse(2), // if false, try 201
+                Instruction::Jump(10),          // if true, skip to "success"
+                // Second part of union: 201
+                Instruction::LoadVar("_1".to_string()),
                 Instruction::LoadConst(Value::Int(201)),
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(4), // neither matched, try next arm
-                Instruction::Pop(1),
-                Instruction::LoadConst(Value::string("success")),
-                Instruction::Jump(3),
-                Instruction::Pop(1),
+                Instruction::PopJumpIfFalse(2), // if false, try catch-all
+                Instruction::Jump(5),           // if true, skip to "success"
+                // Catch-all arm
+                Instruction::LoadVar("_1".to_string()),
+                Instruction::StoreVar("_".to_string()),
                 Instruction::LoadConst(Value::string("other")),
+                Instruction::Jump(2), // skip to return
+                // Union arm result
+                Instruction::LoadConst(Value::string("success")),
                 Instruction::Return,
             ],
         )],
@@ -325,7 +325,6 @@ fn match_union_literal_two_values() -> anyhow::Result<()> {
 // ============================================================================
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_in_arithmetic() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: "
@@ -339,19 +338,28 @@ fn match_in_arithmetic() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                Instruction::LoadConst(Value::Int(1)),
-                // match expression
-                Instruction::LoadConst(Value::Int(2)), // scrutinee
-                Instruction::LoadVar("@match_scrut_0".to_string()),
-                Instruction::LoadConst(Value::Int(2)), // literal 2
+                Instruction::LoadConst(Value::Null),   // slot for _
+                Instruction::LoadConst(Value::Null),   // slot for _2 (match result)
+                Instruction::LoadConst(Value::Null),   // slot for _3 (scrutinee)
+                Instruction::LoadConst(Value::Int(2)), // scrutinee value
+                Instruction::StoreVar("_3".to_string()),
+                Instruction::LoadVar("_3".to_string()), // load for comparison
+                Instruction::LoadConst(Value::Int(2)),  // literal 2
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(4),
-                Instruction::Pop(1),
-                Instruction::LoadConst(Value::Int(20)),
-                Instruction::Jump(3),
-                Instruction::Pop(1),
+                Instruction::PopJumpIfFalse(2), // if false, skip to catch-all
+                Instruction::Jump(6),           // if true, skip to 20
+                // Catch-all arm
+                Instruction::LoadVar("_3".to_string()),
+                Instruction::StoreVar("_".to_string()),
                 Instruction::LoadConst(Value::Int(0)),
-                // addition
+                Instruction::StoreVar("_2".to_string()), // store match result
+                Instruction::Jump(3),                    // skip to addition
+                // First arm
+                Instruction::LoadConst(Value::Int(20)),
+                Instruction::StoreVar("_2".to_string()), // store match result
+                // Addition: 1 + match result
+                Instruction::LoadConst(Value::Int(1)),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::BinOp(baml_vm::BinOp::Add),
                 Instruction::Return,
             ],
@@ -364,7 +372,6 @@ fn match_in_arithmetic() -> anyhow::Result<()> {
 // ============================================================================
 
 #[test]
-#[ignore = "needs rewrite for MIR-based bytecode format"]
 fn match_nested() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: "
@@ -381,32 +388,38 @@ fn match_nested() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             vec![
-                // Outer match scrutinee
+                Instruction::LoadConst(Value::Null), // slot for outer _
+                Instruction::LoadConst(Value::Null), // slot for _1 (outer scrutinee)
+                Instruction::LoadConst(Value::Null), // slot for inner _
+                Instruction::LoadConst(Value::Null), // slot for _3 (inner scrutinee)
+                // Outer scrutinee
                 Instruction::LoadConst(Value::Int(1)),
-                // outer: 1 pattern
-                Instruction::LoadVar("@match_scrut_0".to_string()),
+                Instruction::StoreVar("_1".to_string()),
+                Instruction::LoadVar("_1".to_string()),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(14), // skip to outer catch-all
-                Instruction::Pop(1),
+                Instruction::PopJumpIfFalse(2), // if outer != 1, skip to outer catch-all
+                Instruction::Jump(5),           // if outer == 1, skip to inner match
+                // Outer catch-all arm
+                Instruction::LoadVar("_1".to_string()),
+                Instruction::StoreVar("_".to_string()),
+                Instruction::LoadConst(Value::Int(0)),
+                Instruction::Jump(13), // skip to return
                 // Inner match scrutinee
                 Instruction::LoadConst(Value::Int(2)),
-                // inner: 2 pattern
-                Instruction::LoadVar("@match_scrut_1".to_string()),
+                Instruction::StoreVar("_3".to_string()),
+                Instruction::LoadVar("_3".to_string()),
                 Instruction::LoadConst(Value::Int(2)),
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(4),
-                Instruction::Pop(1),
-                Instruction::LoadConst(Value::Int(12)),
-                Instruction::Jump(3),
-                Instruction::Pop(1),
+                Instruction::PopJumpIfFalse(2), // if inner != 2, skip to inner catch-all
+                Instruction::Jump(5),           // if inner == 2, skip to 12
+                // Inner catch-all arm
+                Instruction::LoadVar("_3".to_string()),
+                Instruction::StoreVar("_".to_string()),
                 Instruction::LoadConst(Value::Int(10)),
-                // End of inner match - replace scrutinee on stack
-                Instruction::PopReplace(1),
-                Instruction::Jump(3), // skip outer catch-all
-                // Outer catch-all
-                Instruction::Pop(1),
-                Instruction::LoadConst(Value::Int(0)),
+                Instruction::Jump(2), // skip to return
+                // Inner first arm
+                Instruction::LoadConst(Value::Int(12)),
                 Instruction::Return,
             ],
         )],

--- a/baml_language/crates/baml_codegen/tests/operators.rs
+++ b/baml_language/crates/baml_codegen/tests/operators.rs
@@ -87,7 +87,6 @@ fn basic_add() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "assignment statements not yet in HIR"]
 fn basic_assign_add() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -99,13 +98,17 @@ fn basic_assign_add() -> anyhow::Result<()> {
         "#,
         expected: vec![(
             "main",
+            // x is Real (used 3 times: init, compound assign read, return)
+            // Compound assignment x += 2 expands to x = x + 2
             vec![
+                Instruction::LoadConst(Value::Null), // slot for x
                 Instruction::LoadConst(Value::Int(1)),
-                Instruction::LoadVar("x".to_string()),
+                Instruction::StoreVar("x".to_string()), // let x = 1
+                Instruction::LoadVar("x".to_string()),  // read x
                 Instruction::LoadConst(Value::Int(2)),
-                Instruction::BinOp(BinOp::Add),
-                Instruction::StoreVar("x".to_string()),
-                Instruction::LoadVar("x".to_string()),
+                Instruction::BinOp(BinOp::Add),         // x + 2
+                Instruction::StoreVar("x".to_string()), // x = (x + 2)
+                Instruction::LoadVar("x".to_string()),  // return x
                 Instruction::Return,
             ],
         )],

--- a/baml_language/crates/baml_codegen/tests/while_loops.rs
+++ b/baml_language/crates/baml_codegen/tests/while_loops.rs
@@ -240,7 +240,6 @@ fn continue_factorial() -> anyhow::Result<()> {
         expected: vec![(
             "Factorial",
             // MIR-based codegen with local pre-allocation
-            // Note: should_continue initialization to true appears to be missing in codegen
             vec![
                 // Pre-allocate locals
                 Instruction::LoadConst(Value::Null),
@@ -248,8 +247,8 @@ fn continue_factorial() -> anyhow::Result<()> {
                 // Initialize result = 1
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("result".to_string()),
-                // Pre-allocate should_continue (should be Bool(true) but codegen produces Null)
-                Instruction::LoadConst(Value::Null),
+                // Initialize should_continue = true
+                Instruction::LoadConst(Value::Bool(true)),
                 Instruction::StoreVar("should_continue".to_string()),
                 // Loop condition: should_continue
                 Instruction::LoadVar("should_continue".to_string()),

--- a/baml_language/crates/baml_hir/src/body.rs
+++ b/baml_language/crates/baml_hir/src/body.rs
@@ -2074,6 +2074,19 @@ impl LoweringContext {
                                     span,
                                 )
                             }
+                            SyntaxKind::WORD => {
+                                // Handle boolean and null literals (parsed as WORD tokens)
+                                match token.text() {
+                                    "true" => {
+                                        self.alloc_expr(Expr::Literal(Literal::Bool(true)), span)
+                                    }
+                                    "false" => {
+                                        self.alloc_expr(Expr::Literal(Literal::Bool(false)), span)
+                                    }
+                                    "null" => self.alloc_expr(Expr::Literal(Literal::Null), span),
+                                    _ => self.alloc_expr(Expr::Missing, span),
+                                }
+                            }
                             _ => self.alloc_expr(Expr::Missing, span),
                         }
                     })

--- a/baml_language/crates/baml_syntax/src/ast.rs
+++ b/baml_language/crates/baml_syntax/src/ast.rs
@@ -685,20 +685,22 @@ impl LetStmt {
         })
     }
 
-    /// Get the initializer as a token (for direct literals like integers).
+    /// Get the initializer as a token (for direct literals like integers, bools, null).
     /// Returns the literal token if the initializer is a simple literal.
     pub fn initializer_token(&self) -> Option<SyntaxToken> {
         self.syntax
             .children_with_tokens()
             .filter_map(rowan::NodeOrToken::into_token)
             .find(|token| {
-                matches!(
-                    token.kind(),
+                match token.kind() {
                     SyntaxKind::INTEGER_LITERAL
-                        | SyntaxKind::FLOAT_LITERAL
-                        | SyntaxKind::STRING_LITERAL
-                        | SyntaxKind::RAW_STRING_LITERAL
-                )
+                    | SyntaxKind::FLOAT_LITERAL
+                    | SyntaxKind::STRING_LITERAL
+                    | SyntaxKind::RAW_STRING_LITERAL => true,
+                    // Boolean and null literals are parsed as WORD tokens
+                    SyntaxKind::WORD => matches!(token.text(), "true" | "false" | "null"),
+                    _ => false,
+                }
             })
     }
 }

--- a/baml_language/crates/baml_vm/tests/classes.rs
+++ b/baml_language/crates/baml_vm/tests/classes.rs
@@ -257,7 +257,6 @@ fn nested_field_read() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "constructor with preceding variables not yet working"]
 fn constructor_with_preceding_variables() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -279,7 +278,6 @@ fn constructor_with_preceding_variables() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "nested constructor with preceding variables not yet working"]
 fn nested_constructor_with_preceding_variables() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -306,7 +304,7 @@ fn nested_constructor_with_preceding_variables() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "method calls not yet working"]
+#[ignore = "method call codegen missing self argument"]
 fn basic_method_decl() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -332,7 +330,7 @@ fn basic_method_decl() -> anyhow::Result<()> {
 
 // Method tests
 #[test]
-#[ignore = "mut self methods not yet working"]
+#[ignore = "method call codegen missing self argument"]
 fn mut_self_method_decl() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"

--- a/baml_language/crates/baml_vm/tests/functions.rs
+++ b/baml_language/crates/baml_vm/tests/functions.rs
@@ -109,7 +109,6 @@ fn early_return() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "while loop causing infinite loop"]
 fn return_with_stack() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"

--- a/baml_language/crates/baml_vm/tests/if_else.rs
+++ b/baml_language/crates/baml_vm/tests/if_else.rs
@@ -3,7 +3,6 @@
 use baml_tests::bytecode::{ExecState, Program, Value, assert_vm_executes};
 
 #[test]
-#[ignore = "if/else codegen issue"]
 fn exec_if_branch() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: "
@@ -22,7 +21,6 @@ fn exec_if_branch() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "if/else codegen issue"]
 fn exec_else_branch() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: "
@@ -41,7 +39,6 @@ fn exec_else_branch() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "if/else codegen issue"]
 fn exec_else_if_branch() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: "

--- a/baml_language/crates/baml_vm/tests/strings.rs
+++ b/baml_language/crates/baml_vm/tests/strings.rs
@@ -3,7 +3,6 @@
 use baml_tests::bytecode::{ExecState, Object, Program, Value, assert_vm_executes};
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn concat_strings() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -20,7 +19,6 @@ fn concat_strings() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_equality_true() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -34,7 +32,6 @@ fn string_equality_true() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_equality_false() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -48,7 +45,6 @@ fn string_equality_false() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_not_equal_true() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -62,7 +58,6 @@ fn string_not_equal_true() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_less_than() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -76,7 +71,6 @@ fn string_less_than() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_less_than_or_equal() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -90,7 +84,6 @@ fn string_less_than_or_equal() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_greater_than() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -104,7 +97,6 @@ fn string_greater_than() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_greater_than_or_equal() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -118,7 +110,6 @@ fn string_greater_than_or_equal() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_length() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -133,7 +124,6 @@ fn string_length() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_to_lower_case() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -148,7 +138,6 @@ fn string_to_lower_case() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_to_upper_case() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -163,7 +152,6 @@ fn string_to_upper_case() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_trim() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -178,7 +166,7 @@ fn string_trim() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
+#[ignore = "string method with args not yet implemented"]
 fn string_includes() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -193,7 +181,7 @@ fn string_includes() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
+#[ignore = "string method with args not yet implemented"]
 fn string_starts_with() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -208,7 +196,7 @@ fn string_starts_with() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
+#[ignore = "string method with args not yet implemented"]
 fn string_ends_with() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -223,7 +211,7 @@ fn string_ends_with() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
+#[ignore = "string method with args not yet implemented"]
 fn string_split() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -242,7 +230,6 @@ fn string_split() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_substring() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -257,7 +244,6 @@ fn string_substring() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
 fn string_substring_bounds() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -272,7 +258,7 @@ fn string_substring_bounds() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "strings not yet implemented"]
+#[ignore = "string method with args not yet implemented"]
 fn string_replace() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"

--- a/baml_language/crates/baml_vm/tests/while_loops.rs
+++ b/baml_language/crates/baml_vm/tests/while_loops.rs
@@ -3,7 +3,6 @@
 use baml_tests::bytecode::{ExecState, Program, Value, assert_vm_executes};
 
 #[test]
-#[ignore = "loop codegen causes infinite loop"]
 fn while_loop() -> anyhow::Result<()> {
     const SOURCE: &str = r#"
         function GCD(a: int, b: int) -> int {
@@ -34,7 +33,6 @@ fn while_loop() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "loop codegen causes infinite loop"]
 fn while_with_scope() -> anyhow::Result<()> {
     const SOURCE: &str = r#"
         function Fib(n: int) -> int {
@@ -65,7 +63,6 @@ fn while_with_scope() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "loop codegen causes infinite loop"]
 fn break_factorial() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -119,7 +116,6 @@ fn break_nested_loops() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "loop codegen causes infinite loop"]
 fn continue_factorial() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -152,7 +148,6 @@ fn continue_factorial() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "loop codegen causes infinite loop"]
 fn continue_nested() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"


### PR DESCRIPTION
## Summary
- Boolean and null literals (`true`, `false`, `null`) were not being recognized in let statement initializers because they are parsed as `WORD` tokens rather than dedicated keyword tokens
- Updated `LetStmt::initializer_token()` to match `WORD` tokens with text "true", "false", or "null"
- Updated HIR lowering to convert these to the correct `Literal` expressions

## Test plan
- [x] Unskipped `continue_factorial` and `continue_nested` tests which now pass
- [x] Updated expected bytecode in codegen tests
- [x] All existing tests continue to pass