### PR TITLE
Add copy propagation and wildcard elimination optimizations

### DIFF
--- a/baml_language/crates/baml_codegen/src/analysis.rs
+++ b/baml_language/crates/baml_codegen/src/analysis.rs
@@ -9,6 +9,8 @@
 //! - Phi-like local detection (locals assigned in all predecessors, used once at join)
 //! - Constant propagation (pure constants with single definition inlined at all use sites)
 //! - Call result immediate (single-use Call results used at continuation block start)
+//! - Copy propagation (locals that are simple copies of parameters/other locals)
+//! - Wildcard elimination (unused `_` pattern bindings are eliminated)
 
 use std::collections::{HashMap, HashSet};
 
@@ -72,6 +74,11 @@ pub(crate) enum LocalClassification {
     /// At def site (after Call): don't emit Store (leave on stack).
     /// At use site: don't emit `LoadVar` (value already on stack from Call).
     CallResultImmediate,
+    /// Copy of another local: `_X = copy _Y` where _Y is a parameter or simple local.
+    /// At def site: don't emit anything (skip the copy entirely).
+    /// At use sites: load from the source local instead.
+    /// The source local is stored in `AnalysisResult::copy_sources`.
+    CopyOf,
     /// Dead local - defined but never used, can be eliminated.
     Dead,
 }
@@ -123,6 +130,9 @@ pub(crate) struct AnalysisResult<'db> {
     /// Jump threading: maps empty goto-only blocks to their final target.
     /// Used during emission to skip intermediate jumps.
     pub redirect_targets: HashMap<BlockId, BlockId>,
+    /// Copy propagation: maps locals classified as `CopyOf` to their source local.
+    /// When emitting a use of local X, if X is in this map, load from the mapped local instead.
+    pub copy_sources: HashMap<Local, Local>,
 }
 
 // ============================================================================
@@ -147,8 +157,8 @@ impl<'db> AnalysisResult<'db> {
         // Step 5: Build jump threading redirect map
         let redirect_targets = build_redirect_targets(mir);
 
-        // Step 6: Classify each local (including phi-like detection)
-        let classifications =
+        // Step 6: Classify each local (including phi-like detection and copy propagation)
+        let (classifications, copy_sources) =
             classify_locals(mir, &def_use, &dominators, &predecessors, &redirect_targets);
 
         Self {
@@ -158,6 +168,7 @@ impl<'db> AnalysisResult<'db> {
             rpo,
             predecessors,
             redirect_targets,
+            copy_sources,
         }
     }
 
@@ -168,6 +179,17 @@ impl<'db> AnalysisResult<'db> {
             .get(&target)
             .copied()
             .unwrap_or(target)
+    }
+
+    /// Resolve a local through copy propagation.
+    /// If the local is a copy of another local, returns the source local.
+    /// Follows chains: if A copies B and B copies C, resolves A to C.
+    pub(crate) fn resolve_copy_source(&self, local: Local) -> Local {
+        let mut current = local;
+        while let Some(&source) = self.copy_sources.get(&current) {
+            current = source;
+        }
+        current
     }
 }
 
@@ -628,32 +650,49 @@ fn collect_uses_in_terminator<'db>(
 // Local Classification
 // ============================================================================
 
-/// Classify each local as Virtual, Real, `PhiLike`, or Dead.
+/// Classify each local as Virtual, Real, `PhiLike`, `CopyOf`, or Dead.
+///
+/// Returns both the classifications and the `copy_sources` map for copy propagation.
 fn classify_locals<'db>(
     mir: &MirFunction<'db>,
     def_use: &HashMap<Local, LocalDefUse<'db>>,
     dominators: &Dominators,
     predecessors: &HashMap<BlockId, Vec<BlockId>>,
     redirect_targets: &HashMap<BlockId, BlockId>,
-) -> HashMap<Local, LocalClassification> {
+) -> (HashMap<Local, LocalClassification>, HashMap<Local, Local>) {
     let all_defs = collect_all_definitions(mir);
 
     let mut classifications = HashMap::new();
+    let mut copy_sources: HashMap<Local, Local> = HashMap::new();
 
     for (idx, _local_decl) in mir.locals.iter().enumerate() {
         let local = Local(idx);
         let du = &def_use[&local];
 
         let local_decl = mir.local(local);
+
+        // Check if this is an unused wildcard binding.
+        // NOTE: We currently only check for exactly "_". In the future, we may want
+        // more robust checking (e.g., any name starting with "_", or type-based analysis
+        // to verify the binding truly has no observable side effects). For now, this
+        // simple check handles the common pattern-matching wildcard case.
+        let is_unused_wildcard = du.uses.is_empty() && local_decl.name.as_deref() == Some("_");
+
         let classification = if idx > 0 && idx <= mir.arity {
             // Parameters are always real (they come from the caller)
             LocalClassification::Parameter
-        } else if idx != 0 && du.uses.is_empty() && local_decl.name.is_none() {
-            // Dead compiler temp - defined but never used (skip _0 which is implicitly used by return)
-            // NOTE: To also eliminate dead user variables (e.g., `let x = 5;` where x is never read),
-            // remove the `&& local_decl.name.is_none()` check above. Currently we preserve user
-            // variables for debugging/semantics even if unused.
+        } else if idx != 0
+            && du.uses.is_empty()
+            && (local_decl.name.is_none() || is_unused_wildcard)
+        {
+            // Dead local: either an unused compiler temp, or an unused wildcard binding.
+            // Skip _0 which is implicitly used by return.
             LocalClassification::Dead
+        } else if let Some(source) = get_copy_source(local, du, mir, &all_defs) {
+            // Copy propagation: this local is just `_X = copy _Y` where _Y is suitable.
+            // We can eliminate _X and use _Y directly at all use sites.
+            copy_sources.insert(local, source);
+            LocalClassification::CopyOf
         } else if can_be_virtual(local, du, dominators, mir, def_use, predecessors, &all_defs) {
             LocalClassification::Virtual
         } else if is_phi_like(local, du, mir, predecessors, &all_defs) {
@@ -678,7 +717,7 @@ fn classify_locals<'db>(
         classifications.insert(local, classification);
     }
 
-    classifications
+    (classifications, copy_sources)
 }
 
 /// Collect all definition sites for each local.
@@ -1290,6 +1329,56 @@ fn is_call_result_immediate(local: Local, du: &LocalDefUse<'_>, mir: &MirFunctio
 
     // Check that the continuation block is the use block
     continuation_target == Some(use_loc.block)
+}
+
+/// Check if a local is a simple copy of another local (for copy propagation).
+///
+/// Returns `Some(source_local)` if the local is defined as `_X = copy _Y` where:
+/// 1. There is exactly one definition of `_X`
+/// 2. The definition is `Rvalue::Use(Operand::Copy(Place::Local(source)))` or
+///    `Rvalue::Use(Operand::Move(Place::Local(source)))`
+/// 3. The source is a parameter (not modified) or another suitable local
+///
+/// This optimization is particularly useful for match expressions where the
+/// scrutinee is copied into a temporary before comparisons.
+fn get_copy_source(
+    local: Local,
+    du: &LocalDefUse<'_>,
+    mir: &MirFunction<'_>,
+    all_defs: &HashMap<Local, Vec<(BlockId, usize)>>,
+) -> Option<Local> {
+    // Must have exactly one definition
+    let def = du.def.as_ref()?;
+
+    // Definition must not be from a terminator (Call/Await results aren't copies)
+    if def.statement_idx == TERMINATOR_IDX {
+        return None;
+    }
+
+    // Must have exactly one definition site
+    let defs = all_defs.get(&local)?;
+    if defs.len() != 1 {
+        return None;
+    }
+
+    // The rvalue must be a simple copy/move of a local (not a field or index)
+    let source = match &def.rvalue {
+        Rvalue::Use(Operand::Copy(Place::Local(src))) => *src,
+        Rvalue::Use(Operand::Move(Place::Local(src))) => *src,
+        _ => return None,
+    };
+
+    // The source must be a parameter (parameters are never reassigned in MIR)
+    // We only propagate copies of parameters to keep the analysis simple and safe.
+    // Propagating copies of other locals would require verifying the source isn't
+    // modified between the copy and all uses of the copy.
+    let source_idx = source.0;
+    if source_idx == 0 || source_idx > mir.arity {
+        // Source is not a parameter (_0 is return value, > arity are locals)
+        return None;
+    }
+
+    Some(source)
 }
 
 // ============================================================================

--- a/baml_language/crates/baml_codegen/src/emit.rs
+++ b/baml_language/crates/baml_codegen/src/emit.rs
@@ -143,8 +143,9 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
                 | LocalClassification::PhiLike
                 | LocalClassification::ReturnPhi
                 | LocalClassification::CallResultImmediate
+                | LocalClassification::CopyOf
                 | LocalClassification::Dead => {
-                    // Virtual, phi-like, return-phi, call-result-immediate, and dead locals don't get slots!
+                    // Virtual, phi-like, return-phi, call-result-immediate, copy-of, and dead locals don't get slots!
                 }
             }
         }
@@ -248,6 +249,11 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
                             self.emit_rvalue_pull(value, mir);
                             return;
                         }
+                        LocalClassification::CopyOf => {
+                            // Copy propagation - skip the copy entirely.
+                            // Uses of this local will load from the source instead.
+                            return;
+                        }
                         LocalClassification::Dead => {
                             // Dead store elimination - skip entirely
                             return;
@@ -333,6 +339,12 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
                         // ReturnPhi: value is already on the stack from the assignment.
                         // CallResultImmediate: value is already on the stack from the Call.
                         // Don't emit any instruction - the value is there waiting for us.
+                    }
+                    LocalClassification::CopyOf => {
+                        // Copy propagation: load from the source local instead.
+                        let source = self.analysis.resolve_copy_source(*local);
+                        let slot = self.local_slots[&source];
+                        self.emit(Instruction::LoadVar(slot));
                     }
                     _ => {
                         // Real/Parameter local: emit LoadVar
@@ -584,8 +596,10 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
                         // PhiLike/ReturnPhi: keep value on stack (no-op) - value goes to join/return.
                         // CallResultImmediate: keep value on stack (no-op) - value used immediately.
                     }
-                    LocalClassification::Virtual | LocalClassification::Dead => {
-                        // Virtual or Dead local - just pop the value
+                    LocalClassification::Virtual
+                    | LocalClassification::CopyOf
+                    | LocalClassification::Dead => {
+                        // Virtual, CopyOf, or Dead local - just pop the value
                         self.emit(Instruction::Pop(1));
                     }
                 }

