### PR TITLE
Add type checking errors for invalid $watch usage

### DIFF
--- a/baml_language/crates/baml_diagnostics/src/compiler_error.rs
+++ b/baml_language/crates/baml_diagnostics/src/compiler_error.rs
@@ -90,6 +90,8 @@ const UNKNOWN_CLIENT_PROPERTY: ErrorCode = ErrorCode(27);
 const NON_EXHAUSTIVE_MATCH: ErrorCode = ErrorCode(62);
 const UNREACHABLE_ARM: ErrorCode = ErrorCode(63);
 const UNKNOWN_ENUM_VARIANT: ErrorCode = ErrorCode(64);
+const WATCH_ON_NON_VARIABLE: ErrorCode = ErrorCode(65);
+const WATCH_ON_UNWATCHED_VARIABLE: ErrorCode = ErrorCode(66);
 
 /// Render an ariadne Report to a String.
 ///

--- a/baml_language/crates/baml_diagnostics/src/compiler_error/error_format.rs
+++ b/baml_language/crates/baml_diagnostics/src/compiler_error/error_format.rs
@@ -10,7 +10,7 @@ use super::{
     NOT_INDEXABLE, NameError, ParseError, RESERVED_FIELD_NAME, Report, ReportKind, TYPE_MISMATCH,
     TypeError, UNEXPECTED_EOF, UNEXPECTED_TOKEN, UNKNOWN_ATTRIBUTE, UNKNOWN_CLIENT_PROPERTY,
     UNKNOWN_ENUM_VARIANT, UNKNOWN_GENERATOR_PROPERTY, UNKNOWN_HTTP_CONFIG_FIELD, UNKNOWN_TYPE,
-    UNKNOWN_VARIABLE, UNREACHABLE_ARM,
+    UNKNOWN_VARIABLE, UNREACHABLE_ARM, WATCH_ON_NON_VARIABLE, WATCH_ON_UNWATCHED_VARIABLE,
 };
 
 /// The message format and id of each compiler error variant.
@@ -119,6 +119,18 @@ where
                 format!("Enum '{enum_name}' has no variant '{variant_name}'"),
                 span,
                 UNKNOWN_ENUM_VARIANT,
+            ),
+            TypeError::WatchOnNonVariable { span } => simple_error(
+                "$watch can only be used on simple variable expressions".to_string(),
+                span,
+                WATCH_ON_NON_VARIABLE,
+            ),
+            TypeError::WatchOnUnwatchedVariable { name, span } => simple_error(
+                format!(
+                    "Cannot use $watch on '{name}': variable must be declared with `watch let`"
+                ),
+                span,
+                WATCH_ON_UNWATCHED_VARIABLE,
             ),
         },
         CompilerError::NameError(name_error) => match name_error {

--- a/baml_language/crates/baml_diagnostics/src/compiler_error/type_error.rs
+++ b/baml_language/crates/baml_diagnostics/src/compiler_error/type_error.rs
@@ -48,6 +48,10 @@ pub enum TypeError<T> {
         variant_name: String,
         span: Span,
     },
+    /// Using $watch on a non-variable expression (e.g., `arr[0].$watch`).
+    WatchOnNonVariable { span: Span },
+    /// Using $watch on a variable not declared with `watch let`.
+    WatchOnUnwatchedVariable { name: String, span: Span },
 }
 
 impl<T> TypeError<T> {
@@ -123,6 +127,13 @@ impl<T> TypeError<T> {
                 variant_name: variant_name.clone(),
                 span: *span,
             },
+            TypeError::WatchOnNonVariable { span } => TypeError::WatchOnNonVariable { span: *span },
+            TypeError::WatchOnUnwatchedVariable { name, span } => {
+                TypeError::WatchOnUnwatchedVariable {
+                    name: name.clone(),
+                    span: *span,
+                }
+            }
         }
     }
 }

--- a/baml_language/crates/baml_language_server/src/server/api/diagnostics.rs
+++ b/baml_language/crates/baml_language_server/src/server/api/diagnostics.rs
@@ -492,6 +492,16 @@ fn type_error_to_diagnostic<T: std::fmt::Display>(
             span,
             "E0064",
         ),
