### PR TITLE
Implement assert statement in compiler

### DIFF
--- a/baml_language/crates/baml_codegen/src/analysis.rs
+++ b/baml_language/crates/baml_codegen/src/analysis.rs
@@ -509,6 +509,10 @@ fn collect_def_use<'db>(mir: &MirFunction<'db>) -> HashMap<Local, LocalDefUse<'d
                     // VizEnter/VizExit don't use any locals
                 }
                 StatementKind::Nop => {}
+                StatementKind::Assert(operand) => {
+                    // Assert uses the condition operand
+                    collect_uses_in_operand(operand, block.id, stmt_idx, &mut def_use);
+                }
             }
         }
 
@@ -939,6 +943,8 @@ fn is_stack_neutral_statement(kind: &StatementKind<'_>) -> bool {
         // These modify the stack
         StatementKind::Assign { .. } => false,
         StatementKind::Drop(_) => false,
+        // Assert pushes condition then pops it
+        StatementKind::Assert(_) => false,
     }
 }
 
@@ -1343,6 +1349,7 @@ fn has_side_effect(kind: &StatementKind<'_>, rvalue_reads: &HashSet<Local>) -> b
         StatementKind::WatchNotify(_) => true, // WatchNotify has side effects (emits notification)
         StatementKind::VizEnter(_) | StatementKind::VizExit(_) => true, // VizEnter/VizExit emit notifications
         StatementKind::Nop => false,
+        StatementKind::Assert(_) => true, // Assert has side effects (can throw)
     }
 }
 

--- a/baml_language/crates/baml_codegen/src/emit.rs
+++ b/baml_language/crates/baml_codegen/src/emit.rs
@@ -409,6 +409,10 @@ impl<'ctx, 'obj, 'db> StackifyCodegen<'ctx, 'obj, 'db> {
                 self.emit(Instruction::VizExit(*node_idx));
             }
             StatementKind::Nop => {}
+            StatementKind::Assert(operand) => {
+                self.emit_operand_pull(operand, mir);
+                self.emit(Instruction::Assert);
+            }
         }
     }
 

