### PR TITLE
Implement enum variant values in expressions

### DIFF
--- a/baml_language/crates/baml_codegen/src/emit.rs
+++ b/baml_language/crates/baml_codegen/src/emit.rs
@@ -34,6 +34,10 @@ struct StackifyCodegen<'ctx, 'obj, 'db> {
     classes: &'ctx HashMap<String, HashMap<String, usize>>,
     /// Pre-allocated Class object indices.
     class_object_indices: &'ctx HashMap<String, usize>,
+    /// Pre-allocated Enum object indices.
+    enum_object_indices: &'ctx HashMap<String, usize>,
+    /// Enum variant mappings (enum name -> variant name -> variant index).
+    enum_variants: &'ctx HashMap<String, HashMap<String, usize>>,
     /// Shared object pool.
     objects: &'obj mut ObjectPool,
 
@@ -67,6 +71,8 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
             globals: ctx.globals,
             classes: ctx.classes,
             class_object_indices: ctx.class_object_indices,
+            enum_object_indices: ctx.enum_object_indices,
+            enum_variants: ctx.enum_variants,
             objects: ctx.objects,
             analysis,
             local_slots: HashMap::new(),
@@ -396,10 +402,29 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
                             self.emit(Instruction::StoreField(field_idx));
                         }
                     }
-                    AggregateKind::EnumVariant { .. } => {
-                        // TODO: Implement enum variant construction
-                        let idx = self.add_constant(Value::Null);
+                    AggregateKind::EnumVariant { enum_name, variant } => {
+                        // Look up the enum object index
+                        let enum_obj_idx = self
+                            .enum_object_indices
+                            .get(enum_name)
+                            .copied()
+                            .unwrap_or_else(|| panic!("undefined enum: {enum_name}"));
+
+                        // Look up the variant index
+                        let variant_idx = self
+                            .enum_variants
+                            .get(enum_name)
+                            .and_then(|variants| variants.get(variant))
+                            .copied()
+                            .unwrap_or_else(|| panic!("undefined variant: {enum_name}.{variant}"));
+
+                        // Load variant index onto stack, then allocate variant
+                        #[allow(clippy::cast_possible_wrap)]
+                        let idx = self.add_constant(Value::Int(variant_idx as i64));
                         self.emit(Instruction::LoadConst(idx));
+                        self.emit(Instruction::AllocVariant(ObjectIndex::from_raw(
+                            enum_obj_idx,
+                        )));
                     }
                 }
             }
@@ -482,11 +507,31 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
                 let idx = self.add_constant(Value::Null);
                 self.emit(Instruction::LoadConst(idx));
             }
-            Constant::EnumVariant { .. } => {
-                // TODO: Implement proper enum variant constant emission
-                // This needs to look up the enum object and create a Variant object
-                let idx = self.add_constant(Value::Null);
+            Constant::EnumVariant { enum_name, variant } => {
+                // Look up the enum object index
+                let enum_name_str = enum_name.to_string();
+                let enum_obj_idx = self
+                    .enum_object_indices
+                    .get(&enum_name_str)
+                    .copied()
+                    .unwrap_or_else(|| panic!("undefined enum: {enum_name_str}"));
+
+                // Look up the variant index
+                let variant_str = variant.to_string();
+                let variant_idx = self
+                    .enum_variants
+                    .get(&enum_name_str)
+                    .and_then(|variants| variants.get(&variant_str))
+                    .copied()
+                    .unwrap_or_else(|| panic!("undefined variant: {enum_name_str}.{variant_str}"));
+
+                // Load variant index onto stack, then allocate variant
+                #[allow(clippy::cast_possible_wrap)]
+                let idx = self.add_constant(Value::Int(variant_idx as i64));
                 self.emit(Instruction::LoadConst(idx));
+                self.emit(Instruction::AllocVariant(ObjectIndex::from_raw(
+                    enum_obj_idx,
+                )));
             }
         }
     }

--- a/baml_language/crates/baml_codegen/src/lib.rs
+++ b/baml_language/crates/baml_codegen/src/lib.rs
@@ -36,6 +36,10 @@ pub(crate) struct MirCodegenContext<'ctx, 'obj> {
     pub classes: &'ctx HashMap<String, HashMap<String, usize>>,
     /// Pre-allocated Class object indices in the program's object pool.
     pub class_object_indices: &'ctx HashMap<String, usize>,
+    /// Pre-allocated Enum object indices in the program's object pool.
+    pub enum_object_indices: &'ctx HashMap<String, usize>,
+    /// Enum variant mappings (enum name -> variant name -> variant index).
+    pub enum_variants: &'ctx HashMap<String, HashMap<String, usize>>,
     /// Shared object pool for strings, etc.
     pub objects: &'obj mut ObjectPool,
 }