+        TypeError::WatchOnNonVariable { span } => (
+            "$watch can only be used on simple variable expressions".to_string(),
+            span,
+            "E0065",
+        ),
+        TypeError::WatchOnUnwatchedVariable { name, span } => (
+            format!("Cannot use $watch on `{name}`: variable must be declared with `watch let`"),
+            span,
+            "E0066",
+        ),
     };
 
     let (_, source_text, line_index) = file_info.get(&span.file_id)?;
@@ -535,6 +545,8 @@ fn get_type_error_file_id<T>(error: &TypeError<T>) -> FileId {
         TypeError::NonExhaustiveMatch { span, .. } => span.file_id,
         TypeError::UnreachableArm { span, .. } => span.file_id,
         TypeError::UnknownEnumVariant { span, .. } => span.file_id,
+        TypeError::WatchOnNonVariable { span, .. } => span.file_id,
+        TypeError::WatchOnUnwatchedVariable { span, .. } => span.file_id,
     }
 }
 

--- a/baml_language/crates/baml_onionskin/src/compiler.rs
+++ b/baml_language/crates/baml_onionskin/src/compiler.rs
@@ -2292,6 +2292,8 @@ fn get_error_file_id(error: &StoredCompilerError) -> FileId {
             TypeError::NonExhaustiveMatch { span, .. } => span.file_id,
             TypeError::UnreachableArm { span, .. } => span.file_id,
             TypeError::UnknownEnumVariant { span, .. } => span.file_id,
+            TypeError::WatchOnNonVariable { span, .. } => span.file_id,
+            TypeError::WatchOnUnwatchedVariable { span, .. } => span.file_id,
         },
         CompilerError::NameError(e) => match e {
             baml_diagnostics::NameError::DuplicateName { second, .. } => second.file_id,

--- a/baml_language/crates/baml_tir/src/lib.rs
+++ b/baml_language/crates/baml_tir/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! This follows patterns from rust-analyzer and ruff for incremental type checking.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use baml_base::{FileId, Name, Span};
 use baml_diagnostics::compiler_error::TypeError;
@@ -295,6 +295,8 @@ pub struct TypeContext<'db> {
     errors: Vec<TypeError<Ty<'db>>>,
     /// The current file being typechecked
     file_id: FileId,
+    /// Variables declared with `watch let` (tracked for $watch validation).
+    watched_vars: HashSet<Name>,
 }
 
 impl<'db> TypeContext<'db> {
@@ -315,6 +317,7 @@ impl<'db> TypeContext<'db> {
             return_types: Vec::new(),
             errors: Vec::new(),
             file_id,
+            watched_vars: HashSet::new(),
         }
     }
 
@@ -337,6 +340,7 @@ impl<'db> TypeContext<'db> {
             return_types: Vec::new(),
             errors: Vec::new(),
             file_id,
+            watched_vars: HashSet::new(),
         }
     }
 
@@ -361,6 +365,7 @@ impl<'db> TypeContext<'db> {
             return_types: Vec::new(),
             errors: Vec::new(),
             file_id,
+            watched_vars: HashSet::new(),
         }
     }
 
@@ -429,6 +434,16 @@ impl<'db> TypeContext<'db> {
     /// Add a type error.
     pub fn push_error(&mut self, error: TypeError<Ty<'db>>) {
         self.errors.push(error);
+    }
+
+    /// Mark a variable as watched (declared with `watch let`).
+    pub fn mark_watched(&mut self, name: Name) {
+        self.watched_vars.insert(name);
+    }
+
+    /// Check if a variable is watched (declared with `watch let`).
+    pub fn is_watched(&self, name: &Name) -> bool {
+        self.watched_vars.contains(name)
     }
 
     /// Get the database reference.
@@ -960,6 +975,28 @@ fn infer_expr<'db>(ctx: &mut TypeContext<'db>, expr_id: ExprId, body: &ExprBody)
         }
 
         Expr::FieldAccess { base, field } => {
+            // Special validation for $watch accessor
+            if field.as_str() == "$watch" {
+                // $watch can only be used on simple variable expressions
+                let base_expr = &body.exprs[*base];
+                match base_expr {
+                    Expr::Path(segments) if segments.len() == 1 => {
+                        // Simple variable - check if it's declared as watched
+                        let var_name = &segments[0];
+                        if !ctx.is_watched(var_name) {
+                            ctx.push_error(TypeError::WatchOnUnwatchedVariable {
+                                name: var_name.to_string(),
+                                span,
+                            });
+                        }
+                    }
+                    _ => {
+                        // Not a simple variable (e.g., arr[0].$watch, obj.field.$watch)
+                        ctx.push_error(TypeError::WatchOnNonVariable { span });
+                    }
+                }
+            }
+
             let base_ty = infer_expr(ctx, *base, body);
             infer_field_access(ctx, &base_ty, field, span)
         }
