### PR TITLE
add abort error details

### DIFF
--- a/engine/baml-runtime/src/errors.rs
+++ b/engine/baml-runtime/src/errors.rs
@@ -111,10 +111,8 @@ impl std::fmt::Display for ExposedError {
             } => {
                 write!(f, "LLM client \"{client_name}\" timed out: {message}")
             }
-            ExposedError::AbortError {
-                detailed_message: _,
-            } => {
-                write!(f, "AbortError")
+            ExposedError::AbortError { detailed_message } => {
+                write!(f, "AbortError: {detailed_message}")
             }
         }
     }
@@ -176,11 +174,11 @@ impl IntoBamlError for &anyhow::Error {
                     message: Cow::Owned(message.clone()),
                     status_code: 408, // HTTP 408 Request Timeout
                 },
-                ExposedError::AbortError {
-                    detailed_message: _,
-                } => baml_types::tracing::events::BamlError::Base {
-                    message: "AbortError".into(),
-                },
+                ExposedError::AbortError { detailed_message } => {
+                    baml_types::tracing::events::BamlError::Base {
+                        message: Cow::Owned(format!("AbortError: {detailed_message}")),
+                    }
+                }
             };
         }
         if let Some(baml_error) = self.downcast_ref::<baml_types::tracing::events::BamlError<'_>>()


### PR DESCRIPTION
Our DB just shows AbortError without any details. This should help us figure out where these errors are coming from.

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit a5605d332d8982bfa4bd87b389478cd1387a3015. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->