@@ -140,6 +144,43 @@ pub fn compile_files(
         }
     }
 
+    // Build enums map (enum name -> variant name -> variant index) and add Enum objects to program
+    // Also build enum_variant_names for type inference (enum name -> list of variant names)
+    let mut enum_variants: HashMap<String, HashMap<String, usize>> = HashMap::new();
+    let mut enum_variant_names: HashMap<Name, Vec<Name>> = HashMap::new();
+    let mut enum_object_indices: HashMap<String, usize> = HashMap::new();
+
+    for file in files {
+        let item_tree = baml_hir::file_item_tree(db, *file);
+        let items_struct = baml_hir::file_items(db, *file);
+        for item in items_struct.items(db) {
+            if let ItemId::Enum(enum_loc) = item {
+                let enum_def = &item_tree[enum_loc.id(db)];
+                let enum_name = enum_def.name.to_string();
+
+                let mut variant_indices = HashMap::new();
+                let mut variant_names = Vec::new();
+                let mut variant_name_list: Vec<Name> = Vec::new();
+                for (idx, variant) in enum_def.variants.iter().enumerate() {
+                    variant_indices.insert(variant.name.to_string(), idx);
+                    variant_names.push(variant.name.to_string());
+                    variant_name_list.push(variant.name.clone());
+                }
+
+                // Add Enum object to program and record its index
+                let enum_obj = Object::Enum(Enum {
+                    name: enum_name.clone(),
+                    variant_names,
+                });
+                let enum_obj_idx = program.add_object(enum_obj);
+                enum_object_indices.insert(enum_name.clone(), enum_obj_idx);
+
+                enum_variants.insert(enum_name, variant_indices);
+                enum_variant_names.insert(enum_def.name.clone(), variant_name_list);
+            }
+        }
+    }
+
     // Add builtin functions to globals FIRST (stable indices)
     for (path, (native_fn, arity)) in &builtins {
         let builtin_fn = Function {
@@ -205,16 +246,10 @@ pub fn compile_files(
                     }
                     baml_hir::FunctionBody::Expr(_) => {
                         // Run type inference
-                        // Note: type_aliases and enum_variants are not passed here,
-                        // so exhaustiveness checking for type aliases and enums won't work.
-                        // This is acceptable since codegen is for runtime execution,
-                        // and type errors should be caught in the THIR phase.
-                        //
-                        // TODO(codegen-inference): Re-evaluate whether we need full type context.
-                        // Currently this works because:
-                        //   1. Exhaustiveness errors are caught in the THIR/Diagnostics phase
-                        //   2. The core type inference doesn't depend on these maps
-                        //   3. Codegen only uses inference.expr_types and path_segment_types
+                        // Note: type_aliases is not passed here, so exhaustiveness
+                        // checking for type aliases won't work. This is acceptable
+                        // since codegen is for runtime execution, and type errors
+                        // should be caught in the THIR phase.
                         let inference = baml_thir::infer_function(
                             db,
                             &signature,
@@ -222,7 +257,7 @@ pub fn compile_files(
                             Some(typing_context.clone()),
                             Some(class_field_types.clone()),
                             None, // type_aliases - not needed for codegen
-                            None, // enum_variants - not needed for codegen
+                            Some(enum_variant_names.clone()), // enum_variants - needed for enum variant detection
                             *func_loc,
                         );
 
@@ -237,6 +272,8 @@ pub fn compile_files(
                             globals: &globals,
                             classes: &classes,
                             class_object_indices: &class_object_indices,
+                            enum_object_indices: &enum_object_indices,
+                            enum_variants: &enum_variants,
                             objects: &mut program.objects,
                         };
                         compile_mir_function(&mir, ctx)

--- a/baml_language/crates/baml_codegen/tests/enums.rs
+++ b/baml_language/crates/baml_codegen/tests/enums.rs
@@ -6,7 +6,6 @@ use baml_tests::{
 };
 
 #[test]
-#[ignore = "enums not yet in HIR"]
 fn return_enum_variant() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -32,8 +31,9 @@ fn return_enum_variant() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "enums not yet in HIR"]
 fn assign_enum_variant() -> anyhow::Result<()> {
+    // When a variable is single-use, the compiler optimizes it away (stackification).
+    // The enum value stays on the stack and is returned directly.
     assert_compiles(Program {
         source: r#"
             enum Shape {
@@ -52,7 +52,6 @@ fn assign_enum_variant() -> anyhow::Result<()> {
             vec![
                 Instruction::LoadConst(Value::Int(1)), // Rectangle is variant index 1
                 Instruction::AllocVariant(Value::enm("Shape")),
-                Instruction::LoadVar("s".to_string()),
                 Instruction::Return,
             ],
         )],

--- a/baml_language/crates/baml_diagnostics/src/compiler_error.rs
+++ b/baml_language/crates/baml_diagnostics/src/compiler_error.rs
@@ -61,6 +61,7 @@ const UNEXPECTED_TOKEN: ErrorCode = ErrorCode(10);
 const DUPLICATE_NAME: ErrorCode = ErrorCode(11);
 const NON_EXHAUSTIVE_MATCH: ErrorCode = ErrorCode(62);
 const UNREACHABLE_ARM: ErrorCode = ErrorCode(63);
+const UNKNOWN_ENUM_VARIANT: ErrorCode = ErrorCode(64);
 
 /// Render an ariadne Report to a String.
 ///

--- a/baml_language/crates/baml_diagnostics/src/compiler_error/error_format.rs
+++ b/baml_language/crates/baml_diagnostics/src/compiler_error/error_format.rs
@@ -4,8 +4,8 @@ use baml_base::Span;
 use super::{
     ARGUMENT_COUNT_MISMATCH, CompilerError, DUPLICATE_NAME, ErrorCode, INVALID_OPERATOR,
     NO_SUCH_FIELD, NON_EXHAUSTIVE_MATCH, NOT_CALLABLE, NOT_INDEXABLE, NameError, ParseError,
-    Report, ReportKind, TYPE_MISMATCH, TypeError, UNEXPECTED_EOF, UNEXPECTED_TOKEN, UNKNOWN_TYPE,
-    UNKNOWN_VARIABLE, UNREACHABLE_ARM,
+    Report, ReportKind, TYPE_MISMATCH, TypeError, UNEXPECTED_EOF, UNEXPECTED_TOKEN,
+    UNKNOWN_ENUM_VARIANT, UNKNOWN_TYPE, UNKNOWN_VARIABLE, UNREACHABLE_ARM,
 };
 
 /// The message format and id of each compiler error variant.
@@ -102,6 +102,15 @@ where
                 "Unreachable match arm: previous arms already cover all cases".to_string(),
                 span,
                 UNREACHABLE_ARM,
+            ),
+            TypeError::UnknownEnumVariant {
+                enum_name,
+                variant_name,
+                span,
+            } => simple_error(
+                format!("Enum '{enum_name}' has no variant '{variant_name}'"),
+                span,
+                UNKNOWN_ENUM_VARIANT,
             ),
         },
         CompilerError::NameError(name_error) => match name_error {

--- a/baml_language/crates/baml_diagnostics/src/compiler_error/type_error.rs
+++ b/baml_language/crates/baml_diagnostics/src/compiler_error/type_error.rs
@@ -42,6 +42,12 @@ pub enum TypeError<T> {
     },
     /// Match arm is unreachable - it can never match because previous arms cover all cases.
     UnreachableArm { span: Span },
+    /// Reference to an unknown enum variant.
+    UnknownEnumVariant {
+        enum_name: String,
+        variant_name: String,
+        span: Span,
+    },
 }
 
 impl<T> TypeError<T> {
@@ -108,6 +114,15 @@ impl<T> TypeError<T> {
                 span: *span,
             },
             TypeError::UnreachableArm { span } => TypeError::UnreachableArm { span: *span },
+            TypeError::UnknownEnumVariant {
+                enum_name,
+                variant_name,
+                span,
+            } => TypeError::UnknownEnumVariant {
+                enum_name: enum_name.clone(),
+                variant_name: variant_name.clone(),
+                span: *span,
+            },
         }
     }
 }

--- a/baml_language/crates/baml_language_server/src/lsp_db/diagnostics.rs
+++ b/baml_language/crates/baml_language_server/src/lsp_db/diagnostics.rs
@@ -291,6 +291,15 @@ fn convert_type_error<T: std::fmt::Display>(
             "E0012",
         ),
         TypeError::UnreachableArm { span } => ("Unreachable match arm".to_string(), span, "E0013"),
+        TypeError::UnknownEnumVariant {
+            enum_name,
+            variant_name,
+            span,
+        } => (
+            format!("Unknown variant `{variant_name}` for enum `{enum_name}`"),
+            span,
+            "E0064",
+        ),
     };
 
     let range = span_to_range_with_index(line_index, span);

--- a/baml_language/crates/baml_language_server/src/server/api/diagnostics.rs
+++ b/baml_language/crates/baml_language_server/src/server/api/diagnostics.rs
@@ -410,6 +410,15 @@ fn type_error_to_diagnostic<T: std::fmt::Display>(
             "E0012",
         ),
         TypeError::UnreachableArm { span } => ("Unreachable match arm".to_string(), span, "E0013"),
+        TypeError::UnknownEnumVariant {
+            enum_name,
+            variant_name,
+            span,
+        } => (
+            format!("Unknown variant `{variant_name}` for enum `{enum_name}`"),
+            span,
+            "E0064",
+        ),
     };
 
     let (_, source_text, line_index) = file_info.get(&span.file_id)?;