@@ -1676,7 +1713,7 @@ fn check_stmt(ctx: &mut TypeContext<'_>, stmt_id: StmtId, body: &ExprBody) {
             type_annotation,
             type_span,
             initializer,
-            ..
+            is_watched,
         } => {
             let ty = if let Some(init) = initializer {
                 let init_ty = infer_expr(ctx, *init, body);
@@ -1705,15 +1742,21 @@ fn check_stmt(ctx: &mut TypeContext<'_>, stmt_id: StmtId, body: &ExprBody) {
                 Ty::Unknown
             };
 
-            // Extract variable name from pattern
+            // Extract variable name from pattern and track watched status
             let pat = &body.patterns[*pattern];
             match pat {
                 Pattern::Binding(name) => {
                     ctx.define(name.clone(), ty);
+                    if *is_watched {
+                        ctx.mark_watched(name.clone());
+                    }
                 }
                 Pattern::TypedBinding { name, ty: _ } => {
                     // TODO: Check declared type matches inferred type
                     ctx.define(name.clone(), ty);
+                    if *is_watched {
+                        ctx.mark_watched(name.clone());
+                    }
                 }
                 Pattern::Literal(_) | Pattern::EnumVariant { .. } | Pattern::Union(_) => {
                     // Literals/enum variants/unions don't introduce bindings in let statements

--- a/baml_language/crates/baml_tir/src/pretty.rs
+++ b/baml_language/crates/baml_tir/src/pretty.rs
@@ -627,5 +627,11 @@ pub fn short_display(error: &TypeError<Ty<'_>>) -> String {
             variant_name,
             ..
         } => format!("Enum '{enum_name}' has no variant '{variant_name}'"),
+        TypeError::WatchOnNonVariable { .. } => {
+            "$watch can only be used on simple variable expressions".to_string()
+        }
+        TypeError::WatchOnUnwatchedVariable { name, .. } => {
+            format!("Cannot use $watch on '{name}': variable must be declared with `watch let`")
+        }
     }
 }

--- a/baml_language/crates/baml_vm/src/vm.rs
+++ b/baml_language/crates/baml_vm/src/vm.rs
@@ -1610,7 +1610,7 @@ impl Vm {
                     // Track this so we can unregister on scope exit
                     self.watched_vars.insert(
                         local_var_index,
-                        (watched_var_name.to_string(), function.name.clone()),
+                        (watched_var_name.clone(), function.name.clone()),
                     );
 
                     // If it's an object, build the entire dependency graph


### PR DESCRIPTION
## Summary

This PR addresses two issues identified in code review for #2908:

1. **$watch on non-variable expressions**: Using `$watch` on complex expressions like `arr[0].$watch` or `obj.field.$watch` now produces a clear type error instead of silently falling through to incorrect behavior at MIR lowering time.

2. **$watch on unwatched variables**: Using `$watch` on variables not declared with `watch let` now produces a type error, preventing silent no-ops at runtime.

## Changes

- Add `WatchOnNonVariable` and `WatchOnUnwatchedVariable` `TypeError` variants
- Track watched variables in `TypeContext` during type checking via new `watched_vars: HashSet<Name>` field
- Validate `$watch` usage in `Expr::FieldAccess` handling
- Add proper error messages and LSP diagnostics with error codes E0065 and E0066

## Files Modified

- `baml_diagnostics/src/compiler_error/type_error.rs` - New error variants
- `baml_diagnostics/src/compiler_error.rs` - Error codes
- `baml_diagnostics/src/compiler_error/error_format.rs` - Error formatting
- `baml_tir/src/lib.rs` - Type checking validation
- `baml_tir/src/pretty.rs` - Pretty printing
- `baml_onionskin/src/compiler.rs` - Error handling
- `baml_language_server/src/server/api/diagnostics.rs` - LSP diagnostics

## Test plan

- [x] All existing tests pass (299 tests)
- [x] `cargo check` passes
- [x] Pre-commit hooks pass