--- a/baml_language/crates/baml_codegen/tests/for_loops.rs
+++ b/baml_language/crates/baml_codegen/tests/for_loops.rs
@@ -27,10 +27,10 @@ fn for_loop_sum() -> anyhow::Result<()> {
         expected: vec![(
             "Sum",
             // MIR-based codegen with local pre-allocation:
-            // Locals: _0 (return), xs (param), result, _iter, _len, _i, x
+            // Locals: _0 (return), xs (param), result, _len, _i, x
+            // Note: _iter is eliminated by copy propagation (uses xs directly)
             vec![
-                // Pre-allocate all locals
-                Instruction::LoadConst(Value::Null),
+                // Pre-allocate locals (4: result, _len, _i, x)
                 Instruction::LoadConst(Value::Null),
                 Instruction::LoadConst(Value::Null),
                 Instruction::LoadConst(Value::Null),
@@ -38,12 +38,9 @@ fn for_loop_sum() -> anyhow::Result<()> {
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
-                // _iter = xs
-                Instruction::LoadVar("xs".to_string()),
-                Instruction::StoreVar("_iter".to_string()),
-                // _len = baml.Array.length(_iter)
+                // _len = baml.Array.length(xs) - using param directly
                 Instruction::LoadGlobal(Value::function("baml.Array.length")),
-                Instruction::LoadVar("_iter".to_string()),
+                Instruction::LoadVar("xs".to_string()),
                 Instruction::Call(1),
                 Instruction::StoreVar("_len".to_string()),
                 // _i = 0
@@ -58,8 +55,8 @@ fn for_loop_sum() -> anyhow::Result<()> {
                 // Loop exit: load result and return
                 Instruction::LoadVar("result".to_string()),
                 Instruction::Return,
-                // Loop body: x = _iter[_i]
-                Instruction::LoadVar("_iter".to_string()),
+                // Loop body: x = xs[_i] - using param directly
+                Instruction::LoadVar("xs".to_string()),
                 Instruction::LoadVar("_i".to_string()),
                 Instruction::LoadArrayElement,
                 Instruction::StoreVar("x".to_string()),
@@ -100,9 +97,9 @@ fn for_with_break() -> anyhow::Result<()> {
         expected: vec![(
             "ForWithBreak",
             // MIR-based codegen with local pre-allocation
+            // Note: _iter is eliminated by copy propagation (uses xs directly)
             vec![
-                // Pre-allocate all locals
-                Instruction::LoadConst(Value::Null),
+                // Pre-allocate locals (4: result, _len, _i, x)
                 Instruction::LoadConst(Value::Null),
                 Instruction::LoadConst(Value::Null),
                 Instruction::LoadConst(Value::Null),
@@ -110,12 +107,9 @@ fn for_with_break() -> anyhow::Result<()> {
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
-                // _iter = xs
-                Instruction::LoadVar("xs".to_string()),
-                Instruction::StoreVar("_iter".to_string()),
-                // _len = baml.Array.length(_iter)
+                // _len = baml.Array.length(xs) - using param directly
                 Instruction::LoadGlobal(Value::function("baml.Array.length")),
-                Instruction::LoadVar("_iter".to_string()),
+                Instruction::LoadVar("xs".to_string()),
                 Instruction::Call(1),
                 Instruction::StoreVar("_len".to_string()),
                 // _i = 0
@@ -126,8 +120,8 @@ fn for_with_break() -> anyhow::Result<()> {
                 Instruction::LoadVar("_len".to_string()),
                 Instruction::CmpOp(CmpOp::Lt),
                 Instruction::PopJumpIfFalse(19),
-                // Loop body: x = _iter[_i]
-                Instruction::LoadVar("_iter".to_string()),
+                // Loop body: x = xs[_i] - using param directly
+                Instruction::LoadVar("xs".to_string()),
                 Instruction::LoadVar("_i".to_string()),
                 Instruction::LoadArrayElement,
                 Instruction::StoreVar("x".to_string()),
@@ -178,9 +172,9 @@ fn for_with_continue() -> anyhow::Result<()> {
         expected: vec![(
             "ForWithContinue",
             // MIR-based codegen with local pre-allocation
+            // Note: _iter is eliminated by copy propagation (uses xs directly)
             vec![
-                // Pre-allocate all locals
-                Instruction::LoadConst(Value::Null),
+                // Pre-allocate locals (4: result, _len, _i, x)
                 Instruction::LoadConst(Value::Null),
                 Instruction::LoadConst(Value::Null),
                 Instruction::LoadConst(Value::Null),
@@ -188,12 +182,9 @@ fn for_with_continue() -> anyhow::Result<()> {
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
-                // _iter = xs
-                Instruction::LoadVar("xs".to_string()),
-                Instruction::StoreVar("_iter".to_string()),
-                // _len = baml.Array.length(_iter)
+                // _len = baml.Array.length(xs) - using param directly
                 Instruction::LoadGlobal(Value::function("baml.Array.length")),
-                Instruction::LoadVar("_iter".to_string()),
+                Instruction::LoadVar("xs".to_string()),
                 Instruction::Call(1),
                 Instruction::StoreVar("_len".to_string()),
                 // _i = 0
@@ -208,8 +199,8 @@ fn for_with_continue() -> anyhow::Result<()> {
                 // Loop exit: load result and return
                 Instruction::LoadVar("result".to_string()),
                 Instruction::Return,
-                // Loop body: x = _iter[_i]
-                Instruction::LoadVar("_iter".to_string()),
+                // Loop body: x = xs[_i] - using param directly
+                Instruction::LoadVar("xs".to_string()),
                 Instruction::LoadVar("_i".to_string()),
                 Instruction::LoadArrayElement,
                 Instruction::StoreVar("x".to_string()),
@@ -223,7 +214,7 @@ fn for_with_continue() -> anyhow::Result<()> {
                 Instruction::LoadConst(Value::Int(10)),
                 Instruction::CmpOp(CmpOp::Gt),
                 Instruction::PopJumpIfFalse(2),
-                // continue - jump threading: direct to loop condition (was Jump(6) -> Jump(-25))
+                // continue - jump threading: direct to loop condition
                 Instruction::Jump(-19),
                 // result += x
                 Instruction::LoadVar("result".to_string()),
@@ -258,11 +249,10 @@ fn for_nested() -> anyhow::Result<()> {
         expected: vec![(
             "NestedFor",
             // MIR-based codegen with local pre-allocation
-            // Locals: _0, as, bs, result, _iter, _len, _i, a, _iter1, _len1, _i1, b
+            // Locals: _0, as, bs, result, _len, _i, a, _len1, _i1, b
+            // Note: _iter and _iter1 are eliminated by copy propagation (use params directly)
             vec![
-                // Pre-allocate all locals (9 nulls)
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
+                // Pre-allocate locals (7: result, _len, _i, a, _len1, _i1, b)
                 Instruction::LoadConst(Value::Null),
                 Instruction::LoadConst(Value::Null),
                 Instruction::LoadConst(Value::Null),
@@ -273,12 +263,9 @@ fn for_nested() -> anyhow::Result<()> {
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
-                // Outer loop: _iter = as
-                Instruction::LoadVar("as".to_string()),
-                Instruction::StoreVar("_iter".to_string()),
-                // _len = baml.Array.length(_iter)
+                // _len = baml.Array.length(as) - using param directly
                 Instruction::LoadGlobal(Value::function("baml.Array.length")),
-                Instruction::LoadVar("_iter".to_string()),
+                Instruction::LoadVar("as".to_string()),
                 Instruction::Call(1),
                 Instruction::StoreVar("_len".to_string()),
                 // _i = 0
@@ -293,8 +280,8 @@ fn for_nested() -> anyhow::Result<()> {
                 // Outer loop exit: load result and return
                 Instruction::LoadVar("result".to_string()),
                 Instruction::Return,
-                // Outer loop body: a = _iter[_i]
-                Instruction::LoadVar("_iter".to_string()),
+                // Outer loop body: a = as[_i] - using param directly
+                Instruction::LoadVar("as".to_string()),
                 Instruction::LoadVar("_i".to_string()),
                 Instruction::LoadArrayElement,
                 Instruction::StoreVar("a".to_string()),
@@ -303,12 +290,9 @@ fn for_nested() -> anyhow::Result<()> {
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::BinOp(BinOp::Add),
                 Instruction::StoreVar("_i".to_string()),
-                // Inner loop: _iter1 = bs
-                Instruction::LoadVar("bs".to_string()),
-                Instruction::StoreVar("_iter1".to_string()),
-                // _len1 = baml.Array.length(_iter1)
+                // _len1 = baml.Array.length(bs) - using param directly
                 Instruction::LoadGlobal(Value::function("baml.Array.length")),
-                Instruction::LoadVar("_iter1".to_string()),
+                Instruction::LoadVar("bs".to_string()),
                 Instruction::Call(1),
                 Instruction::StoreVar("_len1".to_string()),
                 // _i1 = 0
@@ -321,9 +305,9 @@ fn for_nested() -> anyhow::Result<()> {
                 Instruction::PopJumpIfFalse(2),
                 Instruction::Jump(2),
                 // Inner loop exit: jump back to outer loop condition
-                Instruction::Jump(-28),
-                // Inner loop body: b = _iter1[_i1]
-                Instruction::LoadVar("_iter1".to_string()),
+                Instruction::Jump(-26),
+                // Inner loop body: b = bs[_i1] - using param directly
+                Instruction::LoadVar("bs".to_string()),
                 Instruction::LoadVar("_i1".to_string()),
                 Instruction::LoadArrayElement,
                 Instruction::StoreVar("b".to_string()),

--- a/baml_language/crates/baml_codegen/tests/match_expr.rs
+++ b/baml_language/crates/baml_codegen/tests/match_expr.rs
@@ -22,14 +22,9 @@ fn match_catch_all_underscore() -> anyhow::Result<()> {
         ",
         expected: vec![(
             "main",
-            // Scrutinee stored to _ (wasteful for wildcard, but correct)
-            vec![
-                Instruction::LoadConst(Value::Null), // slot for _
-                Instruction::LoadConst(Value::Int(42)),
-                Instruction::StoreVar("_".to_string()),
-                Instruction::LoadConst(Value::Int(100)),
-                Instruction::Return,
-            ],
+            // Wildcard elimination: _ binding is unused so eliminated entirely
+            // Scrutinee 42 is also unused, so no code for it
+            vec![Instruction::LoadConst(Value::Int(100)), Instruction::Return],
         )],
     })
 }
@@ -75,16 +70,14 @@ fn match_literal_int_with_fallback() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             // Constant propagation: scrutinee 1 is inlined at each use site
+            // Wildcard elimination: _ binding is unused so eliminated
             vec![
-                Instruction::LoadConst(Value::Null), // slot for _ (catch-all binding)
                 Instruction::LoadConst(Value::Int(1)), // scrutinee (inlined for comparison)
                 Instruction::LoadConst(Value::Int(1)), // literal 1
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(2), // if false, skip to catch-all
-                Instruction::Jump(5),           // if true, skip to arm body (100)
-                Instruction::LoadConst(Value::Int(1)), // scrutinee (inlined for catch-all)
-                Instruction::StoreVar("_".to_string()), // bind to _
-                Instruction::LoadConst(Value::Int(0)), // catch-all result
+                Instruction::Jump(3),           // if true, skip to arm body (100)
+                Instruction::LoadConst(Value::Int(0)), // catch-all result (no _ binding)
                 Instruction::Jump(2),           // skip to return
                 Instruction::LoadConst(Value::Int(100)), // first arm result
                 Instruction::Return,
@@ -142,18 +135,16 @@ fn match_literal_null() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             // Constant propagation: scrutinee null is inlined at each use
+            // Wildcard elimination: _ binding is unused so eliminated
             vec![
-                Instruction::LoadConst(Value::Null), // slot for _ (catch-all binding)
                 Instruction::LoadConst(Value::Null), // scrutinee (inlined for comparison)
                 Instruction::LoadConst(Value::Null), // literal null
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(2), // if false, skip to catch-all
-                Instruction::Jump(5),           // if true, skip to "nothing"
-                Instruction::LoadConst(Value::Null), // scrutinee (inlined for catch-all)
-                Instruction::StoreVar("_".to_string()), // bind to _
-                Instruction::LoadConst(Value::string("something")), // catch-all result
-                Instruction::Jump(2),           // skip to return
-                Instruction::LoadConst(Value::string("nothing")), // first arm result
+                Instruction::Jump(3),           // if true, skip to "nothing"
+                Instruction::LoadConst(Value::string("something")), // catch-all result (no _ binding)
+                Instruction::Jump(2),                               // skip to return
+                Instruction::LoadConst(Value::string("nothing")),   // first arm result
                 Instruction::Return,
             ],
         )],
@@ -182,8 +173,8 @@ fn match_typed_pattern_single_class() -> anyhow::Result<()> {
         "#,
         expected: vec![(
             "main",
+            // Wildcard elimination: _ binding is unused so eliminated
             vec![
-                Instruction::LoadConst(Value::Null), // slot for _
                 Instruction::LoadConst(Value::Null), // slot for _3 (scrutinee)
                 // let result = Success { data: "hello" }
                 Instruction::AllocInstance(Value::class("Success")),
@@ -196,10 +187,8 @@ fn match_typed_pattern_single_class() -> anyhow::Result<()> {
                 Instruction::LoadConst(Value::class("Success")),
                 Instruction::CmpOp(CmpOp::InstanceOf),
                 Instruction::PopJumpIfFalse(2), // if false, skip to catch-all
-                Instruction::Jump(5),           // if true, skip to s.data
-                // catch-all arm
-                Instruction::LoadVar("_3".to_string()),
-                Instruction::StoreVar("_".to_string()),
+                Instruction::Jump(3),           // if true, skip to s.data
+                // catch-all arm (no _ binding)
                 Instruction::LoadConst(Value::string("unknown")),
                 Instruction::Jump(3), // skip to return
                 // s: Success arm - access s.data (s is virtual, so use _3 directly)
@@ -285,23 +274,21 @@ fn match_union_literal_two_values() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             // Constant propagation: scrutinee 200 is inlined at each use
+            // Wildcard elimination: _ binding is unused so eliminated
             vec![
-                Instruction::LoadConst(Value::Null), // slot for _ (catch-all binding)
                 // First part of union: 200
                 Instruction::LoadConst(Value::Int(200)), // scrutinee (inlined)
                 Instruction::LoadConst(Value::Int(200)), // literal
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(2), // if false, try 201
-                Instruction::Jump(10),          // if true, skip to "success"
+                Instruction::Jump(8),           // if true, skip to "success"
                 // Second part of union: 201
                 Instruction::LoadConst(Value::Int(200)), // scrutinee (inlined)
                 Instruction::LoadConst(Value::Int(201)), // literal
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(2), // if false, try catch-all
-                Instruction::Jump(5),           // if true, skip to "success"
-                // Catch-all arm
-                Instruction::LoadConst(Value::Int(200)), // scrutinee (inlined for catch-all)
-                Instruction::StoreVar("_".to_string()),
+                Instruction::Jump(3),           // if true, skip to "success"
+                // Catch-all arm (no _ binding)
                 Instruction::LoadConst(Value::string("other")),
                 Instruction::Jump(2), // skip to return
                 // Union arm result
@@ -331,17 +318,15 @@ fn match_in_arithmetic() -> anyhow::Result<()> {
             "main",
             // Constant propagation: scrutinee 2 is inlined at each use
             // _2 (match result) still needs slot (assigned in multiple branches)
+            // Wildcard elimination: _ binding is unused so eliminated
             vec![
-                Instruction::LoadConst(Value::Null), // slot for _ (catch-all binding)
                 Instruction::LoadConst(Value::Null), // slot for _2 (match result)
                 Instruction::LoadConst(Value::Int(2)), // scrutinee (inlined)
                 Instruction::LoadConst(Value::Int(2)), // literal 2
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(2), // if false, skip to catch-all
-                Instruction::Jump(6),           // if true, skip to 20
-                // Catch-all arm
-                Instruction::LoadConst(Value::Int(2)), // scrutinee (inlined for catch-all)
-                Instruction::StoreVar("_".to_string()),
+                Instruction::Jump(4),           // if true, skip to 20
+                // Catch-all arm (no _ binding)
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("_2".to_string()), // store match result
                 Instruction::Jump(3),                    // skip to addition
@@ -379,29 +364,24 @@ fn match_nested() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             // Constant propagation: scrutinees 1 and 2 are inlined at each use
+            // Wildcard elimination: both _ bindings are unused so eliminated
             vec![
-                Instruction::LoadConst(Value::Null), // slot for outer _ (catch-all binding)
-                Instruction::LoadConst(Value::Null), // slot for inner _ (catch-all binding)
                 // Outer match: compare with 1
                 Instruction::LoadConst(Value::Int(1)), // scrutinee (inlined)
                 Instruction::LoadConst(Value::Int(1)), // literal
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(2), // if outer != 1, skip to outer catch-all
-                Instruction::Jump(5),           // if outer == 1, skip to inner match
-                // Outer catch-all arm
-                Instruction::LoadConst(Value::Int(1)), // scrutinee (inlined for catch-all)
-                Instruction::StoreVar("_".to_string()),
+                Instruction::Jump(3),           // if outer == 1, skip to inner match
+                // Outer catch-all arm (no _ binding)
                 Instruction::LoadConst(Value::Int(0)),
-                Instruction::Jump(11), // skip to return
+                Instruction::Jump(9), // skip to return
                 // Inner match: compare with 2
                 Instruction::LoadConst(Value::Int(2)), // scrutinee (inlined)
                 Instruction::LoadConst(Value::Int(2)), // literal
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(2), // if inner != 2, skip to inner catch-all
-                Instruction::Jump(5),           // if inner == 2, skip to 12
-                // Inner catch-all arm
-                Instruction::LoadConst(Value::Int(2)), // scrutinee (inlined for catch-all)
-                Instruction::StoreVar("_".to_string()),
+                Instruction::Jump(3),           // if inner == 2, skip to 12
+                // Inner catch-all arm (no _ binding)
                 Instruction::LoadConst(Value::Int(10)),
                 Instruction::Jump(2), // skip to return
                 // Inner first arm

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -9,433 +9,358 @@ Globals: 98
 
 Function BoolLiteralAfterTypedBool (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (b)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (false)
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (true)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +8   (to 19)
-     12   JUMP +2                (to 14)
-     13   JUMP +6                (to 19)
-     14   LOAD_CONST 3           (unreachable)
-     15   JUMP +4                (to 19)
-     16   LOAD_VAR 2             (_2)
-     17   STORE_VAR 3            (x)
-     18   LOAD_CONST 4           (any bool)
-     19   RETURN                 
+     1    LOAD_VAR 1             (b)
+     2    LOAD_CONST 1           (false)
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (b)
+     6    LOAD_CONST 2           (true)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +8   (to 16)
+     9    JUMP +2                (to 11)
+     10   JUMP +6                (to 16)
+     11   LOAD_CONST 3           (unreachable)
+     12   JUMP +4                (to 16)
+     13   LOAD_VAR 1             (b)
+     14   STORE_VAR 2            (x)
+     15   LOAD_CONST 4           (any bool)
+     16   RETURN                 
 
 Function BoolUnionPattern (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (b)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (true)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +7                (to 14)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (false)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +3   (to 14)
-     12   JUMP +2                (to 14)
-     13   JUMP +1                (to 14)
-     14   LOAD_CONST 3           (covered)
-     15   RETURN                 
+     0    LOAD_VAR 1             (b)
+     1    LOAD_CONST 0           (true)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +7                (to 11)
+     5    LOAD_VAR 1             (b)
+     6    LOAD_CONST 1           (false)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +3   (to 11)
+     9    JUMP +2                (to 11)
+     10   JUMP +1                (to 11)
+     11   LOAD_CONST 2           (covered)
+     12   RETURN                 
 
 Function BoolWithCatchAll (arity: 1, kind: Exec):
+     0   LOAD_VAR 1             (b)
+     1   LOAD_CONST 0           (true)
+     2   CMP_OP ==              
+     3   POP_JUMP_IF_FALSE +2   (to 5)
+     4   JUMP +3                (to 7)
+     5   LOAD_CONST 1           (no)
+     6   JUMP +2                (to 8)
+     7   LOAD_CONST 2           (yes)
+     8   RETURN                 
+
+Function DeeplyNestedLiterals (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (x)
+     1    LOAD_CONST 0           (200)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +12               (to 16)
+     5    LOAD_VAR 1             (x)
+     6    LOAD_CONST 1           (201)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +7                (to 16)
+     10   LOAD_VAR 1             (x)
+     11   LOAD_CONST 2           (204)
+     12   CMP_OP ==              
+     13   POP_JUMP_IF_FALSE +3   (to 16)
+     14   JUMP +2                (to 16)
+     15   JUMP +1                (to 16)
+     16   LOAD_CONST 3           (all success codes)
+     17   RETURN                 
+
+Function DuplicateBoolLiteral (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (b)
+     1    LOAD_CONST 0           (true)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +16               (to 20)
+     5    LOAD_VAR 1             (b)
+     6    LOAD_CONST 0           (true)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +9                (to 18)
+     10   LOAD_VAR 1             (b)
+     11   LOAD_CONST 1           (false)
+     12   CMP_OP ==              
+     13   POP_JUMP_IF_FALSE +8   (to 21)
+     14   JUMP +2                (to 16)
+     15   JUMP +6                (to 21)
+     16   LOAD_CONST 2           (false)
+     17   JUMP +4                (to 21)
+     18   LOAD_CONST 3           (second true)
+     19   JUMP +2                (to 21)
+     20   LOAD_CONST 4           (first true)
+     21   RETURN                 
+
+Function DuplicateEnumVariant (arity: 1, kind: Exec):
+     0    LOAD_VAR 1              (s)
+     1    LOAD_CONST 0            (0)
+     2    ALLOC_VARIANT 3         (<enum Status>)
+     3    CMP_OP ==               
+     4    POP_JUMP_IF_FALSE +2    (to 6)
+     5    JUMP +26                (to 31)
+     6    LOAD_VAR 1              (s)
+     7    LOAD_CONST 0            (0)
+     8    ALLOC_VARIANT 3         (<enum Status>)
+     9    CMP_OP ==               
+     10   POP_JUMP_IF_FALSE +2    (to 12)
+     11   JUMP +18                (to 29)
+     12   LOAD_VAR 1              (s)
+     13   LOAD_CONST 1            (1)
+     14   ALLOC_VARIANT 3         (<enum Status>)
+     15   CMP_OP ==               
+     16   POP_JUMP_IF_FALSE +2    (to 18)
+     17   JUMP +10                (to 27)
+     18   LOAD_VAR 1              (s)
+     19   LOAD_CONST 2            (2)
+     20   ALLOC_VARIANT 3         (<enum Status>)
+     21   CMP_OP ==               
+     22   POP_JUMP_IF_FALSE +10   (to 32)
+     23   JUMP +2                 (to 25)
+     24   JUMP +8                 (to 32)
+     25   LOAD_CONST 3            (pending)
+     26   JUMP +6                 (to 32)
+     27   LOAD_CONST 4            (inactive)
+     28   JUMP +4                 (to 32)
+     29   LOAD_CONST 5            (second)
+     30   JUMP +2                 (to 32)
+     31   LOAD_CONST 6            (first)
+     32   RETURN                  
+
+Function DuplicateIntLiteral (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (x)
+     1    LOAD_CONST 0           (1)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +10               (to 14)
+     5    LOAD_VAR 1             (x)
+     6    LOAD_CONST 0           (1)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +3                (to 12)
+     10   LOAD_CONST 1           (other)
+     11   JUMP +4                (to 15)
+     12   LOAD_CONST 2           (second one)
+     13   JUMP +2                (to 15)
+     14   LOAD_CONST 3           (first one)
+     15   RETURN                 
+
+Function DuplicateStringLiteral (arity: 1, kind: Exec):
+     0   LOAD_CONST 0   (first user)
+     1   RETURN         
+
+Function EnumVariantAfterTypedEnum (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (b)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (true)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +5                (to 13)
-     9    LOAD_VAR 2             (_2)
-     10   STORE_VAR 3            (_)
+     1    LOAD_VAR 1             (s)
+     2    LOAD_CONST 1           (false)
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +10               (to 14)
+     5    LOAD_VAR 1             (s)
+     6    LOAD_CONST 2           (0)
+     7    ALLOC_VARIANT 3        (<enum Status>)
+     8    CMP_OP ==              
+     9    POP_JUMP_IF_FALSE +8   (to 17)
+     10   JUMP +2                (to 12)
+     11   JUMP +6                (to 17)
+     12   LOAD_CONST 3           (unreachable)
+     13   JUMP +4                (to 17)
+     14   LOAD_VAR 1             (s)
+     15   STORE_VAR 2            (x)
+     16   LOAD_CONST 4           (any status)
+     17   RETURN                 
+
+Function EnumVariantUnion (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +16               (to 21)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 1           (2)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +10               (to 21)
+     12   LOAD_VAR 1             (s)
+     13   LOAD_CONST 2           (1)
+     14   ALLOC_VARIANT 3        (<enum Status>)
+     15   CMP_OP ==              
+     16   POP_JUMP_IF_FALSE +6   (to 22)
+     17   JUMP +2                (to 19)
+     18   JUMP +4                (to 22)
+     19   LOAD_CONST 3           (inactive)
+     20   JUMP +2                (to 22)
+     21   LOAD_CONST 4           (actionable)
+     22   RETURN                 
+
+Function EnumVariantUnionWithCatchAll (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +9                (to 14)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 1           (2)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +3                (to 14)
+     12   LOAD_CONST 2           (other)
+     13   JUMP +2                (to 15)
+     14   LOAD_CONST 3           (actionable)
+     15   RETURN                 
+
+Function ExhaustiveAliasOfLiterals (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (code)
+     1    LOAD_CONST 0           (200)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (code)
+     6    LOAD_CONST 1           (201)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +6   (to 14)
+     9    JUMP +2                (to 11)
+     10   JUMP +4                (to 14)
+     11   LOAD_CONST 2           (created)
+     12   JUMP +2                (to 14)
+     13   LOAD_CONST 3           (ok)
+     14   RETURN                 
+
+Function ExhaustiveBool (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (b)
+     1    LOAD_CONST 0           (true)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (b)
+     6    LOAD_CONST 1           (false)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +6   (to 14)
+     9    JUMP +2                (to 11)
+     10   JUMP +4                (to 14)
      11   LOAD_CONST 2           (no)
      12   JUMP +2                (to 14)
      13   LOAD_CONST 3           (yes)
      14   RETURN                 
 
-Function DeeplyNestedLiterals (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (x)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (200)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +12               (to 19)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (201)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +2   (to 13)
-     12   JUMP +7                (to 19)
-     13   LOAD_VAR 2             (_2)
-     14   LOAD_CONST 3           (204)
-     15   CMP_OP ==              
-     16   POP_JUMP_IF_FALSE +3   (to 19)
-     17   JUMP +2                (to 19)
-     18   JUMP +1                (to 19)
-     19   LOAD_CONST 4           (all success codes)
-     20   RETURN                 
+Function ExhaustiveClassPlusLiteral (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (x)
+     1    LOAD_CONST 0           (<class Success>)
+     2    CMP_OP instanceof      
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (x)
+     6    LOAD_CONST 1           (200)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +7   (to 15)
+     9    JUMP +2                (to 11)
+     10   JUMP +5                (to 15)
+     11   LOAD_CONST 2           (http ok)
+     12   JUMP +3                (to 15)
+     13   LOAD_VAR 1             (x)
+     14   LOAD_FIELD 0           
+     15   RETURN                 
 
-Function DuplicateBoolLiteral (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (b)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (true)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +16               (to 23)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 1           (true)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +2   (to 13)
-     12   JUMP +9                (to 21)
-     13   LOAD_VAR 2             (_2)
-     14   LOAD_CONST 2           (false)
+Function ExhaustiveCustomBool (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (b)
+     1    LOAD_CONST 0           (true)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (b)
+     6    LOAD_CONST 1           (false)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +6   (to 14)
+     9    JUMP +2                (to 11)
+     10   JUMP +4                (to 14)
+     11   LOAD_CONST 2           (no)
+     12   JUMP +2                (to 14)
+     13   LOAD_CONST 3           (yes)
+     14   RETURN                 
+
+Function ExhaustiveDoubleMaybe (arity: 1, kind: Exec):
+     0    LOAD_VAR 1              (dm)
+     1    LOAD_CONST 0            (<class Success>)
+     2    CMP_OP instanceof       
+     3    POP_JUMP_IF_FALSE +2    (to 5)
+     4    JUMP +17                (to 21)
+     5    LOAD_VAR 1              (dm)
+     6    LOAD_CONST 1            (<class Failure>)
+     7    CMP_OP instanceof       
+     8    POP_JUMP_IF_FALSE +2    (to 10)
+     9    JUMP +9                 (to 18)
+     10   LOAD_VAR 1              (dm)
+     11   LOAD_CONST 2            (null)
+     12   CMP_OP ==               
+     13   POP_JUMP_IF_FALSE +10   (to 23)
+     14   JUMP +2                 (to 16)
+     15   JUMP +8                 (to 23)
+     16   LOAD_CONST 3            (nothing)
+     17   JUMP +6                 (to 23)
+     18   LOAD_VAR 1              (dm)
+     19   LOAD_FIELD 0            
+     20   JUMP +3                 (to 23)
+     21   LOAD_VAR 1              (dm)
+     22   LOAD_FIELD 0            
+     23   RETURN                  
+
+Function ExhaustiveEnumAllVariants (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +18               (to 23)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 1           (1)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +10               (to 21)
+     12   LOAD_VAR 1             (s)
+     13   LOAD_CONST 2           (2)
+     14   ALLOC_VARIANT 3        (<enum Status>)
      15   CMP_OP ==              
      16   POP_JUMP_IF_FALSE +8   (to 24)
      17   JUMP +2                (to 19)
      18   JUMP +6                (to 24)
-     19   LOAD_CONST 3           (false)
+     19   LOAD_CONST 3           (pending)
      20   JUMP +4                (to 24)
-     21   LOAD_CONST 4           (second true)
+     21   LOAD_CONST 4           (inactive)
      22   JUMP +2                (to 24)
-     23   LOAD_CONST 5           (first true)
+     23   LOAD_CONST 5           (active)
      24   RETURN                 
 
-Function DuplicateEnumVariant (arity: 1, kind: Exec):
-     0    LOAD_CONST 0            (null)
-     1    LOAD_VAR 1              (s)
-     2    STORE_VAR 2             (_2)
-     3    LOAD_VAR 2              (_2)
-     4    LOAD_CONST 1            (0)
-     5    ALLOC_VARIANT 3         (<enum Status>)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +26                (to 34)
-     9    LOAD_VAR 2              (_2)
-     10   LOAD_CONST 1            (0)
-     11   ALLOC_VARIANT 3         (<enum Status>)
-     12   CMP_OP ==               
-     13   POP_JUMP_IF_FALSE +2    (to 15)
-     14   JUMP +18                (to 32)
-     15   LOAD_VAR 2              (_2)
-     16   LOAD_CONST 2            (1)
-     17   ALLOC_VARIANT 3         (<enum Status>)
-     18   CMP_OP ==               
-     19   POP_JUMP_IF_FALSE +2    (to 21)
-     20   JUMP +10                (to 30)
-     21   LOAD_VAR 2              (_2)
-     22   LOAD_CONST 3            (2)
-     23   ALLOC_VARIANT 3         (<enum Status>)
-     24   CMP_OP ==               
-     25   POP_JUMP_IF_FALSE +10   (to 35)
-     26   JUMP +2                 (to 28)
-     27   JUMP +8                 (to 35)
-     28   LOAD_CONST 4            (pending)
-     29   JUMP +6                 (to 35)
-     30   LOAD_CONST 5            (inactive)
-     31   JUMP +4                 (to 35)
-     32   LOAD_CONST 6            (second)
-     33   JUMP +2                 (to 35)
-     34   LOAD_CONST 7            (first)
-     35   RETURN                  
-
-Function DuplicateIntLiteral (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (x)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (1)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +12               (to 20)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 1           (1)
-     11   CMP_OP ==              
-     12   POP_JUMP_IF_FALSE +2   (to 14)
-     13   JUMP +5                (to 18)
-     14   LOAD_VAR 2             (_2)
-     15   STORE_VAR 3            (_)
-     16   LOAD_CONST 2           (other)
-     17   JUMP +4                (to 21)
-     18   LOAD_CONST 3           (second one)
-     19   JUMP +2                (to 21)
-     20   LOAD_CONST 4           (first one)
-     21   RETURN                 
-
-Function DuplicateStringLiteral (arity: 1, kind: Exec):
-     0    LOAD_CONST 0   (null)
-     1    LOAD_CONST 0   (null)
-     2    LOAD_CONST 0   (null)
-     3    LOAD_CONST 0   (null)
-     4    LOAD_CONST 0   (null)
-     5    LOAD_VAR 1     (role)
-     6    STORE_VAR 2    (_2)
-     7    LOAD_VAR 2     (_2)
-     8    STORE_VAR 3    (_)
-     9    LOAD_CONST 1   (first user)
-     10   RETURN         
-
-Function EnumVariantAfterTypedEnum (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (s)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (false)
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +10               (to 17)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (0)
-     10   ALLOC_VARIANT 3        (<enum Status>)
-     11   CMP_OP ==              
-     12   POP_JUMP_IF_FALSE +8   (to 20)
-     13   JUMP +2                (to 15)
-     14   JUMP +6                (to 20)
-     15   LOAD_CONST 3           (unreachable)
-     16   JUMP +4                (to 20)
-     17   LOAD_VAR 2             (_2)
-     18   STORE_VAR 3            (x)
-     19   LOAD_CONST 4           (any status)
-     20   RETURN                 
-
-Function EnumVariantUnion (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (s)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (0)
-     5    ALLOC_VARIANT 3        (<enum Status>)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +16               (to 24)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (2)
-     11   ALLOC_VARIANT 3        (<enum Status>)
-     12   CMP_OP ==              
-     13   POP_JUMP_IF_FALSE +2   (to 15)
-     14   JUMP +10               (to 24)
-     15   LOAD_VAR 2             (_2)
-     16   LOAD_CONST 3           (1)
-     17   ALLOC_VARIANT 3        (<enum Status>)
-     18   CMP_OP ==              
-     19   POP_JUMP_IF_FALSE +6   (to 25)
-     20   JUMP +2                (to 22)
-     21   JUMP +4                (to 25)
-     22   LOAD_CONST 4           (inactive)
-     23   JUMP +2                (to 25)
-     24   LOAD_CONST 5           (actionable)
-     25   RETURN                 
-
-Function EnumVariantUnionWithCatchAll (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (s)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (0)
-     6    ALLOC_VARIANT 3        (<enum Status>)
-     7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +2   (to 10)
-     9    JUMP +11               (to 20)
-     10   LOAD_VAR 2             (_2)
-     11   LOAD_CONST 2           (2)
-     12   ALLOC_VARIANT 3        (<enum Status>)
-     13   CMP_OP ==              
-     14   POP_JUMP_IF_FALSE +2   (to 16)
-     15   JUMP +5                (to 20)
-     16   LOAD_VAR 2             (_2)
-     17   STORE_VAR 3            (_)
-     18   LOAD_CONST 3           (other)
-     19   JUMP +2                (to 21)
-     20   LOAD_CONST 4           (actionable)
-     21   RETURN                 
-
-Function ExhaustiveAliasOfLiterals (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (code)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (200)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (201)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +6   (to 17)
-     12   JUMP +2                (to 14)
-     13   JUMP +4                (to 17)
-     14   LOAD_CONST 3           (created)
-     15   JUMP +2                (to 17)
-     16   LOAD_CONST 4           (ok)
-     17   RETURN                 
-
-Function ExhaustiveBool (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (b)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (true)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (false)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +6   (to 17)
-     12   JUMP +2                (to 14)
-     13   JUMP +4                (to 17)
-     14   LOAD_CONST 3           (no)
-     15   JUMP +2                (to 17)
-     16   LOAD_CONST 4           (yes)
-     17   RETURN                 
-
-Function ExhaustiveClassPlusLiteral (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (x)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (<class Success>)
-     5    CMP_OP instanceof      
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (200)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +7   (to 18)
-     12   JUMP +2                (to 14)
-     13   JUMP +5                (to 18)
-     14   LOAD_CONST 3           (http ok)
-     15   JUMP +3                (to 18)
-     16   LOAD_VAR 2             (_2)
-     17   LOAD_FIELD 0           
-     18   RETURN                 
-
-Function ExhaustiveCustomBool (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (b)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (true)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (false)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +6   (to 17)
-     12   JUMP +2                (to 14)
-     13   JUMP +4                (to 17)
-     14   LOAD_CONST 3           (no)
-     15   JUMP +2                (to 17)
-     16   LOAD_CONST 4           (yes)
-     17   RETURN                 
-
-Function ExhaustiveDoubleMaybe (arity: 1, kind: Exec):
-     0    LOAD_CONST 0            (null)
-     1    LOAD_VAR 1              (dm)
-     2    STORE_VAR 2             (_2)
-     3    LOAD_VAR 2              (_2)
-     4    LOAD_CONST 1            (<class Success>)
-     5    CMP_OP instanceof       
-     6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +17                (to 24)
-     8    LOAD_VAR 2              (_2)
-     9    LOAD_CONST 2            (<class Failure>)
-     10   CMP_OP instanceof       
-     11   POP_JUMP_IF_FALSE +2    (to 13)
-     12   JUMP +9                 (to 21)
-     13   LOAD_VAR 2              (_2)
-     14   LOAD_CONST 0            (null)
-     15   CMP_OP ==               
-     16   POP_JUMP_IF_FALSE +10   (to 26)
-     17   JUMP +2                 (to 19)
-     18   JUMP +8                 (to 26)
-     19   LOAD_CONST 3            (nothing)
-     20   JUMP +6                 (to 26)
-     21   LOAD_VAR 2              (_2)
-     22   LOAD_FIELD 0            
-     23   JUMP +3                 (to 26)
-     24   LOAD_VAR 2              (_2)
-     25   LOAD_FIELD 0            
-     26   RETURN                  
-
-Function ExhaustiveEnumAllVariants (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (s)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (0)
-     5    ALLOC_VARIANT 3        (<enum Status>)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +18               (to 26)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (1)
-     11   ALLOC_VARIANT 3        (<enum Status>)
-     12   CMP_OP ==              
-     13   POP_JUMP_IF_FALSE +2   (to 15)
-     14   JUMP +10               (to 24)
-     15   LOAD_VAR 2             (_2)
-     16   LOAD_CONST 3           (2)
-     17   ALLOC_VARIANT 3        (<enum Status>)
-     18   CMP_OP ==              
-     19   POP_JUMP_IF_FALSE +8   (to 27)
-     20   JUMP +2                (to 22)
-     21   JUMP +6                (to 27)
-     22   LOAD_CONST 4           (pending)
-     23   JUMP +4                (to 27)
-     24   LOAD_CONST 5           (inactive)
-     25   JUMP +2                (to 27)
-     26   LOAD_CONST 6           (active)
-     27   RETURN                 
-
 Function ExhaustiveEnumWithCatchAll (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (s)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (0)
-     6    ALLOC_VARIANT 3        (<enum Status>)
-     7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +2   (to 10)
-     9    JUMP +5                (to 14)
-     10   LOAD_VAR 2             (_2)
-     11   STORE_VAR 3            (_)
-     12   LOAD_CONST 2           (other)
-     13   JUMP +2                (to 15)
-     14   LOAD_CONST 3           (active)
-     15   RETURN                 
+     0   LOAD_VAR 1             (s)
+     1   LOAD_CONST 0           (0)
+     2   ALLOC_VARIANT 3        (<enum Status>)
+     3   CMP_OP ==              
+     4   POP_JUMP_IF_FALSE +2   (to 6)
+     5   JUMP +3                (to 8)
+     6   LOAD_CONST 1           (other)
+     7   JUMP +2                (to 9)
+     8   LOAD_CONST 2           (active)
+     9   RETURN                 
 
 Function ExhaustiveEnumWithTypedPattern (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (s)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (false)
-     6    POP_JUMP_IF_FALSE +5   (to 11)
-     7    JUMP +2                (to 9)
-     8    JUMP +3                (to 11)
-     9    LOAD_VAR 2             (_2)
-     10   STORE_VAR 3            (x)
-     11   LOAD_CONST 2           (any status)
-     12   RETURN                 
+     0   LOAD_CONST 0           (null)
+     1   LOAD_VAR 1             (s)
+     2   LOAD_CONST 1           (false)
+     3   POP_JUMP_IF_FALSE +5   (to 8)
+     4   JUMP +2                (to 6)
+     5   JUMP +3                (to 8)
+     6   LOAD_VAR 1             (s)
+     7   STORE_VAR 2            (x)
+     8   LOAD_CONST 2           (any status)
+     9   RETURN                 
 
 Function ExhaustiveFalseType (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (f)
@@ -448,171 +373,147 @@ Function ExhaustiveFalseType (arity: 1, kind: Exec):
      7   RETURN                 
 
 Function ExhaustiveIntLiterals (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (code)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (200)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +16               (to 23)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (201)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +2   (to 13)
-     12   JUMP +9                (to 21)
-     13   LOAD_VAR 2             (_2)
-     14   LOAD_CONST 3           (204)
-     15   CMP_OP ==              
-     16   POP_JUMP_IF_FALSE +8   (to 24)
-     17   JUMP +2                (to 19)
-     18   JUMP +6                (to 24)
-     19   LOAD_CONST 4           (No Content)
-     20   JUMP +4                (to 24)
-     21   LOAD_CONST 5           (Created)
-     22   JUMP +2                (to 24)
-     23   LOAD_CONST 6           (OK)
-     24   RETURN                 
+     0    LOAD_VAR 1             (code)
+     1    LOAD_CONST 0           (200)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +16               (to 20)
+     5    LOAD_VAR 1             (code)
+     6    LOAD_CONST 1           (201)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +9                (to 18)
+     10   LOAD_VAR 1             (code)
+     11   LOAD_CONST 2           (204)
+     12   CMP_OP ==              
+     13   POP_JUMP_IF_FALSE +8   (to 21)
+     14   JUMP +2                (to 16)
+     15   JUMP +6                (to 21)
+     16   LOAD_CONST 3           (No Content)
+     17   JUMP +4                (to 21)
+     18   LOAD_CONST 4           (Created)
+     19   JUMP +2                (to 21)
+     20   LOAD_CONST 5           (OK)
+     21   RETURN                 
 
 Function ExhaustiveLiteralWithBaseType (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (x)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (200)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +10               (to 18)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (false)
-     11   POP_JUMP_IF_FALSE +8   (to 19)
-     12   JUMP +2                (to 14)
-     13   JUMP +6                (to 19)
-     14   LOAD_VAR 2             (_2)
-     15   STORE_VAR 3            (n)
-     16   LOAD_CONST 3           (other)
-     17   JUMP +2                (to 19)
-     18   LOAD_CONST 4           (ok)
-     19   RETURN                 
+     1    LOAD_VAR 1             (x)
+     2    LOAD_CONST 1           (200)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +10               (to 15)
+     6    LOAD_VAR 1             (x)
+     7    LOAD_CONST 2           (false)
+     8    POP_JUMP_IF_FALSE +8   (to 16)
+     9    JUMP +2                (to 11)
+     10   JUMP +6                (to 16)
+     11   LOAD_VAR 1             (x)
+     12   STORE_VAR 2            (n)
+     13   LOAD_CONST 3           (other)
+     14   JUMP +2                (to 16)
+     15   LOAD_CONST 4           (ok)
+     16   RETURN                 
 
 Function ExhaustiveMixedLiterals (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (x)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (200)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +5                (to 13)
-     9    LOAD_VAR 2             (_2)
-     10   STORE_VAR 3            (_)
-     11   LOAD_CONST 2           (string success)
-     12   JUMP +2                (to 14)
-     13   LOAD_CONST 3           (http ok)
-     14   RETURN                 
+     0   LOAD_VAR 1             (x)
+     1   LOAD_CONST 0           (200)
+     2   CMP_OP ==              
+     3   POP_JUMP_IF_FALSE +2   (to 5)
+     4   JUMP +3                (to 7)
+     5   LOAD_CONST 1           (string success)
+     6   JUMP +2                (to 8)
+     7   LOAD_CONST 2           (http ok)
+     8   RETURN                 
 
 Function ExhaustiveNullableEnum (arity: 1, kind: Exec):
-     0    LOAD_CONST 0            (null)
-     1    LOAD_VAR 1              (s)
-     2    STORE_VAR 2             (_2)
-     3    LOAD_VAR 2              (_2)
-     4    LOAD_CONST 1            (0)
-     5    ALLOC_VARIANT 3         (<enum Status>)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +25                (to 33)
-     9    LOAD_VAR 2              (_2)
-     10   LOAD_CONST 2            (1)
-     11   ALLOC_VARIANT 3         (<enum Status>)
-     12   CMP_OP ==               
-     13   POP_JUMP_IF_FALSE +2    (to 15)
-     14   JUMP +17                (to 31)
-     15   LOAD_VAR 2              (_2)
-     16   LOAD_CONST 3            (2)
-     17   ALLOC_VARIANT 3         (<enum Status>)
-     18   CMP_OP ==               
-     19   POP_JUMP_IF_FALSE +2    (to 21)
-     20   JUMP +9                 (to 29)
-     21   LOAD_VAR 2              (_2)
-     22   LOAD_CONST 0            (null)
-     23   CMP_OP ==               
-     24   POP_JUMP_IF_FALSE +10   (to 34)
-     25   JUMP +2                 (to 27)
-     26   JUMP +8                 (to 34)
-     27   LOAD_CONST 4            (no status)
-     28   JUMP +6                 (to 34)
-     29   LOAD_CONST 5            (pending)
-     30   JUMP +4                 (to 34)
-     31   LOAD_CONST 6            (inactive)
-     32   JUMP +2                 (to 34)
-     33   LOAD_CONST 7            (active)
-     34   RETURN                  
+     0    LOAD_VAR 1              (s)
+     1    LOAD_CONST 0            (0)
+     2    ALLOC_VARIANT 3         (<enum Status>)
+     3    CMP_OP ==               
+     4    POP_JUMP_IF_FALSE +2    (to 6)
+     5    JUMP +25                (to 30)
+     6    LOAD_VAR 1              (s)
+     7    LOAD_CONST 1            (1)
+     8    ALLOC_VARIANT 3         (<enum Status>)
+     9    CMP_OP ==               
+     10   POP_JUMP_IF_FALSE +2    (to 12)
+     11   JUMP +17                (to 28)
+     12   LOAD_VAR 1              (s)
+     13   LOAD_CONST 2            (2)
+     14   ALLOC_VARIANT 3         (<enum Status>)
+     15   CMP_OP ==               
+     16   POP_JUMP_IF_FALSE +2    (to 18)
+     17   JUMP +9                 (to 26)
+     18   LOAD_VAR 1              (s)
+     19   LOAD_CONST 3            (null)
+     20   CMP_OP ==               
+     21   POP_JUMP_IF_FALSE +10   (to 31)
+     22   JUMP +2                 (to 24)
+     23   JUMP +8                 (to 31)
+     24   LOAD_CONST 4            (no status)
+     25   JUMP +6                 (to 31)
+     26   LOAD_CONST 5            (pending)
+     27   JUMP +4                 (to 31)
+     28   LOAD_CONST 6            (inactive)
+     29   JUMP +2                 (to 31)
+     30   LOAD_CONST 7            (active)
+     31   RETURN                  
 
 Function ExhaustiveNullableEnumWithTypedPattern (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (s)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (false)
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 0           (null)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +8   (to 19)
-     12   JUMP +2                (to 14)
-     13   JUMP +6                (to 19)
-     14   LOAD_CONST 2           (no status)
-     15   JUMP +4                (to 19)
-     16   LOAD_VAR 2             (_2)
-     17   STORE_VAR 3            (x)
-     18   LOAD_CONST 3           (some status)
-     19   RETURN                 
+     1    LOAD_VAR 1             (s)
+     2    LOAD_CONST 1           (false)
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (s)
+     6    LOAD_CONST 0           (null)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +8   (to 16)
+     9    JUMP +2                (to 11)
+     10   JUMP +6                (to 16)
+     11   LOAD_CONST 2           (no status)
+     12   JUMP +4                (to 16)
+     13   LOAD_VAR 1             (s)
+     14   STORE_VAR 2            (x)
+     15   LOAD_CONST 3           (some status)
+     16   RETURN                 
 
 Function ExhaustiveOptional (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (x)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (false)
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 0           (null)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +8   (to 19)
-     12   JUMP +2                (to 14)
-     13   JUMP +6                (to 19)
-     14   LOAD_CONST 2           (no value)
-     15   JUMP +4                (to 19)
-     16   LOAD_VAR 2             (_2)
-     17   STORE_VAR 3            (n)
-     18   LOAD_CONST 3           (has value)
-     19   RETURN                 
+     1    LOAD_VAR 1             (x)
+     2    LOAD_CONST 1           (false)
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (x)
+     6    LOAD_CONST 0           (null)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +8   (to 16)
+     9    JUMP +2                (to 11)
+     10   JUMP +6                (to 16)
+     11   LOAD_CONST 2           (no value)
+     12   JUMP +4                (to 16)
+     13   LOAD_VAR 1             (x)
+     14   STORE_VAR 2            (n)
+     15   LOAD_CONST 3           (has value)
+     16   RETURN                 
 
 Function ExhaustiveOptionalSingleton (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (code)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (200)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 0           (null)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +6   (to 17)
+     0    LOAD_VAR 1             (code)
+     1    LOAD_CONST 0           (200)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (code)
+     6    LOAD_CONST 1           (null)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +6   (to 14)
+     9    JUMP +2                (to 11)
+     10   JUMP +4                (to 14)
+     11   LOAD_CONST 2           (no code)
      12   JUMP +2                (to 14)
-     13   JUMP +4                (to 17)
-     14   LOAD_CONST 2           (no code)
-     15   JUMP +2                (to 17)
-     16   LOAD_CONST 3           (OK)
-     17   RETURN                 
+     13   LOAD_CONST 3           (OK)
+     14   RETURN                 
 
 Function ExhaustiveSingletonInt (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (code)
@@ -625,16 +526,8 @@ Function ExhaustiveSingletonInt (arity: 1, kind: Exec):
      7   RETURN                 
 
 Function ExhaustiveStringLiterals (arity: 1, kind: Exec):
-     0   LOAD_CONST 0   (null)
-     1   LOAD_CONST 0   (null)
-     2   LOAD_CONST 0   (null)
-     3   LOAD_CONST 0   (null)
-     4   LOAD_VAR 1     (role)
-     5   STORE_VAR 2    (_2)
-     6   LOAD_VAR 2     (_2)
-     7   STORE_VAR 3    (_)
-     8   LOAD_CONST 1   (User)
-     9   RETURN         
+     0   LOAD_CONST 0   (User)
+     1   RETURN         
 
 Function ExhaustiveTrueType (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (t)
@@ -647,146 +540,119 @@ Function ExhaustiveTrueType (arity: 1, kind: Exec):
      7   RETURN                 
 
 Function ExhaustiveTypeAlias (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (r)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (<class Success>)
-     5    CMP_OP instanceof      
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +10               (to 17)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (<class Failure>)
-     10   CMP_OP instanceof      
-     11   POP_JUMP_IF_FALSE +8   (to 19)
-     12   JUMP +2                (to 14)
-     13   JUMP +6                (to 19)
-     14   LOAD_VAR 2             (_2)
+     0    LOAD_VAR 1             (r)
+     1    LOAD_CONST 0           (<class Success>)
+     2    CMP_OP instanceof      
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +10               (to 14)
+     5    LOAD_VAR 1             (r)
+     6    LOAD_CONST 1           (<class Failure>)
+     7    CMP_OP instanceof      
+     8    POP_JUMP_IF_FALSE +8   (to 16)
+     9    JUMP +2                (to 11)
+     10   JUMP +6                (to 16)
+     11   LOAD_VAR 1             (r)
+     12   LOAD_FIELD 0           
+     13   JUMP +3                (to 16)
+     14   LOAD_VAR 1             (r)
      15   LOAD_FIELD 0           
-     16   JUMP +3                (to 19)
-     17   LOAD_VAR 2             (_2)
-     18   LOAD_FIELD 0           
-     19   RETURN                 
+     16   RETURN                 
 
 Function ExhaustiveTypeAliasWithCatchAll (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (r)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (<class Success>)
-     6    CMP_OP instanceof      
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +5                (to 13)
-     9    LOAD_VAR 2             (_2)
-     10   STORE_VAR 3            (_)
-     11   LOAD_CONST 2           (fallback)
-     12   JUMP +3                (to 15)
-     13   LOAD_VAR 2             (_2)
-     14   LOAD_FIELD 0           
-     15   RETURN                 
+     0   LOAD_VAR 1             (r)
+     1   LOAD_CONST 0           (<class Success>)
+     2   CMP_OP instanceof      
+     3   POP_JUMP_IF_FALSE +2   (to 5)
+     4   JUMP +3                (to 7)
+     5   LOAD_CONST 1           (fallback)
+     6   JUMP +3                (to 9)
+     7   LOAD_VAR 1             (r)
+     8   LOAD_FIELD 0           
+     9   RETURN                 
 
 Function ExhaustiveWithNamedCatchAll (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (x)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (1)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +5                (to 12)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 1           (1)
-     10   BIN_OP +               
-     11   JUMP +2                (to 13)
-     12   LOAD_CONST 2           (100)
-     13   RETURN                 
+     0    LOAD_VAR 1             (x)
+     1    LOAD_CONST 0           (1)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +5                (to 9)
+     5    LOAD_VAR 1             (x)
+     6    LOAD_CONST 0           (1)
+     7    BIN_OP +               
+     8    JUMP +2                (to 10)
+     9    LOAD_CONST 1           (100)
+     10   RETURN                 
 
 Function ExhaustiveWithUnderscore (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (x)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (1)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +12               (to 20)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (2)
-     11   CMP_OP ==              
-     12   POP_JUMP_IF_FALSE +2   (to 14)
-     13   JUMP +5                (to 18)
-     14   LOAD_VAR 2             (_2)
-     15   STORE_VAR 3            (_)
-     16   LOAD_CONST 3           (0)
-     17   JUMP +4                (to 21)
-     18   LOAD_CONST 4           (200)
-     19   JUMP +2                (to 21)
-     20   LOAD_CONST 5           (100)
-     21   RETURN                 
+     0    LOAD_VAR 1             (x)
+     1    LOAD_CONST 0           (1)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +10               (to 14)
+     5    LOAD_VAR 1             (x)
+     6    LOAD_CONST 1           (2)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +3                (to 12)
+     10   LOAD_CONST 2           (0)
+     11   JUMP +4                (to 15)
+     12   LOAD_CONST 3           (200)
+     13   JUMP +2                (to 15)
+     14   LOAD_CONST 4           (100)
+     15   RETURN                 
 
 Function GuardedOnlyNonExhaustive (arity: 1, kind: Exec):
      0    LOAD_CONST 0            (null)
      1    LOAD_CONST 0            (null)
-     2    LOAD_CONST 0            (null)
-     3    LOAD_VAR 1              (x)
-     4    STORE_VAR 2             (_2)
-     5    LOAD_VAR 2              (_2)
-     6    LOAD_CONST 1            (false)
-     7    POP_JUMP_IF_FALSE +8    (to 15)
-     8    LOAD_VAR 2              (_2)
-     9    STORE_VAR 3             (n)
-     10   LOAD_VAR 3              (n)
-     11   LOAD_CONST 2            (0)
-     12   CMP_OP >                
-     13   POP_JUMP_IF_FALSE +2    (to 15)
-     14   JUMP +17                (to 31)
-     15   LOAD_VAR 2              (_2)
-     16   LOAD_CONST 1            (false)
-     17   POP_JUMP_IF_FALSE +17   (to 34)
-     18   LOAD_VAR 2              (_2)
-     19   STORE_VAR 4             (n)
-     20   LOAD_VAR 4              (n)
-     21   LOAD_CONST 2            (0)
-     22   CMP_OP <                
-     23   POP_JUMP_IF_FALSE +11   (to 34)
-     24   JUMP +2                 (to 26)
-     25   JUMP +9                 (to 34)
-     26   LOAD_VAR 4              (n)
-     27   LOAD_CONST 3            (1)
-     28   UNARY_OP -              
-     29   BIN_OP *                
-     30   JUMP +4                 (to 34)
-     31   LOAD_VAR 3              (n)
-     32   LOAD_CONST 4            (2)
-     33   BIN_OP *                
-     34   RETURN                  
+     2    LOAD_VAR 1              (x)
+     3    LOAD_CONST 1            (false)
+     4    POP_JUMP_IF_FALSE +8    (to 12)
+     5    LOAD_VAR 1              (x)
+     6    STORE_VAR 2             (n)
+     7    LOAD_VAR 2              (n)
+     8    LOAD_CONST 2            (0)
+     9    CMP_OP >                
+     10   POP_JUMP_IF_FALSE +2    (to 12)
+     11   JUMP +17                (to 28)
+     12   LOAD_VAR 1              (x)
+     13   LOAD_CONST 1            (false)
+     14   POP_JUMP_IF_FALSE +17   (to 31)
+     15   LOAD_VAR 1              (x)
+     16   STORE_VAR 3             (n)
+     17   LOAD_VAR 3              (n)
+     18   LOAD_CONST 2            (0)
+     19   CMP_OP <                
+     20   POP_JUMP_IF_FALSE +11   (to 31)
+     21   JUMP +2                 (to 23)
+     22   JUMP +9                 (to 31)
+     23   LOAD_VAR 3              (n)
+     24   LOAD_CONST 3            (1)
+     25   UNARY_OP -              
+     26   BIN_OP *                
+     27   JUMP +4                 (to 31)
+     28   LOAD_VAR 2              (n)
+     29   LOAD_CONST 4            (2)
+     30   BIN_OP *                
+     31   RETURN                  
 
 Function GuardedWithFallback (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 0           (null)
-     3    LOAD_VAR 1             (x)
-     4    STORE_VAR 2            (_2)
-     5    LOAD_VAR 2             (_2)
-     6    LOAD_CONST 1           (false)
-     7    POP_JUMP_IF_FALSE +8   (to 15)
-     8    LOAD_VAR 2             (_2)
-     9    STORE_VAR 3            (n)
-     10   LOAD_VAR 3             (n)
+     1    LOAD_VAR 1             (x)
+     2    LOAD_CONST 1           (false)
+     3    POP_JUMP_IF_FALSE +8   (to 11)
+     4    LOAD_VAR 1             (x)
+     5    STORE_VAR 2            (n)
+     6    LOAD_VAR 2             (n)
+     7    LOAD_CONST 2           (0)
+     8    CMP_OP >               
+     9    POP_JUMP_IF_FALSE +2   (to 11)
+     10   JUMP +3                (to 13)
      11   LOAD_CONST 2           (0)
-     12   CMP_OP >               
-     13   POP_JUMP_IF_FALSE +2   (to 15)
-     14   JUMP +5                (to 19)
-     15   LOAD_VAR 2             (_2)
-     16   STORE_VAR 4            (_)
-     17   LOAD_CONST 2           (0)
-     18   JUMP +4                (to 22)
-     19   LOAD_VAR 3             (n)
-     20   LOAD_CONST 3           (2)
-     21   BIN_OP *               
-     22   RETURN                 
+     12   JUMP +4                (to 16)
+     13   LOAD_VAR 2             (n)
+     14   LOAD_CONST 3           (2)
+     15   BIN_OP *               
+     16   RETURN                 
 
 Function HighLineNumberNonExhaustive (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (s)
@@ -800,344 +666,299 @@ Function HighLineNumberNonExhaustive (arity: 1, kind: Exec):
      8   RETURN                 
 
 Function IntLiteralUnionPattern (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (code)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (200)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +14               (to 21)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (201)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +2   (to 13)
-     12   JUMP +9                (to 21)
-     13   LOAD_VAR 2             (_2)
-     14   LOAD_CONST 3           (204)
-     15   CMP_OP ==              
-     16   POP_JUMP_IF_FALSE +6   (to 22)
+     0    LOAD_VAR 1             (code)
+     1    LOAD_CONST 0           (200)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +14               (to 18)
+     5    LOAD_VAR 1             (code)
+     6    LOAD_CONST 1           (201)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +9                (to 18)
+     10   LOAD_VAR 1             (code)
+     11   LOAD_CONST 2           (204)
+     12   CMP_OP ==              
+     13   POP_JUMP_IF_FALSE +6   (to 19)
+     14   JUMP +2                (to 16)
+     15   JUMP +4                (to 19)
+     16   LOAD_CONST 3           (no content)
      17   JUMP +2                (to 19)
-     18   JUMP +4                (to 22)
-     19   LOAD_CONST 4           (no content)
-     20   JUMP +2                (to 22)
-     21   LOAD_CONST 5           (success with body)
-     22   RETURN                 
+     18   LOAD_CONST 4           (success with body)
+     19   RETURN                 
 
 Function LiteralAfterTypedPattern (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (x)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (false)
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (42)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +8   (to 19)
-     12   JUMP +2                (to 14)
-     13   JUMP +6                (to 19)
-     14   LOAD_CONST 3           (unreachable)
-     15   JUMP +4                (to 19)
-     16   LOAD_VAR 2             (_2)
-     17   STORE_VAR 3            (n)
-     18   LOAD_CONST 4           (int)
-     19   RETURN                 
+     1    LOAD_VAR 1             (x)
+     2    LOAD_CONST 1           (false)
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (x)
+     6    LOAD_CONST 2           (42)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +8   (to 16)
+     9    JUMP +2                (to 11)
+     10   JUMP +6                (to 16)
+     11   LOAD_CONST 3           (unreachable)
+     12   JUMP +4                (to 16)
+     13   LOAD_VAR 1             (x)
+     14   STORE_VAR 2            (n)
+     15   LOAD_CONST 4           (int)
+     16   RETURN                 
 
 Function LiteralUnionWithCatchAll (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (code)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (200)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +22               (to 30)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (201)
-     11   CMP_OP ==              
-     12   POP_JUMP_IF_FALSE +2   (to 14)
-     13   JUMP +17               (to 30)
-     14   LOAD_VAR 2             (_2)
-     15   LOAD_CONST 3           (400)
-     16   CMP_OP ==              
-     17   POP_JUMP_IF_FALSE +2   (to 19)
-     18   JUMP +10               (to 28)
-     19   LOAD_VAR 2             (_2)
-     20   LOAD_CONST 4           (404)
-     21   CMP_OP ==              
-     22   POP_JUMP_IF_FALSE +2   (to 24)
-     23   JUMP +5                (to 28)
-     24   LOAD_VAR 2             (_2)
-     25   STORE_VAR 3            (_)
-     26   LOAD_CONST 5           (other)
-     27   JUMP +4                (to 31)
-     28   LOAD_CONST 6           (client error)
-     29   JUMP +2                (to 31)
-     30   LOAD_CONST 7           (success)
-     31   RETURN                 
-
-Function MixedPatterns (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (x)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (0)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +22               (to 30)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (1)
-     11   CMP_OP ==              
-     12   POP_JUMP_IF_FALSE +2   (to 14)
-     13   JUMP +15               (to 28)
-     14   LOAD_VAR 2             (_2)
-     15   LOAD_CONST 3           (false)
-     16   POP_JUMP_IF_FALSE +6   (to 22)
-     17   LOAD_VAR 2             (_2)
-     18   LOAD_CONST 1           (0)
-     19   CMP_OP >               
-     20   POP_JUMP_IF_FALSE +2   (to 22)
-     21   JUMP +5                (to 26)
-     22   LOAD_VAR 2             (_2)
-     23   STORE_VAR 3            (_)
-     24   LOAD_CONST 4           (negative)
-     25   JUMP +6                (to 31)
-     26   LOAD_CONST 5           (positive)
-     27   JUMP +4                (to 31)
-     28   LOAD_CONST 6           (one)
-     29   JUMP +2                (to 31)
-     30   LOAD_CONST 7           (zero)
-     31   RETURN                 
-
-Function MultipleUnreachableSpans (arity: 1, kind: Exec):
-     0    LOAD_CONST 0            (null)
-     1    LOAD_VAR 1              (s)
-     2    STORE_VAR 2             (_2)
-     3    LOAD_VAR 2              (_2)
-     4    LOAD_CONST 1            (0)
-     5    ALLOC_VARIANT 3         (<enum Status>)
-     6    CMP_OP ==               
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +34                (to 42)
-     9    LOAD_VAR 2              (_2)
-     10   LOAD_CONST 1            (0)
-     11   ALLOC_VARIANT 3         (<enum Status>)
-     12   CMP_OP ==               
-     13   POP_JUMP_IF_FALSE +2    (to 15)
-     14   JUMP +26                (to 40)
-     15   LOAD_VAR 2              (_2)
-     16   LOAD_CONST 2            (1)
-     17   ALLOC_VARIANT 3         (<enum Status>)
-     18   CMP_OP ==               
-     19   POP_JUMP_IF_FALSE +2    (to 21)
-     20   JUMP +18                (to 38)
-     21   LOAD_VAR 2              (_2)
-     22   LOAD_CONST 1            (0)
-     23   ALLOC_VARIANT 3         (<enum Status>)
-     24   CMP_OP ==               
-     25   POP_JUMP_IF_FALSE +2    (to 27)
-     26   JUMP +10                (to 36)
-     27   LOAD_VAR 2              (_2)
-     28   LOAD_CONST 3            (2)
-     29   ALLOC_VARIANT 3         (<enum Status>)
-     30   CMP_OP ==               
-     31   POP_JUMP_IF_FALSE +12   (to 43)
-     32   JUMP +2                 (to 34)
-     33   JUMP +10                (to 43)
-     34   LOAD_CONST 4            (pending)
-     35   JUMP +8                 (to 43)
-     36   LOAD_CONST 5            (duplicate 2)
-     37   JUMP +6                 (to 43)
-     38   LOAD_CONST 6            (inactive)
-     39   JUMP +4                 (to 43)
-     40   LOAD_CONST 7            (duplicate 1)
-     41   JUMP +2                 (to 43)
-     42   LOAD_CONST 8            (active)
-     43   RETURN                  
-
-Function NestedEnumVariantUnions (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (s)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (0)
-     5    ALLOC_VARIANT 3        (<enum Status>)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +14               (to 22)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (2)
-     11   ALLOC_VARIANT 3        (<enum Status>)
+     0    LOAD_VAR 1             (code)
+     1    LOAD_CONST 0           (200)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +20               (to 24)
+     5    LOAD_VAR 1             (code)
+     6    LOAD_CONST 1           (201)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +15               (to 24)
+     10   LOAD_VAR 1             (code)
+     11   LOAD_CONST 2           (400)
      12   CMP_OP ==              
      13   POP_JUMP_IF_FALSE +2   (to 15)
      14   JUMP +8                (to 22)
-     15   LOAD_VAR 2             (_2)
-     16   LOAD_CONST 3           (1)
-     17   ALLOC_VARIANT 3        (<enum Status>)
-     18   CMP_OP ==              
-     19   POP_JUMP_IF_FALSE +3   (to 22)
-     20   JUMP +2                (to 22)
-     21   JUMP +1                (to 22)
-     22   LOAD_CONST 4           (all statuses)
-     23   RETURN                 
+     15   LOAD_VAR 1             (code)
+     16   LOAD_CONST 3           (404)
+     17   CMP_OP ==              
+     18   POP_JUMP_IF_FALSE +2   (to 20)
+     19   JUMP +3                (to 22)
+     20   LOAD_CONST 4           (other)
+     21   JUMP +4                (to 25)
+     22   LOAD_CONST 5           (client error)
+     23   JUMP +2                (to 25)
+     24   LOAD_CONST 6           (success)
+     25   RETURN                 
 
-Function NestedLiteralUnions (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (code)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (200)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +47               (to 55)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (201)
-     11   CMP_OP ==              
-     12   POP_JUMP_IF_FALSE +2   (to 14)
-     13   JUMP +42               (to 55)
-     14   LOAD_VAR 2             (_2)
-     15   LOAD_CONST 3           (202)
-     16   CMP_OP ==              
-     17   POP_JUMP_IF_FALSE +2   (to 19)
-     18   JUMP +37               (to 55)
-     19   LOAD_VAR 2             (_2)
-     20   LOAD_CONST 4           (204)
-     21   CMP_OP ==              
-     22   POP_JUMP_IF_FALSE +2   (to 24)
-     23   JUMP +32               (to 55)
-     24   LOAD_VAR 2             (_2)
-     25   LOAD_CONST 5           (400)
-     26   CMP_OP ==              
-     27   POP_JUMP_IF_FALSE +2   (to 29)
-     28   JUMP +25               (to 53)
-     29   LOAD_VAR 2             (_2)
-     30   LOAD_CONST 6           (404)
-     31   CMP_OP ==              
-     32   POP_JUMP_IF_FALSE +2   (to 34)
-     33   JUMP +20               (to 53)
-     34   LOAD_VAR 2             (_2)
-     35   LOAD_CONST 7           (405)
-     36   CMP_OP ==              
-     37   POP_JUMP_IF_FALSE +2   (to 39)
-     38   JUMP +15               (to 53)
-     39   LOAD_VAR 2             (_2)
-     40   LOAD_CONST 8           (406)
-     41   CMP_OP ==              
-     42   POP_JUMP_IF_FALSE +2   (to 44)
-     43   JUMP +10               (to 53)
-     44   LOAD_VAR 2             (_2)
-     45   LOAD_CONST 9           (409)
-     46   CMP_OP ==              
-     47   POP_JUMP_IF_FALSE +2   (to 49)
-     48   JUMP +5                (to 53)
-     49   LOAD_VAR 2             (_2)
-     50   STORE_VAR 3            (_)
-     51   LOAD_CONST 10          (other)
-     52   JUMP +4                (to 56)
-     53   LOAD_CONST 11          (client error)
-     54   JUMP +2                (to 56)
-     55   LOAD_CONST 12          (success)
-     56   RETURN                 
-
-Function NestedMatchSpans (arity: 2, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 0           (null)
-     3    LOAD_VAR 1             (x)
-     4    STORE_VAR 3            (_3)
-     5    LOAD_VAR 3             (_3)
-     6    LOAD_CONST 1           (0)
+Function MixedPatterns (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (x)
+     1    LOAD_CONST 0           (0)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +20               (to 24)
+     5    LOAD_VAR 1             (x)
+     6    LOAD_CONST 1           (1)
      7    CMP_OP ==              
      8    POP_JUMP_IF_FALSE +2   (to 10)
-     9    JUMP +5                (to 14)
-     10   LOAD_VAR 3             (_3)
-     11   STORE_VAR 5            (_)
-     12   LOAD_CONST 2           (other)
-     13   JUMP +24               (to 37)
-     14   LOAD_VAR 2             (y)
-     15   STORE_VAR 4            (_5)
-     16   LOAD_VAR 4             (_5)
-     17   LOAD_CONST 3           (true)
-     18   CMP_OP ==              
-     19   POP_JUMP_IF_FALSE +2   (to 21)
-     20   JUMP +16               (to 36)
-     21   LOAD_VAR 4             (_5)
-     22   LOAD_CONST 4           (false)
-     23   CMP_OP ==              
-     24   POP_JUMP_IF_FALSE +2   (to 26)
-     25   JUMP +9                (to 34)
-     26   LOAD_VAR 4             (_5)
-     27   LOAD_CONST 3           (true)
-     28   CMP_OP ==              
-     29   POP_JUMP_IF_FALSE +8   (to 37)
-     30   JUMP +2                (to 32)
-     31   JUMP +6                (to 37)
-     32   LOAD_CONST 5           (unreachable nested)
-     33   JUMP +4                (to 37)
-     34   LOAD_CONST 6           (zero false)
-     35   JUMP +2                (to 37)
-     36   LOAD_CONST 7           (zero true)
-     37   RETURN                 
+     9    JUMP +13               (to 22)
+     10   LOAD_VAR 1             (x)
+     11   LOAD_CONST 2           (false)
+     12   POP_JUMP_IF_FALSE +6   (to 18)
+     13   LOAD_VAR 1             (x)
+     14   LOAD_CONST 0           (0)
+     15   CMP_OP >               
+     16   POP_JUMP_IF_FALSE +2   (to 18)
+     17   JUMP +3                (to 20)
+     18   LOAD_CONST 3           (negative)
+     19   JUMP +6                (to 25)
+     20   LOAD_CONST 4           (positive)
+     21   JUMP +4                (to 25)
+     22   LOAD_CONST 5           (one)
+     23   JUMP +2                (to 25)
+     24   LOAD_CONST 6           (zero)
+     25   RETURN                 
+
+Function MultipleUnreachableSpans (arity: 1, kind: Exec):
+     0    LOAD_VAR 1              (s)
+     1    LOAD_CONST 0            (0)
+     2    ALLOC_VARIANT 3         (<enum Status>)
+     3    CMP_OP ==               
+     4    POP_JUMP_IF_FALSE +2    (to 6)
+     5    JUMP +34                (to 39)
+     6    LOAD_VAR 1              (s)
+     7    LOAD_CONST 0            (0)
+     8    ALLOC_VARIANT 3         (<enum Status>)
+     9    CMP_OP ==               
+     10   POP_JUMP_IF_FALSE +2    (to 12)
+     11   JUMP +26                (to 37)
+     12   LOAD_VAR 1              (s)
+     13   LOAD_CONST 1            (1)
+     14   ALLOC_VARIANT 3         (<enum Status>)
+     15   CMP_OP ==               
+     16   POP_JUMP_IF_FALSE +2    (to 18)
+     17   JUMP +18                (to 35)
+     18   LOAD_VAR 1              (s)
+     19   LOAD_CONST 0            (0)
+     20   ALLOC_VARIANT 3         (<enum Status>)
+     21   CMP_OP ==               
+     22   POP_JUMP_IF_FALSE +2    (to 24)
+     23   JUMP +10                (to 33)
+     24   LOAD_VAR 1              (s)
+     25   LOAD_CONST 2            (2)
+     26   ALLOC_VARIANT 3         (<enum Status>)
+     27   CMP_OP ==               
+     28   POP_JUMP_IF_FALSE +12   (to 40)
+     29   JUMP +2                 (to 31)
+     30   JUMP +10                (to 40)
+     31   LOAD_CONST 3            (pending)
+     32   JUMP +8                 (to 40)
+     33   LOAD_CONST 4            (duplicate 2)
+     34   JUMP +6                 (to 40)
+     35   LOAD_CONST 5            (inactive)
+     36   JUMP +4                 (to 40)
+     37   LOAD_CONST 6            (duplicate 1)
+     38   JUMP +2                 (to 40)
+     39   LOAD_CONST 7            (active)
+     40   RETURN                  
+
+Function NestedEnumVariantUnions (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +14               (to 19)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 1           (2)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +8                (to 19)
+     12   LOAD_VAR 1             (s)
+     13   LOAD_CONST 2           (1)
+     14   ALLOC_VARIANT 3        (<enum Status>)
+     15   CMP_OP ==              
+     16   POP_JUMP_IF_FALSE +3   (to 19)
+     17   JUMP +2                (to 19)
+     18   JUMP +1                (to 19)
+     19   LOAD_CONST 3           (all statuses)
+     20   RETURN                 
+
+Function NestedLiteralUnions (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (code)
+     1    LOAD_CONST 0           (200)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +45               (to 49)
+     5    LOAD_VAR 1             (code)
+     6    LOAD_CONST 1           (201)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +40               (to 49)
+     10   LOAD_VAR 1             (code)
+     11   LOAD_CONST 2           (202)
+     12   CMP_OP ==              
+     13   POP_JUMP_IF_FALSE +2   (to 15)
+     14   JUMP +35               (to 49)
+     15   LOAD_VAR 1             (code)
+     16   LOAD_CONST 3           (204)
+     17   CMP_OP ==              
+     18   POP_JUMP_IF_FALSE +2   (to 20)
+     19   JUMP +30               (to 49)
+     20   LOAD_VAR 1             (code)
+     21   LOAD_CONST 4           (400)
+     22   CMP_OP ==              
+     23   POP_JUMP_IF_FALSE +2   (to 25)
+     24   JUMP +23               (to 47)
+     25   LOAD_VAR 1             (code)
+     26   LOAD_CONST 5           (404)
+     27   CMP_OP ==              
+     28   POP_JUMP_IF_FALSE +2   (to 30)
+     29   JUMP +18               (to 47)
+     30   LOAD_VAR 1             (code)
+     31   LOAD_CONST 6           (405)
+     32   CMP_OP ==              
+     33   POP_JUMP_IF_FALSE +2   (to 35)
+     34   JUMP +13               (to 47)
+     35   LOAD_VAR 1             (code)
+     36   LOAD_CONST 7           (406)
+     37   CMP_OP ==              
+     38   POP_JUMP_IF_FALSE +2   (to 40)
+     39   JUMP +8                (to 47)
+     40   LOAD_VAR 1             (code)
+     41   LOAD_CONST 8           (409)
+     42   CMP_OP ==              
+     43   POP_JUMP_IF_FALSE +2   (to 45)
+     44   JUMP +3                (to 47)
+     45   LOAD_CONST 9           (other)
+     46   JUMP +4                (to 50)
+     47   LOAD_CONST 10          (client error)
+     48   JUMP +2                (to 50)
+     49   LOAD_CONST 11          (success)
+     50   RETURN                 
+
+Function NestedMatchSpans (arity: 2, kind: Exec):
+     0    LOAD_VAR 1             (x)
+     1    LOAD_CONST 0           (0)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +3                (to 7)
+     5    LOAD_CONST 1           (other)
+     6    JUMP +22               (to 28)
+     7    LOAD_VAR 2             (y)
+     8    LOAD_CONST 2           (true)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +16               (to 27)
+     12   LOAD_VAR 2             (y)
+     13   LOAD_CONST 3           (false)
+     14   CMP_OP ==              
+     15   POP_JUMP_IF_FALSE +2   (to 17)
+     16   JUMP +9                (to 25)
+     17   LOAD_VAR 2             (y)
+     18   LOAD_CONST 2           (true)
+     19   CMP_OP ==              
+     20   POP_JUMP_IF_FALSE +8   (to 28)
+     21   JUMP +2                (to 23)
+     22   JUMP +6                (to 28)
+     23   LOAD_CONST 4           (unreachable nested)
+     24   JUMP +4                (to 28)
+     25   LOAD_CONST 5           (zero false)
+     26   JUMP +2                (to 28)
+     27   LOAD_CONST 6           (zero true)
+     28   RETURN                 
 
 Function NestedTypeAlias (arity: 1, kind: Exec):
-     0    LOAD_CONST 0            (null)
-     1    LOAD_VAR 1              (mr)
-     2    STORE_VAR 2             (_2)
-     3    LOAD_VAR 2              (_2)
-     4    LOAD_CONST 1            (<class Success>)
-     5    CMP_OP instanceof       
-     6    POP_JUMP_IF_FALSE +2    (to 8)
-     7    JUMP +17                (to 24)
-     8    LOAD_VAR 2              (_2)
-     9    LOAD_CONST 2            (<class Failure>)
-     10   CMP_OP instanceof       
-     11   POP_JUMP_IF_FALSE +2    (to 13)
-     12   JUMP +9                 (to 21)
-     13   LOAD_VAR 2              (_2)
-     14   LOAD_CONST 0            (null)
-     15   CMP_OP ==               
-     16   POP_JUMP_IF_FALSE +10   (to 26)
-     17   JUMP +2                 (to 19)
-     18   JUMP +8                 (to 26)
-     19   LOAD_CONST 3            (nothing)
-     20   JUMP +6                 (to 26)
-     21   LOAD_VAR 2              (_2)
+     0    LOAD_VAR 1              (mr)
+     1    LOAD_CONST 0            (<class Success>)
+     2    CMP_OP instanceof       
+     3    POP_JUMP_IF_FALSE +2    (to 5)
+     4    JUMP +17                (to 21)
+     5    LOAD_VAR 1              (mr)
+     6    LOAD_CONST 1            (<class Failure>)
+     7    CMP_OP instanceof       
+     8    POP_JUMP_IF_FALSE +2    (to 10)
+     9    JUMP +9                 (to 18)
+     10   LOAD_VAR 1              (mr)
+     11   LOAD_CONST 2            (null)
+     12   CMP_OP ==               
+     13   POP_JUMP_IF_FALSE +10   (to 23)
+     14   JUMP +2                 (to 16)
+     15   JUMP +8                 (to 23)
+     16   LOAD_CONST 3            (nothing)
+     17   JUMP +6                 (to 23)
+     18   LOAD_VAR 1              (mr)
+     19   LOAD_FIELD 0            
+     20   JUMP +3                 (to 23)
+     21   LOAD_VAR 1              (mr)
      22   LOAD_FIELD 0            
-     23   JUMP +3                 (to 26)
-     24   LOAD_VAR 2              (_2)
-     25   LOAD_FIELD 0            
-     26   RETURN                  
+     23   RETURN                  
 
 Function NestedTypeBindings (arity: 1, kind: Exec):
      0    LOAD_CONST 0            (null)
      1    LOAD_CONST 0            (null)
-     2    LOAD_CONST 0            (null)
-     3    LOAD_VAR 1              (r)
-     4    STORE_VAR 2             (_2)
-     5    LOAD_VAR 2              (_2)
-     6    LOAD_CONST 1            (false)
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +11                (to 19)
-     9    LOAD_VAR 2              (_2)
-     10   LOAD_CONST 2            (<class Failure>)
-     11   CMP_OP instanceof       
-     12   POP_JUMP_IF_FALSE +10   (to 22)
-     13   JUMP +2                 (to 15)
-     14   JUMP +8                 (to 22)
-     15   LOAD_VAR 2              (_2)
-     16   STORE_VAR 4             (f)
-     17   LOAD_CONST 3            (1)
-     18   JUMP +4                 (to 22)
-     19   LOAD_VAR 2              (_2)
-     20   STORE_VAR 3             (s)
-     21   LOAD_CONST 4            (0)
-     22   RETURN                  
+     2    LOAD_VAR 1              (r)
+     3    LOAD_CONST 1            (false)
+     4    POP_JUMP_IF_FALSE +2    (to 6)
+     5    JUMP +11                (to 16)
+     6    LOAD_VAR 1              (r)
+     7    LOAD_CONST 2            (<class Failure>)
+     8    CMP_OP instanceof       
+     9    POP_JUMP_IF_FALSE +10   (to 19)
+     10   JUMP +2                 (to 12)
+     11   JUMP +8                 (to 19)
+     12   LOAD_VAR 1              (r)
+     13   STORE_VAR 3             (f)
+     14   LOAD_CONST 3            (1)
+     15   JUMP +4                 (to 19)
+     16   LOAD_VAR 1              (r)
+     17   STORE_VAR 2             (s)
+     18   LOAD_CONST 4            (0)
+     19   RETURN                  
 
 Function NonExhaustiveAliasOfLiterals (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (code)
@@ -1180,18 +1001,15 @@ Function NonExhaustiveClassPlusLiteralMissingClass (arity: 1, kind: Exec):
      7   RETURN                 
 
 Function NonExhaustiveClassPlusLiteralMissingLiteral (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (x)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (<class Success>)
-     5    CMP_OP instanceof      
-     6    POP_JUMP_IF_FALSE +5   (to 11)
-     7    JUMP +2                (to 9)
-     8    JUMP +3                (to 11)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_FIELD 0           
-     11   RETURN                 
+     0   LOAD_VAR 1             (x)
+     1   LOAD_CONST 0           (<class Success>)
+     2   CMP_OP instanceof      
+     3   POP_JUMP_IF_FALSE +5   (to 8)
+     4   JUMP +2                (to 6)
+     5   JUMP +3                (to 8)
+     6   LOAD_VAR 1             (x)
+     7   LOAD_FIELD 0           
+     8   RETURN                 
 
 Function NonExhaustiveCustomBoolMissing (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (b)
@@ -1204,26 +1022,23 @@ Function NonExhaustiveCustomBoolMissing (arity: 1, kind: Exec):
      7   RETURN                 
 
 Function NonExhaustiveDoubleMaybeMissingNull (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (dm)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (<class Success>)
-     5    CMP_OP instanceof      
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +10               (to 17)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (<class Failure>)
-     10   CMP_OP instanceof      
-     11   POP_JUMP_IF_FALSE +8   (to 19)
-     12   JUMP +2                (to 14)
-     13   JUMP +6                (to 19)
-     14   LOAD_VAR 2             (_2)
+     0    LOAD_VAR 1             (dm)
+     1    LOAD_CONST 0           (<class Success>)
+     2    CMP_OP instanceof      
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +10               (to 14)
+     5    LOAD_VAR 1             (dm)
+     6    LOAD_CONST 1           (<class Failure>)
+     7    CMP_OP instanceof      
+     8    POP_JUMP_IF_FALSE +8   (to 16)
+     9    JUMP +2                (to 11)
+     10   JUMP +6                (to 16)
+     11   LOAD_VAR 1             (dm)
+     12   LOAD_FIELD 0           
+     13   JUMP +3                (to 16)
+     14   LOAD_VAR 1             (dm)
      15   LOAD_FIELD 0           
-     16   JUMP +3                (to 19)
-     17   LOAD_VAR 2             (_2)
-     18   LOAD_FIELD 0           
-     19   RETURN                 
+     16   RETURN                 
 
 Function NonExhaustiveEnumMissingMultiple (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (s)
@@ -1237,144 +1052,123 @@ Function NonExhaustiveEnumMissingMultiple (arity: 1, kind: Exec):
      8   RETURN                 
 
 Function NonExhaustiveEnumMissingOne (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (s)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (0)
-     5    ALLOC_VARIANT 3        (<enum Status>)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +10               (to 18)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (1)
-     11   ALLOC_VARIANT 3        (<enum Status>)
-     12   CMP_OP ==              
-     13   POP_JUMP_IF_FALSE +6   (to 19)
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +10               (to 15)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 1           (1)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +6   (to 16)
+     11   JUMP +2                (to 13)
+     12   JUMP +4                (to 16)
+     13   LOAD_CONST 2           (inactive)
      14   JUMP +2                (to 16)
-     15   JUMP +4                (to 19)
-     16   LOAD_CONST 3           (inactive)
-     17   JUMP +2                (to 19)
-     18   LOAD_CONST 4           (active)
-     19   RETURN                 
+     15   LOAD_CONST 3           (active)
+     16   RETURN                 
 
 Function NonExhaustiveFullResultMissingOne (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (r)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (<class Success>)
-     5    CMP_OP instanceof      
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +10               (to 17)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (<class Failure>)
-     10   CMP_OP instanceof      
-     11   POP_JUMP_IF_FALSE +8   (to 19)
-     12   JUMP +2                (to 14)
-     13   JUMP +6                (to 19)
-     14   LOAD_VAR 2             (_2)
+     0    LOAD_VAR 1             (r)
+     1    LOAD_CONST 0           (<class Success>)
+     2    CMP_OP instanceof      
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +10               (to 14)
+     5    LOAD_VAR 1             (r)
+     6    LOAD_CONST 1           (<class Failure>)
+     7    CMP_OP instanceof      
+     8    POP_JUMP_IF_FALSE +8   (to 16)
+     9    JUMP +2                (to 11)
+     10   JUMP +6                (to 16)
+     11   LOAD_VAR 1             (r)
+     12   LOAD_FIELD 0           
+     13   JUMP +3                (to 16)
+     14   LOAD_VAR 1             (r)
      15   LOAD_FIELD 0           
-     16   JUMP +3                (to 19)
-     17   LOAD_VAR 2             (_2)
-     18   LOAD_FIELD 0           
-     19   RETURN                 
+     16   RETURN                 
 
 Function NonExhaustiveIntLiteral (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (code)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (200)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (201)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +6   (to 17)
+     0    LOAD_VAR 1             (code)
+     1    LOAD_CONST 0           (200)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (code)
+     6    LOAD_CONST 1           (201)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +6   (to 14)
+     9    JUMP +2                (to 11)
+     10   JUMP +4                (to 14)
+     11   LOAD_CONST 2           (Created)
      12   JUMP +2                (to 14)
-     13   JUMP +4                (to 17)
-     14   LOAD_CONST 3           (Created)
-     15   JUMP +2                (to 17)
-     16   LOAD_CONST 4           (OK)
-     17   RETURN                 
-
-Function NonExhaustiveMixedLiterals (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (x)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (200)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +5                (to 13)
-     9    LOAD_VAR 2             (_2)
-     10   STORE_VAR 3            (_)
-     11   LOAD_CONST 2           (string success)
-     12   JUMP +2                (to 14)
-     13   LOAD_CONST 3           (http ok)
+     13   LOAD_CONST 3           (OK)
      14   RETURN                 
 
+Function NonExhaustiveMixedLiterals (arity: 1, kind: Exec):
+     0   LOAD_VAR 1             (x)
+     1   LOAD_CONST 0           (200)
+     2   CMP_OP ==              
+     3   POP_JUMP_IF_FALSE +2   (to 5)
+     4   JUMP +3                (to 7)
+     5   LOAD_CONST 1           (string success)
+     6   JUMP +2                (to 8)
+     7   LOAD_CONST 2           (http ok)
+     8   RETURN                 
+
 Function NonExhaustiveNullableEnumMissingNull (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (s)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (0)
-     5    ALLOC_VARIANT 3        (<enum Status>)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +18               (to 26)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (1)
-     11   ALLOC_VARIANT 3        (<enum Status>)
-     12   CMP_OP ==              
-     13   POP_JUMP_IF_FALSE +2   (to 15)
-     14   JUMP +10               (to 24)
-     15   LOAD_VAR 2             (_2)
-     16   LOAD_CONST 3           (2)
-     17   ALLOC_VARIANT 3        (<enum Status>)
-     18   CMP_OP ==              
-     19   POP_JUMP_IF_FALSE +8   (to 27)
-     20   JUMP +2                (to 22)
-     21   JUMP +6                (to 27)
-     22   LOAD_CONST 4           (pending)
-     23   JUMP +4                (to 27)
-     24   LOAD_CONST 5           (inactive)
-     25   JUMP +2                (to 27)
-     26   LOAD_CONST 6           (active)
-     27   RETURN                 
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +18               (to 23)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 1           (1)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +10               (to 21)
+     12   LOAD_VAR 1             (s)
+     13   LOAD_CONST 2           (2)
+     14   ALLOC_VARIANT 3        (<enum Status>)
+     15   CMP_OP ==              
+     16   POP_JUMP_IF_FALSE +8   (to 24)
+     17   JUMP +2                (to 19)
+     18   JUMP +6                (to 24)
+     19   LOAD_CONST 3           (pending)
+     20   JUMP +4                (to 24)
+     21   LOAD_CONST 4           (inactive)
+     22   JUMP +2                (to 24)
+     23   LOAD_CONST 5           (active)
+     24   RETURN                 
 
 Function NonExhaustiveNullableEnumMissingVariant (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (s)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (0)
-     5    ALLOC_VARIANT 3        (<enum Status>)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +17               (to 25)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (1)
-     11   ALLOC_VARIANT 3        (<enum Status>)
-     12   CMP_OP ==              
-     13   POP_JUMP_IF_FALSE +2   (to 15)
-     14   JUMP +9                (to 23)
-     15   LOAD_VAR 2             (_2)
-     16   LOAD_CONST 0           (null)
-     17   CMP_OP ==              
-     18   POP_JUMP_IF_FALSE +8   (to 26)
-     19   JUMP +2                (to 21)
-     20   JUMP +6                (to 26)
-     21   LOAD_CONST 3           (no status)
-     22   JUMP +4                (to 26)
-     23   LOAD_CONST 4           (inactive)
-     24   JUMP +2                (to 26)
-     25   LOAD_CONST 5           (active)
-     26   RETURN                 
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +17               (to 22)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 1           (1)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +9                (to 20)
+     12   LOAD_VAR 1             (s)
+     13   LOAD_CONST 2           (null)
+     14   CMP_OP ==              
+     15   POP_JUMP_IF_FALSE +8   (to 23)
+     16   JUMP +2                (to 18)
+     17   JUMP +6                (to 23)
+     18   LOAD_CONST 3           (no status)
+     19   JUMP +4                (to 23)
+     20   LOAD_CONST 4           (inactive)
+     21   JUMP +2                (to 23)
+     22   LOAD_CONST 5           (active)
+     23   RETURN                 
 
 Function NonExhaustiveOptionalMissingNull (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (code)
@@ -1397,15 +1191,8 @@ Function NonExhaustiveOptionalMissingValue (arity: 1, kind: Exec):
      7   RETURN                 
 
 Function NonExhaustiveStringLiteral (arity: 1, kind: Exec):
-     0   LOAD_CONST 0   (null)
-     1   LOAD_CONST 0   (null)
-     2   LOAD_CONST 0   (null)
-     3   LOAD_VAR 1     (role)
-     4   STORE_VAR 2    (_2)
-     5   LOAD_VAR 2     (_2)
-     6   STORE_VAR 3    (_)
-     7   LOAD_CONST 1   (User)
-     8   RETURN         
+     0   LOAD_CONST 0   (User)
+     1   RETURN         
 
 Function NonExhaustiveTrueTypeWrongLiteral (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (t)
@@ -1418,223 +1205,154 @@ Function NonExhaustiveTrueTypeWrongLiteral (arity: 1, kind: Exec):
      7   RETURN                 
 
 Function NonExhaustiveTypeAliasMissingOne (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (r)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (<class Success>)
-     5    CMP_OP instanceof      
-     6    POP_JUMP_IF_FALSE +5   (to 11)
-     7    JUMP +2                (to 9)
-     8    JUMP +3                (to 11)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_FIELD 0           
-     11   RETURN                 
+     0   LOAD_VAR 1             (r)
+     1   LOAD_CONST 0           (<class Success>)
+     2   CMP_OP instanceof      
+     3   POP_JUMP_IF_FALSE +5   (to 8)
+     4   JUMP +2                (to 6)
+     5   JUMP +3                (to 8)
+     6   LOAD_VAR 1             (r)
+     7   LOAD_FIELD 0           
+     8   RETURN                 
 
 Function OptionalWithCatchAll (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (x)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 0           (null)
-     6    CMP_OP ==              
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +5                (to 13)
-     9    LOAD_VAR 2             (_2)
-     10   STORE_VAR 3            (_)
-     11   LOAD_CONST 1           (has value)
-     12   JUMP +2                (to 14)
-     13   LOAD_CONST 2           (no value)
-     14   RETURN                 
+     0   LOAD_VAR 1             (x)
+     1   LOAD_CONST 0           (null)
+     2   CMP_OP ==              
+     3   POP_JUMP_IF_FALSE +2   (to 5)
+     4   JUMP +3                (to 7)
+     5   LOAD_CONST 1           (has value)
+     6   JUMP +2                (to 8)
+     7   LOAD_CONST 2           (no value)
+     8   RETURN                 
 
 Function OverlappingTypedPatterns (arity: 1, kind: Exec):
-     0    LOAD_CONST 0            (null)
-     1    LOAD_CONST 0            (null)
-     2    LOAD_CONST 0            (null)
-     3    LOAD_VAR 1              (r)
-     4    STORE_VAR 2             (_2)
-     5    LOAD_VAR 2              (_2)
-     6    LOAD_CONST 1            (<class Success>)
-     7    CMP_OP instanceof       
-     8    POP_JUMP_IF_FALSE +2    (to 10)
-     9    JUMP +10                (to 19)
-     10   LOAD_VAR 2              (_2)
-     11   LOAD_CONST 2            (false)
-     12   POP_JUMP_IF_FALSE +10   (to 22)
-     13   JUMP +2                 (to 15)
-     14   JUMP +8                 (to 22)
-     15   LOAD_VAR 2              (_2)
-     16   STORE_VAR 4             (_)
-     17   LOAD_CONST 3            (covers failure only (success already handled))
-     18   JUMP +4                 (to 22)
-     19   LOAD_VAR 2              (_2)
-     20   STORE_VAR 3             (_)
-     21   LOAD_CONST 4            (success)
-     22   RETURN                  
+     0    LOAD_VAR 1             (r)
+     1    LOAD_CONST 0           (<class Success>)
+     2    CMP_OP instanceof      
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +8                (to 12)
+     5    LOAD_VAR 1             (r)
+     6    LOAD_CONST 1           (false)
+     7    POP_JUMP_IF_FALSE +6   (to 13)
+     8    JUMP +2                (to 10)
+     9    JUMP +4                (to 13)
+     10   LOAD_CONST 2           (covers failure only (success already handled))
+     11   JUMP +2                (to 13)
+     12   LOAD_CONST 3           (success)
+     13   RETURN                 
 
 Function OverlappingWithBindings (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (r)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (<class Success>)
-     6    CMP_OP instanceof      
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +10               (to 18)
-     9    LOAD_VAR 2             (_2)
-     10   LOAD_CONST 2           (false)
-     11   POP_JUMP_IF_FALSE +9   (to 20)
-     12   JUMP +2                (to 14)
-     13   JUMP +7                (to 20)
-     14   LOAD_VAR 2             (_2)
-     15   STORE_VAR 3            (x)
-     16   LOAD_CONST 3           (remaining)
-     17   JUMP +3                (to 20)
-     18   LOAD_VAR 2             (_2)
-     19   LOAD_FIELD 0           
-     20   RETURN                 
-
-Function ParenthesizedSingleLiteral (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_VAR 1             (b)
-     2    STORE_VAR 2            (_2)
-     3    LOAD_VAR 2             (_2)
-     4    LOAD_CONST 1           (true)
-     5    CMP_OP ==              
-     6    POP_JUMP_IF_FALSE +2   (to 8)
-     7    JUMP +9                (to 16)
-     8    LOAD_VAR 2             (_2)
-     9    LOAD_CONST 2           (false)
-     10   CMP_OP ==              
-     11   POP_JUMP_IF_FALSE +6   (to 17)
-     12   JUMP +2                (to 14)
-     13   JUMP +4                (to 17)
-     14   LOAD_CONST 3           (no)
-     15   JUMP +2                (to 17)
-     16   LOAD_CONST 4           (yes)
+     1    LOAD_VAR 1             (r)
+     2    LOAD_CONST 1           (<class Success>)
+     3    CMP_OP instanceof      
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +10               (to 15)
+     6    LOAD_VAR 1             (r)
+     7    LOAD_CONST 2           (false)
+     8    POP_JUMP_IF_FALSE +9   (to 17)
+     9    JUMP +2                (to 11)
+     10   JUMP +7                (to 17)
+     11   LOAD_VAR 1             (r)
+     12   STORE_VAR 2            (x)
+     13   LOAD_CONST 3           (remaining)
+     14   JUMP +3                (to 17)
+     15   LOAD_VAR 1             (r)
+     16   LOAD_FIELD 0           
      17   RETURN                 
 
+Function ParenthesizedSingleLiteral (arity: 1, kind: Exec):
+     0    LOAD_VAR 1             (b)
+     1    LOAD_CONST 0           (true)
+     2    CMP_OP ==              
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (b)
+     6    LOAD_CONST 1           (false)
+     7    CMP_OP ==              
+     8    POP_JUMP_IF_FALSE +6   (to 14)
+     9    JUMP +2                (to 11)
+     10   JUMP +4                (to 14)
+     11   LOAD_CONST 2           (no)
+     12   JUMP +2                (to 14)
+     13   LOAD_CONST 3           (yes)
+     14   RETURN                 
+
 Function PartialUnionPatternCoverage (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (r)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (false)
-     6    POP_JUMP_IF_FALSE +5   (to 11)
-     7    JUMP +2                (to 9)
-     8    JUMP +3                (to 11)
-     9    LOAD_VAR 2             (_2)
-     10   STORE_VAR 3            (x)
-     11   LOAD_CONST 2           (not pending)
-     12   RETURN                 
+     0   LOAD_CONST 0           (null)
+     1   LOAD_VAR 1             (r)
+     2   LOAD_CONST 1           (false)
+     3   POP_JUMP_IF_FALSE +5   (to 8)
+     4   JUMP +2                (to 6)
+     5   JUMP +3                (to 8)
+     6   LOAD_VAR 1             (r)
+     7   STORE_VAR 2            (x)
+     8   LOAD_CONST 2           (not pending)
+     9   RETURN                 
 
 Function PartialUnionPlusCatchAll (arity: 1, kind: Exec):
-     0    LOAD_CONST 0            (null)
-     1    LOAD_CONST 0            (null)
-     2    LOAD_CONST 0            (null)
-     3    LOAD_VAR 1              (r)
-     4    STORE_VAR 2             (_2)
-     5    LOAD_VAR 2              (_2)
-     6    LOAD_CONST 1            (false)
-     7    POP_JUMP_IF_FALSE +2    (to 9)
-     8    JUMP +11                (to 19)
-     9    LOAD_VAR 2              (_2)
-     10   LOAD_CONST 2            (<class Pending>)
-     11   CMP_OP instanceof       
-     12   POP_JUMP_IF_FALSE +10   (to 22)
-     13   JUMP +2                 (to 15)
-     14   JUMP +8                 (to 22)
-     15   LOAD_VAR 2              (_2)
-     16   STORE_VAR 4             (_)
-     17   LOAD_CONST 3            (pending)
-     18   JUMP +4                 (to 22)
-     19   LOAD_VAR 2              (_2)
-     20   STORE_VAR 3             (x)
-     21   LOAD_CONST 4            (success or failure)
-     22   RETURN                  
+     0    LOAD_CONST 0           (null)
+     1    LOAD_VAR 1             (r)
+     2    LOAD_CONST 1           (false)
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +9                (to 13)
+     5    LOAD_VAR 1             (r)
+     6    LOAD_CONST 2           (<class Pending>)
+     7    CMP_OP instanceof      
+     8    POP_JUMP_IF_FALSE +8   (to 16)
+     9    JUMP +2                (to 11)
+     10   JUMP +6                (to 16)
+     11   LOAD_CONST 3           (pending)
+     12   JUMP +4                (to 16)
+     13   LOAD_VAR 1             (r)
+     14   STORE_VAR 2            (x)
+     15   LOAD_CONST 4           (success or failure)
+     16   RETURN                 
 
 Function StringLiteralAfterStringType (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 0           (null)
-     3    LOAD_VAR 1             (s)
-     4    STORE_VAR 2            (_2)
-     5    LOAD_VAR 2             (_2)
-     6    LOAD_CONST 1           (false)
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +5                (to 13)
-     9    LOAD_VAR 2             (_2)
-     10   STORE_VAR 4            (_)
-     11   LOAD_CONST 2           (unreachable)
-     12   JUMP +4                (to 16)
-     13   LOAD_VAR 2             (_2)
-     14   STORE_VAR 3            (x)
-     15   LOAD_CONST 3           (any string)
-     16   RETURN                 
+     1    LOAD_VAR 1             (s)
+     2    LOAD_CONST 1           (false)
+     3    POP_JUMP_IF_FALSE +2   (to 5)
+     4    JUMP +3                (to 7)
+     5    LOAD_CONST 2           (unreachable)
+     6    JUMP +4                (to 10)
+     7    LOAD_VAR 1             (s)
+     8    STORE_VAR 2            (x)
+     9    LOAD_CONST 3           (any string)
+     10   RETURN                 
 
 Function StringLiteralUnionPattern (arity: 1, kind: Exec):
-     0   LOAD_CONST 0   (null)
-     1   LOAD_CONST 0   (null)
-     2   LOAD_CONST 0   (null)
-     3   LOAD_VAR 1     (role)
-     4   STORE_VAR 2    (_2)
-     5   LOAD_VAR 2     (_2)
-     6   STORE_VAR 3    (_)
-     7   LOAD_CONST 1   (chat participant)
-     8   RETURN         
+     0   LOAD_CONST 0   (chat participant)
+     1   RETURN         
 
 Function StringLiteralWithCatchAll (arity: 1, kind: Exec):
-     0   LOAD_CONST 0   (null)
-     1   LOAD_CONST 0   (null)
-     2   LOAD_CONST 0   (null)
-     3   LOAD_CONST 0   (null)
-     4   LOAD_VAR 1     (role)
-     5   STORE_VAR 2    (_2)
-     6   LOAD_VAR 2     (_2)
-     7   STORE_VAR 3    (_)
-     8   LOAD_CONST 1   (User message)
-     9   RETURN         
+     0   LOAD_CONST 0   (User message)
+     1   RETURN         
 
 Function UnionPatternCoversAll (arity: 1, kind: Exec):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_VAR 1             (r)
-     3    STORE_VAR 2            (_2)
-     4    LOAD_VAR 2             (_2)
-     5    LOAD_CONST 1           (false)
-     6    POP_JUMP_IF_FALSE +5   (to 11)
-     7    JUMP +2                (to 9)
-     8    JUMP +3                (to 11)
-     9    LOAD_VAR 2             (_2)
-     10   STORE_VAR 3            (x)
-     11   LOAD_CONST 2           (covered)
-     12   RETURN                 
+     0   LOAD_CONST 0           (null)
+     1   LOAD_VAR 1             (r)
+     2   LOAD_CONST 1           (false)
+     3   POP_JUMP_IF_FALSE +5   (to 8)
+     4   JUMP +2                (to 6)
+     5   JUMP +3                (to 8)
+     6   LOAD_VAR 1             (r)
+     7   STORE_VAR 2            (x)
+     8   LOAD_CONST 2           (covered)
+     9   RETURN                 
 
 Function UnreachableAfterCatchAll (arity: 1, kind: Exec):
      0   LOAD_CONST 0   (null)
-     1   LOAD_CONST 0   (null)
-     2   LOAD_CONST 0   (null)
-     3   LOAD_VAR 1     (x)
-     4   STORE_VAR 2    (_2)
-     5   LOAD_VAR 2     (_2)
-     6   STORE_VAR 3    (_)
-     7   LOAD_CONST 1   (catch all)
-     8   RETURN         
+     1   LOAD_CONST 1   (catch all)
+     2   RETURN         
 
 Function UnreachableMultiple (arity: 1, kind: Exec):
      0   LOAD_CONST 0   (null)
      1   LOAD_CONST 0   (null)
-     2   LOAD_CONST 0   (null)
-     3   LOAD_CONST 0   (null)
-     4   LOAD_VAR 1     (x)
-     5   STORE_VAR 2    (_2)
-     6   LOAD_VAR 2     (_2)
-     7   STORE_VAR 3    (_)
-     8   LOAD_CONST 1   (catch all)
-     9   RETURN         
+     2   LOAD_CONST 1   (catch all)
+     3   RETURN         
 
 Function WrongLiteralTypeBoolWithInt (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (b)
@@ -1647,8 +1365,5 @@ Function WrongLiteralTypeBoolWithInt (arity: 1, kind: Exec):
      7   RETURN                 
 
 Function WrongLiteralTypeIntWithString (arity: 1, kind: Exec):
-     0   LOAD_CONST 0   (null)
-     1   LOAD_VAR 1     (x)
-     2   STORE_VAR 2    (_)
-     3   LOAD_CONST 1   (wrong type)
-     4   RETURN
+     0   LOAD_CONST 0   (wrong type)
+     1   RETURN


### PR DESCRIPTION
## Summary
- **Copy propagation**: Detect locals that are simple copies of parameters (`_X = copy _Y`) and use the parameter directly at all use sites. This eliminates unnecessary STORE_VAR/LOAD_VAR pairs for match scrutinee copies and for-loop iterators.
- **Wildcard elimination**: Extend Dead classification to include unused `_` pattern bindings. This eliminates dead stores in catch-all match arms that don't use the bound value.

## Impact
These optimizations reduce bytecode size by:
- Eliminating unnecessary stack slot allocations
- Removing redundant STORE_VAR/LOAD_VAR instruction pairs
- Skipping dead stores to wildcard bindings

Example improvements:
- For loops: `_iter = xs; ... LoadVar("_iter")` → `LoadVar("xs")` (direct param usage)
- Match wildcards: `StoreVar("_"); LoadConst(result)` → `LoadConst(result)` (no dead store)

## Test plan
- [x] All `cargo test -p baml_codegen` tests pass (updated expectations)
- [x] All `cargo test --workspace` tests pass
- [x] Snapshot updates show reduced bytecode size