@@ -451,6 +460,7 @@ fn get_type_error_file_id<T>(error: &TypeError<T>) -> FileId {
         TypeError::NotIndexable { span, .. } => span.file_id,
         TypeError::NonExhaustiveMatch { span, .. } => span.file_id,
         TypeError::UnreachableArm { span, .. } => span.file_id,
+        TypeError::UnknownEnumVariant { span, .. } => span.file_id,
     }
 }
 

--- a/baml_language/crates/baml_mir/src/lower_typed_ir.rs
+++ b/baml_language/crates/baml_mir/src/lower_typed_ir.rs
@@ -176,6 +176,15 @@ impl<'db, 'ctx> LoweringContext<'db, 'ctx> {
                             Rvalue::Use(Operand::Constant(Constant::Function(name.clone()))),
                         );
                     }
+                } else if let Some((enum_name, variant)) = body.enum_variant_exprs.get(&expr_id) {
+                    // Enum variant value (e.g., Status.Active)
+                    self.builder.assign(
+                        dest,
+                        Rvalue::Use(Operand::Constant(Constant::EnumVariant {
+                            enum_name: enum_name.clone(),
+                            variant: variant.clone(),
+                        })),
+                    );
                 } else {
                     // Multi-segment path that's not a field access chain (e.g., baml.Array.length).
                     // TODO: This is a hack - we're treating these as builtin function references

--- a/baml_language/crates/baml_onionskin/src/compiler.rs
+++ b/baml_language/crates/baml_onionskin/src/compiler.rs
@@ -2220,6 +2220,7 @@ fn get_error_file_id(error: &StoredCompilerError) -> FileId {
             TypeError::NotIndexable { span, .. } => span.file_id,
             TypeError::NonExhaustiveMatch { span, .. } => span.file_id,
             TypeError::UnreachableArm { span, .. } => span.file_id,
+            TypeError::UnknownEnumVariant { span, .. } => span.file_id,
         },
         CompilerError::NameError(e) => match e {
             baml_diagnostics::NameError::DuplicateName { second, .. } => second.file_id,

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 === BYTECODE ===
 Functions: 2
-Objects: 23
+Objects: 24
 Globals: 20
 
 Function GetStatus (arity: 0, kind: Llm):

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-17af2d4231950a65/out/generated_tests.rs
+source: target/debug/build/baml_tests-eb448e436f8a003a/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 26
+Objects: 28
 Globals: 21
 
 Function Foo (arity: 0, kind: Llm):

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-17af2d4231950a65/out/generated_tests.rs
+source: target/debug/build/baml_tests-eb448e436f8a003a/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 103
-Objects: 1127
+Objects: 1228
 Globals: 121
 
 Function BodyTorture (arity: 0, kind: Exec):

--- a/baml_language/crates/baml_thir/src/lib.rs
+++ b/baml_language/crates/baml_thir/src/lib.rs
@@ -234,6 +234,10 @@ pub struct InferenceResult<'db> {
     /// For `o.inner.value` where `o: Outer`, stores `[Outer, Inner, int]`.
     /// Used by codegen to look up field indices at each step.
     pub path_segment_types: HashMap<ExprId, Vec<Ty<'db>>>,
+    /// Expressions that are enum variant values (e.g., `Status.Active`).
+    /// Maps expression ID to (`enum_name`, `variant_name`).
+    /// Used by codegen to emit enum variant construction.
+    pub enum_variant_exprs: HashMap<ExprId, (Name, Name)>,
     /// Type checking errors.
     pub errors: Vec<TypeError<Ty<'db>>>,
 }
@@ -257,6 +261,8 @@ pub struct TypeContext<'db> {
     expr_types: HashMap<ExprId, Ty<'db>>,
     /// For multi-segment paths, the type of each segment.
     path_segment_types: HashMap<ExprId, Vec<Ty<'db>>>,
+    /// Expressions that are enum variant values.
+    enum_variant_exprs: HashMap<ExprId, (Name, Name)>,
     /// Types of all return statements encountered during inference.
     /// Used to validate that all return paths match the declared return type.
     return_types: Vec<(Ty<'db>, Span)>,
@@ -280,6 +286,7 @@ impl<'db> TypeContext<'db> {
             enum_variants: HashMap::new(),
             expr_types: HashMap::new(),
             path_segment_types: HashMap::new(),
+            enum_variant_exprs: HashMap::new(),
             return_types: Vec::new(),
             errors: Vec::new(),
             file_id,
@@ -301,6 +308,7 @@ impl<'db> TypeContext<'db> {
             enum_variants: HashMap::new(),
             expr_types: HashMap::new(),
             path_segment_types: HashMap::new(),
+            enum_variant_exprs: HashMap::new(),
             return_types: Vec::new(),
             errors: Vec::new(),
             file_id,
@@ -324,6 +332,7 @@ impl<'db> TypeContext<'db> {
             enum_variants,
             expr_types: HashMap::new(),
             path_segment_types: HashMap::new(),
+            enum_variant_exprs: HashMap::new(),
             return_types: Vec::new(),
             errors: Vec::new(),
             file_id,
@@ -568,6 +577,7 @@ pub fn infer_function_body<'db>(
         param_types,
         expr_types: ctx.expr_types,
         path_segment_types: ctx.path_segment_types,
+        enum_variant_exprs: ctx.enum_variant_exprs,
         errors: ctx.errors,
     }
 }
@@ -694,6 +704,28 @@ fn infer_expr<'db>(ctx: &mut TypeContext<'db>, expr_id: ExprId, body: &ExprBody)
                         params: param_types,
                         ret: Box::new(return_type),
                     };
+                }
+
+                // Check if this is an enum variant (e.g., Status.Active)
+                if segments.len() == 2 {
+                    let enum_name = &segments[0];
+                    let variant_name = &segments[1];
+
+                    if let Some(variants) = ctx.lookup_enum_variants(enum_name) {
+                        if variants.contains(variant_name) {
+                            // This is a valid enum variant - record it and return the enum type
+                            ctx.enum_variant_exprs
+                                .insert(expr_id, (enum_name.clone(), variant_name.clone()));
+                            return Ty::Named(enum_name.clone());
+                        }
+                        // Enum exists but variant doesn't
+                        ctx.push_error(TypeError::UnknownEnumVariant {
+                            enum_name: enum_name.to_string(),
+                            variant_name: variant_name.to_string(),
+                            span,
+                        });
+                        return Ty::Unknown;
+                    }
                 }
 
                 // Otherwise, treat as variable + field accesses

