### PR TITLE
dont resend the prompt and raw output via BamlValidationError published events

### DIFF
--- a/engine/baml-rpc/src/runtime_api/baml_function_call_error.rs
+++ b/engine/baml-rpc/src/runtime_api/baml_function_call_error.rs
@@ -34,9 +34,8 @@ pub enum BamlFunctionCallError<'a> {
         raw_output: Cow<'a, str>,
     },
     Validation {
-        raw_output: Cow<'a, str>,
+        raw_output: Option<Cow<'a, str>>,
         message: Cow<'a, str>,
-        prompt: Cow<'a, str>,
-        //
+        prompt: Option<Cow<'a, str>>,
     },
 }

--- a/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/errors.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/rpc_converters/errors.rs
@@ -53,14 +53,16 @@ impl<'a> IntoRpcEvent<'a, baml_rpc::runtime_api::BamlFunctionCallError<'a>>
                 prompt: Cow::Borrowed(prompt),
                 raw_output: Cow::Borrowed(raw_output),
             },
+            // prompt and raw_output are already available in the llm_response field
+            // in the database and the http request/response data
             baml_types::tracing::events::BamlError::Validation {
-                raw_output,
+                raw_output: _,
                 message,
-                prompt,
+                prompt: _,
             } => baml_rpc::runtime_api::BamlFunctionCallError::Validation {
-                raw_output: Cow::Borrowed(raw_output),
+                raw_output: None,
                 message: Cow::Borrowed(message),
-                prompt: Cow::Borrowed(prompt),
+                prompt: None,
             },
         }
     }


### PR DESCRIPTION
We already have this info in llm request, llm response fields

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit c8c4da5eebe52a91d0248c7c68297fcafffed52c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->