### PR TITLE
Implement spread operator for class constructors

### DIFF
--- a/baml_language/crates/baml_codegen/tests/classes.rs
+++ b/baml_language/crates/baml_codegen/tests/classes.rs
@@ -68,7 +68,6 @@ fn class_constructor_return_directly() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "spread operator not yet in HIR"]
 fn class_constructor_with_spread_operator() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -90,28 +89,31 @@ fn class_constructor_with_spread_operator() -> anyhow::Result<()> {
         "#,
         expected: vec![(
             "main",
+            // Spread is at position 2, overrides named fields at positions 0 and 1.
+            // All fields come from the spread (last assignment wins).
+            // Spread is stored to temp local, then accessed for each field.
             vec![
-                Instruction::AllocInstance(Value::class("Point")),
+                Instruction::LoadConst(Value::Null),
                 Instruction::LoadGlobal(Value::function("default_point")),
                 Instruction::Call(0),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::StoreVar("_2".to_string()),
+                Instruction::AllocInstance(Value::class("Point")),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(0),
                 Instruction::StoreField(0),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(1),
                 Instruction::StoreField(1),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(2),
                 Instruction::StoreField(2),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(3),
                 Instruction::StoreField(3),
-                Instruction::Pop(1),
-                Instruction::LoadVar("p".to_string()),
                 Instruction::Return,
             ],
         )],
@@ -272,7 +274,6 @@ fn field_assignment_simple() -> anyhow::Result<()> {
 // ============================================================================
 
 #[test]
-#[ignore = "spread operator not yet in HIR"]
 fn class_constructor_with_spread_before_named_fields() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -294,26 +295,28 @@ fn class_constructor_with_spread_before_named_fields() -> anyhow::Result<()> {
         "#,
         expected: vec![(
             "main",
+            // Spread is at position 0, named fields x,y at positions 1,2.
+            // x and y from named (override spread), z and w from spread.
             vec![
-                Instruction::AllocInstance(Value::class("Point")),
+                Instruction::LoadConst(Value::Null),
                 Instruction::LoadGlobal(Value::function("default_point")),
                 Instruction::Call(0),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
-                Instruction::LoadField(2),
-                Instruction::StoreField(2),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
-                Instruction::LoadField(3),
-                Instruction::StoreField(3),
-                Instruction::Pop(1),
+                Instruction::StoreVar("_2".to_string()),
+                Instruction::AllocInstance(Value::class("Point")),
                 Instruction::Copy(0),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreField(0),
                 Instruction::Copy(0),
                 Instruction::LoadConst(Value::Int(2)),
                 Instruction::StoreField(1),
-                Instruction::LoadVar("p".to_string()),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
+                Instruction::LoadField(2),
+                Instruction::StoreField(2),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
+                Instruction::LoadField(3),
+                Instruction::StoreField(3),
                 Instruction::Return,
             ],
         )],
@@ -321,7 +324,6 @@ fn class_constructor_with_spread_before_named_fields() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "spread operator not yet in HIR"]
 fn class_constructor_with_spread_after_named_fields() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -343,28 +345,30 @@ fn class_constructor_with_spread_after_named_fields() -> anyhow::Result<()> {
         "#,
         expected: vec![(
             "main",
+            // Spread at position 2 overrides named fields at positions 0,1.
+            // All fields from spread.
             vec![
-                Instruction::AllocInstance(Value::class("Point")),
+                Instruction::LoadConst(Value::Null),
                 Instruction::LoadGlobal(Value::function("default_point")),
                 Instruction::Call(0),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::StoreVar("_2".to_string()),
+                Instruction::AllocInstance(Value::class("Point")),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(0),
                 Instruction::StoreField(0),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(1),
                 Instruction::StoreField(1),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(2),
                 Instruction::StoreField(2),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(3),
                 Instruction::StoreField(3),
-                Instruction::Pop(1),
-                Instruction::LoadVar("p".to_string()),
                 Instruction::Return,
             ],
         )],
@@ -372,7 +376,6 @@ fn class_constructor_with_spread_after_named_fields() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "spread operator not yet in HIR"]
 fn class_constructor_with_multiple_spread_operators() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -404,55 +407,65 @@ fn class_constructor_with_multiple_spread_operators() -> anyhow::Result<()> {
         expected: vec![
             (
                 "xy_one_last",
+                // ...x_one() at pos 0, ...xy_one() at pos 1
+                // xy_one wins for all fields; x_one called but result popped (unused)
                 vec![
-                    Instruction::AllocInstance(Value::class("Point")),
+                    Instruction::LoadConst(Value::Null),
+                    Instruction::LoadGlobal(Value::function("x_one")),
+                    Instruction::Call(0),
+                    Instruction::Pop(1),
                     Instruction::LoadGlobal(Value::function("xy_one")),
                     Instruction::Call(0),
-                    Instruction::Copy(1),
-                    Instruction::Copy(1),
+                    Instruction::StoreVar("_4".to_string()),
+                    Instruction::AllocInstance(Value::class("Point")),
+                    Instruction::Copy(0),
+                    Instruction::LoadVar("_4".to_string()),
                     Instruction::LoadField(0),
                     Instruction::StoreField(0),
-                    Instruction::Copy(1),
-                    Instruction::Copy(1),
+                    Instruction::Copy(0),
+                    Instruction::LoadVar("_4".to_string()),
                     Instruction::LoadField(1),
                     Instruction::StoreField(1),
-                    Instruction::Copy(1),
-                    Instruction::Copy(1),
+                    Instruction::Copy(0),
+                    Instruction::LoadVar("_4".to_string()),
                     Instruction::LoadField(2),
                     Instruction::StoreField(2),
-                    Instruction::Copy(1),
-                    Instruction::Copy(1),
+                    Instruction::Copy(0),
+                    Instruction::LoadVar("_4".to_string()),
                     Instruction::LoadField(3),
                     Instruction::StoreField(3),
-                    Instruction::Pop(1),
-                    Instruction::LoadVar("p".to_string()),
                     Instruction::Return,
                 ],
             ),
             (
                 "x_one_last",
+                // ...xy_one() at pos 0, ...x_one() at pos 1
+                // x_one wins for all fields; xy_one called but result popped (unused)
                 vec![
-                    Instruction::AllocInstance(Value::class("Point")),
+                    Instruction::LoadConst(Value::Null),
+                    Instruction::LoadGlobal(Value::function("xy_one")),
+                    Instruction::Call(0),
+                    Instruction::Pop(1),
                     Instruction::LoadGlobal(Value::function("x_one")),
                     Instruction::Call(0),
-                    Instruction::Copy(1),
-                    Instruction::Copy(1),
+                    Instruction::StoreVar("_4".to_string()),
+                    Instruction::AllocInstance(Value::class("Point")),
+                    Instruction::Copy(0),
+                    Instruction::LoadVar("_4".to_string()),
                     Instruction::LoadField(0),
                     Instruction::StoreField(0),
-                    Instruction::Copy(1),
-                    Instruction::Copy(1),
+                    Instruction::Copy(0),
+                    Instruction::LoadVar("_4".to_string()),
                     Instruction::LoadField(1),
                     Instruction::StoreField(1),
-                    Instruction::Copy(1),
-                    Instruction::Copy(1),
+                    Instruction::Copy(0),
+                    Instruction::LoadVar("_4".to_string()),
                     Instruction::LoadField(2),
                     Instruction::StoreField(2),
-                    Instruction::Copy(1),
-                    Instruction::Copy(1),
+                    Instruction::Copy(0),
+                    Instruction::LoadVar("_4".to_string()),
                     Instruction::LoadField(3),
                     Instruction::StoreField(3),
-                    Instruction::Pop(1),
-                    Instruction::LoadVar("p".to_string()),
                     Instruction::Return,
                 ],
             ),
@@ -461,7 +474,6 @@ fn class_constructor_with_multiple_spread_operators() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "spread operator not yet in HIR"]
 fn class_constructor_with_spread_operator_does_not_break_locals() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: r#"
@@ -484,29 +496,34 @@ fn class_constructor_with_spread_operator_does_not_break_locals() -> anyhow::Res
         "#,
         expected: vec![(
             "main",
+            // Spread at position 2 overrides named fields.
+            // 'p' is assigned but never used (dead store, but still generated).
+            // 'x' is a constant, inlined.
             vec![
-                Instruction::AllocInstance(Value::class("Point")),
+                Instruction::LoadConst(Value::Null),
+                Instruction::LoadConst(Value::Null),
                 Instruction::LoadGlobal(Value::function("default_point")),
                 Instruction::Call(0),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::StoreVar("_2".to_string()),
+                Instruction::AllocInstance(Value::class("Point")),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(0),
                 Instruction::StoreField(0),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(1),
                 Instruction::StoreField(1),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(2),
                 Instruction::StoreField(2),
-                Instruction::Copy(1),
-                Instruction::Copy(1),
+                Instruction::Copy(0),
+                Instruction::LoadVar("_2".to_string()),
                 Instruction::LoadField(3),
                 Instruction::StoreField(3),
-                Instruction::Pop(1),
+                Instruction::StoreVar("p".to_string()),
                 Instruction::LoadConst(Value::Int(0)),
-                Instruction::LoadVar("x".to_string()),
                 Instruction::Return,
             ],
         )],

--- a/baml_language/crates/baml_hir/src/body.rs
+++ b/baml_language/crates/baml_hir/src/body.rs
@@ -123,6 +123,16 @@ pub type ExprId = Idx<Expr>;
 pub type StmtId = Idx<Stmt>;
 pub type PatId = Idx<Pattern>;
 
+/// A spread element in an object constructor: `...expr`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpreadField {
+    /// The expression being spread
+    pub expr: ExprId,
+    /// Position index where this spread appears among all elements
+    /// Used to determine override order (later positions override earlier)
+    pub position: usize,
+}
+
 /// Expressions in BAML function bodies.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
@@ -162,10 +172,12 @@ pub enum Expr {
     /// Function call: `call_f1()`, `transform(user)`
     Call { callee: ExprId, args: Vec<ExprId> },
 
-    /// Object constructor: `Point { x: 1, y: 2 }`
+    /// Object constructor: `Point { x: 1, y: 2, ...spread }`
     Object {
         type_name: Option<Name>,
         fields: Vec<(Name, ExprId)>,
+        /// Spread elements with their positions for override semantics
+        spreads: Vec<SpreadField>,
     },
 
     /// Array constructor: `[1, 2, 3]`
@@ -1867,101 +1879,141 @@ impl LoweringContext {
             .find(|token| token.kind() == SyntaxKind::WORD)
             .map(|token| Name::new(token.text()));
 
-        // Extract fields from OBJECT_FIELD children
-        let fields =
-            node.children()
-                .filter(|n| n.kind() == SyntaxKind::OBJECT_FIELD)
-                .filter_map(|field_node| {
-                    let field_span = field_node.text_range();
+        // Track position for override semantics
+        let mut position = 0;
+        let mut fields = Vec::new();
+        let mut spreads = Vec::new();
+
+        // Process children in order to track positions correctly
+        for child in node.children() {
+            match child.kind() {
+                SyntaxKind::OBJECT_FIELD => {
+                    let field_span = child.text_range();
                     // OBJECT_FIELD has: WORD (field name), COLON, value (EXPR or literal token)
-                    let field_name = field_node
+                    let field_name = child
                         .children_with_tokens()
                         .filter_map(baml_syntax::NodeOrToken::into_token)
                         .find(|token| token.kind() == SyntaxKind::WORD)
-                        .map(|token| Name::new(token.text()))?;
+                        .map(|token| Name::new(token.text()));
 
-                    // Try to get value as a child node first
-                    let value = field_node
+                    if let Some(field_name) = field_name {
+                        // Try to get value as a child node first
+                        let value = child
+                            .children()
+                            .next()
+                            .map(|n| self.lower_expr(&n))
+                            .or_else(|| {
+                                // Try to get value as a direct token (literal or identifier)
+                                // Skip the field name WORD and look for the value token after COLON
+                                let mut seen_colon = false;
+                                child
+                                    .children_with_tokens()
+                                    .filter_map(baml_syntax::NodeOrToken::into_token)
+                                    .find_map(|token| {
+                                        if token.kind() == SyntaxKind::COLON {
+                                            seen_colon = true;
+                                            return None;
+                                        }
+                                        if !seen_colon {
+                                            return None;
+                                        }
+                                        let span = token.text_range();
+                                        match token.kind() {
+                                            SyntaxKind::INTEGER_LITERAL => {
+                                                let value =
+                                                    token.text().parse::<i64>().unwrap_or(0);
+                                                Some(self.alloc_expr(
+                                                    Expr::Literal(Literal::Int(value)),
+                                                    span,
+                                                ))
+                                            }
+                                            SyntaxKind::FLOAT_LITERAL => Some(self.alloc_expr(
+                                                Expr::Literal(Literal::Float(
+                                                    token.text().to_string(),
+                                                )),
+                                                span,
+                                            )),
+                                            SyntaxKind::STRING_LITERAL
+                                            | SyntaxKind::RAW_STRING_LITERAL => {
+                                                let text = token.text();
+                                                let content = if text.starts_with("#\"")
+                                                    && text.ends_with("\"#")
+                                                {
+                                                    &text[2..text.len() - 2]
+                                                } else if text.starts_with('"')
+                                                    && text.ends_with('"')
+                                                {
+                                                    &text[1..text.len() - 1]
+                                                } else {
+                                                    text
+                                                };
+                                                Some(self.alloc_expr(
+                                                    Expr::Literal(Literal::String(
+                                                        content.to_string(),
+                                                    )),
+                                                    span,
+                                                ))
+                                            }
+                                            SyntaxKind::WORD => {
+                                                // Variable reference or boolean/null literal
+                                                let text = token.text();
+                                                let expr = match text {
+                                                    "true" => self.alloc_expr(
+                                                        Expr::Literal(Literal::Bool(true)),
+                                                        span,
+                                                    ),
+                                                    "false" => self.alloc_expr(
+                                                        Expr::Literal(Literal::Bool(false)),
+                                                        span,
+                                                    ),
+                                                    "null" => self.alloc_expr(
+                                                        Expr::Literal(Literal::Null),
+                                                        span,
+                                                    ),
+                                                    _ => self.alloc_expr(
+                                                        Expr::Path(vec![Name::new(text)]),
+                                                        span,
+                                                    ),
+                                                };
+                                                Some(expr)
+                                            }
+                                            _ => None,
+                                        }
+                                    })
+                            })
+                            .unwrap_or_else(|| self.alloc_expr(Expr::Missing, field_span));
+
+                        fields.push((field_name, value));
+                    }
+                    position += 1;
+                }
+                SyntaxKind::SPREAD_ELEMENT => {
+                    // SPREAD_ELEMENT has: DOT_DOT_DOT, expr
+                    // Get the expression being spread (child node after the ... token)
+                    let spread_expr = child
                         .children()
                         .next()
                         .map(|n| self.lower_expr(&n))
-                        .or_else(|| {
-                            // Try to get value as a direct token (literal or identifier)
-                            // Skip the field name WORD and look for the value token after COLON
-                            let mut seen_colon = false;
-                            field_node
-                                .children_with_tokens()
-                                .filter_map(baml_syntax::NodeOrToken::into_token)
-                                .find_map(|token| {
-                                    if token.kind() == SyntaxKind::COLON {
-                                        seen_colon = true;
-                                        return None;
-                                    }
-                                    if !seen_colon {
-                                        return None;
-                                    }
-                                    let span = token.text_range();
-                                    match token.kind() {
-                                        SyntaxKind::INTEGER_LITERAL => {
-                                            let value = token.text().parse::<i64>().unwrap_or(0);
-                                            Some(self.alloc_expr(
-                                                Expr::Literal(Literal::Int(value)),
-                                                span,
-                                            ))
-                                        }
-                                        SyntaxKind::FLOAT_LITERAL => Some(self.alloc_expr(
-                                            Expr::Literal(Literal::Float(token.text().to_string())),
-                                            span,
-                                        )),
-                                        SyntaxKind::STRING_LITERAL
-                                        | SyntaxKind::RAW_STRING_LITERAL => {
-                                            let text = token.text();
-                                            let content = if text.starts_with("#\"")
-                                                && text.ends_with("\"#")
-                                            {
-                                                &text[2..text.len() - 2]
-                                            } else if text.starts_with('"') && text.ends_with('"') {
-                                                &text[1..text.len() - 1]
-                                            } else {
-                                                text
-                                            };
-                                            Some(self.alloc_expr(
-                                                Expr::Literal(Literal::String(content.to_string())),
-                                                span,
-                                            ))
-                                        }
-                                        SyntaxKind::WORD => {
-                                            // Variable reference or boolean/null literal
-                                            let text = token.text();
-                                            let expr = match text {
-                                                "true" => self.alloc_expr(
-                                                    Expr::Literal(Literal::Bool(true)),
-                                                    span,
-                                                ),
-                                                "false" => self.alloc_expr(
-                                                    Expr::Literal(Literal::Bool(false)),
-                                                    span,
-                                                ),
-                                                "null" => self
-                                                    .alloc_expr(Expr::Literal(Literal::Null), span),
-                                                _ => self.alloc_expr(
-                                                    Expr::Path(vec![Name::new(text)]),
-                                                    span,
-                                                ),
-                                            };
-                                            Some(expr)
-                                        }
-                                        _ => None,
-                                    }
-                                })
-                        })
-                        .unwrap_or_else(|| self.alloc_expr(Expr::Missing, field_span));
+                        .unwrap_or_else(|| self.alloc_expr(Expr::Missing, child.text_range()));
 
-                    Some((field_name, value))
-                })
-                .collect();
+                    spreads.push(SpreadField {
+                        expr: spread_expr,
+                        position,
+                    });
+                    position += 1;
+                }
+                _ => {}
+            }
+        }
 
-        self.alloc_expr(Expr::Object { type_name, fields }, node.text_range())
+        self.alloc_expr(
+            Expr::Object {
+                type_name,
+                fields,
+                spreads,
+            },
+            node.text_range(),
+        )
     }
 
     fn lower_map_literal(&mut self, node: &baml_syntax::SyntaxNode) -> ExprId {

--- a/baml_language/crates/baml_hir/src/pretty.rs
+++ b/baml_language/crates/baml_hir/src/pretty.rs
@@ -129,19 +129,46 @@ impl<'a> CodePrinter<'a> {
                 }
                 self.output.push(']');
             }
-            Expr::Object { type_name, fields } => {
+            Expr::Object {
+                type_name,
+                fields,
+                spreads,
+            } => {
                 if let Some(name) = type_name {
                     self.output.push_str(name.as_ref());
                     self.output.push(' ');
                 }
                 self.output.push_str("{ ");
-                for (i, (name, value)) in fields.iter().enumerate() {
-                    if i > 0 {
+
+                // Build a combined list of elements with their positions
+                // for proper ordering in output
+                let mut elements: Vec<(usize, bool, usize)> = Vec::new();
+                for (i, _) in fields.iter().enumerate() {
+                    // We don't have position info for fields in the current struct,
+                    // so we'll output fields first, then spreads
+                    elements.push((i, false, i));
+                }
+                for (i, spread) in spreads.iter().enumerate() {
+                    elements.push((spread.position, true, i));
+                }
+                elements.sort_by_key(|(pos, _, _)| *pos);
+
+                let mut first = true;
+                for (_, is_spread, idx) in elements {
+                    if !first {
                         self.output.push_str(", ");
                     }
-                    self.output.push_str(name.as_ref());
-                    self.output.push_str(": ");
-                    self.print_expr(*value);
+                    first = false;
+
+                    if is_spread {
+                        self.output.push_str("...");
+                        self.print_expr(spreads[idx].expr);
+                    } else {
+                        let (name, value) = &fields[idx];
+                        self.output.push_str(name.as_ref());
+                        self.output.push_str(": ");
+                        self.print_expr(*value);
+                    }
                 }
                 self.output.push_str(" }");
             }

--- a/baml_language/crates/baml_lexer/src/tokens.rs
+++ b/baml_language/crates/baml_lexer/src/tokens.rs
@@ -138,6 +138,8 @@ pub enum TokenKind {
     Comma,
     #[token(";")]
     Semicolon,
+    #[token("...")]
+    DotDotDot,
     #[token(".")]
     Dot,
     #[token("$")]

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/constructors.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/constructors.baml
@@ -23,39 +23,4 @@ class Person {
 
 //----
 //- diagnostics
-// Error: Expected field name or '}', found Dot
-//    ╭─[ 0:8:25 ]
-//    │
-//  8 │ let y = MyClass { a: 1, ...x };
-//    │                         ┬  
-//    │                         ╰── Expected field name or '}', found Dot
-//    │ 
-//    │ Note: Error code: E0010
-// ───╯
-// Error: Expected field name or '}', found Dot
-//    ╭─[ 0:8:26 ]
-//    │
-//  8 │ let y = MyClass { a: 1, ...x };
-//    │                          ┬  
-//    │                          ╰── Expected field name or '}', found Dot
-//    │ 
-//    │ Note: Error code: E0010
-// ───╯
-// Error: Expected field name or '}', found Dot
-//    ╭─[ 0:8:27 ]
-//    │
-//  8 │ let y = MyClass { a: 1, ...x };
-//    │                           ┬  
-//    │                           ╰── Expected field name or '}', found Dot
-//    │ 
-//    │ Note: Error code: E0010
-// ───╯
-// Error: Expected Colon, found RBrace
-//    ╭─[ 0:8:30 ]
-//    │
-//  8 │ let y = MyClass { a: 1, ...x };
-//    │                              ┬  
-//    │                              ╰── Expected Colon, found RBrace
-//    │ 
-//    │ Note: Error code: E0010
-// ───╯
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/invalid2.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/invalid2.baml
@@ -162,30 +162,12 @@ function Foo6(arg: int) -> float {
 //     │ 
 //     │ Note: Error code: E0010
 // ────╯
-// Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '.', found Dot
+// Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '...', found DotDotDot
 //     ╭─[ 0:23:12 ]
 //     │
 //  23 │   prompt #"..."#
-//     │            ┬  
-//     │            ╰── Expected Only 'client' and 'prompt' allowed in LLM function, found '.', found Dot
-//     │ 
-//     │ Note: Error code: E0010
-// ────╯
-// Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '.', found Dot
-//     ╭─[ 0:23:13 ]
-//     │
-//  23 │   prompt #"..."#
-//     │             ┬  
-//     │             ╰── Expected Only 'client' and 'prompt' allowed in LLM function, found '.', found Dot
-//     │ 
-//     │ Note: Error code: E0010
-// ────╯
-// Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '.', found Dot
-//     ╭─[ 0:23:14 ]
-//     │
-//  23 │   prompt #"..."#
-//     │              ┬  
-//     │              ╰── Expected Only 'client' and 'prompt' allowed in LLM function, found '.', found Dot
+//     │            ─┬─  
+//     │             ╰─── Expected Only 'client' and 'prompt' allowed in LLM function, found '...', found DotDotDot
 //     │ 
 //     │ Note: Error code: E0010
 // ────╯

--- a/baml_language/crates/baml_mir/src/lower.rs
+++ b/baml_language/crates/baml_mir/src/lower.rs
@@ -26,6 +26,14 @@ use crate::{
     Rvalue, UnaryOp as MirUnaryOp,
 };
 
+/// Source of a field value in spread expansion.
+enum FieldSource {
+    /// Field value comes from a named field assignment.
+    Named(ExprId),
+    /// Field value comes from a spread source (local containing spread value, field index).
+    Spread(Local, usize),
+}
+
 /// Lower a function from VIR to MIR.
 ///
 /// This is the main entry point for VIR → MIR lowering.
@@ -407,30 +415,145 @@ impl<'db, 'ctx> LoweringContext<'db, 'ctx> {
                 self.builder.assign(dest, Rvalue::Array(elem_operands));
             }
 
-            Expr::Object { type_name, fields } => {
-                let field_operands: Vec<Operand<'db>> = fields
-                    .iter()
-                    .map(|(_, value)| {
-                        let value_ty = Self::lower_typed_ir_ty(body.ty(*value));
-                        let value_local = self.builder.temp(value_ty);
-                        self.lower_expr(*value, Place::local(value_local), body);
-                        Operand::copy_local(value_local)
-                    })
-                    .collect();
+            Expr::Object {
+                type_name,
+                fields,
+                spreads,
+            } => {
+                // If there are no spreads, use the simple aggregate approach
+                if spreads.is_empty() {
+                    let field_operands: Vec<Operand<'db>> = fields
+                        .iter()
+                        .map(|(_, value)| {
+                            let value_ty = Self::lower_typed_ir_ty(body.ty(*value));
+                            let value_local = self.builder.temp(value_ty);
+                            self.lower_expr(*value, Place::local(value_local), body);
+                            Operand::copy_local(value_local)
+                        })
+                        .collect();
 
-                let kind = if let Some(name) = type_name {
-                    AggregateKind::Class(name.to_string())
+                    let kind = if let Some(name) = type_name {
+                        AggregateKind::Class(name.to_string())
+                    } else {
+                        AggregateKind::Class("Anonymous".to_string())
+                    };
+
+                    self.builder.assign(
+                        dest,
+                        Rvalue::Aggregate {
+                            kind,
+                            fields: field_operands,
+                        },
+                    );
                 } else {
-                    AggregateKind::Class("Anonymous".to_string())
-                };
+                    // With spreads, we need to determine the final value for each field
+                    // based on position-based override semantics (last assignment wins).
+                    //
+                    // Algorithm:
+                    // 1. Evaluate all spread sources into temp locals
+                    // 2. Get all class fields in definition order
+                    // 3. For each class field, determine source (named field or spread)
+                    //    based on which has the highest position
+                    // 4. Generate field operands accordingly
 
-                self.builder.assign(
-                    dest,
-                    Rvalue::Aggregate {
-                        kind,
-                        fields: field_operands,
-                    },
-                );
+                    let class_name = type_name
+                        .as_ref()
+                        .map(std::string::ToString::to_string)
+                        .unwrap_or_else(|| "Anonymous".to_string());
+
+                    // Get class fields and invert to get field_index -> field_name
+                    let class_field_map = self.class_fields.get(&class_name);
+                    let class_fields_ordered: Vec<(usize, String)> =
+                        if let Some(field_map) = class_field_map {
+                            let mut fields_vec: Vec<(usize, String)> = field_map
+                                .iter()
+                                .map(|(name, &idx)| (idx, name.clone()))
+                                .collect();
+                            fields_vec.sort_by_key(|(idx, _)| *idx);
+                            fields_vec
+                        } else {
+                            // Fallback: use named fields order if class not found
+                            fields
+                                .iter()
+                                .enumerate()
+                                .map(|(idx, (name, _))| (idx, name.to_string()))
+                                .collect()
+                        };
+
+                    // Evaluate all spread sources into temp locals
+                    let spread_locals: Vec<(Local, usize)> = spreads
+                        .iter()
+                        .map(|spread| {
+                            let spread_ty = Self::lower_typed_ir_ty(body.ty(spread.expr));
+                            let spread_local = self.builder.temp(spread_ty);
+                            self.lower_expr(spread.expr, Place::local(spread_local), body);
+                            (spread_local, spread.position)
+                        })
+                        .collect();
+
+                    // Build a map of named field name -> (value_expr_id, position)
+                    // Position is the index in the fields vector
+                    let named_field_map: HashMap<String, (ExprId, usize)> = fields
+                        .iter()
+                        .enumerate()
+                        .map(|(pos, (name, value))| (name.to_string(), (*value, pos)))
+                        .collect();
+
+                    // For each class field, determine the source and generate operand
+                    let field_operands: Vec<Operand<'db>> = class_fields_ordered
+                        .iter()
+                        .map(|(field_idx, field_name)| {
+                            // Find the highest-positioned source for this field
+                            let mut best_source: Option<FieldSource> = None;
+                            let mut best_position: Option<usize> = None;
+
+                            // Check named fields
+                            if let Some(&(value_expr, pos)) = named_field_map.get(field_name) {
+                                best_source = Some(FieldSource::Named(value_expr));
+                                best_position = Some(pos);
+                            }
+
+                            // Check spreads (all spreads provide all fields of the class)
+                            for (spread_local, spread_pos) in &spread_locals {
+                                if best_position.is_none() || *spread_pos > best_position.unwrap() {
+                                    best_source =
+                                        Some(FieldSource::Spread(*spread_local, *field_idx));
+                                    best_position = Some(*spread_pos);
+                                }
+                            }
+
+                            // Generate the operand based on the source
+                            match best_source {
+                                Some(FieldSource::Named(value_expr)) => {
+                                    let value_ty = Self::lower_typed_ir_ty(body.ty(value_expr));
+                                    let value_local = self.builder.temp(value_ty);
+                                    self.lower_expr(value_expr, Place::local(value_local), body);
+                                    Operand::copy_local(value_local)
+                                }
+                                Some(FieldSource::Spread(spread_local, field_idx)) => {
+                                    // Load field from spread source
+                                    Operand::Copy(Place::field(
+                                        Place::local(spread_local),
+                                        field_idx,
+                                    ))
+                                }
+                                None => {
+                                    // This shouldn't happen if the class has fields
+                                    // Fall back to null
+                                    Operand::Constant(Constant::Null)
+                                }
+                            }
+                        })
+                        .collect();
+
+                    self.builder.assign(
+                        dest,
+                        Rvalue::Aggregate {
+                            kind: AggregateKind::Class(class_name),
+                            fields: field_operands,
+                        },
+                    );
+                }
             }
 
             Expr::Map { entries } => {

--- a/baml_language/crates/baml_parser/src/parser.rs
+++ b/baml_language/crates/baml_parser/src/parser.rs
@@ -71,6 +71,7 @@ fn token_kind_to_syntax_kind(kind: TokenKind) -> SyntaxKind {
         TokenKind::DoubleColon => SyntaxKind::DOUBLE_COLON,
         TokenKind::Comma => SyntaxKind::COMMA,
         TokenKind::Semicolon => SyntaxKind::SEMICOLON,
+        TokenKind::DotDotDot => SyntaxKind::DOT_DOT_DOT,
         TokenKind::Dot => SyntaxKind::DOT,
         TokenKind::Dollar => SyntaxKind::DOLLAR,
 
@@ -2493,14 +2494,37 @@ impl<'a> Parser<'a> {
         });
     }
 
-    /// Parse the body of an object literal/constructor: { field: value, ... }
+    /// Parse the body of an object literal/constructor: { field: value, ...spread }
     fn parse_object_literal_body(&mut self) {
         self.expect(TokenKind::LBrace);
 
         // Parse fields until we hit the closing brace
         while !self.at(TokenKind::RBrace) && !self.at_end() {
+            // Check for spread element: ...expr
+            if self.at(TokenKind::DotDotDot) {
+                self.parse_spread_element();
+
+                // Handle comma between elements
+                if !self.at(TokenKind::RBrace) {
+                    if !self.eat(TokenKind::Comma) {
+                        // Missing comma - error but try to continue
+                        self.error_unexpected_token("',' or '}' after spread element".to_string());
+                        // Try to recover
+                        if !self.at(TokenKind::Word)
+                            && !self.at(TokenKind::Quote)
+                            && !self.at(TokenKind::Hash)
+                            && !self.at(TokenKind::DotDotDot)
+                            && !self.at(TokenKind::RBrace)
+                        {
+                            self.bump();
+                        }
+                    }
+                }
             // Check for valid field start
-            if self.at(TokenKind::Word) || self.at(TokenKind::Quote) || self.at(TokenKind::Hash) {
+            } else if self.at(TokenKind::Word)
+                || self.at(TokenKind::Quote)
+                || self.at(TokenKind::Hash)
+            {
                 self.parse_object_field();
 
                 // Handle comma between fields
@@ -2512,6 +2536,7 @@ impl<'a> Parser<'a> {
                         if !self.at(TokenKind::Word)
                             && !self.at(TokenKind::Quote)
                             && !self.at(TokenKind::Hash)
+                            && !self.at(TokenKind::DotDotDot)
                             && !self.at(TokenKind::RBrace)
                         {
                             // Skip unexpected token
@@ -2524,13 +2549,21 @@ impl<'a> Parser<'a> {
                 continue;
             } else {
                 // Unexpected token in object literal
-                self.error_unexpected_token("field name or '}'".to_string());
+                self.error_unexpected_token("field name, spread element, or '}'".to_string());
                 // Skip the unexpected token to avoid getting stuck
                 self.bump();
             }
         }
 
         self.expect(TokenKind::RBrace);
+    }
+
+    /// Parse a spread element: ...expr
+    fn parse_spread_element(&mut self) {
+        self.with_node(SyntaxKind::SPREAD_ELEMENT, |p| {
+            p.expect(TokenKind::DotDotDot);
+            p.parse_expr();
+        });
     }
 
     /// Parse a single object field: name: value

--- a/baml_language/crates/baml_syntax/src/syntax_kind.rs
+++ b/baml_language/crates/baml_syntax/src/syntax_kind.rs
@@ -59,6 +59,7 @@ pub enum SyntaxKind {
     DOUBLE_COLON, // ::
     COMMA,        // ,
     SEMICOLON,    // ;
+    DOT_DOT_DOT,  // ...
     DOT,          // .
     DOLLAR,       // $
     ARROW,        // ->
@@ -229,6 +230,7 @@ pub enum SyntaxKind {
     GENERIC_ARGS,
     OBJECT_LITERAL,
     OBJECT_FIELD,
+    SPREAD_ELEMENT, // ...expr in object/array literals
     ARRAY_LITERAL,
     MAP_LITERAL,
 

--- a/baml_language/crates/baml_tir/src/lib.rs
+++ b/baml_language/crates/baml_tir/src/lib.rs
@@ -933,18 +933,37 @@ fn infer_expr<'db>(ctx: &mut TypeContext<'db>, expr_id: ExprId, body: &ExprBody)
             }
         }
 
-        Expr::Object { type_name, fields } => {
+        Expr::Object {
+            type_name,
+            fields,
+            spreads,
+        } => {
             // Infer field types
             for (_, value_expr) in fields {
                 infer_expr(ctx, *value_expr, body);
             }
-            // Return the named type if type_name is provided
-            if let Some(name) = type_name {
+
+            // Determine the expected object type
+            let obj_ty = if let Some(name) = type_name {
                 Ty::Named(name.clone())
             } else {
-                // Anonymous object - return Unknown for now
                 Ty::Unknown
+            };
+
+            // Type check spread expressions - they must be the same type as the object
+            for spread in spreads {
+                let spread_ty = infer_expr(ctx, spread.expr, body);
+                // If we have a named type, verify the spread is compatible
+                if !matches!(obj_ty, Ty::Unknown) && !spread_ty.is_subtype_of(&obj_ty) {
+                    ctx.push_error(TypeError::TypeMismatch {
+                        expected: obj_ty.clone(),
+                        found: spread_ty,
+                        span,
+                    });
+                }
             }
+
+            obj_ty
         }
 
         Expr::Map { entries } => {

--- a/baml_language/crates/baml_tir/src/pretty.rs
+++ b/baml_language/crates/baml_tir/src/pretty.rs
@@ -184,12 +184,27 @@ impl<'a, 'db> TreeRenderer<'a, 'db> {
             Expr::FieldAccess { field, .. } => format!("FieldAccess(.{field}): {ty}"),
             Expr::Index { .. } => format!("Index: {ty}"),
             Expr::Array { elements } => format!("Array[{}]: {}", elements.len(), ty),
-            Expr::Object { type_name, fields } => {
+            Expr::Object {
+                type_name,
+                fields,
+                spreads,
+            } => {
                 let name = type_name
                     .as_ref()
                     .map(std::string::ToString::to_string)
                     .unwrap_or_default();
-                format!("Object({} {{ {} fields }}): {}", name, fields.len(), ty)
+                let spread_info = if spreads.is_empty() {
+                    String::new()
+                } else {
+                    format!(", {} spreads", spreads.len())
+                };
+                format!(
+                    "Object({} {{ {} fields{} }}): {}",
+                    name,
+                    fields.len(),
+                    spread_info,
+                    ty
+                )
             }
             Expr::Map { entries } => {
                 format!("Map({{ {} entries }}): {}", entries.len(), ty)
@@ -236,13 +251,29 @@ impl<'a, 'db> TreeRenderer<'a, 'db> {
                     self.render_expr(*elem, body, result, i == elements.len() - 1);
                 }
             }
-            Expr::Object { fields, .. } => {
-                for (i, (name, value)) in fields.iter().enumerate() {
-                    let is_last = i == fields.len() - 1;
+            Expr::Object {
+                fields, spreads, ..
+            } => {
+                let total_elements = fields.len() + spreads.len();
+                let mut element_idx = 0;
+
+                for (name, value) in fields {
+                    element_idx += 1;
+                    let is_last = element_idx == total_elements;
                     let field_prefix = self.make_prefix(is_last);
                     writeln!(self.output, "{field_prefix}{name}:").ok();
                     self.push_continuation(!is_last);
                     self.render_expr(*value, body, result, true);
+                    self.pop_continuation();
+                }
+
+                for spread in spreads {
+                    element_idx += 1;
+                    let is_last = element_idx == total_elements;
+                    let spread_prefix = self.make_prefix(is_last);
+                    writeln!(self.output, "{spread_prefix}...").ok();
+                    self.push_continuation(!is_last);
+                    self.render_expr(spread.expr, body, result, true);
                     self.pop_continuation();
                 }
             }
@@ -497,7 +528,11 @@ pub fn expr_to_string(expr_id: ExprId, body: &ExprBody) -> String {
             let elems: Vec<String> = elements.iter().map(|e| expr_to_string(*e, body)).collect();
             format!("[{}]", elems.join(", "))
         }
-        Expr::Object { type_name, fields } => {
+        Expr::Object {
+            type_name,
+            fields,
+            spreads,
+        } => {
             let name = type_name
                 .as_ref()
                 .map(|n| format!("{n} "))
@@ -506,7 +541,12 @@ pub fn expr_to_string(expr_id: ExprId, body: &ExprBody) -> String {
                 .iter()
                 .map(|(n, v)| format!("{}: {}", n, expr_to_string(*v, body)))
                 .collect();
-            format!("{}{{ {} }}", name, field_strs.join(", "))
+            let spread_strs: Vec<String> = spreads
+                .iter()
+                .map(|s| format!("...{}", expr_to_string(s.expr, body)))
+                .collect();
+            let all_elements: Vec<String> = field_strs.into_iter().chain(spread_strs).collect();
+            format!("{}{{ {} }}", name, all_elements.join(", "))
         }
         Expr::Map { entries } => {
             let entry_strs: Vec<String> = entries

--- a/baml_language/crates/baml_vir/src/expr.rs
+++ b/baml_language/crates/baml_vir/src/expr.rs
@@ -22,6 +22,16 @@ pub type ExprId = Idx<Expr>;
 /// Pattern ID - index into the pattern arena.
 pub type PatId = Idx<Pattern>;
 
+/// A spread element in an object constructor: `...expr`
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpreadField {
+    /// The expression being spread
+    pub expr: ExprId,
+    /// Position index where this spread appears among all elements
+    /// Used to determine override order (later positions override earlier)
+    pub position: usize,
+}
+
 /// A typed expression body containing all expressions for a function.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExprBody {
@@ -177,10 +187,12 @@ pub enum Expr {
     /// Array literal: `[elem1, elem2, ...]`
     Array { elements: Vec<ExprId> },
 
-    /// Object/struct literal: `TypeName { field1: value1, ... }`
+    /// Object/struct literal: `TypeName { field1: value1, ...spread }`
     Object {
         type_name: Option<Name>,
         fields: Vec<(Name, ExprId)>,
+        /// Spread elements with their positions for override semantics
+        spreads: Vec<SpreadField>,
     },
 
     /// Map literal: `{ key: value, ... }`

--- a/baml_language/crates/baml_vir/src/lower.rs
+++ b/baml_language/crates/baml_vir/src/lower.rs
@@ -28,7 +28,8 @@ use rustc_hash::FxHashMap;
 use text_size::TextRange;
 
 use crate::{
-    AssignOp, BinaryOp, Expr, ExprBody, ExprId, Literal, MatchArm, PatId, Pattern, Ty, UnaryOp,
+    AssignOp, BinaryOp, Expr, ExprBody, ExprId, Literal, MatchArm, PatId, Pattern, SpreadField, Ty,
+    UnaryOp,
 };
 
 /// Error that occurs when lowering HIR to VIR.
@@ -386,15 +387,27 @@ impl<'db> LoweringContext<'db> {
                 ))
             }
 
-            HirExpr::Object { type_name, fields } => {
+            HirExpr::Object {
+                type_name,
+                fields,
+                spreads,
+            } => {
                 let mut field_ids = Vec::with_capacity(fields.len());
                 for (name, expr) in fields {
                     field_ids.push((name.clone(), self.lower_expr(*expr, hir_body)?));
+                }
+                let mut spread_ids = Vec::with_capacity(spreads.len());
+                for spread in spreads {
+                    spread_ids.push(SpreadField {
+                        expr: self.lower_expr(spread.expr, hir_body)?,
+                        position: spread.position,
+                    });
                 }
                 Ok(self.builder.alloc(
                     Expr::Object {
                         type_name: type_name.clone(),
                         fields: field_ids,
+                        spreads: spread_ids,
                     },
                     ty,
                     span.map(|s| s.range),

--- a/baml_language/crates/baml_vir/src/pretty.rs
+++ b/baml_language/crates/baml_vir/src/pretty.rs
@@ -229,7 +229,11 @@ impl<'a> PrettyPrinter<'a> {
                 }
             }
 
-            Expr::Object { type_name, fields } => {
+            Expr::Object {
+                type_name,
+                fields,
+                spreads,
+            } => {
                 self.indent(level);
                 let name = type_name
                     .as_ref()
@@ -241,6 +245,12 @@ impl<'a> PrettyPrinter<'a> {
                     self.indent(level + 1);
                     writeln!(self.output, "{field_name}:").unwrap();
                     self.print_expr(*value, level + 2);
+                }
+                for spread in spreads {
+                    self.output.push('\n');
+                    self.indent(level + 1);
+                    writeln!(self.output, "...(position {})", spread.position).unwrap();
+                    self.print_expr(spread.expr, level + 2);
                 }
             }
 

--- a/baml_language/crates/baml_vm/tests/classes.rs
+++ b/baml_language/crates/baml_vm/tests/classes.rs
@@ -30,7 +30,6 @@ fn class_constructor() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "spread operator in constructors not yet implemented"]
 fn class_constructor_with_spread_operator() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: "
@@ -64,7 +63,6 @@ fn class_constructor_with_spread_operator() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "spread operator in constructors not yet implemented"]
 fn class_constructor_with_multiple_spread_operators() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: "
@@ -102,7 +100,6 @@ fn class_constructor_with_multiple_spread_operators() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "spread operator in constructors not yet implemented"]
 fn class_constructor_with_spread_operator_before_named_fields() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: "
@@ -136,7 +133,6 @@ fn class_constructor_with_spread_operator_before_named_fields() -> anyhow::Resul
 }
 
 #[test]
-#[ignore = "spread operator in constructors not yet implemented"]
 fn class_constructor_with_spread_operator_does_not_break_locals() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: "


### PR DESCRIPTION
## Summary
- Add support for spread syntax (`...expr`) in object literals
- Implement position-based override semantics (later elements override earlier ones)

## Changes
- **Lexer**: Add `DotDotDot` token
- **Syntax**: Add `DOT_DOT_DOT` and `SPREAD_ELEMENT` node kinds
- **Parser**: Parse spread elements in object literals
- **HIR**: Add `SpreadField` struct and `spreads` field to `Expr::Object`
- **TIR**: Type checking for spread expressions
- **VIR**: Propagate spread info through lowering
- **MIR**: Expand spreads with position-based field resolution

## Semantics
```baml
// Spread after named fields: spread overrides
Point { x: 1, ...spread() }  // All fields from spread()

// Spread before named fields: named fields override  
Point { ...spread(), x: 1 }  // x from named, rest from spread

// Multiple spreads: later wins
Point { ...a(), ...b() }  // All fields from b()
```

## Test plan
- [x] 4 VM tests pass (`baml_vm/tests/classes.rs`)
- [x] 5 codegen tests pass (`baml_codegen/tests/classes.rs`)
- [x] Full test suite passes (`cargo test`)