--- a/baml_language/crates/baml_thir/src/pretty.rs
+++ b/baml_language/crates/baml_thir/src/pretty.rs
@@ -557,5 +557,10 @@ pub fn short_display(error: &TypeError<Ty<'_>>) -> String {
             format!("Non-exhaustive match on {scrutinee_type}: missing {missing}")
         }
         TypeError::UnreachableArm { .. } => "Unreachable match arm".to_string(),
+        TypeError::UnknownEnumVariant {
+            enum_name,
+            variant_name,
+            ..
+        } => format!("Enum '{enum_name}' has no variant '{variant_name}'"),
     }
 }

--- a/baml_language/crates/baml_typed_ir/src/expr.rs
+++ b/baml_language/crates/baml_typed_ir/src/expr.rs
@@ -33,6 +33,10 @@ pub struct ExprBody {
     pub expr_types: rustc_hash::FxHashMap<ExprId, Ty>,
     /// Source spans for expressions.
     pub expr_spans: rustc_hash::FxHashMap<ExprId, TextRange>,
+    /// Expressions that are enum variant values (e.g., `Status.Active`).
+    /// Maps expression ID to (`enum_name`, `variant_name`).
+    /// Used by MIR lowering to emit enum variant constants.
+    pub enum_variant_exprs: rustc_hash::FxHashMap<ExprId, (Name, Name)>,
     /// Root expression of the body.
     pub root: ExprId,
 }
