### PR TITLE
try build ts arm64 linux to fix vertex credentials parsing issue

### DIFF
--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -30,7 +30,7 @@ jobs:
             # Target glibc 2.17. This is the oldest glibc we can practically support.
             # Note that ubuntu-22.04-arm has glibc 2.35, but our users need older glibc.
             # See https://github.com/BoundaryML/baml/issues/2736
-            container: ghcr.io/rust-cross/manylinux2014-cross:aarch64
+            container: ghcr.io/rust-cross/manylinux_2_28-cross:aarch64
             before: |
               echo "CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8" >> "$GITHUB_ENV"
             node_build: pnpm build:napi-release --target aarch64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
       - cursor/implement-collector-clear-and-update-docs-7c67
       - greg/bedrock-pdf-citations
       - typescript-x86-musl
+      - ts-x86-linux
 concurrency:
   # No suffix specified - in reusable workflows we need a statically-defined suffix
   # to prevent workflow_call workflows from triggering a concurrency deadlock


### PR DESCRIPTION
From discord thread:
```
    Failed to create request builder: Error {
             context: "Failed to build request",
             source: Error {
                 context: "Failed to parse credentials as JSON string: \"{\\n...\\n}\"",
                 source: Str(
                     "invalid private key in credentials",
                 ),
             },
         }
     BamlValidationError: BamlValidationError: LLM Failure: Failed to create request builder: Error {
         context: "Failed to build request",
         source: Error {
             context: "Failed to parse credentials as JSON string: \"{\\n...\\n}\"",
             source: Str(
                 "invalid private key in credentials",
             ),
         },
     } (Unspecified error code: 2) - Failed to create request builder: Error {
         context: "Failed to build request",
         source: Error {
             context: "Failed to parse credentials as JSON string: \"{\\n...\\n}\"",
             source: Str(
                 "invalid private key in credentials",
             ),
```
But this works (amd64)
docker run --rm --platform linux/amd64 -v /Users/aaronvillalpando/Projects/linuxgcp/gloo-ai-a37a32fa3313.json:/app/credentials.json:ro -e GOOGLE_APPLICATION_CREDENTIALS=/app/credentials.json -e BAML_INTERNAL_LOG=debug  timeout: 3m
      linuxgcp-amd64 2>&1 | head -80)
linux arm64 did not


<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **CI updates for release pipelines**
> 
> - For `aarch64-unknown-linux-gnu` in `build-typescript-release.reusable.yaml`, change container from `ghcr.io/rust-cross/manylinux2014-cross:aarch64` to `ghcr.io/rust-cross/manylinux_2_28-cross:aarch64`.

> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51f837ff0dbff103ebc0d247270cfff4893ad3b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->