--- a/baml_language/crates/baml_codegen/tests/assertions.rs
+++ b/baml_language/crates/baml_codegen/tests/assertions.rs
@@ -7,7 +7,6 @@ use baml_tests::{
 use baml_vm::{BinOp, CmpOp};
 
 #[test]
-#[ignore = "assert not yet in HIR"]
 fn assert_statement_ok() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: "
@@ -33,7 +32,6 @@ fn assert_statement_ok() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "assert not yet in HIR"]
 fn assert_statement_not_ok() -> anyhow::Result<()> {
     assert_compiles(Program {
         source: "

--- a/baml_language/crates/baml_hir/src/body.rs
+++ b/baml_language/crates/baml_hir/src/body.rs
@@ -260,6 +260,9 @@ pub enum Stmt {
         value: ExprId,
     },
 
+    /// Assert statement: `assert condition;`
+    Assert { condition: ExprId },
+
     /// Missing/error statement
     Missing,
 
@@ -670,6 +673,7 @@ impl LoweringContext {
                         SyntaxKind::CONTINUE_STMT => {
                             self.alloc_stmt(Stmt::Continue, node.text_range())
                         }
+                        SyntaxKind::ASSERT_STMT => self.lower_assert_stmt(node),
                         _ => self.alloc_stmt(Stmt::Missing, node.text_range()),
                     };
                     stmts.push(stmt_id);
@@ -2413,6 +2417,33 @@ impl LoweringContext {
         };
 
         self.alloc_stmt(Stmt::Return(return_value), node.text_range())
+    }
+
+    fn lower_assert_stmt(&mut self, node: &baml_syntax::SyntaxNode) -> StmtId {
+        use baml_syntax::SyntaxKind;
+
+        // ASSERT_STMT structure: assert keyword, expression
+        let condition = node
+            .children()
+            .find(|n| {
+                matches!(
+                    n.kind(),
+                    SyntaxKind::EXPR
+                        | SyntaxKind::BINARY_EXPR
+                        | SyntaxKind::UNARY_EXPR
+                        | SyntaxKind::CALL_EXPR
+                        | SyntaxKind::PATH_EXPR
+                        | SyntaxKind::FIELD_ACCESS_EXPR
+                        | SyntaxKind::INDEX_EXPR
+                        | SyntaxKind::IF_EXPR
+                        | SyntaxKind::BLOCK_EXPR
+                        | SyntaxKind::PAREN_EXPR
+                )
+            })
+            .map(|n| self.lower_expr(&n))
+            .unwrap_or_else(|| self.alloc_expr(Expr::Missing, node.text_range()));
+
+        self.alloc_stmt(Stmt::Assert { condition }, node.text_range())
     }
 
     fn lower_while_stmt(&mut self, node: &baml_syntax::SyntaxNode) -> StmtId {

--- a/baml_language/crates/baml_hir/src/pretty.rs
+++ b/baml_language/crates/baml_hir/src/pretty.rs
@@ -293,6 +293,11 @@ impl<'a> CodePrinter<'a> {
                 self.print_expr(*value);
                 self.output.push(';');
             }
+            Stmt::Assert { condition } => {
+                self.output.push_str("assert ");
+                self.print_expr(*condition);
+                self.output.push(';');
+            }
             Stmt::Missing => {
                 self.output.push_str("<missing>;");
             }

--- a/baml_language/crates/baml_lexer/src/tokens.rs
+++ b/baml_language/crates/baml_lexer/src/tokens.rs
@@ -77,6 +77,8 @@ pub enum TokenKind {
     Return,
     #[token("match")]
     Match,
+    #[token("assert")]
+    Assert,
 
     // Other keywords
     #[token("watch")]
@@ -269,6 +271,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Continue => "continue",
             TokenKind::Return => "return",
             TokenKind::Match => "match",
+            TokenKind::Assert => "assert",
             TokenKind::Watch => "watch",
             TokenKind::Instanceof => "instanceof",
             TokenKind::Env => "env",

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/assert.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/assert.baml
@@ -29,30 +29,4 @@ function assertBool() -> int {
 
 //----
 //- diagnostics
-// Error: Unknown variable assert
-//    ╭─[ 0:9:2 ]
-//    │
-//  9 │     assert 3 == 1;
-//    │     ───┬──  
-//    │        ╰──── Unknown variable assert
-//    │ 
-//    │ Note: Error code: E0003
-// ───╯
-// Error: Unknown variable assert
-//    ╭─[ 0:3:2 ]
-//    │
-//  3 │     assert 2 + 2 == 4;
-//    │     ───┬──  
-//    │        ╰──── Unknown variable assert
-//    │ 
-//    │ Note: Error code: E0003
-// ───╯
-// Error: Unknown variable assert
-//     ╭─[ 0:17:2 ]
-//     │
-//  17 │     assert "string";
-//     │     ───┬──  
-//     │        ╰──── Unknown variable assert
-//     │ 
-//     │ Note: Error code: E0003
-// ────╯
+// <no-diagnostics-expected>

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/constraints/constraints_everywhere.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/constraints/constraints_everywhere.baml
@@ -49,12 +49,12 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ 
 //    │ Note: Error code: E0010
 // ───╯
-// Error: Expected top-level declaration, found identifier
+// Error: Expected top-level declaration, found assert
 //    ╭─[ 0:9:37 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                     ───┬──  
-//    │                                        ╰──── Expected top-level declaration, found identifier
+//    │                                        ╰──── Expected top-level declaration, found assert
 //    │ 
 //    │ Note: Error code: E0010
 // ───╯

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/tests/field_level_assertions_v2.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/tests/field_level_assertions_v2.baml
@@ -30,6 +30,24 @@ test MyTest {
 //    │ 
 //    │ Note: Error code: E0010
 // ───╯
+// Error: Expected config key, found assert
+//    ╭─[ 0:9:29 ]
+//    │
+//  9 │   functions [TestFunction] @assert({{ true }})
+//    │                             ───┬──  
+//    │                                ╰──── Expected config key, found assert
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯
+// Error: Expected config key, found '('
+//    ╭─[ 0:9:35 ]
+//    │
+//  9 │   functions [TestFunction] @assert({{ true }})
+//    │                                   ┬  
+//    │                                   ╰── Expected config key, found '('
+//    │ 
+//    │ Note: Error code: E0010
+// ───╯
 // Error: Expected config key, found '{'
 //    ╭─[ 0:9:36 ]
 //    │

--- a/baml_language/crates/baml_mir/src/builder.rs
+++ b/baml_language/crates/baml_mir/src/builder.rs
@@ -194,6 +194,11 @@ impl<'db> MirBuilder<'db> {
         self.push_statement(StatementKind::WatchNotify(local), None);
     }
 
+    /// Emit an assert statement.
+    pub fn assert(&mut self, condition: Operand<'db>) {
+        self.push_statement(StatementKind::Assert(condition), None);
+    }
+
     // ========================================================================
     // Terminator Emission
     // ========================================================================

--- a/baml_language/crates/baml_mir/src/ir.rs
+++ b/baml_language/crates/baml_mir/src/ir.rs
@@ -186,6 +186,10 @@ pub enum StatementKind<'db> {
 
     /// No-op (placeholder for removed statements).
     Nop,
+
+    /// Assert that a condition is true.
+    /// Evaluates the operand and panics if it's false.
+    Assert(Operand<'db>),
 }
 
 // ============================================================================

--- a/baml_language/crates/baml_mir/src/lower.rs
+++ b/baml_language/crates/baml_mir/src/lower.rs
@@ -487,6 +487,21 @@ impl<'db, 'ctx> LoweringContext<'db, 'ctx> {
                 }
             }
 
+            Expr::Assert { condition } => {
+                // Evaluate the condition
+                let cond_local = self
+                    .builder
+                    .temp(Self::lower_typed_ir_ty(body.ty(*condition)));
+                self.lower_expr(*condition, Place::local(cond_local), body);
+
+                // Emit assert statement
+                self.builder.assert(Operand::copy_local(cond_local));
+
+                // Return unit
+                self.builder
+                    .assign(dest, Rvalue::Use(Operand::Constant(Constant::Null)));
+            }
+
             // ========== Assignment ==========
             Expr::Assign { target, value } => {
                 let value_ty = Self::lower_typed_ir_ty(body.ty(*value));

--- a/baml_language/crates/baml_mir/src/pretty.rs
+++ b/baml_language/crates/baml_mir/src/pretty.rs
@@ -149,6 +149,11 @@ fn write_statement(f: &mut impl Write, stmt: &Statement<'_>) -> fmt::Result {
         StatementKind::Nop => {
             write!(f, "nop;")
         }
+        StatementKind::Assert(operand) => {
+            write!(f, "assert(")?;
+            write_operand(f, operand)?;
+            write!(f, ");")
+        }
     }
 }
 

--- a/baml_language/crates/baml_parser/src/parser.rs
+++ b/baml_language/crates/baml_parser/src/parser.rs
@@ -50,6 +50,7 @@ fn token_kind_to_syntax_kind(kind: TokenKind) -> SyntaxKind {
         TokenKind::Env => SyntaxKind::KW_ENV,
         TokenKind::Dynamic => SyntaxKind::KW_DYNAMIC,
         TokenKind::Match => SyntaxKind::KW_MATCH,
+        TokenKind::Assert => SyntaxKind::KW_ASSERT,
 
         // Literals
         TokenKind::Word => SyntaxKind::WORD,
@@ -956,12 +957,13 @@ impl<'a> Parser<'a> {
             p.expect(TokenKind::At);
 
             // Attribute name (can be dotted like stream.done)
-            if p.at(TokenKind::Word) {
+            // Allow keywords like 'assert' as attribute names (for @assert)
+            if p.at(TokenKind::Word) || p.at(TokenKind::Assert) {
                 p.bump();
                 // Handle dotted attribute names like @stream.done
                 while p.at(TokenKind::Dot) {
                     p.bump(); // consume dot
-                    if p.at(TokenKind::Word) {
+                    if p.at(TokenKind::Word) || p.at(TokenKind::Assert) {
                         p.bump(); // consume next segment
                     } else {
                         p.error_unexpected_token("attribute name segment after dot".to_string());
@@ -985,8 +987,8 @@ impl<'a> Parser<'a> {
         self.with_node(SyntaxKind::BLOCK_ATTRIBUTE, |p| {
             p.expect(TokenKind::AtAt);
 
-            // Attribute name (can be a Word or reserved keyword like Dynamic)
-            if p.at(TokenKind::Word) || p.at(TokenKind::Dynamic) {
+            // Attribute name (can be a Word or reserved keyword like Dynamic or Assert)
+            if p.at(TokenKind::Word) || p.at(TokenKind::Dynamic) || p.at(TokenKind::Assert) {
                 p.bump();
             } else {
                 p.error_unexpected_token("attribute name".to_string());
@@ -1560,6 +1562,8 @@ impl<'a> Parser<'a> {
             self.parse_break_stmt();
         } else if self.at(TokenKind::Continue) {
             self.parse_continue_stmt();
+        } else if self.at(TokenKind::Assert) {
+            self.parse_assert_stmt();
         } else {
             // Expression statement
             self.parse_expr_stmt();
@@ -1633,6 +1637,18 @@ impl<'a> Parser<'a> {
             if !p.at(TokenKind::RBrace) && !p.at_end() {
                 p.parse_expr();
             }
+
+            // Consume trailing semicolon
+            p.eat(TokenKind::Semicolon);
+        });
+    }
+
+    fn parse_assert_stmt(&mut self) {
+        self.with_node(SyntaxKind::ASSERT_STMT, |p| {
+            p.expect(TokenKind::Assert);
+
+            // Condition expression
+            p.parse_expr();
 
             // Consume trailing semicolon
             p.eat(TokenKind::Semicolon);

--- a/baml_language/crates/baml_syntax/src/ast.rs
+++ b/baml_language/crates/baml_syntax/src/ast.rs
@@ -1035,7 +1035,8 @@ impl BlockExpr {
                         | SyntaxKind::WHILE_STMT
                         | SyntaxKind::FOR_EXPR
                         | SyntaxKind::BREAK_STMT
-                        | SyntaxKind::CONTINUE_STMT => Some(BlockElement::Stmt(n)),
+                        | SyntaxKind::CONTINUE_STMT
+                        | SyntaxKind::ASSERT_STMT => Some(BlockElement::Stmt(n)),
                         // Header comment (//# name)
                         SyntaxKind::HEADER_COMMENT => Some(BlockElement::HeaderComment(n)),
                         // Expression nodes

--- a/baml_language/crates/baml_syntax/src/syntax_kind.rs
+++ b/baml_language/crates/baml_syntax/src/syntax_kind.rs
@@ -30,6 +30,7 @@ pub enum SyntaxKind {
     KW_CONTINUE,
     KW_RETURN,
     KW_MATCH,
+    KW_ASSERT,
 
     // Other keywords
     KW_WATCH,
@@ -225,6 +226,7 @@ pub enum SyntaxKind {
     BREAK_STMT,
     CONTINUE_STMT,
     RETURN_STMT,
+    ASSERT_STMT,
 
     // Expression components
     CALL_ARGS,

--- a/baml_language/crates/baml_tir/src/lib.rs
+++ b/baml_language/crates/baml_tir/src/lib.rs
@@ -1842,6 +1842,19 @@ fn check_stmt(ctx: &mut TypeContext<'_>, stmt_id: StmtId, body: &ExprBody) {
             // TODO: Check that the operation is valid for the types
         }
 
+        Stmt::Assert { condition } => {
+            // Type-check the condition expression
+            let cond_ty = infer_expr(ctx, *condition, body);
+            if !cond_ty.is_subtype_of(&Ty::Bool) {
+                let span = body.get_expr_span(*condition).unwrap_or_default();
+                ctx.push_error(TypeError::TypeMismatch {
+                    expected: Ty::Bool,
+                    found: cond_ty,
+                    span,
+                });
+            }
+        }
+
         Stmt::Missing => {}
 
         Stmt::HeaderComment { .. } => {

--- a/baml_language/crates/baml_tir/src/pretty.rs
+++ b/baml_language/crates/baml_tir/src/pretty.rs
@@ -451,6 +451,12 @@ impl<'a, 'db> TreeRenderer<'a, 'db> {
                 self.render_expr(*value, body, result, true);
                 self.pop_continuation();
             }
+            Stmt::Assert { condition } => {
+                writeln!(self.output, "{prefix}Assert").ok();
+                self.push_continuation(false);
+                self.render_expr(*condition, body, result, true);
+                self.pop_continuation();
+            }
             Stmt::Missing => {
                 writeln!(self.output, "{prefix}<missing stmt>").ok();
             }

--- a/baml_language/crates/baml_vir/src/expr.rs
+++ b/baml_language/crates/baml_vir/src/expr.rs
@@ -159,6 +159,11 @@ pub enum Expr {
     /// Continue to next iteration. Diverges (type is Never).
     Continue,
 
+    /// Assert statement: `assert condition;`
+    ///
+    /// Evaluates `condition` and panics if false. Returns Unit.
+    Assert { condition: ExprId },
+
     // ========== Assignment ==========
     /// Simple assignment: `target = value`. Returns Unit.
     Assign { target: ExprId, value: ExprId },

--- a/baml_language/crates/baml_vir/src/lower.rs
+++ b/baml_language/crates/baml_vir/src/lower.rs
@@ -694,6 +694,17 @@ impl<'db> LoweringContext<'db> {
                 ))
             }
 
+            HirStmt::Assert { condition } => {
+                let condition_id = self.lower_expr(*condition, hir_body)?;
+                Ok(self.builder.alloc(
+                    Expr::Assert {
+                        condition: condition_id,
+                    },
+                    Ty::Unit,
+                    text_range,
+                ))
+            }
+
             HirStmt::HeaderComment { name, level } => Ok(self.builder.alloc(
                 Expr::NotifyBlock {
                     name: name.clone(),

--- a/baml_language/crates/baml_vir/src/pretty.rs
+++ b/baml_language/crates/baml_vir/src/pretty.rs
@@ -143,6 +143,12 @@ impl<'a> PrettyPrinter<'a> {
                 self.output.push_str("continue");
             }
 
+            Expr::Assert { condition } => {
+                self.indent(level);
+                self.output.push_str("assert\n");
+                self.print_expr(*condition, level + 1);
+            }
+
             Expr::Assign { target, value } => {
                 self.indent(level);
                 self.output.push_str("assign\n");

--- a/baml_language/crates/baml_vm/tests/assertions.rs
+++ b/baml_language/crates/baml_vm/tests/assertions.rs
@@ -6,7 +6,6 @@ use baml_tests::bytecode::{
 use baml_vm::RuntimeError;
 
 #[test]
-#[ignore = "assert statements not yet implemented in HIR"]
 fn assert_ok() -> anyhow::Result<()> {
     assert_vm_executes(Program {
         source: r#"
@@ -23,7 +22,6 @@ fn assert_ok() -> anyhow::Result<()> {
 }
 
 #[test]
-#[ignore = "assertion error handling not matching expected"]
 fn assert_not_ok() -> anyhow::Result<()> {
     assert_vm_fails(FailingProgram {
         source: r#"


### PR DESCRIPTION
## Summary

Adds support for the `assert` statement across the entire compiler pipeline:

- **Lexer**: Add `Assert` keyword token
- **Syntax**: Add `KW_ASSERT` and `ASSERT_STMT` syntax kinds  
- **Parser**: Add `parse_assert_stmt()` and allow `assert` as attribute name (for `@assert`/`@@assert` decorators)
- **HIR**: Add `Stmt::Assert` variant and `lower_assert_stmt()` function
- **TIR**: Add type checking (condition must be bool)
- **VIR**: Add `Expr::Assert` and lowering from HIR
- **MIR**: Add `StatementKind::Assert` and lowering from VIR
- **Codegen**: Add bytecode emission for `Instruction::Assert`

The assert statement evaluates a boolean condition and raises an `AssertionError` at runtime if the condition is false.

Example usage:
```baml
function example() -> int {
    assert 2 + 2 == 4;
    42
}
```

## Test plan

- [x] `cargo test --package baml_codegen --test assertions` - verifies bytecode generation
- [x] `cargo test --package baml_vm --test assertions` - verifies runtime behavior
- [x] `cargo test -p baml_lsp_tests` - all 191 LSP tests pass
- [x] `cargo test` - full test suite passes