@@ -94,6 +98,10 @@ pub enum Expr {
     Var(Name),
 
     /// Multi-segment path (e.g., `user.name`, `Status.Active`).
+    ///
+    /// Resolution of what this path refers to (variable + field access,
+    /// enum variant, module item) is tracked via metadata passed through
+    /// from THIR. See `enum_variant_exprs` for enum variant paths.
     Path(Vec<Name>),
 
     // ========== Binding & Sequencing ==========

--- a/baml_language/crates/baml_typed_ir/src/lower.rs
+++ b/baml_language/crates/baml_typed_ir/src/lower.rs
@@ -103,6 +103,7 @@ struct ExprBodyBuilder {
     patterns: Arena<Pattern>,
     expr_types: FxHashMap<ExprId, Ty>,
     expr_spans: FxHashMap<ExprId, TextRange>,
+    enum_variant_exprs: FxHashMap<ExprId, (baml_base::Name, baml_base::Name)>,
 }
 
 impl ExprBodyBuilder {
@@ -112,6 +113,7 @@ impl ExprBodyBuilder {
             patterns: Arena::new(),
             expr_types: FxHashMap::default(),
             expr_spans: FxHashMap::default(),
+            enum_variant_exprs: FxHashMap::default(),
         }
     }
 
@@ -142,8 +144,18 @@ impl ExprBodyBuilder {
             patterns: self.patterns,
             expr_types: self.expr_types,
             expr_spans: self.expr_spans,
+            enum_variant_exprs: self.enum_variant_exprs,
             root,
         }
+    }
+
+    fn record_enum_variant(
+        &mut self,
+        id: ExprId,
+        enum_name: baml_base::Name,
+        variant: baml_base::Name,
+    ) {
+        self.enum_variant_exprs.insert(id, (enum_name, variant));
     }
 }
 
