### PR TITLE
Fix type inference for generic builtin function calls

### DIFF
--- a/baml_language/crates/baml_tir/src/lib.rs
+++ b/baml_language/crates/baml_tir/src/lib.rs
@@ -33,6 +33,31 @@ pub use pretty::{expr_to_string, render_body_tree, render_function_tree};
 use text_size::TextRange;
 pub use types::*;
 
+/// Substitute type variable bindings into a `TypePattern`, falling back to `Ty::Unknown`
+/// for unbound type variables.
+///
+/// This is used for builtin function type inference where some type variables may be
+/// bound from arguments but others might not be.
+fn substitute_with_fallback<'db>(
+    pattern: &baml_vm::TypePattern,
+    bindings: &Bindings<'db>,
+) -> Ty<'db> {
+    use baml_vm::TypePattern;
+    match pattern {
+        TypePattern::Var(name) => bindings.get(name).cloned().unwrap_or(Ty::Unknown),
+        TypePattern::Int => Ty::Int,
+        TypePattern::Float => Ty::Float,
+        TypePattern::String => Ty::String,
+        TypePattern::Bool => Ty::Bool,
+        TypePattern::Null => Ty::Null,
+        TypePattern::Array(elem) => Ty::List(Box::new(substitute_with_fallback(elem, bindings))),
+        TypePattern::Map { key, value } => Ty::Map {
+            key: Box::new(substitute_with_fallback(key, bindings)),
+            value: Box::new(substitute_with_fallback(value, bindings)),
+        },
+    }
+}
+
 // ============================================================================
 // Path Resolution
 // ============================================================================
@@ -795,30 +820,63 @@ fn infer_expr<'db>(ctx: &mut TypeContext<'db>, expr_id: ExprId, body: &ExprBody)
                 }
                 Expr::Path(segments) if segments.len() >= 2 => {
                     // First, check if this is a direct builtin function call
-                    // (e.g., baml.Array.length(arr))
+                    // (e.g., baml.Array.length(arr), baml.deep_copy(x))
                     let full_path = segments
                         .iter()
                         .map(smol_str::SmolStr::as_str)
                         .collect::<Vec<_>>()
                         .join(".");
                     if let Some(def) = builtins::lookup_builtin_by_path(&full_path) {
-                        // It's a builtin function - build function type from definition
-                        // For methods called as functions, receiver is the first argument
-                        let mut param_types: Vec<Ty<'db>> = Vec::new();
+                        // It's a builtin function - infer argument types first so we can
+                        // bind type variables (e.g., T in deep_copy(x: T) -> T)
+                        let arg_types: Vec<Ty<'db>> =
+                            args.iter().map(|arg| infer_expr(ctx, *arg, body)).collect();
+
+                        // Build parameter patterns and match against argument types to
+                        // extract type variable bindings
+                        let mut param_patterns: Vec<&baml_vm::TypePattern> = Vec::new();
                         if let Some(ref receiver_pattern) = def.receiver {
-                            param_types.push(builtins::substitute_unknown(receiver_pattern));
+                            param_patterns.push(receiver_pattern);
                         }
                         for (_, pattern) in &def.params {
-                            param_types.push(builtins::substitute_unknown(pattern));
+                            param_patterns.push(pattern);
                         }
-                        let return_type = builtins::substitute_unknown(&def.returns);
+
+                        // Try to match each argument against its parameter pattern
+                        let mut bindings = builtins::Bindings::new();
+                        for (arg_ty, param_pattern) in arg_types.iter().zip(param_patterns.iter()) {
+                            if let Some(new_bindings) =
+                                builtins::match_pattern(param_pattern, arg_ty)
+                            {
+                                // Merge bindings (first binding wins for consistency)
+                                for (name, ty) in new_bindings {
+                                    bindings.entry(name).or_insert(ty);
+                                }
+                            }
+                        }
+
+                        // Build function type using bindings for type variables
+                        let param_types: Vec<Ty<'db>> = param_patterns
+                            .iter()
+                            .map(|p| {
+                                if bindings.is_empty() {
+                                    builtins::substitute_unknown(p)
+                                } else {
+                                    substitute_with_fallback(p, &bindings)
+                                }
+                            })
+                            .collect();
+
+                        let return_type = if bindings.is_empty() {
+                            builtins::substitute_unknown(&def.returns)
+                        } else {
+                            substitute_with_fallback(&def.returns, &bindings)
+                        };
 
                         let callee_ty = Ty::Function {
                             params: param_types,
                             ret: Box::new(return_type),
                         };
-                        let arg_types: Vec<Ty<'db>> =
-                            args.iter().map(|arg| infer_expr(ctx, *arg, body)).collect();
                         (callee_ty, arg_types)
                     } else {
                         // Method call via Path: `receiver.method(args)`

--- a/baml_language/crates/baml_vm/tests/builtins.rs
+++ b/baml_language/crates/baml_vm/tests/builtins.rs
@@ -3,7 +3,6 @@
 use baml_tests::bytecode::{ExecState, Program, Value, assert_vm_executes};
 
 #[test]
-#[ignore = "builtin method calls not yet implemented"]
 fn builtin_method_call() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -18,7 +17,6 @@ fn builtin_method_call() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "builtin method calls not yet implemented"]
 fn bind_method_call() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -35,7 +33,6 @@ fn bind_method_call() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "baml.unstable.string not yet implemented"]
 fn any_value_to_string() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"

