### PR TITLE
Optimize ReturnPhi to allow stack-neutral statements before return

### DIFF
--- a/baml_language/crates/baml_codegen/src/analysis.rs
+++ b/baml_language/crates/baml_codegen/src/analysis.rs
@@ -910,10 +910,35 @@ fn is_phi_like(
     true
 }
 
+/// Check if a MIR statement is stack-neutral (doesn't push or pop from the eval stack).
+///
+/// Stack-neutral statements can safely execute while a value meant for return sits on
+/// the stack, enabling optimizations like `ReturnPhi` even when there are statements
+/// between the assignment to `_0` and the `Return` terminator.
+fn is_stack_neutral_statement(kind: &StatementKind<'_>) -> bool {
+    match kind {
+        // These don't touch the stack at all - just update external state
+        StatementKind::Unwatch(_) => true,
+        StatementKind::VizEnter(_) | StatementKind::VizExit(_) => true,
+        StatementKind::NotifyBlock { .. } => true,
+        StatementKind::WatchNotify(_) => true,
+        StatementKind::Nop => true,
+
+        // WatchOptions pushes 2 (channel, filter) then Watch pops 2 - net neutral
+        // The return value stays at TOS throughout
+        StatementKind::WatchOptions { .. } => true,
+
+        // These modify the stack
+        StatementKind::Assign { .. } => false,
+        StatementKind::Drop(_) => false,
+    }
+}
+
 /// Check if `_0` (the return place) is a "return-phi" local.
 ///
-/// Return-phi applies when `_0` is assigned immediately before Return in each defining block.
-/// This allows us to:
+/// Return-phi applies when `_0` is assigned before Return in each defining block,
+/// with only stack-neutral statements (like Unwatch, `VizExit`) between the assignment
+/// and Return. This allows us to:
 /// - At def sites: emit rvalue but NOT `StoreVar` (leave value on stack)
 /// - At Return: skip `LoadVar` for _0 (value already on stack)
 ///
@@ -939,55 +964,76 @@ fn is_return_phi(
         return false;
     }
 
-    // Build a set of return-only blocks (empty statements + Return terminator)
-    let return_only_blocks: HashSet<BlockId> = mir
-        .blocks
-        .iter()
-        .filter(|b| b.statements.is_empty() && matches!(b.terminator, Some(Terminator::Return)))
-        .map(|b| b.id)
-        .collect();
+    // Helper: check if a block leads to Return through only stack-neutral statements.
+    // Follows Goto chains, ensuring all intermediate blocks have only stack-neutral statements.
+    let leads_to_return_safely = |start: BlockId| -> bool {
+        let mut current = start;
+        let mut visited = HashSet::new();
 
-    // Helper: resolve a target through the redirect chain
-    let resolve_target =
-        |target: BlockId| -> BlockId { redirect_targets.get(&target).copied().unwrap_or(target) };
+        loop {
+            // Avoid infinite loops
+            if !visited.insert(current) {
+                return false;
+            }
+
+            let block = mir.block(current);
+
+            // All statements in this block must be stack-neutral
+            if !block
+                .statements
+                .iter()
+                .all(|s| is_stack_neutral_statement(&s.kind))
+            {
+                return false;
+            }
+
+            match &block.terminator {
+                Some(Terminator::Return) => return true,
+                Some(Terminator::Goto { target }) => {
+                    // Follow the redirect chain
+                    current = redirect_targets.get(target).copied().unwrap_or(*target);
+                }
+                _ => return false,
+            }
+        }
+    };
 
     // Each definition block must:
-    // 1. Have the definition as the last statement (or be a terminator definition)
-    // 2. End with Return OR Goto/Call to a return-only block (after following redirects)
+    // 1. Have the definition followed only by stack-neutral statements (or be a terminator definition)
+    // 2. End with Return OR lead to Return through only stack-neutral blocks
     for &(block_id, stmt_idx) in defs {
         let block = mir.block(block_id);
 
         // Handle terminator definitions (Call, DispatchFuture, Await)
         if stmt_idx == TERMINATOR_IDX {
-            // For terminator definitions, check if the continuation is return-only
+            // For terminator definitions, check if the continuation leads to return safely
             let continuation = match &block.terminator {
                 Some(Terminator::Call { target, .. }) => Some(*target),
                 Some(Terminator::DispatchFuture { resume, .. }) => Some(*resume),
                 Some(Terminator::Await { target, .. }) => Some(*target),
                 _ => None,
             };
-            let valid = continuation.is_some_and(|target| {
-                let resolved = resolve_target(target);
-                return_only_blocks.contains(&resolved)
-            });
+            let valid = continuation.is_some_and(leads_to_return_safely);
             if !valid {
                 return false;
             }
             continue;
         }
 
-        // For regular Assign statements: definition must be the last statement
-        if stmt_idx + 1 != block.statements.len() {
+        // For regular Assign statements: all statements after the definition must be stack-neutral
+        let statements_after_def_are_neutral = block.statements[stmt_idx + 1..]
+            .iter()
+            .all(|s| is_stack_neutral_statement(&s.kind));
+        if !statements_after_def_are_neutral {
             return false;
         }
 
-        // Block must end with Return or Goto to return-only block
-        // Follow redirect chain for jump threading
+        // Block must end with Return or lead to Return through stack-neutral blocks
         let valid_terminator = match &block.terminator {
             Some(Terminator::Return) => true,
             Some(Terminator::Goto { target }) => {
-                let resolved = resolve_target(*target);
-                return_only_blocks.contains(&resolved)
+                let resolved = redirect_targets.get(target).copied().unwrap_or(*target);
+                leads_to_return_safely(resolved)
             }
             _ => false,
         };

--- a/baml_language/crates/baml_codegen/tests/watch.rs
+++ b/baml_language/crates/baml_codegen/tests/watch.rs
@@ -21,8 +21,7 @@ fn watch_primitive() -> anyhow::Result<()> {
         expected: vec![(
             "primitive",
             vec![
-                // Initialize locals with null
-                Instruction::LoadConst(Value::Null),
+                // Initialize locals with null (only "value" needs a slot now, _0 is ReturnPhi)
                 Instruction::LoadConst(Value::Null),
                 // Initialize watched variable
                 Instruction::LoadConst(Value::Int(0)),
@@ -30,16 +29,15 @@ fn watch_primitive() -> anyhow::Result<()> {
                 // Register watch (only once, at initialization)
                 Instruction::LoadConst(Value::string("value")), // channel "value"
                 Instruction::LoadConst(Value::Null),            // filter null
-                Instruction::Watch(2),
+                Instruction::Watch(1),
                 // Assignment: value = 1
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("value".to_string()),
-                // Return value
+                // Return value - _0 is ReturnPhi, so value stays on stack through Unwatch
                 Instruction::LoadVar("value".to_string()),
-                Instruction::StoreVar("_0".to_string()),
-                // Unwatch on scope exit
-                Instruction::Unwatch(2),
-                Instruction::LoadVar("_0".to_string()),
+                // Unwatch on scope exit (stack-neutral, doesn't disturb TOS)
+                Instruction::Unwatch(1),
+                // No StoreVar/LoadVar for _0 - value already on stack
                 Instruction::Return,
             ],
         )],
@@ -66,20 +64,17 @@ fn viz_header_before_if_emits_viz_enter_exit() -> anyhow::Result<()> {
         expected: vec![(
             "header_before_if",
             vec![
-                Instruction::LoadConst(Value::Null), // result temp init
-                Instruction::NotifyBlock(0),         // //# MyHeader
-                Instruction::VizEnter(0),            // VizEnter because header precedes if
+                // No result temp init - _0 is ReturnPhi (VizExit is stack-neutral)
+                Instruction::NotifyBlock(0), // //# MyHeader
+                Instruction::VizEnter(0),    // VizEnter because header precedes if
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::PopJumpIfFalse(2),
-                Instruction::Jump(4),
-                Instruction::LoadConst(Value::Int(2)), // else branch
-                Instruction::StoreVar("_0".to_string()),
                 Instruction::Jump(3),
-                Instruction::LoadConst(Value::Int(1)), // then branch
-                Instruction::StoreVar("_0".to_string()),
-                Instruction::VizExit(0), // VizExit at join
-                Instruction::LoadVar("_0".to_string()),
-                Instruction::Return,
+                Instruction::LoadConst(Value::Int(2)), // else branch - stays on stack
+                Instruction::Jump(2),
+                Instruction::LoadConst(Value::Int(1)), // then branch - stays on stack
+                Instruction::VizExit(0),               // VizExit at join (stack-neutral)
+                Instruction::Return,                   // value already on stack
             ],
         )],
     })
@@ -165,7 +160,7 @@ fn viz_multiple_headers_only_one_before_if() -> anyhow::Result<()> {
         expected: vec![(
             "multiple_headers",
             vec![
-                Instruction::LoadConst(Value::Null),   // result temp
+                // No result temp - _0 is ReturnPhi (VizExit is stack-neutral)
                 Instruction::NotifyBlock(0), // //# FirstHeader - no VizEnter (not before control flow)
                 Instruction::NotifyBlock(1), // //# SecondHeader
                 Instruction::VizEnter(0),    // VizEnter because this header precedes if
@@ -173,15 +168,12 @@ fn viz_multiple_headers_only_one_before_if() -> anyhow::Result<()> {
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::CmpOp(CmpOp::Gt),
                 Instruction::PopJumpIfFalse(2),
-                Instruction::Jump(4),
-                Instruction::LoadConst(Value::Int(3)), // else branch
-                Instruction::StoreVar("_0".to_string()),
                 Instruction::Jump(3),
-                Instruction::LoadConst(Value::Int(2)), // then branch
-                Instruction::StoreVar("_0".to_string()),
-                Instruction::VizExit(0), // VizExit at join
-                Instruction::LoadVar("_0".to_string()),
-                Instruction::Return,
+                Instruction::LoadConst(Value::Int(3)), // else branch - stays on stack
+                Instruction::Jump(2),
+                Instruction::LoadConst(Value::Int(2)), // then branch - stays on stack
+                Instruction::VizExit(0),               // VizExit at join (stack-neutral)
+                Instruction::Return,                   // value already on stack
             ],
         )],
     })


### PR DESCRIPTION
## Summary

- Extends the `is_return_phi` optimization to handle cases where stack-neutral statements appear between the `_0` assignment and Return
- Stack-neutral statements (Unwatch, VizExit, VizEnter, NotifyBlock, WatchOptions, WatchNotify) don't disturb values on the stack
- Previously these cases required storing `_0` to a local slot and reloading it after the side-effect instruction

## Changes

- Add `is_stack_neutral_statement` helper function to classify MIR statements
- Replace simple "return-only blocks" check with `leads_to_return_safely` that follows Goto chains through blocks with only stack-neutral statements
- Update watch.rs tests to expect the optimized bytecode output

## Example

For a watched variable:
```baml
function primitive() -> int {
    watch let value = 0;
    value = 1;
    value
}
```

**Before:** `LoadVar("value"), StoreVar("_0"), Unwatch, LoadVar("_0"), Return`
**After:** `LoadVar("value"), Unwatch, Return`

Saves 2 instructions and 1 local slot per occurrence.

## Test plan

- [x] All existing tests pass
- [x] Updated watch.rs tests verify optimized bytecode for:
  - `watch_primitive` - Unwatch between value and return
  - `viz_header_before_if_emits_viz_enter_exit` - VizExit at join point
  - `viz_multiple_headers_only_one_before_if` - VizExit at join point