@@ -254,9 +266,22 @@ impl<'db> LoweringContext<'db> {
                     // which should have type `fn(Array<T>) -> int` but generics are currently hacked
                     // and not properly implemented. When real generics are added, this will need
                     // proper type instantiation.
-                    Ok(self
+                    let expr_id = self
                         .builder
-                        .alloc(Expr::Path(segments.clone()), ty, text_range))
+                        .alloc(Expr::Path(segments.clone()), ty, text_range);
+
+                    // Check if this path is an enum variant and record it for MIR lowering
+                    if let Some((enum_name, variant)) =
+                        self.inference.enum_variant_exprs.get(&hir_id)
+                    {
+                        self.builder.record_enum_variant(
+                            expr_id,
+                            enum_name.clone(),
+                            variant.clone(),
+                        );
+                    }
+
+                    Ok(expr_id)
                 }
             }
 

--- a/baml_language/crates/baml_vm/tests/enums.rs
+++ b/baml_language/crates/baml_vm/tests/enums.rs
@@ -3,7 +3,6 @@
 use baml_tests::bytecode::{ExecState, Object, Program, Value, Variant, assert_vm_executes};
 
 #[test]
-#[ignore = "enum variants not yet implemented"]
 fn return_enum_variant() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -26,7 +25,6 @@ fn return_enum_variant() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "enum variants not yet implemented"]
 fn assign_enum_variant() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -50,7 +48,6 @@ fn assign_enum_variant() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "enum variants not yet implemented"]
 fn take_and_return_enum_variant() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"


### PR DESCRIPTION
## Summary
- Add support for using enum variants as values (e.g., `Status.Active`, `Shape.Rectangle`)
- Previously enums only worked in pattern matching; now they can be used as expressions

## Changes
- **THIR**: Add enum variant detection in path expression inference
- **TypedIR**: Propagate `enum_variant_exprs` metadata through lowering  
- **MIR**: Emit `Constant::EnumVariant` for enum variant paths
- **Codegen**: Register enums and emit `LoadConst` + `AllocVariant` bytecode
- **Diagnostics**: Add `TypeError::UnknownEnumVariant` for invalid variant references
- Enable previously ignored enum tests in `baml_codegen/tests/enums.rs`

## Test plan
- [x] All 236 tests in `baml_tests` pass
- [x] All 72 tests in `baml_codegen` pass (including 2 previously ignored enum tests)
- [x] Snapshots updated for increased object count (enums now added as objects)