### PR TITLE
Optimize exhaustive match expressions with DCE for unreachable blocks

### DIFF
--- a/baml_language/crates/baml_codegen/src/analysis.rs
+++ b/baml_language/crates/baml_codegen/src/analysis.rs
@@ -251,6 +251,14 @@ fn compute_rpo(mir: &MirFunction<'_>) -> Vec<BlockId> {
     postorder
 }
 
+/// Check if a block is a "dead" unreachable block that can be skipped during emission.
+///
+/// A block is dead if it has no statements and terminates with `Unreachable`.
+/// Such blocks exist only as targets for impossible control flow paths.
+pub(crate) fn is_dead_unreachable_block(block: &baml_mir::BasicBlock<'_>) -> bool {
+    block.statements.is_empty() && matches!(block.terminator, Some(Terminator::Unreachable))
+}
+
 // ============================================================================
 // Jump Threading
 // ============================================================================

--- a/baml_language/crates/baml_codegen/src/emit.rs
+++ b/baml_language/crates/baml_codegen/src/emit.rs
@@ -105,7 +105,18 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
             self.block_addresses.insert(block_id, self.current_pc());
             // Track the next block for fall-through optimization
             self.next_block = rpo.get(i + 1).copied();
-            self.emit_block(mir.block(block_id), mir);
+
+            // Skip emitting dead unreachable blocks - they're targets for impossible
+            // control flow paths (e.g., exhaustive match fallthrough). We record
+            // their address (current PC) so jumps to them resolve, but don't emit
+            // any instructions. If somehow reached, execution falls through to
+            // whatever comes next.
+            let block = mir.block(block_id);
+            if crate::analysis::is_dead_unreachable_block(block) {
+                continue;
+            }
+
+            self.emit_block(block, mir);
         }
 
         // 3. Patch all jump targets
