### PR TITLE
Fix instanceof operator MIR lowering

### DIFF
--- a/baml_language/crates/baml_mir/src/lower.rs
+++ b/baml_language/crates/baml_mir/src/lower.rs
@@ -711,6 +711,29 @@ impl<'db, 'ctx> LoweringContext<'db, 'ctx> {
         dest: Place,
         body: &ExprBody,
     ) {
+        // Special case: instanceof operator - RHS is a type name, not a value
+        if op == BinaryOp::Instanceof {
+            let lhs_ty = Self::lower_typed_ir_ty(body.ty(lhs));
+            let lhs_local = self.builder.temp(lhs_ty);
+            self.lower_expr(lhs, Place::local(lhs_local), body);
+
+            // Extract the type name from RHS (should be a Var or single-segment Path)
+            let type_name = match body.expr(rhs) {
+                Expr::Var(name) => name.clone(),
+                Expr::Path(segments) if segments.len() == 1 => segments[0].clone(),
+                _ => panic!("instanceof RHS must be a simple type name"),
+            };
+
+            self.builder.assign(
+                dest,
+                Rvalue::IsType {
+                    operand: Operand::copy_local(lhs_local),
+                    ty: Ty::Named(type_name),
+                },
+            );
+            return;
+        }
+
         let lhs_ty = Self::lower_typed_ir_ty(body.ty(lhs));
         let rhs_ty = Self::lower_typed_ir_ty(body.ty(rhs));
 

--- a/baml_language/crates/baml_vm/tests/instanceof.rs
+++ b/baml_language/crates/baml_vm/tests/instanceof.rs
@@ -3,7 +3,6 @@
 use baml_tests::bytecode::{ExecState, Program, Value, assert_vm_executes};
 
 #[test]
-#[ignore = "instanceof not yet implemented"]
 fn instance_of_returns_true() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -23,7 +22,6 @@ fn instance_of_returns_true() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "instanceof not yet implemented"]
 fn instance_of_returns_false() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -47,7 +45,6 @@ fn instance_of_returns_false() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "instanceof not yet implemented"]
 fn instanceof_narrowing_true_branch() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -75,7 +72,6 @@ fn instanceof_narrowing_true_branch() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "instanceof not yet implemented"]
 fn instanceof_narrowing_false_branch() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -103,7 +99,6 @@ fn instanceof_narrowing_false_branch() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "instanceof not yet implemented"]
 fn instanceof_chained_checks() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"


### PR DESCRIPTION
## Summary
- Fix instanceof operator to correctly handle type names in the RHS
- Previously, type names like `Foo` in `x instanceof Foo` were being treated as function references, causing "undefined function" errors
- Added special handling in `lower_binary_op` to extract the type name and use `Rvalue::IsType` directly

## Test plan
- [x] All 5 instanceof tests in `baml_vm/tests/instanceof.rs` now pass
- [x] Removed `#[ignore = "instanceof not yet implemented"]` from all tests
- [x] Full test suite passes