--- a/baml_language/crates/baml_vm/tests/deep_copy.rs
+++ b/baml_language/crates/baml_vm/tests/deep_copy.rs
@@ -4,7 +4,6 @@ use baml_tests::bytecode::{ExecState, Instance, Object, Program, Value, assert_v
 use indexmap::indexmap;
 
 #[test]
-#[ignore = "deep_copy builtin not yet implemented"]
 fn deep_copy_object() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -53,7 +52,6 @@ fn deep_copy_object() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_copy builtin not yet implemented"]
 fn deep_copy_independence() -> anyhow::Result<()> {
     // Test that deep copy creates truly independent objects
     assert_vm_executes(Program {
@@ -84,7 +82,6 @@ fn deep_copy_independence() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_copy builtin not yet implemented"]
 fn deep_copy_nested_arrays_in_class() -> anyhow::Result<()> {
     // Test deep copy with nested arrays inside class instances
     assert_vm_executes(Program {
@@ -110,7 +107,6 @@ fn deep_copy_nested_arrays_in_class() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_copy builtin not yet implemented"]
 fn deep_copy_map_in_class() -> anyhow::Result<()> {
     // Test deep copy with maps inside class instances
     assert_vm_executes(Program {
@@ -138,7 +134,6 @@ fn deep_copy_map_in_class() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_copy builtin not yet implemented"]
 fn deep_copy_complex_nested_structure() -> anyhow::Result<()> {
     // Test deep copy with complex nested structures
     assert_vm_executes(Program {
@@ -187,7 +182,6 @@ fn deep_copy_complex_nested_structure() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_copy builtin not yet implemented"]
 fn deep_copy_circular_reference() -> anyhow::Result<()> {
     // Test that deep_copy handles circular references correctly
     assert_vm_executes(Program {
@@ -221,7 +215,6 @@ fn deep_copy_circular_reference() -> anyhow::Result<()> {
 // ============ deep_equals tests ============
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_primitives() -> anyhow::Result<()> {
     // Test equality of primitive values
     assert_vm_executes(Program {
@@ -238,7 +231,6 @@ fn deep_equals_primitives() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_different_primitives() -> anyhow::Result<()> {
     // Test inequality of different primitive values
     assert_vm_executes(Program {
@@ -255,7 +247,6 @@ fn deep_equals_different_primitives() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_simple_objects() -> anyhow::Result<()> {
     // Test equality of simple class instances
     assert_vm_executes(Program {
@@ -277,7 +268,6 @@ fn deep_equals_simple_objects() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_different_objects() -> anyhow::Result<()> {
     // Test inequality when objects have different values
     assert_vm_executes(Program {
@@ -299,7 +289,6 @@ fn deep_equals_different_objects() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_nested_objects() -> anyhow::Result<()> {
     // Test deep equality with nested objects
     assert_vm_executes(Program {
@@ -329,7 +318,6 @@ fn deep_equals_nested_objects() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_nested_objects_different() -> anyhow::Result<()> {
     // Test inequality with different nested objects
     assert_vm_executes(Program {
@@ -359,7 +347,6 @@ fn deep_equals_nested_objects_different() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_with_arrays() -> anyhow::Result<()> {
     // Test equality with arrays in class fields
     assert_vm_executes(Program {
@@ -380,7 +367,6 @@ fn deep_equals_with_arrays() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_with_maps() -> anyhow::Result<()> {
     // Test equality with maps in class fields
     assert_vm_executes(Program {
@@ -401,7 +387,6 @@ fn deep_equals_with_maps() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_same_reference() -> anyhow::Result<()> {
     // Test that same reference is equal (optimization path)
     assert_vm_executes(Program {
@@ -422,7 +407,6 @@ fn deep_equals_same_reference() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "deep_equals builtin not yet implemented"]
 fn deep_equals_circular_structure() -> anyhow::Result<()> {
     // Test deep equals with circular references
     assert_vm_executes(Program {

--- a/baml_language/crates/baml_vm/tests/strings.rs
+++ b/baml_language/crates/baml_vm/tests/strings.rs
@@ -166,7 +166,6 @@ fn string_trim() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "string method with args not yet implemented"]
 fn string_includes() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -181,7 +180,6 @@ fn string_includes() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "string method with args not yet implemented"]
 fn string_starts_with() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -196,7 +194,6 @@ fn string_starts_with() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "string method with args not yet implemented"]
 fn string_ends_with() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -211,7 +208,6 @@ fn string_ends_with() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "string method with args not yet implemented"]
 fn string_split() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -258,7 +254,6 @@ fn string_substring_bounds() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "string method with args not yet implemented"]
 fn string_replace() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"


### PR DESCRIPTION
## Summary

- Fix type inference for generic builtin functions like `baml.deep_copy(x)` to preserve argument types instead of returning `Unknown`
- Add `substitute_with_fallback` function for proper type variable binding
- Enable 24 previously ignored tests that now pass

## Test plan

- [x] All 38 builtin/deep_copy/strings tests pass
- [x] Pre-commit hooks pass (fmt, clippy)
- [x] No regressions in baml_tir, baml_mir, baml_vm test suites