@@ -791,6 +802,18 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
             }
 
             Terminator::Unreachable => {
+                // TODO(#UNREACHABLE): This code should NEVER be reached at runtime.
+                // Currently we emit a safety return of null, but this is a fallback
+                // that masks bugs. We should instead:
+                //
+                // 1. Add a `Panic` instruction to the VM that halts execution with
+                //    an error message like "reached unreachable code".
+                // 2. Emit `Instruction::Panic("unreachable")` here instead.
+                // 3. Consider adding dead code elimination to remove unreachable
+                //    blocks entirely during compilation.
+                //
+                // For now, we return null to avoid undefined behavior if this is
+                // somehow reached due to a compiler bug or type system unsoundness.
                 let idx = self.add_constant(Value::Null);
                 self.emit(Instruction::LoadConst(idx));
                 self.emit(Instruction::Return);

--- a/baml_language/crates/baml_codegen/tests/match_expr.rs
+++ b/baml_language/crates/baml_codegen/tests/match_expr.rs
@@ -100,18 +100,19 @@ fn match_literal_bool_exhaustive() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             // Constant propagation: scrutinee true is inlined at each comparison
+            // Exhaustive match: unreachable fallthrough block is eliminated by DCE
             vec![
                 Instruction::LoadConst(Value::Bool(true)), // scrutinee (inlined)
                 Instruction::LoadConst(Value::Bool(true)), // literal true
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(2), // if false, try next arm
-                Instruction::Jump(9),           // if true, skip to "yes"
+                Instruction::Jump(8),           // if true, skip to "yes"
                 Instruction::LoadConst(Value::Bool(true)), // scrutinee (inlined)
                 Instruction::LoadConst(Value::Bool(false)), // literal false
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(6), // if false (shouldn't happen)
-                Instruction::Jump(2),           // if true, skip to "no"
-                Instruction::Jump(4),           // unreachable fallthrough
+                Instruction::PopJumpIfFalse(2), // if false (unreachable - jumps to eliminated block)
+                Instruction::Jump(1),           // if true, skip to "no"
+                // Unreachable block eliminated - jump target points here
                 Instruction::LoadConst(Value::string("no")),
                 Instruction::Jump(2), // skip to return
                 Instruction::LoadConst(Value::string("yes")),
@@ -222,6 +223,7 @@ fn match_typed_pattern_two_classes() -> anyhow::Result<()> {
         "#,
         expected: vec![(
             "main",
+            // Exhaustive match: unreachable fallthrough block is eliminated by DCE
             vec![
                 Instruction::LoadConst(Value::Null), // slot for _3 (scrutinee)
                 // let result = Success { data: "ok" }
@@ -235,14 +237,14 @@ fn match_typed_pattern_two_classes() -> anyhow::Result<()> {
                 Instruction::LoadConst(Value::class("Success")),
                 Instruction::CmpOp(CmpOp::InstanceOf),
                 Instruction::PopJumpIfFalse(2), // if false, try Failure
-                Instruction::Jump(10),          // if true, skip to s.data
+                Instruction::Jump(9),           // if true, skip to s.data
                 // f: Failure instanceof check
                 Instruction::LoadVar("_3".to_string()),
                 Instruction::LoadConst(Value::class("Failure")),
                 Instruction::CmpOp(CmpOp::InstanceOf),
-                Instruction::PopJumpIfFalse(8), // if false (shouldn't happen)
-                Instruction::Jump(2),           // if true, skip to f.reason
-                Instruction::Jump(6),           // unreachable fallthrough
+                Instruction::PopJumpIfFalse(2), // if false (unreachable - jumps to eliminated block)
+                Instruction::Jump(1),           // if true, skip to f.reason
+                // Unreachable block eliminated - jump target points here
                 // f: Failure arm - access f.reason
                 Instruction::LoadVar("_3".to_string()),
                 Instruction::LoadField(0),
@@ -317,25 +319,21 @@ fn match_in_arithmetic() -> anyhow::Result<()> {
         expected: vec![(
             "main",
             // Constant propagation: scrutinee 2 is inlined at each use
-            // _2 (match result) still needs slot (assigned in multiple branches)
+            // Phi-like optimization: match result stays on stack (no Store/Load)!
             // Wildcard elimination: _ binding is unused so eliminated
             vec![
-                Instruction::LoadConst(Value::Null), // slot for _2 (match result)
                 Instruction::LoadConst(Value::Int(2)), // scrutinee (inlined)
                 Instruction::LoadConst(Value::Int(2)), // literal 2
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(2), // if false, skip to catch-all
-                Instruction::Jump(4),           // if true, skip to 20
-                // Catch-all arm (no _ binding)
+                Instruction::Jump(3),           // if true, skip to first arm
+                // Catch-all arm: value stays on stack
                 Instruction::LoadConst(Value::Int(0)),
-                Instruction::StoreVar("_2".to_string()), // store match result
-                Instruction::Jump(3),                    // skip to addition
-                // First arm
+                Instruction::Jump(2), // skip to addition
+                // First arm: value stays on stack
                 Instruction::LoadConst(Value::Int(20)),
-                Instruction::StoreVar("_2".to_string()), // store match result
-                // Addition: 1 + match result
+                // Addition: 1 + match result (match result already on stack)
                 Instruction::LoadConst(Value::Int(1)),
-                Instruction::LoadVar("_2".to_string()),
                 Instruction::BinOp(baml_vm::BinOp::Add),
                 Instruction::Return,
             ],

--- a/baml_language/crates/baml_mir/src/lower.rs
+++ b/baml_language/crates/baml_mir/src/lower.rs
@@ -815,7 +815,11 @@ impl<'db, 'ctx> LoweringContext<'db, 'ctx> {
                 );
             }
 
-            Expr::Match { scrutinee, arms } => {
+            Expr::Match {
+                scrutinee,
+                arms,
+                is_exhaustive,
+            } => {
                 // Lower scrutinee to a temp
                 let scrutinee_ty = Self::lower_typed_ir_ty(body.ty(*scrutinee));
                 let scrutinee_local = self.builder.temp(scrutinee_ty.clone());
@@ -824,10 +828,33 @@ impl<'db, 'ctx> LoweringContext<'db, 'ctx> {
                 // Create join block
                 let join_block = self.builder.create_block();
 
+                // For exhaustive matches, the last arm's failure path is unreachable.
+                // We create a single unreachable block to use as that target, avoiding
+                // the creation of an empty fallthrough block that would need to be emitted.
+                let unreachable_block = if *is_exhaustive {
+                    let saved_block = self.builder.current_block();
+                    let block = self.builder.create_block();
+                    self.builder.set_current_block(block);
+                    self.builder.unreachable();
+                    self.builder.set_current_block(saved_block);
+                    Some(block)
+                } else {
+                    None
+                };
+
                 // For each arm, create test and body blocks
-                for arm in arms {
+                let last_arm_idx = arms.len().saturating_sub(1);
+                for (i, arm) in arms.iter().enumerate() {
+                    let is_last_arm = i == last_arm_idx;
                     let arm_block = self.builder.create_block();
-                    let next_block = self.builder.create_block();
+
+                    // For the last arm of an exhaustive match, pattern failure goes
+                    // to the unreachable block. Otherwise, create a next_block.
+                    let next_block = if is_last_arm && *is_exhaustive {
+                        unreachable_block.expect("unreachable_block created for exhaustive match")
+                    } else {
+                        self.builder.create_block()
+                    };
 
                     // Generate pattern test
                     self.lower_pattern_test(
@@ -863,11 +890,18 @@ impl<'db, 'ctx> LoweringContext<'db, 'ctx> {
                     self.lower_expr(arm.body, dest.clone(), body);
                     self.builder.goto(join_block);
 
-                    self.builder.set_current_block(next_block);
+                    // Only set current block to next_block if it's not the unreachable block
+                    if !(is_last_arm && *is_exhaustive) {
+                        self.builder.set_current_block(next_block);
+                    }
                 }
 
-                // Fallthrough (should be unreachable with exhaustive matching)
-                self.builder.goto(join_block);
+                if !*is_exhaustive {
+                    // Non-exhaustive match: fallthrough could be reached.
+                    // This is typically a type error, but we generate valid MIR.
+                    // TODO: Consider emitting a runtime panic instruction instead.
+                    self.builder.goto(join_block);
+                }
                 self.builder.set_current_block(join_block);
             }
 

--- a/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_5_mir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-eb448e436f8a003a/out/generated_tests.rs
+source: target/debug/build/baml_tests-1e9ee45736f74339/out/generated_tests.rs
 expression: output
 ---
 === MIR ===
@@ -33,7 +33,7 @@ fn MixedLiteralAndTyped(x: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 42_i64;
-        branch copy _3 -> [bb3, bb5];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -45,22 +45,22 @@ fn MixedLiteralAndTyped(x: Int) -> String {
     }
 
     bb3: {
-        _0 = const "mixed";
-        goto -> bb2;
+        unreachable;
     }
 
     bb4: {
+        _0 = const "mixed";
         goto -> bb2;
     }
 
     bb5: {
         _4 = is_type(copy _2, Int);
-        branch copy _4 -> [bb6, bb4];
+        branch copy _4 -> [bb6, bb3];
     }
 
     bb6: {
         _5 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
 }

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-17af2d4231950a65/out/generated_tests.rs
+source: target/debug/build/baml_tests-1e9ee45736f74339/out/generated_tests.rs
 expression: output
 ---
 === MIR ===
@@ -22,7 +22,7 @@ fn NestedLiteralUnions(code: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 200_i64;
-        branch copy _3 -> [bb3, bb5];
+        branch copy _3 -> [bb4, bb6];
     }
 
     bb1: {
@@ -34,66 +34,66 @@ fn NestedLiteralUnions(code: Int) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "success";
         goto -> bb2;
     }
 
-    bb4: {
-        _7 = copy _2 == const 400_i64;
-        branch copy _7 -> [bb8, bb10];
-    }
-
     bb5: {
-        _4 = copy _2 == const 201_i64;
-        branch copy _4 -> [bb3, bb6];
+        _7 = copy _2 == const 400_i64;
+        branch copy _7 -> [bb9, bb11];
     }
 
     bb6: {
-        _5 = copy _2 == const 202_i64;
-        branch copy _5 -> [bb3, bb7];
+        _4 = copy _2 == const 201_i64;
+        branch copy _4 -> [bb4, bb7];
     }
 
     bb7: {
-        _6 = copy _2 == const 204_i64;
-        branch copy _6 -> [bb3, bb4];
+        _5 = copy _2 == const 202_i64;
+        branch copy _5 -> [bb4, bb8];
     }
 
     bb8: {
+        _6 = copy _2 == const 204_i64;
+        branch copy _6 -> [bb4, bb5];
+    }
+
+    bb9: {
         _0 = const "client error";
         goto -> bb2;
     }
 
-    bb9: {
-        _12 = copy _2;
-        goto -> bb14;
-    }
-
     bb10: {
-        _8 = copy _2 == const 404_i64;
-        branch copy _8 -> [bb8, bb11];
+        _12 = copy _2;
+        goto -> bb15;
     }
 
     bb11: {
-        _9 = copy _2 == const 405_i64;
-        branch copy _9 -> [bb8, bb12];
+        _8 = copy _2 == const 404_i64;
+        branch copy _8 -> [bb9, bb12];
     }
 
     bb12: {
-        _10 = copy _2 == const 406_i64;
-        branch copy _10 -> [bb8, bb13];
+        _9 = copy _2 == const 405_i64;
+        branch copy _9 -> [bb9, bb13];
     }
 
     bb13: {
-        _11 = copy _2 == const 409_i64;
-        branch copy _11 -> [bb8, bb9];
+        _10 = copy _2 == const 406_i64;
+        branch copy _10 -> [bb9, bb14];
     }
 
     bb14: {
-        _0 = const "other";
-        goto -> bb2;
+        _11 = copy _2 == const 409_i64;
+        branch copy _11 -> [bb9, bb10];
     }
 
     bb15: {
+        _0 = const "other";
         goto -> bb2;
     }
 
@@ -110,7 +110,7 @@ fn ExhaustiveEnumWithTypedPattern(s: Named("Status")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = is_type(copy _2, Named("Status"));
-        branch copy _3 -> [bb5, bb4];
+        branch copy _3 -> [bb5, bb3];
     }
 
     bb1: {
@@ -122,17 +122,17 @@ fn ExhaustiveEnumWithTypedPattern(s: Named("Status")) -> String {
     }
 
     bb3: {
-        _0 = const "any status";
-        goto -> bb2;
+        unreachable;
     }
 
     bb4: {
+        _0 = const "any status";
         goto -> bb2;
     }
 
     bb5: {
         _4 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
 }
@@ -148,7 +148,7 @@ fn ParenthesizedSingleLiteral(b: Bool) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const true;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -160,21 +160,21 @@ fn ParenthesizedSingleLiteral(b: Bool) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "yes";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = copy _2 == const false;
-        branch copy _4 -> [bb5, bb6];
-    }
-
     bb5: {
-        _0 = const "no";
-        goto -> bb2;
+        _4 = copy _2 == const false;
+        branch copy _4 -> [bb6, bb3];
     }
 
     bb6: {
+        _0 = const "no";
         goto -> bb2;
     }
 
@@ -291,7 +291,7 @@ fn UnreachableMultiple(x: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
     bb1: {
@@ -303,42 +303,42 @@ fn UnreachableMultiple(x: Int) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "catch all";
         goto -> bb2;
     }
 
-    bb4: {
+    bb5: {
         _4 = is_type(copy _2, Int);
-        branch copy _4 -> [bb7, bb6];
+        branch copy _4 -> [bb8, bb7];
     }
 
-    bb5: {
+    bb6: {
         _0 = const "unreachable 1";
         goto -> bb2;
     }
 
-    bb6: {
-        _6 = is_type(copy _2, Int);
-        branch copy _6 -> [bb10, bb9];
-    }
-
     bb7: {
-        _5 = copy _2;
-        goto -> bb5;
+        _6 = is_type(copy _2, Int);
+        branch copy _6 -> [bb10, bb3];
     }
 
     bb8: {
-        _0 = const "unreachable 2";
-        goto -> bb2;
+        _5 = copy _2;
+        goto -> bb6;
     }
 
     bb9: {
+        _0 = const "unreachable 2";
         goto -> bb2;
     }
 
     bb10: {
         _7 = copy _2;
-        goto -> bb8;
+        goto -> bb9;
     }
 
 }
@@ -622,7 +622,7 @@ fn EnumVariantAfterTypedEnum(s: Named("Status")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = is_type(copy _2, Named("Status"));
-        branch copy _3 -> [bb5, bb4];
+        branch copy _3 -> [bb6, bb5];
     }
 
     bb1: {
@@ -634,26 +634,26 @@ fn EnumVariantAfterTypedEnum(s: Named("Status")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "any status";
         goto -> bb2;
     }
 
-    bb4: {
-        _5 = copy _2 == const Status.Active;
-        branch copy _5 -> [bb6, bb7];
-    }
-
     bb5: {
-        _4 = copy _2;
-        goto -> bb3;
+        _5 = copy _2 == const Status.Active;
+        branch copy _5 -> [bb7, bb3];
     }
 
     bb6: {
-        _0 = const "unreachable";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb4;
     }
 
     bb7: {
+        _0 = const "unreachable";
         goto -> bb2;
     }
 
@@ -671,7 +671,7 @@ fn BoolLiteralAfterTypedBool(b: Bool) -> String {
     bb0: {
         _2 = copy _1;
         _3 = is_type(copy _2, Bool);
-        branch copy _3 -> [bb5, bb4];
+        branch copy _3 -> [bb6, bb5];
     }
 
     bb1: {
@@ -683,26 +683,26 @@ fn BoolLiteralAfterTypedBool(b: Bool) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "any bool";
         goto -> bb2;
     }
 
-    bb4: {
-        _5 = copy _2 == const true;
-        branch copy _5 -> [bb6, bb7];
-    }
-
     bb5: {
-        _4 = copy _2;
-        goto -> bb3;
+        _5 = copy _2 == const true;
+        branch copy _5 -> [bb7, bb3];
     }
 
     bb6: {
-        _0 = const "unreachable";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb4;
     }
 
     bb7: {
+        _0 = const "unreachable";
         goto -> bb2;
     }
 
@@ -722,7 +722,7 @@ fn LiteralUnionWithCatchAll(code: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 200_i64;
-        branch copy _3 -> [bb3, bb5];
+        branch copy _3 -> [bb4, bb6];
     }
 
     bb1: {
@@ -734,41 +734,41 @@ fn LiteralUnionWithCatchAll(code: Int) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "success";
         goto -> bb2;
     }
 
-    bb4: {
-        _5 = copy _2 == const 400_i64;
-        branch copy _5 -> [bb6, bb8];
-    }
-
     bb5: {
-        _4 = copy _2 == const 201_i64;
-        branch copy _4 -> [bb3, bb4];
+        _5 = copy _2 == const 400_i64;
+        branch copy _5 -> [bb7, bb9];
     }
 
     bb6: {
+        _4 = copy _2 == const 201_i64;
+        branch copy _4 -> [bb4, bb5];
+    }
+
+    bb7: {
         _0 = const "client error";
         goto -> bb2;
     }
 
-    bb7: {
-        _7 = copy _2;
-        goto -> bb9;
-    }
-
     bb8: {
-        _6 = copy _2 == const 404_i64;
-        branch copy _6 -> [bb6, bb7];
+        _7 = copy _2;
+        goto -> bb10;
     }
 
     bb9: {
-        _0 = const "other";
-        goto -> bb2;
+        _6 = copy _2 == const 404_i64;
+        branch copy _6 -> [bb7, bb8];
     }
 
     bb10: {
+        _0 = const "other";
         goto -> bb2;
     }
 
@@ -840,7 +840,7 @@ fn ExhaustiveStringLiterals(role: Named("Role")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
     bb1: {
@@ -852,31 +852,31 @@ fn ExhaustiveStringLiterals(role: Named("Role")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "User";
         goto -> bb2;
     }
 
-    bb4: {
+    bb5: {
         _4 = copy _2;
-        goto -> bb5;
+        goto -> bb6;
     }
 
-    bb5: {
+    bb6: {
         _0 = const "Assistant";
         goto -> bb2;
     }
 
-    bb6: {
-        _5 = copy _2;
-        goto -> bb7;
-    }
-
     bb7: {
-        _0 = const "System";
-        goto -> bb2;
+        _5 = copy _2;
+        goto -> bb8;
     }
 
     bb8: {
+        _0 = const "System";
         goto -> bb2;
     }
 
@@ -895,7 +895,7 @@ fn ExhaustiveTypeAliasWithCatchAll(r: Named("Result")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = is_type(copy _2, Named("Success"));
-        branch copy _3 -> [bb5, bb4];
+        branch copy _3 -> [bb6, bb5];
     }
 
     bb1: {
@@ -907,27 +907,27 @@ fn ExhaustiveTypeAliasWithCatchAll(r: Named("Result")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _5 = copy _4;
         _0 = copy _5.0;
         goto -> bb2;
     }
 
-    bb4: {
-        _6 = copy _2;
-        goto -> bb6;
-    }
-
     bb5: {
-        _4 = copy _2;
-        goto -> bb3;
+        _6 = copy _2;
+        goto -> bb7;
     }
 
     bb6: {
-        _0 = const "fallback";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb4;
     }
 
     bb7: {
+        _0 = const "fallback";
         goto -> bb2;
     }
 
@@ -945,7 +945,7 @@ fn DuplicateIntLiteral(x: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 1_i64;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -957,31 +957,31 @@ fn DuplicateIntLiteral(x: Int) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "first one";
         goto -> bb2;
     }
 
-    bb4: {
+    bb5: {
         _4 = copy _2 == const 1_i64;
-        branch copy _4 -> [bb5, bb6];
+        branch copy _4 -> [bb6, bb7];
     }
 
-    bb5: {
+    bb6: {
         _0 = const "second one";
         goto -> bb2;
     }
 
-    bb6: {
-        _5 = copy _2;
-        goto -> bb7;
-    }
-
     bb7: {
-        _0 = const "other";
-        goto -> bb2;
+        _5 = copy _2;
+        goto -> bb8;
     }
 
     bb8: {
+        _0 = const "other";
         goto -> bb2;
     }
 
@@ -1050,7 +1050,7 @@ fn ExhaustiveLiteralWithBaseType(x: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 200_i64;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -1062,27 +1062,27 @@ fn ExhaustiveLiteralWithBaseType(x: Int) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "ok";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = is_type(copy _2, Int);
-        branch copy _4 -> [bb7, bb6];
-    }
-
     bb5: {
-        _0 = const "other";
-        goto -> bb2;
+        _4 = is_type(copy _2, Int);
+        branch copy _4 -> [bb7, bb3];
     }
 
     bb6: {
+        _0 = const "other";
         goto -> bb2;
     }
 
     bb7: {
         _5 = copy _2;
-        goto -> bb5;
+        goto -> bb6;
     }
 
 }
@@ -1192,7 +1192,7 @@ fn BoolUnionPattern(b: Bool) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const true;
-        branch copy _3 -> [bb3, bb5];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -1204,17 +1204,17 @@ fn BoolUnionPattern(b: Bool) -> String {
     }
 
     bb3: {
-        _0 = const "covered";
-        goto -> bb2;
+        unreachable;
     }
 
     bb4: {
+        _0 = const "covered";
         goto -> bb2;
     }
 
     bb5: {
         _4 = copy _2 == const false;
-        branch copy _4 -> [bb3, bb4];
+        branch copy _4 -> [bb4, bb3];
     }
 
 }
@@ -1230,7 +1230,7 @@ fn StringLiteralUnionPattern(role: Named("Role")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
     bb1: {
@@ -1242,21 +1242,21 @@ fn StringLiteralUnionPattern(role: Named("Role")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "chat participant";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = copy _2;
-        goto -> bb5;
-    }
-
     bb5: {
-        _0 = const "system";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb6;
     }
 
     bb6: {
+        _0 = const "system";
         goto -> bb2;
     }
 
@@ -1273,7 +1273,7 @@ fn ExhaustiveBool(b: Bool) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const true;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -1285,21 +1285,21 @@ fn ExhaustiveBool(b: Bool) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "yes";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = copy _2 == const false;
-        branch copy _4 -> [bb5, bb6];
-    }
-
     bb5: {
-        _0 = const "no";
-        goto -> bb2;
+        _4 = copy _2 == const false;
+        branch copy _4 -> [bb6, bb3];
     }
 
     bb6: {
+        _0 = const "no";
         goto -> bb2;
     }
 
@@ -1488,7 +1488,7 @@ fn BoolWithCatchAll(b: Bool) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const true;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -1500,21 +1500,21 @@ fn BoolWithCatchAll(b: Bool) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "yes";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = copy _2;
-        goto -> bb5;
-    }
-
     bb5: {
-        _0 = const "no";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb6;
     }
 
     bb6: {
+        _0 = const "no";
         goto -> bb2;
     }
 
@@ -1817,7 +1817,7 @@ fn ExhaustiveMixedLiterals(x: Named("MixedLiterals")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 200_i64;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -1829,31 +1829,31 @@ fn ExhaustiveMixedLiterals(x: Named("MixedLiterals")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "http ok";
         goto -> bb2;
     }
 
-    bb4: {
+    bb5: {
         _4 = copy _2;
-        goto -> bb5;
+        goto -> bb6;
     }
 
-    bb5: {
+    bb6: {
         _0 = const "string success";
         goto -> bb2;
     }
 
-    bb6: {
-        _5 = copy _2 == const true;
-        branch copy _5 -> [bb7, bb8];
-    }
-
     bb7: {
-        _0 = const "boolean true";
-        goto -> bb2;
+        _5 = copy _2 == const true;
+        branch copy _5 -> [bb8, bb3];
     }
 
     bb8: {
+        _0 = const "boolean true";
         goto -> bb2;
     }
 
@@ -1962,7 +1962,7 @@ fn NestedMatchSpans(x: Int, y: Bool) -> String {
     bb0: {
         _3 = copy _1;
         _4 = copy _3 == const 0_i64;
-        branch copy _4 -> [bb3, bb4];
+        branch copy _4 -> [bb4, bb5];
     }
 
     bb1: {
@@ -1974,55 +1974,55 @@ fn NestedMatchSpans(x: Int, y: Bool) -> String {
     }
 
     bb3: {
-        _5 = copy _2;
-        _6 = copy _5 == const true;
-        branch copy _6 -> [bb6, bb7];
+        unreachable;
     }
 
     bb4: {
-        _9 = copy _3;
-        goto -> bb12;
+        _5 = copy _2;
+        _6 = copy _5 == const true;
+        branch copy _6 -> [bb8, bb9];
     }
 
     bb5: {
-        goto -> bb2;
+        _9 = copy _3;
+        goto -> bb13;
     }
 
     bb6: {
-        _0 = const "zero true";
-        goto -> bb5;
-    }
-
-    bb7: {
-        _7 = copy _5 == const false;
-        branch copy _7 -> [bb8, bb9];
-    }
-
-    bb8: {
-        _0 = const "zero false";
-        goto -> bb5;
-    }
-
-    bb9: {
-        _8 = copy _5 == const true;
-        branch copy _8 -> [bb10, bb11];
-    }
-
-    bb10: {
-        _0 = const "unreachable nested";
-        goto -> bb5;
-    }
-
-    bb11: {
-        goto -> bb5;
-    }
-
-    bb12: {
-        _0 = const "other";
         goto -> bb2;
     }
 
+    bb7: {
+        unreachable;
+    }
+
+    bb8: {
+        _0 = const "zero true";
+        goto -> bb6;
+    }
+
+    bb9: {
+        _7 = copy _5 == const false;
+        branch copy _7 -> [bb10, bb11];
+    }
+
+    bb10: {
+        _0 = const "zero false";
+        goto -> bb6;
+    }
+
+    bb11: {
+        _8 = copy _5 == const true;
+        branch copy _8 -> [bb12, bb7];
+    }
+
+    bb12: {
+        _0 = const "unreachable nested";
+        goto -> bb6;
+    }
+
     bb13: {
+        _0 = const "other";
         goto -> bb2;
     }
 
@@ -2288,7 +2288,7 @@ fn ExhaustiveWithNamedCatchAll(x: Int) -> Int {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 1_i64;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -2300,23 +2300,23 @@ fn ExhaustiveWithNamedCatchAll(x: Int) -> Int {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const 100_i64;
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = copy _2;
-        goto -> bb5;
-    }
-
     bb5: {
-        _5 = copy _4;
-        _6 = const 1_i64;
-        _0 = copy _5 + copy _6;
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb6;
     }
 
     bb6: {
+        _5 = copy _4;
+        _6 = const 1_i64;
+        _0 = copy _5 + copy _6;
         goto -> bb2;
     }
 
@@ -2462,7 +2462,7 @@ fn WrongLiteralTypeIntWithString(x: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
     bb1: {
@@ -2474,11 +2474,11 @@ fn WrongLiteralTypeIntWithString(x: Int) -> String {
     }
 
     bb3: {
-        _0 = const "wrong type";
-        goto -> bb2;
+        unreachable;
     }
 
     bb4: {
+        _0 = const "wrong type";
         goto -> bb2;
     }
 
@@ -2495,7 +2495,7 @@ fn ExhaustiveEnumWithCatchAll(s: Named("Status")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const Status.Active;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -2507,21 +2507,21 @@ fn ExhaustiveEnumWithCatchAll(s: Named("Status")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "active";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = copy _2;
-        goto -> bb5;
-    }
-
     bb5: {
-        _0 = const "other";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb6;
     }
 
     bb6: {
+        _0 = const "other";
         goto -> bb2;
     }
 
@@ -2544,7 +2544,7 @@ fn GuardedWithFallback(x: Int) -> Int {
     bb0: {
         _2 = copy _1;
         _3 = is_type(copy _2, Int);
-        branch copy _3 -> [bb5, bb4];
+        branch copy _3 -> [bb6, bb5];
     }
 
     bb1: {
@@ -2556,35 +2556,35 @@ fn GuardedWithFallback(x: Int) -> Int {
     }
 
     bb3: {
-        _6 = copy _4;
-        _7 = const 0_i64;
-        _5 = copy _6 > copy _7;
-        branch copy _5 -> [bb6, bb4];
+        unreachable;
     }
 
     bb4: {
-        _10 = copy _2;
-        goto -> bb7;
+        _6 = copy _4;
+        _7 = const 0_i64;
+        _5 = copy _6 > copy _7;
+        branch copy _5 -> [bb7, bb5];
     }
 
     bb5: {
-        _4 = copy _2;
-        goto -> bb3;
+        _10 = copy _2;
+        goto -> bb8;
     }
 
     bb6: {
+        _4 = copy _2;
+        goto -> bb4;
+    }
+
+    bb7: {
         _8 = copy _4;
         _9 = const 2_i64;
         _0 = copy _8 * copy _9;
         goto -> bb2;
     }
 
-    bb7: {
-        _0 = const 0_i64;
-        goto -> bb2;
-    }
-
     bb8: {
+        _0 = const 0_i64;
         goto -> bb2;
     }
 
@@ -2863,7 +2863,7 @@ fn ExhaustiveNullableEnumWithTypedPattern(s: Optional(Named("Status"))) -> Strin
     bb0: {
         _2 = copy _1;
         _3 = is_type(copy _2, Named("Status"));
-        branch copy _3 -> [bb5, bb4];
+        branch copy _3 -> [bb6, bb5];
     }
 
     bb1: {
@@ -2875,26 +2875,26 @@ fn ExhaustiveNullableEnumWithTypedPattern(s: Optional(Named("Status"))) -> Strin
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "some status";
         goto -> bb2;
     }
 
-    bb4: {
-        _5 = copy _2 == const null;
-        branch copy _5 -> [bb6, bb7];
-    }
-
     bb5: {
-        _4 = copy _2;
-        goto -> bb3;
+        _5 = copy _2 == const null;
+        branch copy _5 -> [bb7, bb3];
     }
 
     bb6: {
-        _0 = const "no status";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb4;
     }
 
     bb7: {
+        _0 = const "no status";
         goto -> bb2;
     }
 
@@ -2913,7 +2913,7 @@ fn DuplicateStringLiteral(role: Named("Role")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
     bb1: {
@@ -2925,41 +2925,41 @@ fn DuplicateStringLiteral(role: Named("Role")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "first user";
         goto -> bb2;
     }
 
-    bb4: {
+    bb5: {
         _4 = copy _2;
-        goto -> bb5;
+        goto -> bb6;
     }
 
-    bb5: {
+    bb6: {
         _0 = const "second user";
         goto -> bb2;
     }
 
-    bb6: {
+    bb7: {
         _5 = copy _2;
-        goto -> bb7;
+        goto -> bb8;
     }
 
-    bb7: {
+    bb8: {
         _0 = const "assistant";
         goto -> bb2;
     }
 
-    bb8: {
-        _6 = copy _2;
-        goto -> bb9;
-    }
-
     bb9: {
-        _0 = const "system";
-        goto -> bb2;
+        _6 = copy _2;
+        goto -> bb10;
     }
 
     bb10: {
+        _0 = const "system";
         goto -> bb2;
     }
 
@@ -3020,7 +3020,7 @@ fn ExhaustiveOptional(x: Optional(Int)) -> String {
     bb0: {
         _2 = copy _1;
         _3 = is_type(copy _2, Int);
-        branch copy _3 -> [bb5, bb4];
+        branch copy _3 -> [bb6, bb5];
     }
 
     bb1: {
@@ -3032,26 +3032,26 @@ fn ExhaustiveOptional(x: Optional(Int)) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "has value";
         goto -> bb2;
     }
 
-    bb4: {
-        _5 = copy _2 == const null;
-        branch copy _5 -> [bb6, bb7];
-    }
-
     bb5: {
-        _4 = copy _2;
-        goto -> bb3;
+        _5 = copy _2 == const null;
+        branch copy _5 -> [bb7, bb3];
     }
 
     bb6: {
-        _0 = const "no value";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb4;
     }
 
     bb7: {
+        _0 = const "no value";
         goto -> bb2;
     }
 
@@ -3100,7 +3100,7 @@ fn NonExhaustiveMixedLiterals(x: Named("MixedLiterals")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 200_i64;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -3112,21 +3112,21 @@ fn NonExhaustiveMixedLiterals(x: Named("MixedLiterals")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "http ok";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = copy _2;
-        goto -> bb5;
-    }
-
     bb5: {
-        _0 = const "string success";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb6;
     }
 
     bb6: {
+        _0 = const "string success";
         goto -> bb2;
     }
 
@@ -3176,7 +3176,7 @@ fn UnreachableAfterCatchAll(x: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
     bb1: {
@@ -3188,27 +3188,27 @@ fn UnreachableAfterCatchAll(x: Int) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "catch all";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = is_type(copy _2, Int);
-        branch copy _4 -> [bb7, bb6];
-    }
-
     bb5: {
-        _0 = const "never reached";
-        goto -> bb2;
+        _4 = is_type(copy _2, Int);
+        branch copy _4 -> [bb7, bb3];
     }
 
     bb6: {
+        _0 = const "never reached";
         goto -> bb2;
     }
 
     bb7: {
         _5 = copy _2;
-        goto -> bb5;
+        goto -> bb6;
     }
 
 }
@@ -3224,7 +3224,7 @@ fn OptionalWithCatchAll(x: Optional(Int)) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const null;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -3236,21 +3236,21 @@ fn OptionalWithCatchAll(x: Optional(Int)) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "no value";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = copy _2;
-        goto -> bb5;
-    }
-
     bb5: {
-        _0 = const "has value";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb6;
     }
 
     bb6: {
+        _0 = const "has value";
         goto -> bb2;
     }
 
@@ -3268,7 +3268,7 @@ fn DuplicateBoolLiteral(b: Bool) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const true;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -3280,31 +3280,31 @@ fn DuplicateBoolLiteral(b: Bool) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "first true";
         goto -> bb2;
     }
 
-    bb4: {
+    bb5: {
         _4 = copy _2 == const true;
-        branch copy _4 -> [bb5, bb6];
+        branch copy _4 -> [bb6, bb7];
     }
 
-    bb5: {
+    bb6: {
         _0 = const "second true";
         goto -> bb2;
     }
 
-    bb6: {
-        _5 = copy _2 == const false;
-        branch copy _5 -> [bb7, bb8];
-    }
-
     bb7: {
-        _0 = const "false";
-        goto -> bb2;
+        _5 = copy _2 == const false;
+        branch copy _5 -> [bb8, bb3];
     }
 
     bb8: {
+        _0 = const "false";
         goto -> bb2;
     }
 
@@ -3377,7 +3377,7 @@ fn StringLiteralAfterStringType(s: String) -> String {
     bb0: {
         _2 = copy _1;
         _3 = is_type(copy _2, String);
-        branch copy _3 -> [bb5, bb4];
+        branch copy _3 -> [bb6, bb5];
     }
 
     bb1: {
@@ -3389,26 +3389,26 @@ fn StringLiteralAfterStringType(s: String) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "any string";
         goto -> bb2;
     }
 
-    bb4: {
-        _5 = copy _2;
-        goto -> bb6;
-    }
-
     bb5: {
-        _4 = copy _2;
-        goto -> bb3;
+        _5 = copy _2;
+        goto -> bb7;
     }
 
     bb6: {
-        _0 = const "unreachable";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb4;
     }
 
     bb7: {
+        _0 = const "unreachable";
         goto -> bb2;
     }
 
@@ -3508,7 +3508,7 @@ fn ExhaustiveWithUnderscore(x: Int) -> Int {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 1_i64;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -3520,31 +3520,31 @@ fn ExhaustiveWithUnderscore(x: Int) -> Int {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const 100_i64;
         goto -> bb2;
     }
 
-    bb4: {
+    bb5: {
         _4 = copy _2 == const 2_i64;
-        branch copy _4 -> [bb5, bb6];
+        branch copy _4 -> [bb6, bb7];
     }
 
-    bb5: {
+    bb6: {
         _0 = const 200_i64;
         goto -> bb2;
     }
 
-    bb6: {
-        _5 = copy _2;
-        goto -> bb7;
-    }
-
     bb7: {
-        _0 = const 0_i64;
-        goto -> bb2;
+        _5 = copy _2;
+        goto -> bb8;
     }
 
     bb8: {
+        _0 = const 0_i64;
         goto -> bb2;
     }
 
@@ -3599,7 +3599,7 @@ fn NonExhaustiveStringLiteral(role: Named("Role")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
     bb1: {
@@ -3611,21 +3611,21 @@ fn NonExhaustiveStringLiteral(role: Named("Role")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "User";
         goto -> bb2;
     }
 
-    bb4: {
-        _4 = copy _2;
-        goto -> bb5;
-    }
-
     bb5: {
-        _0 = const "Assistant";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb6;
     }
 
     bb6: {
+        _0 = const "Assistant";
         goto -> bb2;
     }
 
@@ -3643,7 +3643,7 @@ fn StringLiteralWithCatchAll(role: Named("Role")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2;
-        goto -> bb3;
+        goto -> bb4;
     }
 
     bb1: {
@@ -3655,31 +3655,31 @@ fn StringLiteralWithCatchAll(role: Named("Role")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "User message";
         goto -> bb2;
     }
 
-    bb4: {
+    bb5: {
         _4 = copy _2;
-        goto -> bb5;
+        goto -> bb6;
     }
 
-    bb5: {
+    bb6: {
         _0 = const "Assistant message";
         goto -> bb2;
     }
 
-    bb6: {
-        _5 = copy _2;
-        goto -> bb7;
-    }
-
     bb7: {
-        _0 = const "Other";
-        goto -> bb2;
+        _5 = copy _2;
+        goto -> bb8;
     }
 
     bb8: {
+        _0 = const "Other";
         goto -> bb2;
     }
 
@@ -3734,7 +3734,7 @@ fn MixedPatterns(x: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const 0_i64;
-        branch copy _3 -> [bb3, bb4];
+        branch copy _3 -> [bb4, bb5];
     }
 
     bb1: {
@@ -3746,53 +3746,53 @@ fn MixedPatterns(x: Int) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "zero";
         goto -> bb2;
     }
 
-    bb4: {
+    bb5: {
         _4 = copy _2 == const 1_i64;
-        branch copy _4 -> [bb5, bb6];
+        branch copy _4 -> [bb6, bb7];
     }
 
-    bb5: {
+    bb6: {
         _0 = const "one";
         goto -> bb2;
     }
 
-    bb6: {
-        _5 = is_type(copy _2, Int);
-        branch copy _5 -> [bb9, bb8];
-    }
-
     bb7: {
-        _8 = copy _6;
-        _9 = const 0_i64;
-        _7 = copy _8 > copy _9;
-        branch copy _7 -> [bb10, bb8];
+        _5 = is_type(copy _2, Int);
+        branch copy _5 -> [bb10, bb9];
     }
 
     bb8: {
-        _10 = copy _2;
-        goto -> bb11;
+        _8 = copy _6;
+        _9 = const 0_i64;
+        _7 = copy _8 > copy _9;
+        branch copy _7 -> [bb11, bb9];
     }
 
     bb9: {
-        _6 = copy _2;
-        goto -> bb7;
+        _10 = copy _2;
+        goto -> bb12;
     }
 
     bb10: {
+        _6 = copy _2;
+        goto -> bb8;
+    }
+
+    bb11: {
         _0 = const "positive";
         goto -> bb2;
     }
 
-    bb11: {
-        _0 = const "negative";
-        goto -> bb2;
-    }
-
     bb12: {
+        _0 = const "negative";
         goto -> bb2;
     }
 
@@ -3853,7 +3853,7 @@ fn LiteralAfterTypedPattern(x: Int) -> String {
     bb0: {
         _2 = copy _1;
         _3 = is_type(copy _2, Int);
-        branch copy _3 -> [bb5, bb4];
+        branch copy _3 -> [bb6, bb5];
     }
 
     bb1: {
@@ -3865,26 +3865,26 @@ fn LiteralAfterTypedPattern(x: Int) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "int";
         goto -> bb2;
     }
 
-    bb4: {
-        _5 = copy _2 == const 42_i64;
-        branch copy _5 -> [bb6, bb7];
-    }
-
     bb5: {
-        _4 = copy _2;
-        goto -> bb3;
+        _5 = copy _2 == const 42_i64;
+        branch copy _5 -> [bb7, bb3];
     }
 
     bb6: {
-        _0 = const "unreachable";
-        goto -> bb2;
+        _4 = copy _2;
+        goto -> bb4;
     }
 
     bb7: {
+        _0 = const "unreachable";
         goto -> bb2;
     }
 
@@ -3902,7 +3902,7 @@ fn EnumVariantUnionWithCatchAll(s: Named("Status")) -> String {
     bb0: {
         _2 = copy _1;
         _3 = copy _2 == const Status.Active;
-        branch copy _3 -> [bb3, bb5];
+        branch copy _3 -> [bb4, bb6];
     }
 
     bb1: {
@@ -3914,26 +3914,26 @@ fn EnumVariantUnionWithCatchAll(s: Named("Status")) -> String {
     }
 
     bb3: {
+        unreachable;
+    }
+
+    bb4: {
         _0 = const "actionable";
         goto -> bb2;
     }
 
-    bb4: {
-        _5 = copy _2;
-        goto -> bb6;
-    }
-
     bb5: {
-        _4 = copy _2 == const Status.Pending;
-        branch copy _4 -> [bb3, bb4];
+        _5 = copy _2;
+        goto -> bb7;
     }
 
     bb6: {
-        _0 = const "other";
-        goto -> bb2;
+        _4 = copy _2 == const Status.Pending;
+        branch copy _4 -> [bb4, bb5];
     }
 
     bb7: {
+        _0 = const "other";
         goto -> bb2;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-17af2d4231950a65/out/generated_tests.rs
+source: target/debug/build/baml_tests-1e9ee45736f74339/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
@@ -12,34 +12,32 @@ Function BoolLiteralAfterTypedBool (arity: 1, kind: Exec):
      1    LOAD_VAR 1             (b)
      2    LOAD_CONST 1           (false)
      3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +9                (to 13)
+     4    JUMP +8                (to 12)
      5    LOAD_VAR 1             (b)
      6    LOAD_CONST 2           (true)
      7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +8   (to 16)
-     9    JUMP +2                (to 11)
-     10   JUMP +6                (to 16)
-     11   LOAD_CONST 3           (unreachable)
-     12   JUMP +4                (to 16)
-     13   LOAD_VAR 1             (b)
-     14   STORE_VAR 2            (x)
-     15   LOAD_CONST 4           (any bool)
-     16   RETURN                 
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +1                (to 10)
+     10   LOAD_CONST 3           (unreachable)
+     11   JUMP +4                (to 15)
+     12   LOAD_VAR 1             (b)
+     13   STORE_VAR 2            (x)
+     14   LOAD_CONST 4           (any bool)
+     15   RETURN                 
 
 Function BoolUnionPattern (arity: 1, kind: Exec):
      0    LOAD_VAR 1             (b)
      1    LOAD_CONST 0           (true)
      2    CMP_OP ==              
      3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +7                (to 11)
+     4    JUMP +6                (to 10)
      5    LOAD_VAR 1             (b)
      6    LOAD_CONST 1           (false)
      7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +3   (to 11)
-     9    JUMP +2                (to 11)
-     10   JUMP +1                (to 11)
-     11   LOAD_CONST 2           (covered)
-     12   RETURN                 
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +1                (to 10)
+     10   LOAD_CONST 2           (covered)
+     11   RETURN                 
 
 Function BoolWithCatchAll (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (b)
@@ -77,59 +75,57 @@ Function DuplicateBoolLiteral (arity: 1, kind: Exec):
      1    LOAD_CONST 0           (true)
      2    CMP_OP ==              
      3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +16               (to 20)
+     4    JUMP +15               (to 19)
      5    LOAD_VAR 1             (b)
      6    LOAD_CONST 0           (true)
      7    CMP_OP ==              
      8    POP_JUMP_IF_FALSE +2   (to 10)
-     9    JUMP +9                (to 18)
+     9    JUMP +8                (to 17)
      10   LOAD_VAR 1             (b)
      11   LOAD_CONST 1           (false)
      12   CMP_OP ==              
-     13   POP_JUMP_IF_FALSE +8   (to 21)
-     14   JUMP +2                (to 16)
-     15   JUMP +6                (to 21)
-     16   LOAD_CONST 2           (false)
-     17   JUMP +4                (to 21)
-     18   LOAD_CONST 3           (second true)
-     19   JUMP +2                (to 21)
-     20   LOAD_CONST 4           (first true)
-     21   RETURN                 
+     13   POP_JUMP_IF_FALSE +2   (to 15)
+     14   JUMP +1                (to 15)
+     15   LOAD_CONST 2           (false)
+     16   JUMP +4                (to 20)
+     17   LOAD_CONST 3           (second true)
+     18   JUMP +2                (to 20)
+     19   LOAD_CONST 4           (first true)
+     20   RETURN                 
 
 Function DuplicateEnumVariant (arity: 1, kind: Exec):
-     0    LOAD_VAR 1              (s)
-     1    LOAD_CONST 0            (0)
-     2    ALLOC_VARIANT 3         (<enum Status>)
-     3    CMP_OP ==               
-     4    POP_JUMP_IF_FALSE +2    (to 6)
-     5    JUMP +26                (to 31)
-     6    LOAD_VAR 1              (s)
-     7    LOAD_CONST 0            (0)
-     8    ALLOC_VARIANT 3         (<enum Status>)
-     9    CMP_OP ==               
-     10   POP_JUMP_IF_FALSE +2    (to 12)
-     11   JUMP +18                (to 29)
-     12   LOAD_VAR 1              (s)
-     13   LOAD_CONST 1            (1)
-     14   ALLOC_VARIANT 3         (<enum Status>)
-     15   CMP_OP ==               
-     16   POP_JUMP_IF_FALSE +2    (to 18)
-     17   JUMP +10                (to 27)
-     18   LOAD_VAR 1              (s)
-     19   LOAD_CONST 2            (2)
-     20   ALLOC_VARIANT 3         (<enum Status>)
-     21   CMP_OP ==               
-     22   POP_JUMP_IF_FALSE +10   (to 32)
-     23   JUMP +2                 (to 25)
-     24   JUMP +8                 (to 32)
-     25   LOAD_CONST 3            (pending)
-     26   JUMP +6                 (to 32)
-     27   LOAD_CONST 4            (inactive)
-     28   JUMP +4                 (to 32)
-     29   LOAD_CONST 5            (second)
-     30   JUMP +2                 (to 32)
-     31   LOAD_CONST 6            (first)
-     32   RETURN                  
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +25               (to 30)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 0           (0)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +17               (to 28)
+     12   LOAD_VAR 1             (s)
+     13   LOAD_CONST 1           (1)
+     14   ALLOC_VARIANT 3        (<enum Status>)
+     15   CMP_OP ==              
+     16   POP_JUMP_IF_FALSE +2   (to 18)
+     17   JUMP +9                (to 26)
+     18   LOAD_VAR 1             (s)
+     19   LOAD_CONST 2           (2)
+     20   ALLOC_VARIANT 3        (<enum Status>)
+     21   CMP_OP ==              
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +1                (to 24)
+     24   LOAD_CONST 3           (pending)
+     25   JUMP +6                (to 31)
+     26   LOAD_CONST 4           (inactive)
+     27   JUMP +4                (to 31)
+     28   LOAD_CONST 5           (second)
+     29   JUMP +2                (to 31)
+     30   LOAD_CONST 6           (first)
+     31   RETURN                 
 
 Function DuplicateIntLiteral (arity: 1, kind: Exec):
      0    LOAD_VAR 1             (x)
@@ -158,20 +154,19 @@ Function EnumVariantAfterTypedEnum (arity: 1, kind: Exec):
      1    LOAD_VAR 1             (s)
      2    LOAD_CONST 1           (false)
      3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +10               (to 14)
+     4    JUMP +9                (to 13)
      5    LOAD_VAR 1             (s)
      6    LOAD_CONST 2           (0)
      7    ALLOC_VARIANT 3        (<enum Status>)
      8    CMP_OP ==              
-     9    POP_JUMP_IF_FALSE +8   (to 17)
-     10   JUMP +2                (to 12)
-     11   JUMP +6                (to 17)
-     12   LOAD_CONST 3           (unreachable)
-     13   JUMP +4                (to 17)
-     14   LOAD_VAR 1             (s)
-     15   STORE_VAR 2            (x)
-     16   LOAD_CONST 4           (any status)
-     17   RETURN                 
+     9    POP_JUMP_IF_FALSE +2   (to 11)
+     10   JUMP +1                (to 11)
+     11   LOAD_CONST 3           (unreachable)
+     12   JUMP +4                (to 16)
+     13   LOAD_VAR 1             (s)
+     14   STORE_VAR 2            (x)
+     15   LOAD_CONST 4           (any status)
+     16   RETURN                 
 
 Function EnumVariantUnion (arity: 1, kind: Exec):
      0    LOAD_VAR 1             (s)
@@ -179,24 +174,23 @@ Function EnumVariantUnion (arity: 1, kind: Exec):
      2    ALLOC_VARIANT 3        (<enum Status>)
      3    CMP_OP ==              
      4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +16               (to 21)
+     5    JUMP +15               (to 20)
      6    LOAD_VAR 1             (s)
      7    LOAD_CONST 1           (2)
      8    ALLOC_VARIANT 3        (<enum Status>)
      9    CMP_OP ==              
      10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +10               (to 21)
+     11   JUMP +9                (to 20)
      12   LOAD_VAR 1             (s)
      13   LOAD_CONST 2           (1)
      14   ALLOC_VARIANT 3        (<enum Status>)
      15   CMP_OP ==              
-     16   POP_JUMP_IF_FALSE +6   (to 22)
-     17   JUMP +2                (to 19)
-     18   JUMP +4                (to 22)
-     19   LOAD_CONST 3           (inactive)
-     20   JUMP +2                (to 22)
-     21   LOAD_CONST 4           (actionable)
-     22   RETURN                 
+     16   POP_JUMP_IF_FALSE +2   (to 18)
+     17   JUMP +1                (to 18)
+     18   LOAD_CONST 3           (inactive)
+     19   JUMP +2                (to 21)
+     20   LOAD_CONST 4           (actionable)
+     21   RETURN                 
 
 Function EnumVariantUnionWithCatchAll (arity: 1, kind: Exec):
      0    LOAD_VAR 1             (s)
@@ -238,17 +232,16 @@ Function ExhaustiveBool (arity: 1, kind: Exec):
      1    LOAD_CONST 0           (true)
      2    CMP_OP ==              
      3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +9                (to 13)
+     4    JUMP +8                (to 12)
      5    LOAD_VAR 1             (b)
      6    LOAD_CONST 1           (false)
      7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +6   (to 14)
-     9    JUMP +2                (to 11)
-     10   JUMP +4                (to 14)
-     11   LOAD_CONST 2           (no)
-     12   JUMP +2                (to 14)
-     13   LOAD_CONST 3           (yes)
-     14   RETURN                 
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +1                (to 10)
+     10   LOAD_CONST 2           (no)
+     11   JUMP +2                (to 13)
+     12   LOAD_CONST 3           (yes)
+     13   RETURN                 
 
 Function ExhaustiveClassPlusLiteral (arity: 1, kind: Exec):
      0    LOAD_VAR 1             (x)
@@ -317,26 +310,25 @@ Function ExhaustiveEnumAllVariants (arity: 1, kind: Exec):
      2    ALLOC_VARIANT 3        (<enum Status>)
      3    CMP_OP ==              
      4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +18               (to 23)
+     5    JUMP +17               (to 22)
      6    LOAD_VAR 1             (s)
      7    LOAD_CONST 1           (1)
      8    ALLOC_VARIANT 3        (<enum Status>)
      9    CMP_OP ==              
      10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +10               (to 21)
+     11   JUMP +9                (to 20)
      12   LOAD_VAR 1             (s)
      13   LOAD_CONST 2           (2)
      14   ALLOC_VARIANT 3        (<enum Status>)
      15   CMP_OP ==              
-     16   POP_JUMP_IF_FALSE +8   (to 24)
-     17   JUMP +2                (to 19)
-     18   JUMP +6                (to 24)
-     19   LOAD_CONST 3           (pending)
-     20   JUMP +4                (to 24)
-     21   LOAD_CONST 4           (inactive)
-     22   JUMP +2                (to 24)
-     23   LOAD_CONST 5           (active)
-     24   RETURN                 
+     16   POP_JUMP_IF_FALSE +2   (to 18)
+     17   JUMP +1                (to 18)
+     18   LOAD_CONST 3           (pending)
+     19   JUMP +4                (to 23)
+     20   LOAD_CONST 4           (inactive)
+     21   JUMP +2                (to 23)
+     22   LOAD_CONST 5           (active)
+     23   RETURN                 
 
 Function ExhaustiveEnumWithCatchAll (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (s)
@@ -354,13 +346,12 @@ Function ExhaustiveEnumWithTypedPattern (arity: 1, kind: Exec):
      0   LOAD_CONST 0           (null)
      1   LOAD_VAR 1             (s)
      2   LOAD_CONST 1           (false)
-     3   POP_JUMP_IF_FALSE +5   (to 8)
-     4   JUMP +2                (to 6)
-     5   JUMP +3                (to 8)
-     6   LOAD_VAR 1             (s)
-     7   STORE_VAR 2            (x)
-     8   LOAD_CONST 2           (any status)
-     9   RETURN                 
+     3   POP_JUMP_IF_FALSE +2   (to 5)
+     4   JUMP +1                (to 5)
+     5   LOAD_VAR 1             (s)
+     6   STORE_VAR 2            (x)
+     7   LOAD_CONST 2           (any status)
+     8   RETURN                 
 
 Function ExhaustiveFalseType (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (f)
@@ -402,18 +393,17 @@ Function ExhaustiveLiteralWithBaseType (arity: 1, kind: Exec):
      2    LOAD_CONST 1           (200)
      3    CMP_OP ==              
      4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +10               (to 15)
+     5    JUMP +9                (to 14)
      6    LOAD_VAR 1             (x)
      7    LOAD_CONST 2           (false)
-     8    POP_JUMP_IF_FALSE +8   (to 16)
-     9    JUMP +2                (to 11)
-     10   JUMP +6                (to 16)
-     11   LOAD_VAR 1             (x)
-     12   STORE_VAR 2            (n)
-     13   LOAD_CONST 3           (other)
-     14   JUMP +2                (to 16)
-     15   LOAD_CONST 4           (ok)
-     16   RETURN                 
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +1                (to 10)
+     10   LOAD_VAR 1             (x)
+     11   STORE_VAR 2            (n)
+     12   LOAD_CONST 3           (other)
+     13   JUMP +2                (to 15)
+     14   LOAD_CONST 4           (ok)
+     15   RETURN                 
 
 Function ExhaustiveMixedLiterals (arity: 1, kind: Exec):
      0   LOAD_VAR 1             (x)
@@ -427,76 +417,73 @@ Function ExhaustiveMixedLiterals (arity: 1, kind: Exec):
      8   RETURN                 
 
 Function ExhaustiveNullableEnum (arity: 1, kind: Exec):
-     0    LOAD_VAR 1              (s)
-     1    LOAD_CONST 0            (0)
-     2    ALLOC_VARIANT 3         (<enum Status>)
-     3    CMP_OP ==               
-     4    POP_JUMP_IF_FALSE +2    (to 6)
-     5    JUMP +25                (to 30)
-     6    LOAD_VAR 1              (s)
-     7    LOAD_CONST 1            (1)
-     8    ALLOC_VARIANT 3         (<enum Status>)
-     9    CMP_OP ==               
-     10   POP_JUMP_IF_FALSE +2    (to 12)
-     11   JUMP +17                (to 28)
-     12   LOAD_VAR 1              (s)
-     13   LOAD_CONST 2            (2)
-     14   ALLOC_VARIANT 3         (<enum Status>)
-     15   CMP_OP ==               
-     16   POP_JUMP_IF_FALSE +2    (to 18)
-     17   JUMP +9                 (to 26)
-     18   LOAD_VAR 1              (s)
-     19   LOAD_CONST 3            (null)
-     20   CMP_OP ==               
-     21   POP_JUMP_IF_FALSE +10   (to 31)
-     22   JUMP +2                 (to 24)
-     23   JUMP +8                 (to 31)
-     24   LOAD_CONST 4            (no status)
-     25   JUMP +6                 (to 31)
-     26   LOAD_CONST 5            (pending)
-     27   JUMP +4                 (to 31)
-     28   LOAD_CONST 6            (inactive)
-     29   JUMP +2                 (to 31)
-     30   LOAD_CONST 7            (active)
-     31   RETURN                  
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +24               (to 29)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 1           (1)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +16               (to 27)
+     12   LOAD_VAR 1             (s)
+     13   LOAD_CONST 2           (2)
+     14   ALLOC_VARIANT 3        (<enum Status>)
+     15   CMP_OP ==              
+     16   POP_JUMP_IF_FALSE +2   (to 18)
+     17   JUMP +8                (to 25)
+     18   LOAD_VAR 1             (s)
+     19   LOAD_CONST 3           (null)
+     20   CMP_OP ==              
+     21   POP_JUMP_IF_FALSE +2   (to 23)
+     22   JUMP +1                (to 23)
+     23   LOAD_CONST 4           (no status)
+     24   JUMP +6                (to 30)
+     25   LOAD_CONST 5           (pending)
+     26   JUMP +4                (to 30)
+     27   LOAD_CONST 6           (inactive)
+     28   JUMP +2                (to 30)
+     29   LOAD_CONST 7           (active)
+     30   RETURN                 
 
 Function ExhaustiveNullableEnumWithTypedPattern (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
      1    LOAD_VAR 1             (s)
      2    LOAD_CONST 1           (false)
      3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +9                (to 13)
+     4    JUMP +8                (to 12)
      5    LOAD_VAR 1             (s)
      6    LOAD_CONST 0           (null)
      7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +8   (to 16)
-     9    JUMP +2                (to 11)
-     10   JUMP +6                (to 16)
-     11   LOAD_CONST 2           (no status)
-     12   JUMP +4                (to 16)
-     13   LOAD_VAR 1             (s)
-     14   STORE_VAR 2            (x)
-     15   LOAD_CONST 3           (some status)
-     16   RETURN                 
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +1                (to 10)
+     10   LOAD_CONST 2           (no status)
+     11   JUMP +4                (to 15)
+     12   LOAD_VAR 1             (s)
+     13   STORE_VAR 2            (x)
+     14   LOAD_CONST 3           (some status)
+     15   RETURN                 
 
 Function ExhaustiveOptional (arity: 1, kind: Exec):
      0    LOAD_CONST 0           (null)
      1    LOAD_VAR 1             (x)
      2    LOAD_CONST 1           (false)
      3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +9                (to 13)
+     4    JUMP +8                (to 12)
      5    LOAD_VAR 1             (x)
      6    LOAD_CONST 0           (null)
      7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +8   (to 16)
-     9    JUMP +2                (to 11)
-     10   JUMP +6                (to 16)
-     11   LOAD_CONST 2           (no value)
-     12   JUMP +4                (to 16)
-     13   LOAD_VAR 1             (x)
-     14   STORE_VAR 2            (n)
-     15   LOAD_CONST 3           (has value)
-     16   RETURN                 
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +1                (to 10)
+     10   LOAD_CONST 2           (no value)
+     11   JUMP +4                (to 15)
+     12   LOAD_VAR 1             (x)
+     13   STORE_VAR 2            (n)
+     14   LOAD_CONST 3           (has value)
+     15   RETURN                 
 
 Function ExhaustiveOptionalSingleton (arity: 1, kind: Exec):
      0    LOAD_VAR 1             (code)
@@ -692,19 +679,18 @@ Function LiteralAfterTypedPattern (arity: 1, kind: Exec):
      1    LOAD_VAR 1             (x)
      2    LOAD_CONST 1           (false)
      3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +9                (to 13)
+     4    JUMP +8                (to 12)
      5    LOAD_VAR 1             (x)
      6    LOAD_CONST 2           (42)
      7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +8   (to 16)
-     9    JUMP +2                (to 11)
-     10   JUMP +6                (to 16)
-     11   LOAD_CONST 3           (unreachable)
-     12   JUMP +4                (to 16)
-     13   LOAD_VAR 1             (x)
-     14   STORE_VAR 2            (n)
-     15   LOAD_CONST 4           (int)
-     16   RETURN                 
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +1                (to 10)
+     10   LOAD_CONST 3           (unreachable)
+     11   JUMP +4                (to 15)
+     12   LOAD_VAR 1             (x)
+     13   STORE_VAR 2            (n)
+     14   LOAD_CONST 4           (int)
+     15   RETURN                 
 
 Function LiteralUnionWithCatchAll (arity: 1, kind: Exec):
      0    LOAD_VAR 1             (code)
@@ -763,47 +749,46 @@ Function MixedPatterns (arity: 1, kind: Exec):
      25   RETURN                 
 
 Function MultipleUnreachableSpans (arity: 1, kind: Exec):
-     0    LOAD_VAR 1              (s)
-     1    LOAD_CONST 0            (0)
-     2    ALLOC_VARIANT 3         (<enum Status>)
-     3    CMP_OP ==               
-     4    POP_JUMP_IF_FALSE +2    (to 6)
-     5    JUMP +34                (to 39)
-     6    LOAD_VAR 1              (s)
-     7    LOAD_CONST 0            (0)
-     8    ALLOC_VARIANT 3         (<enum Status>)
-     9    CMP_OP ==               
-     10   POP_JUMP_IF_FALSE +2    (to 12)
-     11   JUMP +26                (to 37)
-     12   LOAD_VAR 1              (s)
-     13   LOAD_CONST 1            (1)
-     14   ALLOC_VARIANT 3         (<enum Status>)
-     15   CMP_OP ==               
-     16   POP_JUMP_IF_FALSE +2    (to 18)
-     17   JUMP +18                (to 35)
-     18   LOAD_VAR 1              (s)
-     19   LOAD_CONST 0            (0)
-     20   ALLOC_VARIANT 3         (<enum Status>)
-     21   CMP_OP ==               
-     22   POP_JUMP_IF_FALSE +2    (to 24)
-     23   JUMP +10                (to 33)
-     24   LOAD_VAR 1              (s)
-     25   LOAD_CONST 2            (2)
-     26   ALLOC_VARIANT 3         (<enum Status>)
-     27   CMP_OP ==               
-     28   POP_JUMP_IF_FALSE +12   (to 40)
-     29   JUMP +2                 (to 31)
-     30   JUMP +10                (to 40)
-     31   LOAD_CONST 3            (pending)
-     32   JUMP +8                 (to 40)
-     33   LOAD_CONST 4            (duplicate 2)
-     34   JUMP +6                 (to 40)
-     35   LOAD_CONST 5            (inactive)
-     36   JUMP +4                 (to 40)
-     37   LOAD_CONST 6            (duplicate 1)
-     38   JUMP +2                 (to 40)
-     39   LOAD_CONST 7            (active)
-     40   RETURN                  
+     0    LOAD_VAR 1             (s)
+     1    LOAD_CONST 0           (0)
+     2    ALLOC_VARIANT 3        (<enum Status>)
+     3    CMP_OP ==              
+     4    POP_JUMP_IF_FALSE +2   (to 6)
+     5    JUMP +33               (to 38)
+     6    LOAD_VAR 1             (s)
+     7    LOAD_CONST 0           (0)
+     8    ALLOC_VARIANT 3        (<enum Status>)
+     9    CMP_OP ==              
+     10   POP_JUMP_IF_FALSE +2   (to 12)
+     11   JUMP +25               (to 36)
+     12   LOAD_VAR 1             (s)
+     13   LOAD_CONST 1           (1)
+     14   ALLOC_VARIANT 3        (<enum Status>)
+     15   CMP_OP ==              
+     16   POP_JUMP_IF_FALSE +2   (to 18)
+     17   JUMP +17               (to 34)
+     18   LOAD_VAR 1             (s)
+     19   LOAD_CONST 0           (0)
+     20   ALLOC_VARIANT 3        (<enum Status>)
+     21   CMP_OP ==              
+     22   POP_JUMP_IF_FALSE +2   (to 24)
+     23   JUMP +9                (to 32)
+     24   LOAD_VAR 1             (s)
+     25   LOAD_CONST 2           (2)
+     26   ALLOC_VARIANT 3        (<enum Status>)
+     27   CMP_OP ==              
+     28   POP_JUMP_IF_FALSE +2   (to 30)
+     29   JUMP +1                (to 30)
+     30   LOAD_CONST 3           (pending)
+     31   JUMP +8                (to 39)
+     32   LOAD_CONST 4           (duplicate 2)
+     33   JUMP +6                (to 39)
+     34   LOAD_CONST 5           (inactive)
+     35   JUMP +4                (to 39)
+     36   LOAD_CONST 6           (duplicate 1)
+     37   JUMP +2                (to 39)
+     38   LOAD_CONST 7           (active)
+     39   RETURN                 
 
 Function NestedEnumVariantUnions (arity: 1, kind: Exec):
      0    LOAD_VAR 1             (s)
@@ -811,22 +796,21 @@ Function NestedEnumVariantUnions (arity: 1, kind: Exec):
      2    ALLOC_VARIANT 3        (<enum Status>)
      3    CMP_OP ==              
      4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +14               (to 19)
+     5    JUMP +13               (to 18)
      6    LOAD_VAR 1             (s)
      7    LOAD_CONST 1           (2)
      8    ALLOC_VARIANT 3        (<enum Status>)
      9    CMP_OP ==              
      10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +8                (to 19)
+     11   JUMP +7                (to 18)
      12   LOAD_VAR 1             (s)
      13   LOAD_CONST 2           (1)
      14   ALLOC_VARIANT 3        (<enum Status>)
      15   CMP_OP ==              
-     16   POP_JUMP_IF_FALSE +3   (to 19)
-     17   JUMP +2                (to 19)
-     18   JUMP +1                (to 19)
-     19   LOAD_CONST 3           (all statuses)
-     20   RETURN                 
+     16   POP_JUMP_IF_FALSE +2   (to 18)
+     17   JUMP +1                (to 18)
+     18   LOAD_CONST 3           (all statuses)
+     19   RETURN                 
 
 Function NestedLiteralUnions (arity: 1, kind: Exec):
      0    LOAD_VAR 1             (code)
@@ -888,29 +872,28 @@ Function NestedMatchSpans (arity: 2, kind: Exec):
      3    POP_JUMP_IF_FALSE +2   (to 5)
      4    JUMP +3                (to 7)
      5    LOAD_CONST 1           (other)
-     6    JUMP +22               (to 28)
+     6    JUMP +21               (to 27)
      7    LOAD_VAR 2             (y)
      8    LOAD_CONST 2           (true)
      9    CMP_OP ==              
      10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +16               (to 27)
+     11   JUMP +15               (to 26)
      12   LOAD_VAR 2             (y)
      13   LOAD_CONST 3           (false)
      14   CMP_OP ==              
      15   POP_JUMP_IF_FALSE +2   (to 17)
-     16   JUMP +9                (to 25)
+     16   JUMP +8                (to 24)
      17   LOAD_VAR 2             (y)
      18   LOAD_CONST 2           (true)
      19   CMP_OP ==              
-     20   POP_JUMP_IF_FALSE +8   (to 28)
-     21   JUMP +2                (to 23)
-     22   JUMP +6                (to 28)
-     23   LOAD_CONST 4           (unreachable nested)
-     24   JUMP +4                (to 28)
-     25   LOAD_CONST 5           (zero false)
-     26   JUMP +2                (to 28)
-     27   LOAD_CONST 6           (zero true)
-     28   RETURN                 
+     20   POP_JUMP_IF_FALSE +2   (to 22)
+     21   JUMP +1                (to 22)
+     22   LOAD_CONST 4           (unreachable nested)
+     23   JUMP +4                (to 27)
+     24   LOAD_CONST 5           (zero false)
+     25   JUMP +2                (to 27)
+     26   LOAD_CONST 6           (zero true)
+     27   RETURN                 
 
 Function NestedTypeAlias (arity: 1, kind: Exec):
      0    LOAD_VAR 1              (mr)
@@ -1267,17 +1250,16 @@ Function ParenthesizedSingleLiteral (arity: 1, kind: Exec):
      1    LOAD_CONST 0           (true)
      2    CMP_OP ==              
      3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +9                (to 13)
+     4    JUMP +8                (to 12)
      5    LOAD_VAR 1             (b)
      6    LOAD_CONST 1           (false)
      7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +6   (to 14)
-     9    JUMP +2                (to 11)
-     10   JUMP +4                (to 14)
-     11   LOAD_CONST 2           (no)
-     12   JUMP +2                (to 14)
-     13   LOAD_CONST 3           (yes)
-     14   RETURN                 
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +1                (to 10)
+     10   LOAD_CONST 2           (no)
+     11   JUMP +2                (to 13)
+     12   LOAD_CONST 3           (yes)
+     13   RETURN                 
 
 Function PartialUnionPatternCoverage (arity: 1, kind: Exec):
      0   LOAD_CONST 0           (null)

--- a/baml_language/crates/baml_tir/src/lib.rs
+++ b/baml_language/crates/baml_tir/src/lib.rs
@@ -263,6 +263,10 @@ pub struct InferenceResult<'db> {
     /// Maps expression ID to (`enum_name`, `variant_name`).
     /// Used by codegen to emit enum variant construction.
     pub enum_variant_exprs: HashMap<ExprId, (Name, Name)>,
+    /// Match expressions that are exhaustive (all cases covered).
+    /// Used by codegen to emit `unreachable` for fallthrough paths,
+    /// enabling phi-like optimization for match results.
+    pub exhaustive_matches: HashSet<ExprId>,
     /// Type checking errors.
     pub errors: Vec<TypeError<Ty<'db>>>,
 }
@@ -288,6 +292,8 @@ pub struct TypeContext<'db> {
     path_segment_types: HashMap<ExprId, Vec<Ty<'db>>>,
     /// Expressions that are enum variant values.
     enum_variant_exprs: HashMap<ExprId, (Name, Name)>,
+    /// Match expressions that are exhaustive (all cases covered).
+    exhaustive_matches: HashSet<ExprId>,
     /// Types of all return statements encountered during inference.
     /// Used to validate that all return paths match the declared return type.
     return_types: Vec<(Ty<'db>, Span)>,
@@ -314,6 +320,7 @@ impl<'db> TypeContext<'db> {
             expr_types: HashMap::new(),
             path_segment_types: HashMap::new(),
             enum_variant_exprs: HashMap::new(),
+            exhaustive_matches: HashSet::new(),
             return_types: Vec::new(),
             errors: Vec::new(),
             file_id,
@@ -337,6 +344,7 @@ impl<'db> TypeContext<'db> {
             expr_types: HashMap::new(),
             path_segment_types: HashMap::new(),
             enum_variant_exprs: HashMap::new(),
+            exhaustive_matches: HashSet::new(),
             return_types: Vec::new(),
             errors: Vec::new(),
             file_id,
@@ -362,6 +370,7 @@ impl<'db> TypeContext<'db> {
             expr_types: HashMap::new(),
             path_segment_types: HashMap::new(),
             enum_variant_exprs: HashMap::new(),
+            exhaustive_matches: HashSet::new(),
             return_types: Vec::new(),
             errors: Vec::new(),
             file_id,
@@ -618,6 +627,7 @@ pub fn infer_function_body<'db>(
         expr_types: ctx.expr_types,
         path_segment_types: ctx.path_segment_types,
         enum_variant_exprs: ctx.enum_variant_exprs,
+        exhaustive_matches: ctx.exhaustive_matches,
         errors: ctx.errors,
     }
 }
@@ -1358,6 +1368,9 @@ fn check_match_exhaustiveness<'db>(
             missing_cases,
             span: match_span,
         });
+    } else {
+        // Record that this match is exhaustive for codegen optimization
+        ctx.exhaustive_matches.insert(match_expr_id);
     }
 }
 

--- a/baml_language/crates/baml_vir/src/expr.rs
+++ b/baml_language/crates/baml_vir/src/expr.rs
@@ -213,6 +213,10 @@ pub enum Expr {
     Match {
         scrutinee: ExprId,
         arms: Vec<MatchArm>,
+        /// Whether the match is exhaustive (all cases covered).
+        /// Computed during type checking. Used by codegen to emit `unreachable`
+        /// for the fallthrough path, enabling phi-like optimization.
+        is_exhaustive: bool,
     },
 
     // ========== Watch Notifications ==========

--- a/baml_language/crates/baml_vir/src/lower.rs
+++ b/baml_language/crates/baml_vir/src/lower.rs
@@ -448,10 +448,13 @@ impl<'db> LoweringContext<'db> {
                         body,
                     });
                 }
+                // Check if this match was determined to be exhaustive during type checking
+                let is_exhaustive = self.inference.exhaustive_matches.contains(&hir_id);
                 Ok(self.builder.alloc(
                     Expr::Match {
                         scrutinee: scrutinee_id,
                         arms: lowered_arms,
+                        is_exhaustive,
                     },
                     ty,
                     span.map(|s| s.range),

--- a/baml_language/crates/baml_vir/src/pretty.rs
+++ b/baml_language/crates/baml_vir/src/pretty.rs
@@ -288,9 +288,14 @@ impl<'a> PrettyPrinter<'a> {
                 self.output.push(']');
             }
 
-            Expr::Match { scrutinee, arms } => {
+            Expr::Match {
+                scrutinee,
+                arms,
+                is_exhaustive,
+            } => {
                 self.indent(level);
-                writeln!(self.output, "match : {ty}").unwrap();
+                let exhaustive_marker = if *is_exhaustive { " [exhaustive]" } else { "" };
+                writeln!(self.output, "match{exhaustive_marker} : {ty}").unwrap();
                 self.print_expr(*scrutinee, level + 1);
                 for arm in arms {
                     self.output.push('\n');


### PR DESCRIPTION
## Summary

- Add `is_exhaustive` flag to VIR Match expression, computed from TIR exhaustiveness checking
- For exhaustive matches, emit explicit `unreachable` terminator instead of fallthrough to join block
- Add dead code elimination for unreachable blocks during bytecode emission
- Blocks with only `Terminator::Unreachable` and no statements are skipped during codegen

## Changes

**TIR (`baml_tir/src/lib.rs`)**
- Add `exhaustive_matches: HashSet<ExprId>` to track which matches are exhaustive

**VIR (`baml_vir/src/expr.rs`, `baml_vir/src/lower.rs`)**
- Add `is_exhaustive: bool` field to `Expr::Match`
- Read exhaustiveness from TIR during lowering

**MIR (`baml_mir/src/lower.rs`)**
- For exhaustive matches, create single shared unreachable block
- Last arm's pattern failure goes to unreachable block instead of join block

**Codegen (`baml_codegen/src/analysis.rs`, `baml_codegen/src/emit.rs`)**
- Add `is_dead_unreachable_block()` helper to detect eliminable blocks
- Skip emitting blocks with only `Terminator::Unreachable` and no statements
- Record their addresses so jump targets resolve correctly

## Result

Exhaustive match results now get phi-like optimization (no Store/Load pairs), and dead unreachable code is eliminated from final bytecode.

## Test plan

- [x] All 10 match expression tests pass
- [x] All 34 if_else tests pass
- [x] Full test suite passes (299 tests)
- [x] Snapshot tests updated to reflect new MIR/bytecode