### PR TITLE
Put filenames in ariadne diagnostics

### DIFF
--- a/baml_language/.claude/settings.local.json
+++ b/baml_language/.claude/settings.local.json
@@ -15,7 +15,8 @@
       "Bash(cat:*)",
       "Bash(nix develop:*)",
       "Bash(find:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "WebFetch(domain:docs.rs)"
     ]
   }
 }

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -355,6 +355,8 @@ version = "0.0.0"
 dependencies = [
  "ariadne",
  "baml_base",
+ "baml_workspace",
+ "salsa",
  "text-size",
 ]
 

--- a/baml_language/crates/baml_diagnostics/Cargo.toml
+++ b/baml_language/crates/baml_diagnostics/Cargo.toml
@@ -18,6 +18,8 @@ workspace = true
 
 [dependencies]
 baml_base = { workspace = true }
+baml_workspace = { workspace = true }
 
 ariadne = { workspace = true }
+salsa = { workspace = true }
 text-size = { workspace = true }

--- a/baml_language/crates/baml_diagnostics/src/compiler_error.rs
+++ b/baml_language/crates/baml_diagnostics/src/compiler_error.rs
@@ -4,14 +4,89 @@ pub mod name_error;
 pub mod parse_error;
 pub mod type_error;
 
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt};
 
-use ariadne::{Report, ReportKind};
+use ariadne::{Report, ReportKind, Source};
 use baml_base::{FileId, Span};
+use baml_workspace::Project;
 pub use hir_diagnostic::HirDiagnostic;
 pub use name_error::NameError;
 pub use parse_error::ParseError;
 pub use type_error::TypeError;
+
+/// A cache for ariadne that lazily loads sources from the Salsa database.
+///
+/// This avoids copying source text by using `&str` references into the database.
+pub struct DbSourceCache<'db> {
+    db: &'db dyn salsa::Database,
+    project: Project,
+    sources: HashMap<FileId, Source<&'db str>>,
+    filenames: HashMap<FileId, String>,
+}
+
+impl<'db> DbSourceCache<'db> {
+    /// Create a new source cache backed by the database.
+    pub fn new(db: &'db dyn salsa::Database, project: Project) -> Self {
+        DbSourceCache {
+            db,
+            project,
+            sources: HashMap::new(),
+            filenames: HashMap::new(),
+        }
+    }
+}
+
+/// A wrapper type for displaying file IDs as filenames.
+struct FileIdDisplay {
+    file_id: FileId,
+    filename: Option<String>,
+}
+
+impl fmt::Display for FileIdDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(ref name) = self.filename {
+            write!(f, "{name}")
+        } else {
+            write!(f, "{}", self.file_id)
+        }
+    }
+}
+
+#[allow(refining_impl_trait)]
+impl<'db> ariadne::Cache<FileId> for DbSourceCache<'db> {
+    type Storage = &'db str;
+
+    fn fetch(&mut self, id: &FileId) -> Result<&Source<Self::Storage>, Box<dyn fmt::Debug + '_>> {
+        if !self.sources.contains_key(id) {
+            // Find the file with this FileId
+            let file = self
+                .project
+                .files(self.db)
+                .iter()
+                .find(|f| f.file_id(self.db) == *id)
+                .copied()
+                .ok_or_else(|| Box::new(format!("Unknown file ID: {id}")) as Box<dyn fmt::Debug>)?;
+
+            let text: &'db str = file.text(self.db);
+            self.sources.insert(*id, Source::from(text));
+            self.filenames
+                .insert(*id, file.path(self.db).display().to_string());
+        }
+
+        self.sources
+            .get(id)
+            .ok_or_else(|| Box::new(format!("Unknown file ID: {id}")) as Box<dyn fmt::Debug>)
+    }
+
+    fn display<'a>(&self, id: &'a FileId) -> Option<Box<dyn fmt::Display + 'a>> {
+        // Return the filename if available, otherwise fall back to the file ID
+        let filename = self.filenames.get(id).cloned();
+        Some(Box::new(FileIdDisplay {
+            file_id: *id,
+            filename,
+        }))
+    }
+}
 
 /// Every compiler error that can occur in the compiler.
 /// It is parameterized by several types that are owned by the different compiler phases,
@@ -95,21 +170,13 @@ const WATCH_ON_UNWATCHED_VARIABLE: ErrorCode = ErrorCode(66);
 
 /// Render an ariadne Report to a String.
 ///
-/// The `sources` map should contain the source text for each `FileId` referenced
-/// in the report's spans.
-pub fn render_report_to_string(
-    report: &Report<'_, Span>,
-    sources: &HashMap<FileId, String>,
-) -> String {
+/// Uses the provided cache to look up source text and filenames for the spans
+/// referenced in the report. Reusing the same cache across multiple renders
+/// avoids redundant lookups.
+pub fn render_report_to_string(report: &Report<'_, Span>, cache: &mut DbSourceCache<'_>) -> String {
     let mut output = Vec::new();
 
-    // ariadne::sources expects types that implement AsRef<str>, so we pass String directly
-    let ariadne_sources: HashMap<FileId, String> = sources.clone();
-
-    // Use ariadne's sources helper which creates a cache from a HashMap
-    let mut cache = ariadne::sources(ariadne_sources);
-
-    report.write(&mut cache, &mut output).unwrap_or_else(|_| {
+    report.write(cache, &mut output).unwrap_or_else(|_| {
         // If writing fails, provide a fallback
         output.clear();
         output.extend_from_slice(b"<error rendering diagnostic>");
@@ -124,7 +191,7 @@ pub fn render_report_to_string(
 /// of rendering parse errors.
 pub fn render_parse_error(
     error: &ParseError,
-    sources: &HashMap<FileId, String>,
+    cache: &mut DbSourceCache<'_>,
     color: bool,
 ) -> String {
     let color_mode = if color {
@@ -134,7 +201,7 @@ pub fn render_parse_error(
     };
     let compiler_error: CompilerError<String> = CompilerError::ParseError(error.clone());
     let report = render_error(&color_mode, compiler_error);
-    render_report_to_string(&report, sources)
+    render_report_to_string(&report, cache)
 }
 
 /// Convenience function to render a `TypeError` directly to a string.
@@ -143,7 +210,7 @@ pub fn render_parse_error(
 /// of rendering type errors. The type parameter `Ty` must implement `Display` and `Clone`.
 pub fn render_type_error<Ty: std::fmt::Display + Clone>(
     error: &TypeError<Ty>,
-    sources: &HashMap<FileId, String>,
+    cache: &mut DbSourceCache<'_>,
     color: bool,
 ) -> String {
     let color_mode = if color {
@@ -153,18 +220,14 @@ pub fn render_type_error<Ty: std::fmt::Display + Clone>(
     };
     let compiler_error: CompilerError<Ty> = CompilerError::TypeError(error.clone());
     let report = render_error(&color_mode, compiler_error);
-    render_report_to_string(&report, sources)
+    render_report_to_string(&report, cache)
 }
 
 /// Convenience function to render a `NameError` directly to a string.
 ///
 /// This combines `render_error` and `render_report_to_string` for the common case
 /// of rendering name resolution errors.
-pub fn render_name_error(
-    error: &NameError,
-    sources: &HashMap<FileId, String>,
-    color: bool,
-) -> String {
+pub fn render_name_error(error: &NameError, cache: &mut DbSourceCache<'_>, color: bool) -> String {
     let color_mode = if color {
         ColorMode::Color
     } else {
@@ -173,7 +236,7 @@ pub fn render_name_error(
     // Use String as the type parameter since NameError doesn't use it
     let compiler_error: CompilerError<String> = CompilerError::NameError(error.clone());
     let report = render_error(&color_mode, compiler_error);
-    render_report_to_string(&report, sources)
+    render_report_to_string(&report, cache)
 }
 
 /// Convenience function to render a `HirDiagnostic` directly to a string.
@@ -182,7 +245,7 @@ pub fn render_name_error(
 /// of rendering HIR lowering diagnostics.
 pub fn render_hir_diagnostic(
     error: &HirDiagnostic,
-    sources: &HashMap<FileId, String>,
+    cache: &mut DbSourceCache<'_>,
     color: bool,
 ) -> String {
     let color_mode = if color {
@@ -192,5 +255,5 @@ pub fn render_hir_diagnostic(
     };
     let compiler_error: CompilerError<String> = CompilerError::HirDiagnostic(error.clone());
     let report = render_error(&color_mode, compiler_error);
-    render_report_to_string(&report, sources)
+    render_report_to_string(&report, cache)
 }

--- a/baml_language/crates/baml_diagnostics/src/lib.rs
+++ b/baml_language/crates/baml_diagnostics/src/lib.rs
@@ -6,7 +6,7 @@
 pub mod compiler_error;
 
 pub use compiler_error::{
-    ColorMode, CompilerError, HirDiagnostic, NameError, ParseError, TypeError, render_error,
-    render_hir_diagnostic, render_name_error, render_parse_error, render_report_to_string,
-    render_type_error,
+    ColorMode, CompilerError, DbSourceCache, HirDiagnostic, NameError, ParseError, TypeError,
+    render_error, render_hir_diagnostic, render_name_error, render_parse_error,
+    render_report_to_string, render_type_error,
 };

--- a/baml_language/crates/baml_lsp_tests/src/runner.rs
+++ b/baml_language/crates/baml_lsp_tests/src/runner.rs
@@ -1,7 +1,5 @@
 //! Test runner for inline assertion tests.
 
-use std::collections::HashMap;
-
 use baml_db::{
     RootDatabase,
     baml_hir::{self, file_items, function_body, function_signature},
@@ -9,7 +7,7 @@ use baml_db::{
     baml_tir::{self, class_field_types, type_aliases, typing_context},
 };
 use baml_diagnostics::{
-    render_hir_diagnostic, render_name_error, render_parse_error, render_type_error,
+    DbSourceCache, render_hir_diagnostic, render_name_error, render_parse_error, render_type_error,
 };
 use salsa::Setter;
 
@@ -41,12 +39,10 @@ pub fn run_test(parsed: &ParsedTestFile) -> TestResult {
     let mut db = RootDatabase::new();
     let root = db.set_project_root(std::path::PathBuf::from("."));
 
-    let mut sources: HashMap<baml_db::FileId, String> = HashMap::new();
     let mut source_files = Vec::new();
 
     for (filename, vfile) in &parsed.files {
         let source_file = db.add_file(filename, &vfile.content);
-        sources.insert(source_file.file_id(&db), vfile.content.clone());
         source_files.push(source_file);
     }
 
@@ -55,12 +51,13 @@ pub fn run_test(parsed: &ParsedTestFile) -> TestResult {
 
     // 2. Collect all diagnostics
     let mut all_errors: Vec<String> = Vec::new();
+    let mut cache = DbSourceCache::new(&db, root);
 
     // Collect parse errors
     for source_file in &source_files {
         let errors = baml_parser::parse_errors(&db, *source_file);
         for error in errors.iter() {
-            all_errors.push(render_parse_error(error, &sources, false));
+            all_errors.push(render_parse_error(error, &mut cache, false));
         }
     }
 
@@ -68,17 +65,17 @@ pub fn run_test(parsed: &ParsedTestFile) -> TestResult {
     for source_file in &source_files {
         let lowering_result = baml_hir::file_lowering(&db, *source_file);
         for diag in lowering_result.diagnostics(&db) {
-            all_errors.push(render_hir_diagnostic(diag, &sources, false));
+            all_errors.push(render_hir_diagnostic(diag, &mut cache, false));
         }
     }
 
     // Collect validation errors (duplicates across files, reserved names)
     let validation_result = baml_hir::validate_hir(&db, root);
     for diag in validation_result.hir_diagnostics {
-        all_errors.push(render_hir_diagnostic(&diag, &sources, false));
+        all_errors.push(render_hir_diagnostic(&diag, &mut cache, false));
     }
     for error in validation_result.name_errors {
-        all_errors.push(render_name_error(&error, &sources, false));
+        all_errors.push(render_name_error(&error, &mut cache, false));
     }
 
     // Collect type errors
@@ -106,7 +103,7 @@ pub fn run_test(parsed: &ParsedTestFile) -> TestResult {
                     *func_id,
                 );
                 for error in &result.errors {
-                    all_errors.push(render_type_error(error, &sources, false));
+                    all_errors.push(render_type_error(error, &mut cache, false));
                 }
             }
         }

--- a/baml_language/crates/baml_lsp_tests/test_files/on_hover/unknown_variable.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/on_hover/unknown_variable.baml
@@ -5,7 +5,7 @@ function UseUnknown() -> int {
 //----
 //- diagnostics
 // Error: Unknown variable unknown_var
-//    ╭─[ 0:2:3 ]
+//    ╭─[ unknown_variable.baml:2:3 ]
 //    │
 //  2 │   unknown_var + 1
 //    │   ─────┬─────  
@@ -14,7 +14,7 @@ function UseUnknown() -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Cannot apply operator 'Add' to types unknown and int
-//    ╭─[ 0:2:3 ]
+//    ╭─[ unknown_variable.baml:2:3 ]
 //    │
 //  2 │   unknown_var + 1
 //    │   ───────┬───────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/class/attributes.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/class/attributes.baml
@@ -44,7 +44,7 @@ class HasThreeBlockAttributes {
 //----
 //- diagnostics
 // Error: Attribute '@alias' can only be defined once on field 'key2' in class 'TestClassAlias'
-//    ╭─[ 0:7:32 ]
+//    ╭─[ class_attributes.baml:7:32 ]
 //    │
 //  7 │   key2 string @alias("key21") @alias("key22")
 //    │                ──┬──           ──┬──  
@@ -55,13 +55,13 @@ class HasThreeBlockAttributes {
 //    │ Note: Error code: E0014
 // ───╯
 // Error: Attribute '@@description' can only be defined once on class 'HasThreeBlockAttributes'
-//     ╭─[ 0:22:5 ]
+//     ╭─[ class_attributes.baml:22:5 ]
 //     │
 //  22 │   @@description("A second description")
 //     │     ─────┬─────  
 //     │          ╰─────── duplicate attribute
 //     │
-//     ├─[ 0:22:5 ]
+//     ├─[ class_attributes.baml:22:5 ]
 //     │
 //  20 │   @@description("A test")
 //     │     ─────┬─────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/class/duplicate_definitions.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/class/duplicate_definitions.baml
@@ -60,7 +60,7 @@ type A = int
 //----
 //- diagnostics
 // Error: Duplicate class 'A'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ class_duplicate_definitions.baml:1:1 ]
 //    │
 //  1 │ class A {
 //    │ │ 
@@ -71,7 +71,7 @@ type A = int
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate type alias 'A'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ class_duplicate_definitions.baml:1:1 ]
 //    │
 //  1 │ class A {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/class/generator_keywords1.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/class/generator_keywords1.baml
@@ -29,7 +29,7 @@ class Foo {
 //----
 //- diagnostics
 // Error: Expected Unexpected token in class body, found if
-//     ╭─[ 0:12:5 ]
+//     ╭─[ class_generator_keywords1.baml:12:5 ]
 //     │
 //  12 │     if string
 //     │     ─┬  
@@ -38,7 +38,7 @@ class Foo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: field 'string' is missing a type annotation
-//     ╭─[ 0:12:8 ]
+//     ╭─[ class_generator_keywords1.baml:12:8 ]
 //     │
 //  12 │     if string
 //     │        ───┬──  
@@ -47,7 +47,7 @@ class Foo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Error validating field `ETA` in class `Foo`: When using the python/pydantic generator, a field name must not be exactly equal to the type name (`ETA`). Consider changing the field name or using an @alias.
-//     ╭─[ 0:13:5 ]
+//     ╭─[ class_generator_keywords1.baml:13:5 ]
 //     │
 //  13 │     ETA ETA?
 //     │     ─┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/class/incomplete_class.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/class/incomplete_class.baml
@@ -14,7 +14,7 @@ class InterfaceThree {
 //----
 //- diagnostics
 // Error: field 'foo' is missing a type annotation
-//    ╭─[ 0:3:3 ]
+//    ╭─[ class_incomplete_class.baml:3:3 ]
 //    │
 //  3 │   foo
 //    │   ─┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/class/invalid_keyword_in_type_def.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/class/invalid_keyword_in_type_def.baml
@@ -32,7 +32,7 @@ random_keyword WrongEnum {
 //----
 //- diagnostics
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:10:1 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:10:1 ]
 //     │
 //  10 │ classs WrongClass {
 //     │ ───┬──  
@@ -41,7 +41,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:10:8 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:10:8 ]
 //     │
 //  10 │ classs WrongClass {
 //     │        ─────┬────  
@@ -50,7 +50,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:10:19 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:10:19 ]
 //     │
 //  10 │ classs WrongClass {
 //     │                   ┬  
@@ -59,7 +59,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:11:3 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:11:3 ]
 //     │
 //  11 │   field string
 //     │   ──┬──  
@@ -68,7 +68,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:11:9 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:11:9 ]
 //     │
 //  11 │   field string
 //     │         ───┬──  
@@ -77,7 +77,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:12:1 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:12:1 ]
 //     │
 //  12 │ }
 //     │ ┬  
@@ -86,7 +86,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:14:1 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:14:1 ]
 //     │
 //  14 │ random_keyword WrongEnum {
 //     │ ───────┬──────  
@@ -95,7 +95,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:14:16 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:14:16 ]
 //     │
 //  14 │ random_keyword WrongEnum {
 //     │                ────┬────  
@@ -104,7 +104,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:14:26 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:14:26 ]
 //     │
 //  14 │ random_keyword WrongEnum {
 //     │                          ┬  
@@ -113,7 +113,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:15:3 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:15:3 ]
 //     │
 //  15 │   A
 //     │   ┬  
@@ -122,7 +122,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:16:3 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:16:3 ]
 //     │
 //  16 │   B
 //     │   ┬  
@@ -131,7 +131,7 @@ random_keyword WrongEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:17:1 ]
+//     ╭─[ class_invalid_keyword_in_type_def.baml:17:1 ]
 //     │
 //  17 │ }
 //     │ ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/class/invalid_type_aliases.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/class/invalid_type_aliases.baml
@@ -58,7 +58,7 @@ type Four = int | string | b
 //----
 //- diagnostics
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:1 ]
+//    ╭─[ class_invalid_type_aliases.baml:9:1 ]
 //    │
 //  9 │ typpe Two = float
 //    │ ──┬──  
@@ -67,7 +67,7 @@ type Four = int | string | b
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:7 ]
+//    ╭─[ class_invalid_type_aliases.baml:9:7 ]
 //    │
 //  9 │ typpe Two = float
 //    │       ─┬─  
@@ -76,7 +76,7 @@ type Four = int | string | b
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '='
-//    ╭─[ 0:9:11 ]
+//    ╭─[ class_invalid_type_aliases.baml:9:11 ]
 //    │
 //  9 │ typpe Two = float
 //    │           ┬  
@@ -85,7 +85,7 @@ type Four = int | string | b
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:13 ]
+//    ╭─[ class_invalid_type_aliases.baml:9:13 ]
 //    │
 //  9 │ typpe Two = float
 //    │             ──┬──  
@@ -94,7 +94,7 @@ type Four = int | string | b
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Duplicate type alias 'One'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ class_invalid_type_aliases.baml:1:1 ]
 //    │
 //  1 │ class One {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/class/map_types2.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/class/map_types2.baml
@@ -60,7 +60,7 @@ function InputAndOutput(i1: map<string, string>, i2: map<MapDummy, string>) -> m
 //----
 //- diagnostics
 // Error: Expected type, found '>'
-//     ╭─[ 0:26:10 ]
+//     ╭─[ class_map_types2.baml:26:10 ]
 //     │
 //  26 │   d1 map<>
 //     │          ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/class/partial_class.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/class/partial_class.baml
@@ -13,7 +13,7 @@ class TestClassAlias {
 //----
 //- diagnostics
 // Error: field 'we' is missing a type annotation
-//    ╭─[ 0:2:3 ]
+//    ╭─[ class_partial_class.baml:2:3 ]
 //    │
 //  2 │   we
 //    │   ─┬  
@@ -22,7 +22,7 @@ class TestClassAlias {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Attribute '@alias' can only be defined once on field 'key2' in class 'TestClassAlias'
-//    ╭─[ 0:8:32 ]
+//    ╭─[ class_partial_class.baml:8:32 ]
 //    │
 //  8 │   key2 string @alias("key21") @alias("key22")
 //    │                ──┬──           ──┬──  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/class/secure_types.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/class/secure_types.baml
@@ -29,7 +29,7 @@ class ComplexTypes {
 //----
 //- diagnostics
 // Error: Expected ')', found '.'
-//    ╭─[ 0:4:65 ]
+//    ╭─[ class_secure_types.baml:4:65 ]
 //    │
 //  4 │   b (int, map<bool, string?>, (char | float)[][] | long_word_123.foobar[])
 //    │                                                                 ┬  
@@ -38,7 +38,7 @@ class ComplexTypes {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected Unexpected token in class body, found '.'
-//    ╭─[ 0:4:65 ]
+//    ╭─[ class_secure_types.baml:4:65 ]
 //    │
 //  4 │   b (int, map<bool, string?>, (char | float)[][] | long_word_123.foobar[])
 //    │                                                                 ┬  
@@ -47,7 +47,7 @@ class ComplexTypes {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: field 'foobar' is missing a type annotation
-//    ╭─[ 0:4:66 ]
+//    ╭─[ class_secure_types.baml:4:66 ]
 //    │
 //  4 │   b (int, map<bool, string?>, (char | float)[][] | long_word_123.foobar[])
 //    │                                                                  ───┬──  
@@ -56,7 +56,7 @@ class ComplexTypes {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected Unexpected token in class body, found '['
-//    ╭─[ 0:4:72 ]
+//    ╭─[ class_secure_types.baml:4:72 ]
 //    │
 //  4 │   b (int, map<bool, string?>, (char | float)[][] | long_word_123.foobar[])
 //    │                                                                        ┬  
@@ -65,7 +65,7 @@ class ComplexTypes {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected Unexpected token in class body, found ']'
-//    ╭─[ 0:4:73 ]
+//    ╭─[ class_secure_types.baml:4:73 ]
 //    │
 //  4 │   b (int, map<bool, string?>, (char | float)[][] | long_word_123.foobar[])
 //    │                                                                         ┬  
@@ -74,7 +74,7 @@ class ComplexTypes {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected Unexpected token in class body, found ')'
-//    ╭─[ 0:4:74 ]
+//    ╭─[ class_secure_types.baml:4:74 ]
 //    │
 //  4 │   b (int, map<bool, string?>, (char | float)[][] | long_word_123.foobar[])
 //    │                                                                          ┬  
@@ -83,7 +83,7 @@ class ComplexTypes {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected '>', found '>>'
-//     ╭─[ 0:16:62 ]
+//     ╭─[ class_secure_types.baml:16:62 ]
 //     │
 //  16 │   n map<complex_key_type[], map<another_key, (int | string[])>>
 //     │                                                              ─┬  
@@ -92,7 +92,7 @@ class ComplexTypes {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '>', found '>>'
-//     ╭─[ 0:16:62 ]
+//     ╭─[ class_secure_types.baml:16:62 ]
 //     │
 //  16 │   n map<complex_key_type[], map<another_key, (int | string[])>>
 //     │                                                              ─┬  
@@ -101,7 +101,7 @@ class ComplexTypes {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected Unexpected token in class body, found '>>'
-//     ╭─[ 0:16:62 ]
+//     ╭─[ class_secure_types.baml:16:62 ]
 //     │
 //  16 │   n map<complex_key_type[], map<another_key, (int | string[])>>
 //     │                                                              ─┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/client/bad_response_format.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/client/bad_response_format.baml
@@ -32,7 +32,7 @@ client<llm> MyClient3 {
 //----
 //- diagnostics
 // Error: client_response_type must be one of openai, openai-responses, anthropic, google, vertex, openrouter. Got: invalid
-//    ╭─[ 0:5:25 ]
+//    ╭─[ client_bad_response_format.baml:5:25 ]
 //    │
 //  5 │     client_response_type "invalid"
 //    │                         ─────┬────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_composite_wrong_field.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_composite_wrong_field.baml
@@ -38,7 +38,7 @@ client<llm> InvalidCompositeFields {
 //----
 //- diagnostics
 // Error: Unrecognized field 'request_timeout_ms' in http configuration block. Did you mean 'total_timeout_ms'? Composite clients (fallback/round-robin) only support: total_timeout_ms
-//     ╭─[ 0:13:7 ]
+//     ╭─[ client_http_config_composite_wrong_field.baml:13:7 ]
 //     │
 //  13 │       request_timeout_ms 5000  // Not allowed for composite
 //     │       ─────────┬────────  
@@ -47,7 +47,7 @@ client<llm> InvalidCompositeFields {
 //     │ Note: Error code: E0024
 // ────╯
 // Error: Unrecognized field 'connect_timeout_ms' in http configuration block. Did you mean 'total_timeout_ms'? Composite clients (fallback/round-robin) only support: total_timeout_ms
-//     ╭─[ 0:14:7 ]
+//     ╭─[ client_http_config_composite_wrong_field.baml:14:7 ]
 //     │
 //  14 │       connect_timeout_ms 3000  // Not allowed for composite
 //     │       ─────────┬────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_invalid_fields.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_invalid_fields.baml
@@ -20,7 +20,7 @@ client<llm> InvalidFieldName {
 //----
 //- diagnostics
 // Error: Unrecognized field 'conect_timeout_ms' in http configuration block. Did you mean 'connect_timeout_ms'?
-//    ╭─[ 0:6:7 ]
+//    ╭─[ client_http_config_invalid_fields.baml:6:7 ]
 //    │
 //  6 │       conect_timeout_ms 5000  // Typo in field name
 //    │       ────────┬────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_negative_timeout.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_negative_timeout.baml
@@ -18,7 +18,7 @@ client<llm> NegativeTimeout {
 //----
 //- diagnostics
 // Error: connect_timeout_ms must be non-negative, got: -1000ms
-//    ╭─[ 0:6:7 ]
+//    ╭─[ client_http_config_negative_timeout.baml:6:7 ]
 //    │
 //  6 │       connect_timeout_ms -1000
 //    │       ─────────┬────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_not_map.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_not_map.baml
@@ -16,7 +16,7 @@ client<llm> HttpNotMap {
 //----
 //- diagnostics
 // Error: http must be a configuration block with timeout settings
-//    ╭─[ 0:5:5 ]
+//    ╭─[ client_http_config_not_map.baml:5:5 ]
 //    │
 //  5 │     http "invalid"  // Should be a map
 //    │     ──┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_regular_with_total.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/client/http_config_regular_with_total.baml
@@ -20,7 +20,7 @@ client<llm> RegularWithTotal {
 //----
 //- diagnostics
 // Error: Unrecognized field 'total_timeout_ms' in http configuration block. 'total_timeout_ms' is only available for composite clients (fallback/round-robin). For regular clients, use: connect_timeout_ms, request_timeout_ms, time_to_first_token_timeout_ms, idle_timeout_ms
-//    ╭─[ 0:6:7 ]
+//    ╭─[ client_http_config_regular_with_total.baml:6:7 ]
 //    │
 //  6 │       total_timeout_ms 60000  // Only for composite clients
 //    │       ────────┬───────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/client/required_provider.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/client/required_provider.baml
@@ -18,7 +18,7 @@ client<llm> MyClient {
 //----
 //- diagnostics
 // Error: Missing `provider` field in client. e.g. `provider openai`
-//    ╭─[ 0:1:1 ]
+//    ╭─[ client_required_provider.baml:1:1 ]
 //    │
 //  1 │ ╭─▶ client<llm> MyClient {
 //    ┆ ┆   

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/client/unknown_prop.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/client/unknown_prop.baml
@@ -16,7 +16,7 @@ client<llm> MyClient {
 //----
 //- diagnostics
 // Error: Unknown field `myExtraProp` in client. Only `provider` and `options` are supported.
-//    ╭─[ 0:3:3 ]
+//    ╭─[ client_unknown_prop.baml:3:3 ]
 //    │
 //  3 │   myExtraProp "hello"
 //    │   ─────┬─────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/constraints/block_level.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/constraints/block_level.baml
@@ -41,7 +41,7 @@ test TestFoo {
 //----
 //- diagnostics
 // Error: Expected config key, found '@@'
-//     ╭─[ 0:37:3 ]
+//     ╭─[ constraints_block_level.baml:37:3 ]
 //     │
 //  37 │   @@check(foo_check_1, {{ this }})
 //     │   ─┬  
@@ -50,7 +50,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected config key, found '{'
-//     ╭─[ 0:37:24 ]
+//     ╭─[ constraints_block_level.baml:37:24 ]
 //     │
 //  37 │   @@check(foo_check_1, {{ this }})
 //     │                        ┬  
@@ -59,7 +59,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected config key, found '{'
-//     ╭─[ 0:37:25 ]
+//     ╭─[ constraints_block_level.baml:37:25 ]
 //     │
 //  37 │   @@check(foo_check_1, {{ this }})
 //     │                         ┬  
@@ -68,7 +68,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:37:33 ]
+//     ╭─[ constraints_block_level.baml:37:33 ]
 //     │
 //  37 │   @@check(foo_check_1, {{ this }})
 //     │                                 ┬  
@@ -77,7 +77,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found ')'
-//     ╭─[ 0:37:34 ]
+//     ╭─[ constraints_block_level.baml:37:34 ]
 //     │
 //  37 │   @@check(foo_check_1, {{ this }})
 //     │                                  ┬  
@@ -86,7 +86,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '@@'
-//     ╭─[ 0:38:3 ]
+//     ╭─[ constraints_block_level.baml:38:3 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │   ─┬  
@@ -95,7 +95,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:38:5 ]
+//     ╭─[ constraints_block_level.baml:38:5 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │     ──┬──  
@@ -104,7 +104,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '('
-//     ╭─[ 0:38:10 ]
+//     ╭─[ constraints_block_level.baml:38:10 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │          ┬  
@@ -113,7 +113,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:38:11 ]
+//     ╭─[ constraints_block_level.baml:38:11 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │           ─────┬─────  
@@ -122,7 +122,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found ','
-//     ╭─[ 0:38:22 ]
+//     ╭─[ constraints_block_level.baml:38:22 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │                      ┬  
@@ -131,7 +131,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:38:24 ]
+//     ╭─[ constraints_block_level.baml:38:24 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │                        ┬  
@@ -140,7 +140,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:38:25 ]
+//     ╭─[ constraints_block_level.baml:38:25 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │                         ┬  
@@ -149,7 +149,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:38:27 ]
+//     ╭─[ constraints_block_level.baml:38:27 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │                           ──┬─  
@@ -158,7 +158,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:38:32 ]
+//     ╭─[ constraints_block_level.baml:38:32 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │                                ┬  
@@ -167,7 +167,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:38:33 ]
+//     ╭─[ constraints_block_level.baml:38:33 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │                                 ┬  
@@ -176,7 +176,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found ')'
-//     ╭─[ 0:38:34 ]
+//     ╭─[ constraints_block_level.baml:38:34 ]
 //     │
 //  38 │   @@check(foo_check_2, {{ this }})
 //     │                                  ┬  
@@ -185,7 +185,7 @@ test TestFoo {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:39:1 ]
+//     ╭─[ constraints_block_level.baml:39:1 ]
 //     │
 //  39 │ }
 //     │ ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/constraints/constraints_everywhere.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/constraints/constraints_everywhere.baml
@@ -14,7 +14,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //----
 //- diagnostics
 // Error: Expected ')', found '@'
-//    ╭─[ 0:9:36 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:36 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                    ┬  
@@ -23,7 +23,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected return type (->), found '@'
-//    ╭─[ 0:9:36 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:36 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                    ┬  
@@ -32,7 +32,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected function body, found '@'
-//    ╭─[ 0:9:36 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:36 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                    ┬  
@@ -41,7 +41,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '@'
-//    ╭─[ 0:9:36 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:36 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                    ┬  
@@ -50,7 +50,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found assert
-//    ╭─[ 0:9:37 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:37 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                     ───┬──  
@@ -59,7 +59,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '('
-//    ╭─[ 0:9:43 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:43 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                           ┬  
@@ -68,7 +68,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:44 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:44 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                            ─────┬────  
@@ -77,7 +77,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found ','
-//    ╭─[ 0:9:54 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:54 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                      ┬  
@@ -86,7 +86,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '{'
-//    ╭─[ 0:9:56 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:56 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                        ┬  
@@ -95,7 +95,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '{'
-//    ╭─[ 0:9:57 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:57 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                         ┬  
@@ -104,7 +104,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:58 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:58 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                          ──┬─  
@@ -113,7 +113,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '.'
-//    ╭─[ 0:9:62 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:62 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                              ┬  
@@ -122,7 +122,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:63 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:63 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                               ─┬─  
@@ -131,7 +131,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '>'
-//    ╭─[ 0:9:67 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:67 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                   ┬  
@@ -140,7 +140,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found integer
-//    ╭─[ 0:9:69 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:69 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                     ─┬  
@@ -149,7 +149,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '}'
-//    ╭─[ 0:9:71 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:71 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                       ┬  
@@ -158,7 +158,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '}'
-//    ╭─[ 0:9:72 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:72 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                        ┬  
@@ -167,7 +167,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found ')'
-//    ╭─[ 0:9:73 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:73 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                         ┬  
@@ -176,7 +176,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found ')'
-//    ╭─[ 0:9:74 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:74 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                          ┬  
@@ -185,7 +185,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '->'
-//    ╭─[ 0:9:76 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:76 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                            ─┬  
@@ -194,7 +194,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:79 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:79 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                               ─┬─  
@@ -203,7 +203,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '@'
-//    ╭─[ 0:9:83 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:83 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                   ┬  
@@ -212,7 +212,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:84 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:84 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                    ──┬──  
@@ -221,7 +221,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '('
-//    ╭─[ 0:9:89 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:89 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                         ┬  
@@ -230,7 +230,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:90 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:90 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                          ────┬────  
@@ -239,7 +239,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found ','
-//    ╭─[ 0:9:99 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:99 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                   ┬  
@@ -248,7 +248,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '{'
-//    ╭─[ 0:9:101 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:101 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                     ┬  
@@ -257,7 +257,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '{'
-//    ╭─[ 0:9:102 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:102 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                      ┬  
@@ -266,7 +266,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//    ╭─[ 0:9:104 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:104 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                        ──┬─  
@@ -275,7 +275,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '<'
-//    ╭─[ 0:9:109 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:109 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                             ┬  
@@ -284,7 +284,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found integer
-//    ╭─[ 0:9:111 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:111 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                               ─┬  
@@ -293,7 +293,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '}'
-//    ╭─[ 0:9:114 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:114 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                                  ┬  
@@ -302,7 +302,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '}'
-//    ╭─[ 0:9:115 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:115 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                                   ┬  
@@ -311,7 +311,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found ')'
-//    ╭─[ 0:9:116 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:116 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                                    ┬  
@@ -320,7 +320,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '{'
-//    ╭─[ 0:9:118 ]
+//    ╭─[ constraints_constraints_everywhere.baml:9:118 ]
 //    │
 //  9 │ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //    │                                                                                                                      ┬  
@@ -329,7 +329,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected config block, found identifier
-//     ╭─[ 0:11:4 ]
+//     ╭─[ constraints_constraints_everywhere.baml:11:4 ]
 //     │
 //  11 │    prompt #"fa"#
 //     │    ───┬──  
@@ -338,7 +338,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:11:4 ]
+//     ╭─[ constraints_constraints_everywhere.baml:11:4 ]
 //     │
 //  11 │    prompt #"fa"#
 //     │    ───┬──  
@@ -347,7 +347,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '#'
-//     ╭─[ 0:11:11 ]
+//     ╭─[ constraints_constraints_everywhere.baml:11:11 ]
 //     │
 //  11 │    prompt #"fa"#
 //     │           ┬  
@@ -356,7 +356,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:11:12 ]
+//     ╭─[ constraints_constraints_everywhere.baml:11:12 ]
 //     │
 //  11 │    prompt #"fa"#
 //     │            ┬  
@@ -365,7 +365,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:11:13 ]
+//     ╭─[ constraints_constraints_everywhere.baml:11:13 ]
 //     │
 //  11 │    prompt #"fa"#
 //     │             ─┬  
@@ -374,7 +374,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:11:15 ]
+//     ╭─[ constraints_constraints_everywhere.baml:11:15 ]
 //     │
 //  11 │    prompt #"fa"#
 //     │               ┬  
@@ -383,7 +383,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '#'
-//     ╭─[ 0:11:16 ]
+//     ╭─[ constraints_constraints_everywhere.baml:11:16 ]
 //     │
 //  11 │    prompt #"fa"#
 //     │                ┬  
@@ -392,7 +392,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:12:1 ]
+//     ╭─[ constraints_constraints_everywhere.baml:12:1 ]
 //     │
 //  12 │ }
 //     │ ┬  
@@ -401,7 +401,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Missing `provider` field in client. e.g. `provider openai`
-//     ╭─[ 0:9:119 ]
+//     ╭─[ constraints_constraints_everywhere.baml:9:119 ]
 //     │
 //   9 │ ╭─▶ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> int @check(small_int, {{ this < 10 }}) {
 //  10 │ ├─▶    client Bar
@@ -411,7 +411,7 @@ function FooToInt(foo: Foo, a: Foo @assert(really_old, {{this.age > 20}})) -> in
 //     │     Note: Error code: E0026
 // ────╯
 // Error: Duplicate client 'Bar'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ constraints_constraints_everywhere.baml:1:1 ]
 //    │
 //  1 │ client<llm> Bar {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/duplicate_value.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/duplicate_value.baml
@@ -15,13 +15,13 @@ enum Test {
 //----
 //- diagnostics
 // Error: Duplicate variant 'ONE' in enum 'Test'
-//    ╭─[ 0:4:5 ]
+//    ╭─[ enum_duplicate_value.baml:4:5 ]
 //    │
 //  4 │     ONE
 //    │     ─┬─  
 //    │      ╰─── duplicate definition
 //    │
-//    ├─[ 0:4:5 ]
+//    ├─[ enum_duplicate_value.baml:4:5 ]
 //    │
 //  2 │     ONE
 //    │     ─┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/enum_is_valid.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/enum_is_valid.baml
@@ -25,7 +25,7 @@ generator target{
 //----
 //- diagnostics
 // Error: Enum value 'None' in enum 'Test' is a reserved keyword in Python
-//    ╭─[ 0:2:5 ]
+//    ╭─[ enum_enum_is_valid.baml:2:5 ]
 //    │
 //  2 │     None
 //    │     ──┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/enum_unquoted_description.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/enum_unquoted_description.baml
@@ -28,7 +28,7 @@ enum TestEnum {
 //----
 //- diagnostics
 // Error: Expected ')', found identifier
-//     ╭─[ 0:13:10 ]
+//     ╭─[ enum_enum_unquoted_description.baml:13:10 ]
 //     │
 //  13 │     User is confused
 //     │          ─┬  
@@ -37,7 +37,7 @@ enum TestEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected Unexpected token in enum body, found ')'
-//     ╭─[ 0:14:3 ]
+//     ╭─[ enum_enum_unquoted_description.baml:14:3 ]
 //     │
 //  14 │   )
 //     │   ┬  
@@ -46,7 +46,7 @@ enum TestEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected ')', found identifier
-//     ╭─[ 0:16:10 ]
+//     ╭─[ enum_enum_unquoted_description.baml:16:10 ]
 //     │
 //  16 │     User is excited
 //     │          ─┬  
@@ -55,7 +55,7 @@ enum TestEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected Unexpected token in enum body, found ')'
-//     ╭─[ 0:17:3 ]
+//     ╭─[ enum_enum_unquoted_description.baml:17:3 ]
 //     │
 //  17 │   )
 //     │   ┬  
@@ -64,13 +64,13 @@ enum TestEnum {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Duplicate variant 'is' in enum 'TestEnum'
-//     ╭─[ 0:16:10 ]
+//     ╭─[ enum_enum_unquoted_description.baml:16:10 ]
 //     │
 //  16 │     User is excited
 //     │          ─┬  
 //     │           ╰── duplicate definition
 //     │
-//     ├─[ 0:16:10 ]
+//     ├─[ enum_enum_unquoted_description.baml:16:10 ]
 //     │
 //  13 │     User is confused
 //     │          ─┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/invalid_commas.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/invalid_commas.baml
@@ -29,7 +29,7 @@ enum Test {
 //----
 //- diagnostics
 // Error: Expected Unexpected token in enum body, found ','
-//    ╭─[ 0:2:6 ]
+//    ╭─[ enum_invalid_commas.baml:2:6 ]
 //    │
 //  2 │     A,
 //    │      ┬  
@@ -38,7 +38,7 @@ enum Test {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected Unexpected token in enum body, found ','
-//    ╭─[ 0:3:6 ]
+//    ╭─[ enum_invalid_commas.baml:3:6 ]
 //    │
 //  3 │     B,
 //    │      ┬  
@@ -47,7 +47,7 @@ enum Test {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected Unexpected token in enum body, found ','
-//    ╭─[ 0:4:6 ]
+//    ╭─[ enum_invalid_commas.baml:4:6 ]
 //    │
 //  4 │     C,
 //    │      ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/invalid_value_expr.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/enum/invalid_value_expr.baml
@@ -13,7 +13,7 @@ enum Test {
 //----
 //- diagnostics
 // Error: Expected Unexpected token in enum body, found '|'
-//    ╭─[ 0:2:11 ]
+//    ╭─[ enum_invalid_value_expr.baml:2:11 ]
 //    │
 //  2 │     A int | string
 //    │           ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/builtin.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/builtin.baml
@@ -41,7 +41,7 @@ function GetTodoMissingTypeArg() -> Todo {
 //----
 //- diagnostics
 // Error: Unknown variable baml
-//     ╭─[ 0:15:43 ]
+//     ╭─[ expr_builtin.baml:15:43 ]
 //     │
 //  15 │ ╭─▶ function GetTodoMissingTypeArg() -> Todo {
 //  16 │ ├─▶   baml.fetch_as(baml.HttpRequest {
@@ -51,7 +51,7 @@ function GetTodoMissingTypeArg() -> Todo {
 //     │     Note: Error code: E0003
 // ────╯
 // Error: Unknown variable baml
-//     ╭─[ 0:17:12 ]
+//     ╭─[ expr_builtin.baml:17:12 ]
 //     │
 //  17 │     method: baml.HttpMethod.Get,
 //     │            ──────────┬─────────  
@@ -60,7 +60,7 @@ function GetTodoMissingTypeArg() -> Todo {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable baml
-//     ╭─[ 0:10:12 ]
+//     ╭─[ expr_builtin.baml:10:12 ]
 //     │
 //  10 │     method: baml.HttpMethod.Get,
 //     │            ──────────┬─────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/constructors_invalid.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/constructors_invalid.baml
@@ -72,7 +72,7 @@ function Foo() -> Bar {
 //----
 //- diagnostics
 // Error: Unknown variable a
-//     ╭─[ 0:11:21 ]
+//     ╭─[ expr_constructors_invalid.baml:11:21 ]
 //     │
 //  11 │     query_params: { a 10 },
 //     │                     ┬  
@@ -81,7 +81,7 @@ function Foo() -> Bar {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable Authorization
-//     ╭─[ 0:15:16 ]
+//     ╭─[ expr_constructors_invalid.baml:15:16 ]
 //     │
 //  15 │     headers: { Authorization "Bearer mytoken" },
 //     │                ──────┬──────  
@@ -90,7 +90,7 @@ function Foo() -> Bar {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable foo
-//     ╭─[ 0:16:21 ]
+//     ╭─[ expr_constructors_invalid.baml:16:21 ]
 //     │
 //  16 │     query_params: { foo "bar" },
 //     │                     ─┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/expr_full.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/expr_full.baml
@@ -72,7 +72,7 @@ test TestMakePoem() {
 //----
 //- diagnostics
 // Error: remove parentheses from test name: `test TestPipeline`
-//     ╭─[ 0:44:18 ]
+//     ╭─[ expr_expr_full.baml:44:18 ]
 //     │
 //  44 │ test TestPipeline() {
 //     │                  ─┬  
@@ -81,7 +81,7 @@ test TestMakePoem() {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: remove parentheses from test name: `test TestPyramid`
-//     ╭─[ 0:49:17 ]
+//     ╭─[ expr_expr_full.baml:49:17 ]
 //     │
 //  49 │ test TestPyramid() {
 //     │                 ─┬  
@@ -90,7 +90,7 @@ test TestMakePoem() {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: remove parentheses from test name: `test OuterPyramid`
-//     ╭─[ 0:54:18 ]
+//     ╭─[ expr_expr_full.baml:54:18 ]
 //     │
 //  54 │ test OuterPyramid() {
 //     │                  ─┬  
@@ -99,7 +99,7 @@ test TestMakePoem() {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: remove parentheses from test name: `test TestMakePoem`
-//     ╭─[ 0:67:18 ]
+//     ╭─[ expr_expr_full.baml:67:18 ]
 //     │
 //  67 │ test TestMakePoem() {
 //     │                  ─┬  
@@ -108,7 +108,7 @@ test TestMakePoem() {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Unknown variable poem
-//     ╭─[ 0:41:16 ]
+//     ╭─[ expr_expr_full.baml:41:16 ]
 //     │
 //  41 │   CombinePoems(poem, another)
 //     │                ──┬─  
@@ -117,7 +117,7 @@ test TestMakePoem() {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable another
-//     ╭─[ 0:41:22 ]
+//     ╭─[ expr_expr_full.baml:41:22 ]
 //     │
 //  41 │   CombinePoems(poem, another)
 //     │                      ───┬───  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/extra_dot.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/extra_dot.baml
@@ -59,7 +59,7 @@ function ModernFunction(x: int) -> int {
 //----
 //- diagnostics
 // Error: Expected expression, found '.'
-//     ╭─[ 0:21:3 ]
+//     ╭─[ expr_extra_dot.baml:21:3 ]
 //     │
 //  21 │   .let result = receipt.calculate();
 //     │   ┬  
@@ -68,7 +68,7 @@ function ModernFunction(x: int) -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found '^'
-//     ╭─[ 0:23:3 ]
+//     ╭─[ expr_extra_dot.baml:23:3 ]
 //     │
 //  23 │   ^if (true) {
 //     │   ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/let_annotations.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/let_annotations.baml
@@ -25,7 +25,7 @@ function Ok() -> int {
 //----
 //- diagnostics
 // Error: Expected int, found float
-//    ╭─[ 0:5:10 ]
+//    ╭─[ expr_let_annotations.baml:5:10 ]
 //    │
 //  5 │   let y : int = 10.0;
 //    │          ──┬─  
@@ -34,7 +34,7 @@ function Ok() -> int {
 //    │ Note: Error code: E0001
 // ───╯
 // Error: Expected int, found string
-//    ╭─[ 0:6:9 ]
+//    ╭─[ expr_let_annotations.baml:6:9 ]
 //    │
 //  6 │   let c: int = "hello";
 //    │         ──┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/missing_return_value.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/missing_return_value.baml
@@ -14,7 +14,7 @@ function NoRet(x: int) {
 //----
 //- diagnostics
 // Error: Expected return type (->), found '{'
-//    ╭─[ 0:1:24 ]
+//    ╭─[ expr_missing_return_value.baml:1:24 ]
 //    │
 //  1 │ function NoRet(x: int) {
 //    │                        ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/unknown_name.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/unknown_name.baml
@@ -65,7 +65,7 @@ function Go3(x:int) -> int {
 //----
 //- diagnostics
 // Error: Unknown variable a
-//    ╭─[ 0:2:13 ]
+//    ╭─[ expr_unknown_name.baml:2:13 ]
 //    │
 //  2 │     let y = a;
 //    │             ┬  
@@ -74,7 +74,7 @@ function Go3(x:int) -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable Unknown
-//     ╭─[ 0:13:5 ]
+//     ╭─[ expr_unknown_name.baml:13:5 ]
 //     │
 //  13 │     Unknown(x)
 //     │     ───┬───  
@@ -83,7 +83,7 @@ function Go3(x:int) -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable b
-//    ╭─[ 0:9:12 ]
+//    ╭─[ expr_unknown_name.baml:9:12 ]
 //    │
 //  9 │     Go(z,a,b)
 //    │            ┬  
@@ -92,7 +92,7 @@ function Go3(x:int) -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Expected 1 arguments, found 3
-//    ╭─[ 0:9:5 ]
+//    ╭─[ expr_unknown_name.baml:9:5 ]
 //    │
 //  9 │     Go(z,a,b)
 //    │     ────┬────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/watch_when.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/expr/watch_when.baml
@@ -40,7 +40,7 @@ function BadFunction2(i: string) -> bool {
 //----
 //- diagnostics
 // Error: Expected int, found int.$watch
-//    ╭─[ 0:2:20 ]
+//    ╭─[ expr_watch_when.baml:2:20 ]
 //    │
 //  2 │ ╭─▶   watch let x = 10;
 //  3 │ ├─▶   x.$watch.options(baml.WatchOptions{ when: GoodFunction });
@@ -50,7 +50,7 @@ function BadFunction2(i: string) -> bool {
 //    │     Note: Error code: E0001
 // ───╯
 // Error: Expected int, found int.$watch
-//    ╭─[ 0:3:61 ]
+//    ╭─[ expr_watch_when.baml:3:61 ]
 //    │
 //  3 │ ╭─▶   x.$watch.options(baml.WatchOptions{ when: GoodFunction });
 //  4 │ ├─▶   x.$watch.options(baml.WatchOptions{ when: BadFunction1 });
@@ -60,7 +60,7 @@ function BadFunction2(i: string) -> bool {
 //    │     Note: Error code: E0001
 // ───╯
 // Error: Expected int, found int.$watch
-//    ╭─[ 0:4:61 ]
+//    ╭─[ expr_watch_when.baml:4:61 ]
 //    │
 //  4 │ ╭─▶   x.$watch.options(baml.WatchOptions{ when: BadFunction1 });
 //  5 │ ├─▶   x.$watch.options(baml.WatchOptions{ when: BadFunction2 });

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/duplicate_names.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/duplicate_names.baml
@@ -63,7 +63,7 @@ function Bar(a: string, b: int | bool) -> int {
 //----
 //- diagnostics
 // Error: Expected '(', found '{'
-//    ╭─[ 0:1:14 ]
+//    ╭─[ functions_v2_duplicate_names.baml:1:14 ]
 //    │
 //  1 │ function Bar {
 //    │              ┬  
@@ -72,7 +72,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected parameter name, found '{'
-//    ╭─[ 0:1:14 ]
+//    ╭─[ functions_v2_duplicate_names.baml:1:14 ]
 //    │
 //  1 │ function Bar {
 //    │              ┬  
@@ -81,7 +81,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected type annotation, found '{'
-//    ╭─[ 0:1:14 ]
+//    ╭─[ functions_v2_duplicate_names.baml:1:14 ]
 //    │
 //  1 │ function Bar {
 //    │              ┬  
@@ -90,7 +90,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected ')', found '{'
-//    ╭─[ 0:1:14 ]
+//    ╭─[ functions_v2_duplicate_names.baml:1:14 ]
 //    │
 //  1 │ function Bar {
 //    │              ┬  
@@ -99,7 +99,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected return type (->), found '{'
-//    ╭─[ 0:1:14 ]
+//    ╭─[ functions_v2_duplicate_names.baml:1:14 ]
 //    │
 //  1 │ function Bar {
 //    │              ┬  
@@ -108,7 +108,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Duplicate function 'Bar'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ functions_v2_duplicate_names.baml:1:1 ]
 //    │
 //  1 │ function Bar {
 //    │ │ 
@@ -119,7 +119,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Unknown variable input
-//    ╭─[ 0:2:3 ]
+//    ╭─[ functions_v2_duplicate_names.baml:2:3 ]
 //    │
 //  2 │   input string
 //    │   ──┬──  
@@ -128,7 +128,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable string
-//    ╭─[ 0:2:9 ]
+//    ╭─[ functions_v2_duplicate_names.baml:2:9 ]
 //    │
 //  2 │   input string
 //    │         ───┬──  
@@ -137,7 +137,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable output
-//    ╭─[ 0:3:3 ]
+//    ╭─[ functions_v2_duplicate_names.baml:3:3 ]
 //    │
 //  3 │   output string
 //    │   ───┬──  
@@ -146,7 +146,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable string
-//    ╭─[ 0:3:10 ]
+//    ╭─[ functions_v2_duplicate_names.baml:3:10 ]
 //    │
 //  3 │   output string
 //    │          ───┬──  
@@ -155,7 +155,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable input
-//    ╭─[ 0:2:3 ]
+//    ╭─[ functions_v2_duplicate_names.baml:2:3 ]
 //    │
 //  2 │   input string
 //    │   ──┬──  
@@ -164,7 +164,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable string
-//    ╭─[ 0:2:9 ]
+//    ╭─[ functions_v2_duplicate_names.baml:2:9 ]
 //    │
 //  2 │   input string
 //    │         ───┬──  
@@ -173,7 +173,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable output
-//    ╭─[ 0:3:3 ]
+//    ╭─[ functions_v2_duplicate_names.baml:3:3 ]
 //    │
 //  3 │   output string
 //    │   ───┬──  
@@ -182,7 +182,7 @@ function Bar(a: string, b: int | bool) -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable string
-//    ╭─[ 0:3:10 ]
+//    ╭─[ functions_v2_duplicate_names.baml:3:10 ]
 //    │
 //  3 │   output string
 //    │          ───┬──  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/invalid.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/invalid.baml
@@ -32,7 +32,7 @@ function FooBar(arg) -> bar {
 //----
 //- diagnostics
 // Error: Expected type, found '{'
-//    ╭─[ 0:1:19 ]
+//    ╭─[ functions_v2_invalid.baml:1:19 ]
 //    │
 //  1 │ function Foo() -> {
 //    │                   ┬  
@@ -41,7 +41,7 @@ function FooBar(arg) -> bar {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected type annotation, found ')'
-//    ╭─[ 0:6:20 ]
+//    ╭─[ functions_v2_invalid.baml:6:20 ]
 //    │
 //  6 │ function FooBar(arg) -> bar {
 //    │                    ┬  
@@ -50,7 +50,7 @@ function FooBar(arg) -> bar {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Unknown type bar
-//    ╭─[ 0:1:1 ]
+//    ╭─[ functions_v2_invalid.baml:1:1 ]
 //    │
 //  1 │ function Foo() -> {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/invalid2.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/invalid2.baml
@@ -118,7 +118,7 @@ function Foo6(arg: int) -> float {
 //----
 //- diagnostics
 // Error: Expected LLM function missing 'prompt' field, found '}'
-//    ╭─[ 0:3:1 ]
+//    ╭─[ functions_v2_invalid2.baml:3:1 ]
 //    │
 //  3 │ }
 //    │ ┬  
@@ -127,7 +127,7 @@ function Foo6(arg: int) -> float {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected LLM function missing 'client' field, found '}'
-//    ╭─[ 0:7:1 ]
+//    ╭─[ functions_v2_invalid2.baml:7:1 ]
 //    │
 //  7 │ }
 //    │ ┬  
@@ -136,7 +136,7 @@ function Foo6(arg: int) -> float {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected prompt string, found '}'
-//     ╭─[ 0:18:1 ]
+//     ╭─[ functions_v2_invalid2.baml:18:1 ]
 //     │
 //  18 │ }
 //     │ ┬  
@@ -145,7 +145,7 @@ function Foo6(arg: int) -> float {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '#', found '#'
-//     ╭─[ 0:23:10 ]
+//     ╭─[ functions_v2_invalid2.baml:23:10 ]
 //     │
 //  23 │   prompt #"..."#
 //     │          ┬  
@@ -154,7 +154,7 @@ function Foo6(arg: int) -> float {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '"', found '"'
-//     ╭─[ 0:23:11 ]
+//     ╭─[ functions_v2_invalid2.baml:23:11 ]
 //     │
 //  23 │   prompt #"..."#
 //     │           ┬  
@@ -163,7 +163,7 @@ function Foo6(arg: int) -> float {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '...', found '...'
-//     ╭─[ 0:23:12 ]
+//     ╭─[ functions_v2_invalid2.baml:23:12 ]
 //     │
 //  23 │   prompt #"..."#
 //     │            ─┬─  
@@ -172,7 +172,7 @@ function Foo6(arg: int) -> float {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '"', found '"'
-//     ╭─[ 0:23:15 ]
+//     ╭─[ functions_v2_invalid2.baml:23:15 ]
 //     │
 //  23 │   prompt #"..."#
 //     │               ┬  
@@ -181,7 +181,7 @@ function Foo6(arg: int) -> float {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '#', found '#'
-//     ╭─[ 0:23:16 ]
+//     ╭─[ functions_v2_invalid2.baml:23:16 ]
 //     │
 //  23 │   prompt #"..."#
 //     │                ┬  
@@ -190,7 +190,7 @@ function Foo6(arg: int) -> float {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected LLM function missing 'prompt' field, found '}'
-//     ╭─[ 0:24:1 ]
+//     ╭─[ functions_v2_invalid2.baml:24:1 ]
 //     │
 //  24 │ }
 //     │ ┬  
@@ -199,7 +199,7 @@ function Foo6(arg: int) -> float {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected LLM function missing 'prompt' field, found '}'
-//     ╭─[ 0:30:1 ]
+//     ╭─[ functions_v2_invalid2.baml:30:1 ]
 //     │
 //  30 │ }
 //     │ ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/invalid_no_return.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/invalid_no_return.baml
@@ -14,7 +14,7 @@ function FooBar(arg: int) {
 //----
 //- diagnostics
 // Error: Expected return type (->), found '{'
-//    ╭─[ 0:1:27 ]
+//    ╭─[ functions_v2_invalid_no_return.baml:1:27 ]
 //    │
 //  1 │ function FooBar(arg: int) {
 //    │                           ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/tests/failing_tests.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/tests/failing_tests.baml
@@ -128,7 +128,7 @@ test Bar {
 //----
 //- diagnostics
 // Error: Duplicate test 'Bar' for function 'InputEnum'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ functions_v2_tests_failing_tests.baml:1:1 ]
 //    │
 //  1 │ client<llm> Bar {
 //    │ │ 
@@ -139,7 +139,7 @@ test Bar {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate test 'Foo' for function 'InputImage'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ functions_v2_tests_failing_tests.baml:1:1 ]
 //    │
 //  1 │ client<llm> Bar {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/tests/field_level_assertions_v2.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/tests/field_level_assertions_v2.baml
@@ -22,7 +22,7 @@ test MyTest {
 //----
 //- diagnostics
 // Error: Expected config key, found '@'
-//    ╭─[ 0:9:28 ]
+//    ╭─[ functions_v2_tests_field_level_assertions_v2.baml:9:28 ]
 //    │
 //  9 │   functions [TestFunction] @assert({{ true }})
 //    │                            ┬  
@@ -31,7 +31,7 @@ test MyTest {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected config key, found assert
-//    ╭─[ 0:9:29 ]
+//    ╭─[ functions_v2_tests_field_level_assertions_v2.baml:9:29 ]
 //    │
 //  9 │   functions [TestFunction] @assert({{ true }})
 //    │                             ───┬──  
@@ -40,7 +40,7 @@ test MyTest {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected config key, found '('
-//    ╭─[ 0:9:35 ]
+//    ╭─[ functions_v2_tests_field_level_assertions_v2.baml:9:35 ]
 //    │
 //  9 │   functions [TestFunction] @assert({{ true }})
 //    │                                   ┬  
@@ -49,7 +49,7 @@ test MyTest {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected config key, found '{'
-//    ╭─[ 0:9:36 ]
+//    ╭─[ functions_v2_tests_field_level_assertions_v2.baml:9:36 ]
 //    │
 //  9 │   functions [TestFunction] @assert({{ true }})
 //    │                                    ┬  
@@ -58,7 +58,7 @@ test MyTest {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected config key, found '{'
-//    ╭─[ 0:9:37 ]
+//    ╭─[ functions_v2_tests_field_level_assertions_v2.baml:9:37 ]
 //    │
 //  9 │   functions [TestFunction] @assert({{ true }})
 //    │                                     ┬  
@@ -67,7 +67,7 @@ test MyTest {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '}'
-//    ╭─[ 0:9:45 ]
+//    ╭─[ functions_v2_tests_field_level_assertions_v2.baml:9:45 ]
 //    │
 //  9 │   functions [TestFunction] @assert({{ true }})
 //    │                                             ┬  
@@ -76,7 +76,7 @@ test MyTest {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found ')'
-//    ╭─[ 0:9:46 ]
+//    ╭─[ functions_v2_tests_field_level_assertions_v2.baml:9:46 ]
 //    │
 //  9 │   functions [TestFunction] @assert({{ true }})
 //    │                                              ┬  
@@ -85,7 +85,7 @@ test MyTest {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:10:3 ]
+//     ╭─[ functions_v2_tests_field_level_assertions_v2.baml:10:3 ]
 //     │
 //  10 │   args {
 //     │   ──┬─  
@@ -94,7 +94,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:10:8 ]
+//     ╭─[ functions_v2_tests_field_level_assertions_v2.baml:10:8 ]
 //     │
 //  10 │   args {
 //     │        ┬  
@@ -103,7 +103,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:11:5 ]
+//     ╭─[ functions_v2_tests_field_level_assertions_v2.baml:11:5 ]
 //     │
 //  11 │     input "hello"
 //     │     ──┬──  
@@ -112,7 +112,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:11:11 ]
+//     ╭─[ functions_v2_tests_field_level_assertions_v2.baml:11:11 ]
 //     │
 //  11 │     input "hello"
 //     │           ┬  
@@ -121,7 +121,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:11:12 ]
+//     ╭─[ functions_v2_tests_field_level_assertions_v2.baml:11:12 ]
 //     │
 //  11 │     input "hello"
 //     │            ──┬──  
@@ -130,7 +130,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:11:17 ]
+//     ╭─[ functions_v2_tests_field_level_assertions_v2.baml:11:17 ]
 //     │
 //  11 │     input "hello"
 //     │                 ┬  
@@ -139,7 +139,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:12:3 ]
+//     ╭─[ functions_v2_tests_field_level_assertions_v2.baml:12:3 ]
 //     │
 //  12 │   }
 //     │   ┬  
@@ -148,7 +148,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:13:1 ]
+//     ╭─[ functions_v2_tests_field_level_assertions_v2.baml:13:1 ]
 //     │
 //  13 │ }
 //     │ ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/tests/field_level_check.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/functions_v2/tests/field_level_check.baml
@@ -22,7 +22,7 @@ test MyTest {
 //----
 //- diagnostics
 // Error: Expected config key, found '@'
-//     ╭─[ 0:12:5 ]
+//     ╭─[ functions_v2_tests_field_level_check.baml:12:5 ]
 //     │
 //  12 │   } @check(args_check, {{ true }})
 //     │     ┬  
@@ -31,7 +31,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected config key, found '{'
-//     ╭─[ 0:12:24 ]
+//     ╭─[ functions_v2_tests_field_level_check.baml:12:24 ]
 //     │
 //  12 │   } @check(args_check, {{ true }})
 //     │                        ┬  
@@ -40,7 +40,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected config key, found '{'
-//     ╭─[ 0:12:25 ]
+//     ╭─[ functions_v2_tests_field_level_check.baml:12:25 ]
 //     │
 //  12 │   } @check(args_check, {{ true }})
 //     │                         ┬  
@@ -49,7 +49,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:12:33 ]
+//     ╭─[ functions_v2_tests_field_level_check.baml:12:33 ]
 //     │
 //  12 │   } @check(args_check, {{ true }})
 //     │                                 ┬  
@@ -58,7 +58,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found ')'
-//     ╭─[ 0:12:34 ]
+//     ╭─[ functions_v2_tests_field_level_check.baml:12:34 ]
 //     │
 //  12 │   } @check(args_check, {{ true }})
 //     │                                  ┬  
@@ -67,7 +67,7 @@ test MyTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:13:1 ]
+//     ╭─[ functions_v2_tests_field_level_check.baml:13:1 ]
 //     │
 //  13 │ }
 //     │ ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/generators/error.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/generators/error.baml
@@ -19,7 +19,7 @@ generator default {
 //----
 //- diagnostics
 // Error: Unknown property 'language' in generator 'default'. Valid properties: output_type, output_dir, version, default_client_mode, on_generate, project, client_package_name, module_format
-//    ╭─[ 0:2:3 ]
+//    ╭─[ generators_error.baml:2:3 ]
 //    │
 //  2 │   language python
 //    │   ────┬───  
@@ -28,7 +28,7 @@ generator default {
 //    │ Note: Error code: E0017
 // ───╯
 // Error: Unknown property 'o' in generator 'default'. Valid properties: output_type, output_dir, version, default_client_mode, on_generate, project, client_package_name, module_format
-//    ╭─[ 0:3:3 ]
+//    ╭─[ generators_error.baml:3:3 ]
 //    │
 //  3 │   o o
 //    │   ┬  
@@ -37,7 +37,7 @@ generator default {
 //    │ Note: Error code: E0017
 // ───╯
 // Error: Generator 'default' is missing required property 'output_type'
-//    ╭─[ 0:1:11 ]
+//    ╭─[ generators_error.baml:1:11 ]
 //    │
 //  1 │ generator default {
 //    │           ───┬───  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/generators/quoted_invalid_value.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/generators/quoted_invalid_value.baml
@@ -11,7 +11,7 @@ generator quoted_invalid {
 //----
 //- diagnostics
 // Error: Invalid value 'invalid_output' for property 'output_type' in generator 'quoted_invalid'. Valid values: python/pydantic, python/pydantic/v1, typescript, typescript/react, ruby/sorbet, go, rest/openapi, boundary-cloud
-//    ╭─[ 0:6:14 ]
+//    ╭─[ generators_quoted_invalid_value.baml:6:14 ]
 //    │
 //  6 │   output_type "invalid_output"
 //    │              ────────┬────────  
@@ -20,7 +20,7 @@ generator quoted_invalid {
 //    │ Note: Error code: E0019
 // ───╯
 // Error: Invalid value 'invalid_mode' for property 'default_client_mode' in generator 'quoted_invalid'. Valid values: sync, async. Use "sync" or "async"
-//    ╭─[ 0:7:22 ]
+//    ╭─[ generators_quoted_invalid_value.baml:7:22 ]
 //    │
 //  7 │   default_client_mode "invalid_mode"
 //    │                      ───────┬───────  
@@ -29,7 +29,7 @@ generator quoted_invalid {
 //    │ Note: Error code: E0019
 // ───╯
 // Error: Invalid value 'invalid_format' for property 'module_format' in generator 'quoted_invalid'. Valid values: cjs, esm. Use "cjs" or "esm"
-//    ╭─[ 0:8:16 ]
+//    ╭─[ generators_quoted_invalid_value.baml:8:16 ]
 //    │
 //  8 │   module_format "invalid_format"
 //    │                ────────┬────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/ai_content_pipeline.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/ai_content_pipeline.baml
@@ -63,7 +63,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //----
 //- diagnostics
 // Error: Unknown variable GetEmails
-//    ╭─[ 0:6:18 ]
+//    ╭─[ headers_ai_content_pipeline.baml:6:18 ]
 //    │
 //  6 │     let emails = GetEmails();
 //    │                  ────┬────  
@@ -72,7 +72,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable GetPosts
-//    ╭─[ 0:7:17 ]
+//    ╭─[ headers_ai_content_pipeline.baml:7:17 ]
 //    │
 //  7 │     let posts = GetPosts();
 //    │                 ────┬───  
@@ -81,7 +81,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable ProcessVideo
-//     ╭─[ 0:10:21 ]
+//     ╭─[ headers_ai_content_pipeline.baml:10:21 ]
 //     │
 //  10 │     let processed = ProcessVideo(video_id, zoom_meeting_id);
 //     │                     ──────┬─────  
@@ -90,7 +90,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable GetVideo
-//     ╭─[ 0:11:17 ]
+//     ╭─[ headers_ai_content_pipeline.baml:11:17 ]
 //     │
 //  11 │     let video = GetVideo(video_id);
 //     │                 ────┬───  
@@ -99,7 +99,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Expected bool, found string?
-//     ╭─[ 0:17:18 ]
+//     ╭─[ headers_ai_content_pipeline.baml:17:18 ]
 //     │
 //  17 │ ╭─▶     let summary = if (transcript) {
 //     ┆ ┆   
@@ -110,7 +110,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │     Note: Error code: E0001
 // ────╯
 // Error: Unknown variable SummarizeVideo
-//     ╭─[ 0:21:17 ]
+//     ╭─[ headers_ai_content_pipeline.baml:21:17 ]
 //     │
 //  21 │         let s = SummarizeVideo(transcript, title);
 //     │                 ───────┬──────  
@@ -119,7 +119,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable LabelSummaryCategory
-//     ╭─[ 0:24:24 ]
+//     ╭─[ headers_ai_content_pipeline.baml:24:24 ]
 //     │
 //  24 │         let category = LabelSummaryCategory(s);
 //     │                        ──────────┬─────────  
@@ -128,7 +128,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable SaveSummary
-//     ╭─[ 0:27:29 ]
+//     ╭─[ headers_ai_content_pipeline.baml:27:29 ]
 //     │
 //  27 │         let saved_summary = SaveSummary(video_id, s);
 //     │                             ─────┬─────  
@@ -137,7 +137,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable GetStructure
-//     ╭─[ 0:40:25 ]
+//     ╭─[ headers_ai_content_pipeline.baml:40:25 ]
 //     │
 //  40 │         let structure = GetStructure(kind);
 //     │                         ──────┬─────  
@@ -146,7 +146,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable GenerateContent
-//     ╭─[ 0:41:21 ]
+//     ╭─[ headers_ai_content_pipeline.baml:41:21 ]
 //     │
 //  41 │         let draft = GenerateContent(kind, video_id, summary);
 //     │                     ───────┬───────  
@@ -155,7 +155,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable SaveDraft
-//     ╭─[ 0:44:27 ]
+//     ╭─[ headers_ai_content_pipeline.baml:44:27 ]
 //     │
 //  44 │         let saved_draft = SaveDraft(video_id, draft);
 //     │                           ────┬────  
@@ -164,7 +164,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Expected bool, found unknown | string
-//     ╭─[ 0:50:20 ]
+//     ╭─[ headers_ai_content_pipeline.baml:50:20 ]
 //     │
 //  50 │ ╭─▶     let pr_status = if (summary) {
 //     ┆ ┆   
@@ -175,7 +175,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │     Note: Error code: E0001
 // ────╯
 // Error: Unknown variable CreatePR
-//     ╭─[ 0:52:18 ]
+//     ╭─[ headers_ai_content_pipeline.baml:52:18 ]
 //     │
 //  52 │         let pr = CreatePR(video_id, summary);
 //     │                  ────┬───  
@@ -184,7 +184,7 @@ function AIContentPipeline(video_id: string, zoom_meeting_id: string, transcript
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable pr_status
-//     ╭─[ 0:53:9 ]
+//     ╭─[ headers_ai_content_pipeline.baml:53:9 ]
 //     │
 //  53 │         pr_status
 //     │         ────┬────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/basic_if.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/basic_if.baml
@@ -18,7 +18,7 @@ function BasicIf() -> string {
 //----
 //- diagnostics
 // Error: Expected string, found int
-//    ╭─[ 0:1:1 ]
+//    ╭─[ headers_basic_if.baml:1:1 ]
 //    │
 //  1 │ //# Basic test
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/complex_headers_test.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/complex_headers_test.baml
@@ -67,7 +67,7 @@ function ForLoopWithHeaders() -> int {
 //----
 //- diagnostics
 // Error: Expected string, found int
-//    ╭─[ 0:1:1 ]
+//    ╭─[ headers_complex_headers_test.baml:1:1 ]
 //    │
 //  1 │ //# Main Function
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/complex_workflow.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/complex_workflow.baml
@@ -69,7 +69,7 @@ client<llm> GPT4 {
 //----
 //- diagnostics
 // Error: Cannot apply operator '!' to type string?
-//    ╭─[ 0:6:30 ]
+//    ╭─[ headers_complex_workflow.baml:6:30 ]
 //    │
 //  6 │     let computed_title = if (!title) {
 //    │                              ───┬──  
@@ -78,7 +78,7 @@ client<llm> GPT4 {
 //    │ Note: Error code: E0004
 // ───╯
 // Error: Cannot apply operator 'Add' to types string | string? and string
-//     ╭─[ 0:17:5 ]
+//     ╭─[ headers_complex_workflow.baml:17:5 ]
 //     │
 //  17 │     computed_title + ": " + summary
 //     │     ──────────┬──────────  
@@ -87,7 +87,7 @@ client<llm> GPT4 {
 //     │ Note: Error code: E0004
 // ────╯
 // Error: Cannot apply operator 'Add' to types error and string
-//     ╭─[ 0:17:1 ]
+//     ╭─[ headers_complex_workflow.baml:17:1 ]
 //     │
 //  17 │     computed_title + ": " + summary
 //     │ ─────────────────┬─────────────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/duplicate_function_calls.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/duplicate_function_calls.baml
@@ -15,7 +15,7 @@ function CallsDedup() -> string {
 //----
 //- diagnostics
 // Error: Unknown variable Foo
-//    ╭─[ 0:4:13 ]
+//    ╭─[ headers_duplicate_function_calls.baml:4:13 ]
 //    │
 //  4 │     let a = Foo();
 //    │             ─┬─  
@@ -24,7 +24,7 @@ function CallsDedup() -> string {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable Foo
-//    ╭─[ 0:7:13 ]
+//    ╭─[ headers_duplicate_function_calls.baml:7:13 ]
 //    │
 //  7 │     let b = Foo();
 //    │             ─┬─  
@@ -33,7 +33,7 @@ function CallsDedup() -> string {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable Foo
-//     ╭─[ 0:10:13 ]
+//     ╭─[ headers_duplicate_function_calls.baml:10:13 ]
 //     │
 //  10 │     let c = Foo();
 //     │             ─┬─  
@@ -42,7 +42,7 @@ function CallsDedup() -> string {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Cannot apply operator 'Add' to types unknown and unknown
-//     ╭─[ 0:12:5 ]
+//     ╭─[ headers_duplicate_function_calls.baml:12:5 ]
 //     │
 //  12 │     a + b
 //     │     ──┬──  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/edge_cases.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/edge_cases.baml
@@ -215,7 +215,7 @@ function HeaderOnlyFunction() -> string {
 //----
 //- diagnostics
 // Error: Expected string, found int
-//    ╭─[ 0:1:1 ]
+//    ╭─[ headers_edge_cases.baml:1:1 ]
 //    │
 //  1 │ // Edge cases for MDX headers
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/header_in_llm_function.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/header_in_llm_function.baml
@@ -26,7 +26,7 @@ function FetchDatax(user_id: string) -> Hi {
 //----
 //- diagnostics
 // Error: Header comments (//#) are not allowed inside LLM functions
-//     ╭─[ 0:13:5 ]
+//     ╭─[ headers_header_in_llm_function.baml:13:5 ]
 //     │
 //  13 │     //# collect source material
 //     │     ─────────────┬─────────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/if_then_else.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/if_then_else.baml
@@ -50,7 +50,7 @@ function ComplexHeaderTest(x: int) -> int {
 //----
 //- diagnostics
 // Error: Unknown variable y
-//     ╭─[ 0:17:5 ]
+//     ╭─[ headers_if_then_else.baml:17:5 ]
 //     │
 //  17 │     y
 //     │     ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/if_then_only_header.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/if_then_only_header.baml
@@ -49,7 +49,7 @@ function IfThenOnlyHeader2() -> int {
 //----
 //- diagnostics
 // Error: Duplicate function 'IfThenOnlyHeader2'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ headers_if_then_only_header.baml:1:1 ]
 //    │
 //  1 │ //# Case 1
 //    │ │ 
@@ -60,7 +60,7 @@ function IfThenOnlyHeader2() -> int {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Expected int, found int | null
-//    ╭─[ 0:1:1 ]
+//    ╭─[ headers_if_then_only_header.baml:1:1 ]
 //    │
 //  1 │ //# Case 1
 //    │ │ 
@@ -69,7 +69,7 @@ function IfThenOnlyHeader2() -> int {
 //    │ Note: Error code: E0001
 // ───╯
 // Error: Expected int, found int | null
-//    ╭─[ 0:1:1 ]
+//    ╭─[ headers_if_then_only_header.baml:1:1 ]
 //    │
 //  1 │ //# Case 1
 //    │ │ 
@@ -78,7 +78,7 @@ function IfThenOnlyHeader2() -> int {
 //    │ Note: Error code: E0001
 // ───╯
 // Error: Expected int, found int | null
-//    ╭─[ 0:1:1 ]
+//    ╭─[ headers_if_then_only_header.baml:1:1 ]
 //    │
 //  1 │ //# Case 1
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/nested_if_statements.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/headers/nested_if_statements.baml
@@ -61,7 +61,7 @@ function NestedIfStatements() -> string {
 //----
 //- diagnostics
 // Error: Expected string, found int
-//    ╭─[ 0:1:1 ]
+//    ╭─[ headers_nested_if_statements.baml:1:1 ]
 //    │
 //  1 │ //# Main Function
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/arrays.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/arrays.baml
@@ -43,7 +43,7 @@ function ArrayAssignments() -> int {
 //----
 //- diagnostics
 // Error: Expected int[], found string[]
-//     ╭─[ 0:18:5 ]
+//     ╭─[ invalid_assignment_arrays.baml:18:5 ]
 //     │
 //  18 │     d = ["a", "b"];
 //     │        ─────┬─────  
@@ -52,7 +52,7 @@ function ArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected string[], found int[]
-//     ╭─[ 0:22:5 ]
+//     ╭─[ invalid_assignment_arrays.baml:22:5 ]
 //     │
 //  22 │     e = [1, 2];
 //     │        ───┬───  
@@ -61,7 +61,7 @@ function ArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected int, found int[]
-//     ╭─[ 0:26:5 ]
+//     ╭─[ invalid_assignment_arrays.baml:26:5 ]
 //     │
 //  26 │     f = [1, 2, 3];
 //     │        ─────┬────  
@@ -70,7 +70,7 @@ function ArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected int[], found int
-//     ╭─[ 0:30:6 ]
+//     ╭─[ invalid_assignment_arrays.baml:30:6 ]
 //     │
 //  30 │     g = 42;
 //     │         ─┬  
@@ -79,7 +79,7 @@ function ArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected int[], found string
-//     ╭─[ 0:34:5 ]
+//     ╭─[ invalid_assignment_arrays.baml:34:5 ]
 //     │
 //  34 │     h = "array";
 //     │        ────┬───  
@@ -88,7 +88,7 @@ function ArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected string, found int[]
-//     ╭─[ 0:38:5 ]
+//     ╭─[ invalid_assignment_arrays.baml:38:5 ]
 //     │
 //  38 │     i = [4, 5, 6];
 //     │        ─────┬────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/class_arrays.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/class_arrays.baml
@@ -46,7 +46,7 @@ function ClassArrayAssignments() -> int {
 //----
 //- diagnostics
 // Error: Expected Person[], found Animal[]
-//     ╭─[ 0:25:6 ]
+//     ╭─[ invalid_assignment_class_arrays.baml:25:6 ]
 //     │
 //  25 │     p1 = [Animal { species: "Bird", legs: 2 }];
 //     │         ───────────────────┬──────────────────  
@@ -55,7 +55,7 @@ function ClassArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Animal[], found Person[]
-//     ╭─[ 0:29:6 ]
+//     ╭─[ invalid_assignment_class_arrays.baml:29:6 ]
 //     │
 //  29 │     a1 = [Person { name: "D", age: 4 }];
 //     │         ───────────────┬───────────────  
@@ -64,7 +64,7 @@ function ClassArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Person[], found Person
-//     ╭─[ 0:33:7 ]
+//     ╭─[ invalid_assignment_class_arrays.baml:33:7 ]
 //     │
 //  33 │     p2 = Person { name: "F", age: 6 };
 //     │          ──────────────┬─────────────  
@@ -73,7 +73,7 @@ function ClassArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Person, found Person[]
-//     ╭─[ 0:37:6 ]
+//     ╭─[ invalid_assignment_class_arrays.baml:37:6 ]
 //     │
 //  37 │     p3 = [Person { name: "H", age: 8 }];
 //     │         ───────────────┬───────────────  
@@ -82,7 +82,7 @@ function ClassArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected int[], found Person[]
-//     ╭─[ 0:41:8 ]
+//     ╭─[ invalid_assignment_class_arrays.baml:41:8 ]
 //     │
 //  41 │     nums = [Person { name: "I", age: 9 }];
 //     │           ───────────────┬───────────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/classes.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/classes.baml
@@ -46,7 +46,7 @@ function ClassAssignments() -> int {
 //----
 //- diagnostics
 // Error: Expected Person, found Animal
-//     ╭─[ 0:25:7 ]
+//     ╭─[ invalid_assignment_classes.baml:25:7 ]
 //     │
 //  25 │     p2 = Animal { species: "Bird", legs: 2 };
 //     │          ─────────────────┬─────────────────  
@@ -55,7 +55,7 @@ function ClassAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Animal, found Person
-//     ╭─[ 0:29:7 ]
+//     ╭─[ invalid_assignment_classes.baml:29:7 ]
 //     │
 //  29 │     a2 = Person { name: "Dave", age: 40 };
 //     │          ────────────────┬───────────────  
@@ -64,7 +64,7 @@ function ClassAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Person, found string
-//     ╭─[ 0:33:6 ]
+//     ╭─[ invalid_assignment_classes.baml:33:6 ]
 //     │
 //  33 │     p3 = "not a person";
 //     │         ───────┬───────  
@@ -73,7 +73,7 @@ function ClassAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Person, found int
-//     ╭─[ 0:37:7 ]
+//     ╭─[ invalid_assignment_classes.baml:37:7 ]
 //     │
 //  37 │     p4 = 42;
 //     │          ─┬  
@@ -82,7 +82,7 @@ function ClassAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected int, found Person
-//     ╭─[ 0:41:6 ]
+//     ╭─[ invalid_assignment_classes.baml:41:6 ]
 //     │
 //  41 │     n = Person { name: "Grace", age: 32 };
 //     │         ────────────────┬────────────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/compound_ops.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/compound_ops.baml
@@ -36,7 +36,7 @@ function CompoundAssignments() -> int {
 //----
 //- diagnostics
 // Error: Expected int, found string
-//     ╭─[ 0:15:6 ]
+//     ╭─[ invalid_assignment_compound_ops.baml:15:6 ]
 //     │
 //  15 │     c += "five";
 //     │         ───┬───  
@@ -45,7 +45,7 @@ function CompoundAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected string, found int
-//     ╭─[ 0:19:7 ]
+//     ╭─[ invalid_assignment_compound_ops.baml:19:7 ]
 //     │
 //  19 │     d += 100;
 //     │          ─┬─  
@@ -54,7 +54,7 @@ function CompoundAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected int, found bool
-//     ╭─[ 0:23:7 ]
+//     ╭─[ invalid_assignment_compound_ops.baml:23:7 ]
 //     │
 //  23 │     e += true;
 //     │          ──┬─  
@@ -63,7 +63,7 @@ function CompoundAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected bool, found int
-//     ╭─[ 0:27:7 ]
+//     ╭─[ invalid_assignment_compound_ops.baml:27:7 ]
 //     │
 //  27 │     f += 1;
 //     │          ┬  
@@ -72,7 +72,7 @@ function CompoundAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected float, found string
-//     ╭─[ 0:31:6 ]
+//     ╭─[ invalid_assignment_compound_ops.baml:31:6 ]
 //     │
 //  31 │     g += "add";
 //     │         ───┬──  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/maps.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/maps.baml
@@ -49,7 +49,7 @@ function MapAssignments() -> int {
 //----
 //- diagnostics
 // Error: Expected map<string, int>, found map<string, string>
-//     ╭─[ 0:28:5 ]
+//     ╭─[ invalid_assignment_maps.baml:28:5 ]
 //     │
 //  28 │     d = {"y": "wrong"};
 //     │        ───────┬───────  
@@ -58,7 +58,7 @@ function MapAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected map<string, Person>, found map<string, Animal>
-//     ╭─[ 0:32:5 ]
+//     ╭─[ invalid_assignment_maps.baml:32:5 ]
 //     │
 //  32 │     e = {"a": Animal { species: "Cat", legs: 4 }};
 //     │        ─────────────────────┬────────────────────  
@@ -67,7 +67,7 @@ function MapAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected map<string, int>, found string
-//     ╭─[ 0:36:5 ]
+//     ╭─[ invalid_assignment_maps.baml:36:5 ]
 //     │
 //  36 │     f = "not a map";
 //     │        ──────┬─────  
@@ -76,7 +76,7 @@ function MapAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected map<string, int>, found int
-//     ╭─[ 0:40:6 ]
+//     ╭─[ invalid_assignment_maps.baml:40:6 ]
 //     │
 //  40 │     g = 123;
 //     │         ─┬─  
@@ -85,7 +85,7 @@ function MapAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected string, found map<string, int>
-//     ╭─[ 0:44:5 ]
+//     ╭─[ invalid_assignment_maps.baml:44:5 ]
 //     │
 //  44 │     h = {"k": 7};
 //     │        ────┬────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/nested_arrays.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/nested_arrays.baml
@@ -45,7 +45,7 @@ function NestedArrayAssignments() -> int {
 //----
 //- diagnostics
 // Error: Expected int[][], found int[]
-//     ╭─[ 0:28:5 ]
+//     ╭─[ invalid_assignment_nested_arrays.baml:28:5 ]
 //     │
 //  28 │     d = [3, 4, 5];
 //     │        ─────┬────  
@@ -54,7 +54,7 @@ function NestedArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected int[], found int[][]
-//     ╭─[ 0:32:5 ]
+//     ╭─[ invalid_assignment_nested_arrays.baml:32:5 ]
 //     │
 //  32 │     e = [[4, 5], [6, 7]];
 //     │        ────────┬────────  
@@ -63,7 +63,7 @@ function NestedArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected string[][], found int[][]
-//     ╭─[ 0:36:5 ]
+//     ╭─[ invalid_assignment_nested_arrays.baml:36:5 ]
 //     │
 //  36 │     f = [[1, 2]];
 //     │        ────┬────  
@@ -72,7 +72,7 @@ function NestedArrayAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Person[][], found Animal[][]
-//     ╭─[ 0:40:5 ]
+//     ╭─[ invalid_assignment_nested_arrays.baml:40:5 ]
 //     │
 //  40 │     g = [[Animal { species: "Cat", legs: 4 }]];
 //     │        ───────────────────┬───────────────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/nominal_typing.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/nominal_typing.baml
@@ -68,7 +68,7 @@ function NominalTypingAssignments() -> int {
 //----
 //- diagnostics
 // Error: Expected Person, found Human
-//     ╭─[ 0:43:7 ]
+//     ╭─[ invalid_assignment_nominal_typing.baml:43:7 ]
 //     │
 //  43 │     p2 = Human { name: "F", age: 6 };
 //     │          ─────────────┬─────────────  
@@ -77,7 +77,7 @@ function NominalTypingAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Human, found Person
-//     ╭─[ 0:47:7 ]
+//     ╭─[ invalid_assignment_nominal_typing.baml:47:7 ]
 //     │
 //  47 │     h2 = Person { name: "H", age: 8 };
 //     │          ──────────────┬─────────────  
@@ -86,7 +86,7 @@ function NominalTypingAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Animal, found Creature
-//     ╭─[ 0:51:7 ]
+//     ╭─[ invalid_assignment_nominal_typing.baml:51:7 ]
 //     │
 //  51 │     a2 = Creature { species: "Lizard", legs: 4 };
 //     │          ───────────────────┬───────────────────  
@@ -95,7 +95,7 @@ function NominalTypingAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Creature, found Animal
-//     ╭─[ 0:55:7 ]
+//     ╭─[ invalid_assignment_nominal_typing.baml:55:7 ]
 //     │
 //  55 │     c2 = Animal { species: "Spider", legs: 8 };
 //     │          ──────────────────┬──────────────────  
@@ -104,7 +104,7 @@ function NominalTypingAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Person[], found Human[]
-//     ╭─[ 0:59:10 ]
+//     ╭─[ invalid_assignment_nominal_typing.baml:59:10 ]
 //     │
 //  59 │     people = [Human { name: "J", age: 10 }];
 //     │             ───────────────┬───────────────  
@@ -113,7 +113,7 @@ function NominalTypingAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Human[], found Person[]
-//     ╭─[ 0:63:10 ]
+//     ╭─[ invalid_assignment_nominal_typing.baml:63:10 ]
 //     │
 //  63 │     humans = [Person { name: "L", age: 12 }];
 //     │             ────────────────┬───────────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/optionals.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/optionals.baml
@@ -44,7 +44,7 @@ function OptionalAssignments() -> int {
 //----
 //- diagnostics
 // Error: Expected int?, found string
-//     ╭─[ 0:31:5 ]
+//     ╭─[ invalid_assignment_optionals.baml:31:5 ]
 //     │
 //  31 │     c = "not an int";
 //     │        ──────┬──────  
@@ -53,7 +53,7 @@ function OptionalAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected string?, found int
-//     ╭─[ 0:35:6 ]
+//     ╭─[ invalid_assignment_optionals.baml:35:6 ]
 //     │
 //  35 │     d = 42;
 //     │         ─┬  
@@ -62,7 +62,7 @@ function OptionalAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected Person?, found Animal
-//     ╭─[ 0:39:6 ]
+//     ╭─[ invalid_assignment_optionals.baml:39:6 ]
 //     │
 //  39 │     e = Animal { species: "Cat", legs: 4 };
 //     │         ─────────────────┬────────────────  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/primitives.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/invalid_assignment/primitives.baml
@@ -50,7 +50,7 @@ function PrimitiveAssignments() -> int {
 //----
 //- diagnostics
 // Error: Expected int, found string
-//     ╭─[ 0:21:5 ]
+//     ╭─[ invalid_assignment_primitives.baml:21:5 ]
 //     │
 //  21 │     e = "oops";
 //     │        ───┬───  
@@ -59,7 +59,7 @@ function PrimitiveAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected string, found int
-//     ╭─[ 0:25:6 ]
+//     ╭─[ invalid_assignment_primitives.baml:25:6 ]
 //     │
 //  25 │     f = 42;
 //     │         ─┬  
@@ -68,7 +68,7 @@ function PrimitiveAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected bool, found int
-//     ╭─[ 0:29:6 ]
+//     ╭─[ invalid_assignment_primitives.baml:29:6 ]
 //     │
 //  29 │     g = 123;
 //     │         ─┬─  
@@ -77,7 +77,7 @@ function PrimitiveAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected int, found bool
-//     ╭─[ 0:33:6 ]
+//     ╭─[ invalid_assignment_primitives.baml:33:6 ]
 //     │
 //  33 │     h = false;
 //     │         ──┬──  
@@ -86,7 +86,7 @@ function PrimitiveAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected float, found string
-//     ╭─[ 0:37:5 ]
+//     ╭─[ invalid_assignment_primitives.baml:37:5 ]
 //     │
 //  37 │     i = "pi";
 //     │        ──┬──  
@@ -95,7 +95,7 @@ function PrimitiveAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected bool, found string
-//     ╭─[ 0:41:5 ]
+//     ╭─[ invalid_assignment_primitives.baml:41:5 ]
 //     │
 //  41 │     j = "true";
 //     │        ───┬───  
@@ -104,7 +104,7 @@ function PrimitiveAssignments() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected string, found bool
-//     ╭─[ 0:45:6 ]
+//     ╭─[ invalid_assignment_primitives.baml:45:6 ]
 //     │
 //  45 │     k = true;
 //     │         ──┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/c_for.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/c_for.baml
@@ -102,7 +102,7 @@ function BreakContinue() -> int {
 //----
 //- diagnostics
 // Error: Unknown variable i
-//     ╭─[ 0:21:9 ]
+//     ╭─[ loops_c_for.baml:21:9 ]
 //     │
 //  21 │     for (; i <= 10; i += 1) {
 //     │            ┬  
@@ -111,7 +111,7 @@ function BreakContinue() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:22:8 ]
+//     ╭─[ loops_c_for.baml:22:8 ]
 //     │
 //  22 │        s += i;
 //     │             ┬  
@@ -120,7 +120,7 @@ function BreakContinue() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:21:18 ]
+//     ╭─[ loops_c_for.baml:21:18 ]
 //     │
 //  21 │     for (; i <= 10; i += 1) {
 //     │                     ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/continue.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/continue.baml
@@ -45,7 +45,7 @@ function ContinueNested() -> int {
 //----
 //- diagnostics
 // Error: Expected int, found void
-//    ╭─[ 0:1:1 ]
+//    ╭─[ loops_continue.baml:1:1 ]
 //    │
 //  1 │ function Factorial(limit: int) -> int {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/for.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/for.baml
@@ -61,7 +61,7 @@ function SumUnknownType(xs: int, b: string) -> int {
 //----
 //- diagnostics
 // Error: Expected int, found string
-//     ╭─[ 0:16:12 ]
+//     ╭─[ loops_for.baml:16:12 ]
 //     │
 //  16 │        result = x;
 //     │                 ┬  
@@ -70,7 +70,7 @@ function SumUnknownType(xs: int, b: string) -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Type int has no field 'length'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ loops_for.baml:1:1 ]
 //    │
 //  1 │ function Sum(xs: int[]) -> int {
 //    │ │ 
@@ -79,7 +79,7 @@ function SumUnknownType(xs: int, b: string) -> int {
 //    │ Note: Error code: E0007
 // ───╯
 // Error: Type int is not indexable
-//    ╭─[ 0:1:1 ]
+//    ╭─[ loops_for.baml:1:1 ]
 //    │
 //  1 │ function Sum(xs: int[]) -> int {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/header_requires_let_negative.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/header_requires_let_negative.baml
@@ -75,7 +75,7 @@ function MissingLetAfter() -> int {
 //----
 //- diagnostics
 // Error: Expected ')', found ';'
-//    ╭─[ 0:4:19 ]
+//    ╭─[ loops_header_requires_let_negative.baml:4:19 ]
 //    │
 //  4 │     for (i = 0; i < 3; i += 1) {
 //    │                      ┬  
@@ -84,7 +84,7 @@ function MissingLetAfter() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected block after for expression, found ';'
-//    ╭─[ 0:4:19 ]
+//    ╭─[ loops_header_requires_let_negative.baml:4:19 ]
 //    │
 //  4 │     for (i = 0; i < 3; i += 1) {
 //    │                      ┬  
@@ -93,7 +93,7 @@ function MissingLetAfter() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected expression, found ')'
-//    ╭─[ 0:4:27 ]
+//    ╭─[ loops_header_requires_let_negative.baml:4:27 ]
 //    │
 //  4 │     for (i = 0; i < 3; i += 1) {
 //    │                              ┬  
@@ -102,7 +102,7 @@ function MissingLetAfter() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Unknown variable i
-//    ╭─[ 0:4:14 ]
+//    ╭─[ loops_header_requires_let_negative.baml:4:14 ]
 //    │
 //  4 │     for (i = 0; i < 3; i += 1) {
 //    │                 ┬  
@@ -111,7 +111,7 @@ function MissingLetAfter() -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable i
-//    ╭─[ 0:4:21 ]
+//    ╭─[ loops_header_requires_let_negative.baml:4:21 ]
 //    │
 //  4 │     for (i = 0; i < 3; i += 1) {
 //    │                        ┬  
@@ -120,7 +120,7 @@ function MissingLetAfter() -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable i
-//    ╭─[ 0:5:8 ]
+//    ╭─[ loops_header_requires_let_negative.baml:5:8 ]
 //    │
 //  5 │        s += i;
 //    │             ┬  
@@ -129,7 +129,7 @@ function MissingLetAfter() -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Unknown variable i
-//     ╭─[ 0:14:16 ]
+//     ╭─[ loops_header_requires_let_negative.baml:14:16 ]
 //     │
 //  14 │     for (; s < 2; i += 1) {
 //     │                   ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/header_requires_let_positive.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/loops/header_requires_let_positive.baml
@@ -20,7 +20,7 @@ function InitWithLet() -> int {
 //----
 //- diagnostics
 // Error: Expected ')', found ';'
-//    ╭─[ 0:4:19 ]
+//    ╭─[ loops_header_requires_let_positive.baml:4:19 ]
 //    │
 //  4 │     for (i = 0; i < 3; i += 1) {
 //    │                      ┬  
@@ -29,7 +29,7 @@ function InitWithLet() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected block after for expression, found ';'
-//    ╭─[ 0:4:19 ]
+//    ╭─[ loops_header_requires_let_positive.baml:4:19 ]
 //    │
 //  4 │     for (i = 0; i < 3; i += 1) {
 //    │                      ┬  
@@ -38,7 +38,7 @@ function InitWithLet() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected expression, found ')'
-//    ╭─[ 0:4:27 ]
+//    ╭─[ loops_header_requires_let_positive.baml:4:27 ]
 //    │
 //  4 │     for (i = 0; i < 3; i += 1) {
 //    │                              ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/maps/inconsistent_style.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/maps/inconsistent_style.baml
@@ -22,7 +22,7 @@ function InconsistentStyleUse() -> int{
 //----
 //- diagnostics
 // Error: Expected expression, found ':'
-//    ╭─[ 0:9:19 ]
+//    ╭─[ maps_inconsistent_style.baml:9:19 ]
 //    │
 //  9 │         some_ident: "yes"
 //    │                   ┬  
@@ -31,7 +31,7 @@ function InconsistentStyleUse() -> int{
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Unknown variable name
-//    ╭─[ 0:8:9 ]
+//    ╭─[ maps_inconsistent_style.baml:8:9 ]
 //    │
 //  8 │         name "Hello"
 //    │         ──┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/maps/key_and_value_typecheck.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/maps/key_and_value_typecheck.baml
@@ -46,7 +46,7 @@ function UseMapTypecheck() -> int {
 //----
 //- diagnostics
 // Error: Expected expression, found ':'
-//    ╭─[ 0:3:14 ]
+//    ╭─[ maps_key_and_value_typecheck.baml:3:14 ]
 //    │
 //  3 │     { (1 + 1): "2" }
 //    │              ┬  
@@ -55,7 +55,7 @@ function UseMapTypecheck() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected map<int, string>, found string
-//    ╭─[ 0:1:1 ]
+//    ╭─[ maps_key_and_value_typecheck.baml:1:1 ]
 //    │
 //  1 │ // For now, errors with 'map keys must be string literals'
 //    │ │ 
@@ -64,7 +64,7 @@ function UseMapTypecheck() -> int {
 //    │ Note: Error code: E0001
 // ───╯
 // Error: Type map<int, string> has no field 'has'
-//    ╭─[ 0:8:9 ]
+//    ╭─[ maps_key_and_value_typecheck.baml:8:9 ]
 //    │
 //  8 │     if (map.has(1)) {
 //    │         ───┬───  
@@ -73,7 +73,7 @@ function UseMapTypecheck() -> int {
 //    │ Note: Error code: E0007
 // ───╯
 // Error: Expected int, found string
-//     ╭─[ 0:18:5 ]
+//     ╭─[ maps_key_and_value_typecheck.baml:18:5 ]
 //     │
 //  18 │     map["string"]
 //     │     ──────┬──────  
@@ -82,7 +82,7 @@ function UseMapTypecheck() -> int {
 //     │ Note: Error code: E0001
 // ────╯
 // Error: Expected int, found string
-//    ╭─[ 0:1:1 ]
+//    ╭─[ maps_key_and_value_typecheck.baml:1:1 ]
 //    │
 //  1 │ // For now, errors with 'map keys must be string literals'
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types.baml
@@ -72,7 +72,7 @@ test ReturnDynamicClassTest {
 //----
 //- diagnostics
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:29:3 ]
+//     ╭─[ misc_dynamic_types.baml:29:3 ]
 //     │
 //  29 │   type_builder {
 //     │   ──────┬─────  
@@ -81,7 +81,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:29:3 ]
+//     ╭─[ misc_dynamic_types.baml:29:3 ]
 //     │
 //  29 │   type_builder {
 //     │   ──────┬─────  
@@ -90,7 +90,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:29:16 ]
+//     ╭─[ misc_dynamic_types.baml:29:16 ]
 //     │
 //  29 │   type_builder {
 //     │                ┬  
@@ -99,7 +99,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:46:5 ]
+//     ╭─[ misc_dynamic_types.baml:46:5 ]
 //     │
 //  46 │     dynamic class Resume {
 //     │     ───┬───  
@@ -108,7 +108,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:51:5 ]
+//     ╭─[ misc_dynamic_types.baml:51:5 ]
 //     │
 //  51 │     dynamic enum Job {
 //     │     ───┬───  
@@ -117,7 +117,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:54:3 ]
+//     ╭─[ misc_dynamic_types.baml:54:3 ]
 //     │
 //  54 │   }
 //     │   ┬  
@@ -126,7 +126,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:55:3 ]
+//     ╭─[ misc_dynamic_types.baml:55:3 ]
 //     │
 //  55 │   args {
 //     │   ──┬─  
@@ -135,7 +135,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:55:8 ]
+//     ╭─[ misc_dynamic_types.baml:55:8 ]
 //     │
 //  55 │   args {
 //     │        ┬  
@@ -144,7 +144,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:56:5 ]
+//     ╭─[ misc_dynamic_types.baml:56:5 ]
 //     │
 //  56 │     from_text #"
 //     │     ────┬────  
@@ -153,7 +153,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '#'
-//     ╭─[ 0:56:15 ]
+//     ╭─[ misc_dynamic_types.baml:56:15 ]
 //     │
 //  56 │     from_text #"
 //     │               ┬  
@@ -162,7 +162,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:56:16 ]
+//     ╭─[ misc_dynamic_types.baml:56:16 ]
 //     │
 //  56 │     from_text #"
 //     │                ┬  
@@ -171,7 +171,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:57:7 ]
+//     ╭─[ misc_dynamic_types.baml:57:7 ]
 //     │
 //  57 │       John Doe
 //     │       ──┬─  
@@ -180,7 +180,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:57:12 ]
+//     ╭─[ misc_dynamic_types.baml:57:12 ]
 //     │
 //  57 │       John Doe
 //     │            ─┬─  
@@ -189,7 +189,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:59:7 ]
+//     ╭─[ misc_dynamic_types.baml:59:7 ]
 //     │
 //  59 │       Education
 //     │       ────┬────  
@@ -198,7 +198,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '-'
-//     ╭─[ 0:60:7 ]
+//     ╭─[ misc_dynamic_types.baml:60:7 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │       ┬  
@@ -207,7 +207,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:9 ]
+//     ╭─[ misc_dynamic_types.baml:60:9 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │         ─────┬────  
@@ -216,7 +216,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:20 ]
+//     ╭─[ misc_dynamic_types.baml:60:20 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                    ─┬  
@@ -225,7 +225,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:23 ]
+//     ╭─[ misc_dynamic_types.baml:60:23 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                       ─────┬────  
@@ -234,7 +234,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found ','
-//     ╭─[ 0:60:33 ]
+//     ╭─[ misc_dynamic_types.baml:60:33 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                 ┬  
@@ -243,7 +243,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:35 ]
+//     ╭─[ misc_dynamic_types.baml:60:35 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                   ────┬───  
@@ -252,7 +252,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found ','
-//     ╭─[ 0:60:43 ]
+//     ╭─[ misc_dynamic_types.baml:60:43 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                           ┬  
@@ -261,7 +261,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:45 ]
+//     ╭─[ misc_dynamic_types.baml:60:45 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                             ┬  
@@ -270,7 +270,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '.'
-//     ╭─[ 0:60:46 ]
+//     ╭─[ misc_dynamic_types.baml:60:46 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                              ┬  
@@ -279,7 +279,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:47 ]
+//     ╭─[ misc_dynamic_types.baml:60:47 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                               ┬  
@@ -288,7 +288,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '.'
-//     ╭─[ 0:60:48 ]
+//     ╭─[ misc_dynamic_types.baml:60:48 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                                ┬  
@@ -297,7 +297,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found in
-//     ╭─[ 0:60:50 ]
+//     ╭─[ misc_dynamic_types.baml:60:50 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                                  ─┬  
@@ -306,7 +306,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:53 ]
+//     ╭─[ misc_dynamic_types.baml:60:53 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                                     ────┬───  
@@ -315,7 +315,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:62 ]
+//     ╭─[ misc_dynamic_types.baml:60:62 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                                              ───┬───  
@@ -324,7 +324,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found ','
-//     ╭─[ 0:60:69 ]
+//     ╭─[ misc_dynamic_types.baml:60:69 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                                                     ┬  
@@ -333,7 +333,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found integer
-//     ╭─[ 0:60:71 ]
+//     ╭─[ misc_dynamic_types.baml:60:71 ]
 //     │
 //  60 │       - University of California, Berkeley, B.S. in Computer Science, 2020
 //     │                                                                       ──┬─  
@@ -342,7 +342,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:62:7 ]
+//     ╭─[ misc_dynamic_types.baml:62:7 ]
 //     │
 //  62 │       Experience
 //     │       ─────┬────  
@@ -351,7 +351,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '-'
-//     ╭─[ 0:63:7 ]
+//     ╭─[ misc_dynamic_types.baml:63:7 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │       ┬  
@@ -360,7 +360,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:63:9 ]
+//     ╭─[ misc_dynamic_types.baml:63:9 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │         ────┬───  
@@ -369,7 +369,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:63:18 ]
+//     ╭─[ misc_dynamic_types.baml:63:18 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │                  ────┬───  
@@ -378,7 +378,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found ','
-//     ╭─[ 0:63:26 ]
+//     ╭─[ misc_dynamic_types.baml:63:26 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │                          ┬  
@@ -387,7 +387,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:63:28 ]
+//     ╭─[ misc_dynamic_types.baml:63:28 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │                            ────┬───  
@@ -396,7 +396,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found ','
-//     ╭─[ 0:63:36 ]
+//     ╭─[ misc_dynamic_types.baml:63:36 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │                                    ┬  
@@ -405,7 +405,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:63:38 ]
+//     ╭─[ misc_dynamic_types.baml:63:38 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │                                      ─┬─  
@@ -414,7 +414,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found integer
-//     ╭─[ 0:63:42 ]
+//     ╭─[ misc_dynamic_types.baml:63:42 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │                                          ──┬─  
@@ -423,7 +423,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '-'
-//     ╭─[ 0:63:47 ]
+//     ╭─[ misc_dynamic_types.baml:63:47 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │                                               ┬  
@@ -432,7 +432,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:63:49 ]
+//     ╭─[ misc_dynamic_types.baml:63:49 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │                                                 ─┬─  
@@ -441,7 +441,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found integer
-//     ╭─[ 0:63:53 ]
+//     ╭─[ misc_dynamic_types.baml:63:53 ]
 //     │
 //  63 │       - Software Engineer, Boundary, Sep 2022 - Sep 2023
 //     │                                                     ──┬─  
@@ -450,7 +450,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:65:7 ]
+//     ╭─[ misc_dynamic_types.baml:65:7 ]
 //     │
 //  65 │       Skills
 //     │       ───┬──  
@@ -459,7 +459,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '-'
-//     ╭─[ 0:66:7 ]
+//     ╭─[ misc_dynamic_types.baml:66:7 ]
 //     │
 //  66 │       - Python
 //     │       ┬  
@@ -468,7 +468,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:66:9 ]
+//     ╭─[ misc_dynamic_types.baml:66:9 ]
 //     │
 //  66 │       - Python
 //     │         ───┬──  
@@ -477,7 +477,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '-'
-//     ╭─[ 0:67:7 ]
+//     ╭─[ misc_dynamic_types.baml:67:7 ]
 //     │
 //  67 │       - Java
 //     │       ┬  
@@ -486,7 +486,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:67:9 ]
+//     ╭─[ misc_dynamic_types.baml:67:9 ]
 //     │
 //  67 │       - Java
 //     │         ──┬─  
@@ -495,7 +495,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:68:5 ]
+//     ╭─[ misc_dynamic_types.baml:68:5 ]
 //     │
 //  68 │     "#
 //     │     ┬  
@@ -504,7 +504,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '#'
-//     ╭─[ 0:68:6 ]
+//     ╭─[ misc_dynamic_types.baml:68:6 ]
 //     │
 //  68 │     "#
 //     │      ┬  
@@ -513,7 +513,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:69:3 ]
+//     ╭─[ misc_dynamic_types.baml:69:3 ]
 //     │
 //  69 │   }
 //     │   ┬  
@@ -522,7 +522,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:70:1 ]
+//     ╭─[ misc_dynamic_types.baml:70:1 ]
 //     │
 //  70 │ }
 //     │ ┬  
@@ -531,7 +531,7 @@ test ReturnDynamicClassTest {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Duplicate class 'Resume'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types.baml:1:1 ]
 //    │
 //  1 │ class Resume {
 //    │ │ 
@@ -542,7 +542,7 @@ test ReturnDynamicClassTest {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate enum 'Job'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types.baml:1:1 ]
 //    │
 //  1 │ class Resume {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types_external_cycle_errors.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types_external_cycle_errors.baml
@@ -55,7 +55,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //----
 //- diagnostics
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:14:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:14:3 ]
 //     │
 //  14 │   type_builder {
 //     │   ──────┬─────  
@@ -64,7 +64,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:14:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:14:3 ]
 //     │
 //  14 │   type_builder {
 //     │   ──────┬─────  
@@ -73,7 +73,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:14:16 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:14:16 ]
 //     │
 //  14 │   type_builder {
 //     │                ┬  
@@ -82,7 +82,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:25:5 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:25:5 ]
 //     │
 //  25 │     dynamic class DynamicClass {
 //     │     ───┬───  
@@ -91,7 +91,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:28:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:28:3 ]
 //     │
 //  28 │   }
 //     │   ┬  
@@ -100,7 +100,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:29:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:29:3 ]
 //     │
 //  29 │   args {
 //     │   ──┬─  
@@ -109,7 +109,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:29:8 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:29:8 ]
 //     │
 //  29 │   args {
 //     │        ┬  
@@ -118,7 +118,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:30:5 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:30:5 ]
 //     │
 //  30 │     from_text "Test"
 //     │     ────┬────  
@@ -127,7 +127,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:30:15 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:30:15 ]
 //     │
 //  30 │     from_text "Test"
 //     │               ┬  
@@ -136,7 +136,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:30:16 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:30:16 ]
 //     │
 //  30 │     from_text "Test"
 //     │                ──┬─  
@@ -145,7 +145,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:30:20 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:30:20 ]
 //     │
 //  30 │     from_text "Test"
 //     │                    ┬  
@@ -154,7 +154,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:31:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:31:3 ]
 //     │
 //  31 │   }
 //     │   ┬  
@@ -163,7 +163,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:32:1 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:32:1 ]
 //     │
 //  32 │ }
 //     │ ┬  
@@ -172,7 +172,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:36:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:36:3 ]
 //     │
 //  36 │   type_builder {
 //     │   ──────┬─────  
@@ -181,7 +181,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:36:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:36:3 ]
 //     │
 //  36 │   type_builder {
 //     │   ──────┬─────  
@@ -190,7 +190,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:36:16 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:36:16 ]
 //     │
 //  36 │   type_builder {
 //     │                ┬  
@@ -199,7 +199,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:37:5 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:37:5 ]
 //     │
 //  37 │     dynamic class DynamicClass {
 //     │     ───┬───  
@@ -208,7 +208,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:40:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:40:3 ]
 //     │
 //  40 │   }
 //     │   ┬  
@@ -217,7 +217,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:41:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:41:3 ]
 //     │
 //  41 │   args {
 //     │   ──┬─  
@@ -226,7 +226,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:41:8 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:41:8 ]
 //     │
 //  41 │   args {
 //     │        ┬  
@@ -235,7 +235,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:42:5 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:42:5 ]
 //     │
 //  42 │     from_text "Test"
 //     │     ────┬────  
@@ -244,7 +244,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:42:15 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:42:15 ]
 //     │
 //  42 │     from_text "Test"
 //     │               ┬  
@@ -253,7 +253,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:42:16 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:42:16 ]
 //     │
 //  42 │     from_text "Test"
 //     │                ──┬─  
@@ -262,7 +262,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:42:20 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:42:20 ]
 //     │
 //  42 │     from_text "Test"
 //     │                    ┬  
@@ -271,7 +271,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:43:3 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:43:3 ]
 //     │
 //  43 │   }
 //     │   ┬  
@@ -280,7 +280,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:44:1 ]
+//     ╭─[ misc_dynamic_types_external_cycle_errors.baml:44:1 ]
 //     │
 //  44 │ }
 //     │ ┬  
@@ -289,7 +289,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Duplicate class 'DynamicClass'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_external_cycle_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 
@@ -300,7 +300,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate class 'DynamicClass'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_external_cycle_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types_internal_cycle_errors.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types_internal_cycle_errors.baml
@@ -33,7 +33,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //----
 //- diagnostics
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:14:3 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:14:3 ]
 //     │
 //  14 │   type_builder {
 //     │   ──────┬─────  
@@ -42,7 +42,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:14:3 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:14:3 ]
 //     │
 //  14 │   type_builder {
 //     │   ──────┬─────  
@@ -51,7 +51,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:14:16 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:14:16 ]
 //     │
 //  14 │   type_builder {
 //     │                ┬  
@@ -60,7 +60,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:15:5 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:15:5 ]
 //     │
 //  15 │     dynamic class DynamicClass {
 //     │     ───┬───  
@@ -69,7 +69,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:18:3 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:18:3 ]
 //     │
 //  18 │   }
 //     │   ┬  
@@ -78,7 +78,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:19:3 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:19:3 ]
 //     │
 //  19 │   args {
 //     │   ──┬─  
@@ -87,7 +87,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:19:8 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:19:8 ]
 //     │
 //  19 │   args {
 //     │        ┬  
@@ -96,7 +96,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:20:5 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:20:5 ]
 //     │
 //  20 │     from_text "Test"
 //     │     ────┬────  
@@ -105,7 +105,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:20:15 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:20:15 ]
 //     │
 //  20 │     from_text "Test"
 //     │               ┬  
@@ -114,7 +114,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:20:16 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:20:16 ]
 //     │
 //  20 │     from_text "Test"
 //     │                ──┬─  
@@ -123,7 +123,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:20:20 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:20:20 ]
 //     │
 //  20 │     from_text "Test"
 //     │                    ┬  
@@ -132,7 +132,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:21:3 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:21:3 ]
 //     │
 //  21 │   }
 //     │   ┬  
@@ -141,7 +141,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:22:1 ]
+//     ╭─[ misc_dynamic_types_internal_cycle_errors.baml:22:1 ]
 //     │
 //  22 │ }
 //     │ ┬  
@@ -150,7 +150,7 @@ test AttemptToMakeClassInfinitelyRecursive {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Duplicate class 'DynamicClass'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_internal_cycle_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types_parser_errors.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types_parser_errors.baml
@@ -103,7 +103,7 @@ test IncompleteSyntax {
 //----
 //- diagnostics
 // Error: Expected '}', found type_builder
-//    ╭─[ 0:4:3 ]
+//    ╭─[ misc_dynamic_types_parser_errors.baml:4:3 ]
 //    │
 //  4 │   type_builder {
 //    │   ──────┬─────  
@@ -112,7 +112,7 @@ test IncompleteSyntax {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found type_builder
-//    ╭─[ 0:4:3 ]
+//    ╭─[ misc_dynamic_types_parser_errors.baml:4:3 ]
 //    │
 //  4 │   type_builder {
 //    │   ──────┬─────  
@@ -121,7 +121,7 @@ test IncompleteSyntax {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '{'
-//    ╭─[ 0:4:16 ]
+//    ╭─[ misc_dynamic_types_parser_errors.baml:4:16 ]
 //    │
 //  4 │   type_builder {
 //    │                ┬  
@@ -130,7 +130,7 @@ test IncompleteSyntax {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found dynamic
-//    ╭─[ 0:8:5 ]
+//    ╭─[ misc_dynamic_types_parser_errors.baml:8:5 ]
 //    │
 //  8 │     dynamic class Bar {
 //    │     ───┬───  
@@ -139,7 +139,7 @@ test IncompleteSyntax {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:11:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:11:3 ]
 //     │
 //  11 │   }
 //     │   ┬  
@@ -148,7 +148,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:12:1 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:12:1 ]
 //     │
 //  12 │ }
 //     │ ┬  
@@ -157,7 +157,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:16:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:16:3 ]
 //     │
 //  16 │   type_builder {
 //     │   ──────┬─────  
@@ -166,7 +166,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:16:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:16:3 ]
 //     │
 //  16 │   type_builder {
 //     │   ──────┬─────  
@@ -175,7 +175,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:16:16 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:16:16 ]
 //     │
 //  16 │   type_builder {
 //     │                ┬  
@@ -184,7 +184,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:20:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:20:5 ]
 //     │
 //  20 │     dynamic class Bar {
 //     │     ───┬───  
@@ -193,7 +193,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:23:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:23:3 ]
 //     │
 //  23 │   }
 //     │   ┬  
@@ -202,7 +202,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:24:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:24:3 ]
 //     │
 //  24 │   type_builder {
 //     │   ──────┬─────  
@@ -211,7 +211,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:24:16 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:24:16 ]
 //     │
 //  24 │   type_builder {
 //     │                ┬  
@@ -220,7 +220,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:28:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:28:5 ]
 //     │
 //  28 │     dynamic class B {
 //     │     ───┬───  
@@ -229,7 +229,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:31:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:31:3 ]
 //     │
 //  31 │   }
 //     │   ┬  
@@ -238,7 +238,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:32:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:32:3 ]
 //     │
 //  32 │   args {
 //     │   ──┬─  
@@ -247,7 +247,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:32:8 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:32:8 ]
 //     │
 //  32 │   args {
 //     │        ┬  
@@ -256,7 +256,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:33:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:33:5 ]
 //     │
 //  33 │     from_text "Test"
 //     │     ────┬────  
@@ -265,7 +265,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:33:15 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:33:15 ]
 //     │
 //  33 │     from_text "Test"
 //     │               ┬  
@@ -274,7 +274,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:33:16 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:33:16 ]
 //     │
 //  33 │     from_text "Test"
 //     │                ──┬─  
@@ -283,7 +283,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:33:20 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:33:20 ]
 //     │
 //  33 │     from_text "Test"
 //     │                    ┬  
@@ -292,7 +292,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:34:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:34:3 ]
 //     │
 //  34 │   }
 //     │   ┬  
@@ -301,7 +301,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:35:1 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:35:1 ]
 //     │
 //  35 │ }
 //     │ ┬  
@@ -310,7 +310,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:39:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:39:3 ]
 //     │
 //  39 │   type_builder {
 //     │   ──────┬─────  
@@ -319,7 +319,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:39:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:39:3 ]
 //     │
 //  39 │   type_builder {
 //     │   ──────┬─────  
@@ -328,7 +328,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:39:16 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:39:16 ]
 //     │
 //  39 │   type_builder {
 //     │                ┬  
@@ -337,7 +337,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:40:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:40:5 ]
 //     │
 //  40 │     dynamic Bar {
 //     │     ───┬───  
@@ -346,7 +346,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:40:13 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:40:13 ]
 //     │
 //  40 │     dynamic Bar {
 //     │             ─┬─  
@@ -355,7 +355,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:40:17 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:40:17 ]
 //     │
 //  40 │     dynamic Bar {
 //     │                 ┬  
@@ -364,7 +364,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:41:7 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:41:7 ]
 //     │
 //  41 │       bar int
 //     │       ─┬─  
@@ -373,7 +373,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:41:11 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:41:11 ]
 //     │
 //  41 │       bar int
 //     │           ─┬─  
@@ -382,7 +382,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:42:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:42:5 ]
 //     │
 //  42 │     }
 //     │     ┬  
@@ -391,7 +391,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:43:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:43:3 ]
 //     │
 //  43 │   }
 //     │   ┬  
@@ -400,7 +400,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:44:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:44:3 ]
 //     │
 //  44 │   args {
 //     │   ──┬─  
@@ -409,7 +409,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:44:8 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:44:8 ]
 //     │
 //  44 │   args {
 //     │        ┬  
@@ -418,7 +418,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:45:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:45:5 ]
 //     │
 //  45 │     from_text "Test"
 //     │     ────┬────  
@@ -427,7 +427,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:45:15 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:45:15 ]
 //     │
 //  45 │     from_text "Test"
 //     │               ┬  
@@ -436,7 +436,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:45:16 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:45:16 ]
 //     │
 //  45 │     from_text "Test"
 //     │                ──┬─  
@@ -445,7 +445,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:45:20 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:45:20 ]
 //     │
 //  45 │     from_text "Test"
 //     │                    ┬  
@@ -454,7 +454,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:46:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:46:3 ]
 //     │
 //  46 │   }
 //     │   ┬  
@@ -463,7 +463,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:47:1 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:47:1 ]
 //     │
 //  47 │ }
 //     │ ┬  
@@ -472,7 +472,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:51:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:51:3 ]
 //     │
 //  51 │   type_builder {
 //     │   ──────┬─────  
@@ -481,7 +481,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:51:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:51:3 ]
 //     │
 //  51 │   type_builder {
 //     │   ──────┬─────  
@@ -490,7 +490,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:51:16 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:51:16 ]
 //     │
 //  51 │   type_builder {
 //     │                ┬  
@@ -499,7 +499,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected type alias name, found dynamic
-//     ╭─[ 0:54:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:54:5 ]
 //     │
 //  54 │     dynamic class Bar {
 //     │     ───┬───  
@@ -508,7 +508,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '=', found dynamic
-//     ╭─[ 0:54:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:54:5 ]
 //     │
 //  54 │     dynamic class Bar {
 //     │     ───┬───  
@@ -517,7 +517,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected type, found dynamic
-//     ╭─[ 0:54:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:54:5 ]
 //     │
 //  54 │     dynamic class Bar {
 //     │     ───┬───  
@@ -526,7 +526,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:54:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:54:5 ]
 //     │
 //  54 │     dynamic class Bar {
 //     │     ───┬───  
@@ -535,7 +535,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:57:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:57:3 ]
 //     │
 //  57 │   }
 //     │   ┬  
@@ -544,7 +544,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:58:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:58:3 ]
 //     │
 //  58 │   args {
 //     │   ──┬─  
@@ -553,7 +553,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:58:8 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:58:8 ]
 //     │
 //  58 │   args {
 //     │        ┬  
@@ -562,7 +562,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:59:5 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:59:5 ]
 //     │
 //  59 │     from_text "Test"
 //     │     ────┬────  
@@ -571,7 +571,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:59:15 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:59:15 ]
 //     │
 //  59 │     from_text "Test"
 //     │               ┬  
@@ -580,7 +580,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:59:16 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:59:16 ]
 //     │
 //  59 │     from_text "Test"
 //     │                ──┬─  
@@ -589,7 +589,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:59:20 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:59:20 ]
 //     │
 //  59 │     from_text "Test"
 //     │                    ┬  
@@ -598,7 +598,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:60:3 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:60:3 ]
 //     │
 //  60 │   }
 //     │   ┬  
@@ -607,7 +607,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:61:1 ]
+//     ╭─[ misc_dynamic_types_parser_errors.baml:61:1 ]
 //     │
 //  61 │ }
 //     │ ┬  
@@ -616,7 +616,7 @@ test IncompleteSyntax {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Duplicate class 'Bar'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_parser_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn(from_text: string) -> Resume {
 //    │ │ 
@@ -627,7 +627,7 @@ test IncompleteSyntax {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate class 'Bar'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_parser_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn(from_text: string) -> Resume {
 //    │ │ 
@@ -638,7 +638,7 @@ test IncompleteSyntax {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate class 'Foo'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_parser_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn(from_text: string) -> Resume {
 //    │ │ 
@@ -649,7 +649,7 @@ test IncompleteSyntax {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Unknown type Resume
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_parser_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn(from_text: string) -> Resume {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types_validation_errors.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/dynamic_types_validation_errors.baml
@@ -228,7 +228,7 @@ args {
 //----
 //- diagnostics
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:13:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:13:3 ]
 //     │
 //  13 │   type_builder {
 //     │   ──────┬─────  
@@ -237,7 +237,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:13:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:13:3 ]
 //     │
 //  13 │   type_builder {
 //     │   ──────┬─────  
@@ -246,7 +246,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:13:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:13:16 ]
 //     │
 //  13 │   type_builder {
 //     │                ┬  
@@ -255,7 +255,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:14:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:14:5 ]
 //     │
 //  14 │     dynamic class NonDynamic {
 //     │     ───┬───  
@@ -264,7 +264,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:17:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:17:3 ]
 //     │
 //  17 │   }
 //     │   ┬  
@@ -273,7 +273,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:18:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:18:1 ]
 //     │
 //  18 │ args {
 //     │ ──┬─  
@@ -282,7 +282,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:18:6 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:18:6 ]
 //     │
 //  18 │ args {
 //     │      ┬  
@@ -291,7 +291,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:19:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:19:5 ]
 //     │
 //  19 │     from_text "Test"
 //     │     ────┬────  
@@ -300,7 +300,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:19:15 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:19:15 ]
 //     │
 //  19 │     from_text "Test"
 //     │               ┬  
@@ -309,7 +309,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:19:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:19:16 ]
 //     │
 //  19 │     from_text "Test"
 //     │                ──┬─  
@@ -318,7 +318,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:19:20 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:19:20 ]
 //     │
 //  19 │     from_text "Test"
 //     │                    ┬  
@@ -327,7 +327,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:20:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:20:3 ]
 //     │
 //  20 │   }
 //     │   ┬  
@@ -336,7 +336,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:21:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:21:1 ]
 //     │
 //  21 │ }
 //     │ ┬  
@@ -345,7 +345,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:27:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:27:3 ]
 //     │
 //  27 │   type_builder {
 //     │   ──────┬─────  
@@ -354,7 +354,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:27:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:27:3 ]
 //     │
 //  27 │   type_builder {
 //     │   ──────┬─────  
@@ -363,7 +363,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:27:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:27:16 ]
 //     │
 //  27 │   type_builder {
 //     │                ┬  
@@ -372,7 +372,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:28:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:28:5 ]
 //     │
 //  28 │     dynamic class SomeAlias {
 //     │     ───┬───  
@@ -381,7 +381,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:31:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:31:3 ]
 //     │
 //  31 │   }
 //     │   ┬  
@@ -390,7 +390,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:32:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:32:1 ]
 //     │
 //  32 │ args {
 //     │ ──┬─  
@@ -399,7 +399,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:32:6 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:32:6 ]
 //     │
 //  32 │ args {
 //     │      ┬  
@@ -408,7 +408,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:33:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:33:5 ]
 //     │
 //  33 │     from_text "Test"
 //     │     ────┬────  
@@ -417,7 +417,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:33:15 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:33:15 ]
 //     │
 //  33 │     from_text "Test"
 //     │               ┬  
@@ -426,7 +426,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:33:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:33:16 ]
 //     │
 //  33 │     from_text "Test"
 //     │                ──┬─  
@@ -435,7 +435,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:33:20 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:33:20 ]
 //     │
 //  33 │     from_text "Test"
 //     │                    ┬  
@@ -444,7 +444,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:34:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:34:3 ]
 //     │
 //  34 │   }
 //     │   ┬  
@@ -453,7 +453,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:35:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:35:1 ]
 //     │
 //  35 │ }
 //     │ ┬  
@@ -462,7 +462,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:45:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:45:3 ]
 //     │
 //  45 │   type_builder {
 //     │   ──────┬─────  
@@ -471,7 +471,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:45:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:45:3 ]
 //     │
 //  45 │   type_builder {
 //     │   ──────┬─────  
@@ -480,7 +480,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:45:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:45:16 ]
 //     │
 //  45 │   type_builder {
 //     │                ┬  
@@ -489,7 +489,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:54:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:54:5 ]
 //     │
 //  54 │     dynamic class DynamicClass {
 //     │     ───┬───  
@@ -498,7 +498,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:58:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:58:3 ]
 //     │
 //  58 │   }
 //     │   ┬  
@@ -507,7 +507,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:59:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:59:1 ]
 //     │
 //  59 │ args {
 //     │ ──┬─  
@@ -516,7 +516,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:59:6 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:59:6 ]
 //     │
 //  59 │ args {
 //     │      ┬  
@@ -525,7 +525,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:60:5 ]
 //     │
 //  60 │     from_text "Test"
 //     │     ────┬────  
@@ -534,7 +534,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:60:15 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:60:15 ]
 //     │
 //  60 │     from_text "Test"
 //     │               ┬  
@@ -543,7 +543,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:60:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:60:16 ]
 //     │
 //  60 │     from_text "Test"
 //     │                ──┬─  
@@ -552,7 +552,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:60:20 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:60:20 ]
 //     │
 //  60 │     from_text "Test"
 //     │                    ┬  
@@ -561,7 +561,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:61:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:61:3 ]
 //     │
 //  61 │   }
 //     │   ┬  
@@ -570,7 +570,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:62:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:62:1 ]
 //     │
 //  62 │ }
 //     │ ┬  
@@ -579,7 +579,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:66:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:66:3 ]
 //     │
 //  66 │   type_builder {
 //     │   ──────┬─────  
@@ -588,7 +588,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:66:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:66:3 ]
 //     │
 //  66 │   type_builder {
 //     │   ──────┬─────  
@@ -597,7 +597,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:66:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:66:16 ]
 //     │
 //  66 │   type_builder {
 //     │                ┬  
@@ -606,7 +606,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:67:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:67:5 ]
 //     │
 //  67 │     dynamic class DynamicClass {
 //     │     ───┬───  
@@ -615,7 +615,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:70:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:70:5 ]
 //     │
 //  70 │     dynamic class DynamicClass {
 //     │     ───┬───  
@@ -624,7 +624,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:73:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:73:1 ]
 //     │
 //  73 │ }
 //     │ ┬  
@@ -633,7 +633,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:74:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:74:1 ]
 //     │
 //  74 │ args {
 //     │ ──┬─  
@@ -642,7 +642,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:74:6 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:74:6 ]
 //     │
 //  74 │ args {
 //     │      ┬  
@@ -651,7 +651,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:75:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:75:5 ]
 //     │
 //  75 │     from_text "Test"
 //     │     ────┬────  
@@ -660,7 +660,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:75:15 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:75:15 ]
 //     │
 //  75 │     from_text "Test"
 //     │               ┬  
@@ -669,7 +669,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:75:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:75:16 ]
 //     │
 //  75 │     from_text "Test"
 //     │                ──┬─  
@@ -678,7 +678,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:75:20 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:75:20 ]
 //     │
 //  75 │     from_text "Test"
 //     │                    ┬  
@@ -687,7 +687,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:76:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:76:3 ]
 //     │
 //  76 │   }
 //     │   ┬  
@@ -696,7 +696,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:77:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:77:1 ]
 //     │
 //  77 │ }
 //     │ ┬  
@@ -705,7 +705,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '}', found type_builder
-//     ╭─[ 0:81:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:81:3 ]
 //     │
 //  81 │   type_builder {
 //     │   ──────┬─────  
@@ -714,7 +714,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found type_builder
-//     ╭─[ 0:81:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:81:3 ]
 //     │
 //  81 │   type_builder {
 //     │   ──────┬─────  
@@ -723,7 +723,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:81:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:81:16 ]
 //     │
 //  81 │   type_builder {
 //     │                ┬  
@@ -732,7 +732,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found dynamic
-//     ╭─[ 0:86:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:86:5 ]
 //     │
 //  86 │     dynamic class DynamicClass {
 //     │     ───┬───  
@@ -741,7 +741,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:89:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:89:3 ]
 //     │
 //  89 │   }
 //     │   ┬  
@@ -750,7 +750,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:90:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:90:1 ]
 //     │
 //  90 │ args {
 //     │ ──┬─  
@@ -759,7 +759,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '{'
-//     ╭─[ 0:90:6 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:90:6 ]
 //     │
 //  90 │ args {
 //     │      ┬  
@@ -768,7 +768,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:91:5 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:91:5 ]
 //     │
 //  91 │     from_text "Test"
 //     │     ────┬────  
@@ -777,7 +777,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:91:15 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:91:15 ]
 //     │
 //  91 │     from_text "Test"
 //     │               ┬  
@@ -786,7 +786,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found identifier
-//     ╭─[ 0:91:16 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:91:16 ]
 //     │
 //  91 │     from_text "Test"
 //     │                ──┬─  
@@ -795,7 +795,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '"'
-//     ╭─[ 0:91:20 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:91:20 ]
 //     │
 //  91 │     from_text "Test"
 //     │                    ┬  
@@ -804,7 +804,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:92:3 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:92:3 ]
 //     │
 //  92 │   }
 //     │   ┬  
@@ -813,7 +813,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected top-level declaration, found '}'
-//     ╭─[ 0:93:1 ]
+//     ╭─[ misc_dynamic_types_validation_errors.baml:93:1 ]
 //     │
 //  93 │ }
 //     │ ┬  
@@ -822,7 +822,7 @@ args {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '}', found type_builder
-//      ╭─[ 0:103:3 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:103:3 ]
 //      │
 //  103 │   type_builder {
 //      │   ──────┬─────  
@@ -831,7 +831,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found type_builder
-//      ╭─[ 0:103:3 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:103:3 ]
 //      │
 //  103 │   type_builder {
 //      │   ──────┬─────  
@@ -840,7 +840,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found '{'
-//      ╭─[ 0:103:16 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:103:16 ]
 //      │
 //  103 │   type_builder {
 //      │                ┬  
@@ -849,7 +849,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found dynamic
-//      ╭─[ 0:104:5 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:104:5 ]
 //      │
 //  104 │     dynamic class DynamicEnum {
 //      │     ───┬───  
@@ -858,7 +858,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: field 'C' is missing a type annotation
-//      ╭─[ 0:105:7 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:105:7 ]
 //      │
 //  105 │       C
 //      │       ┬  
@@ -867,7 +867,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found dynamic
-//      ╭─[ 0:107:5 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:107:5 ]
 //      │
 //  107 │     dynamic enum DynamicClass {
 //      │     ───┬───  
@@ -876,7 +876,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found '}'
-//      ╭─[ 0:110:1 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:110:1 ]
 //      │
 //  110 │ }
 //      │ ┬  
@@ -885,7 +885,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found identifier
-//      ╭─[ 0:111:1 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:111:1 ]
 //      │
 //  111 │ args {
 //      │ ──┬─  
@@ -894,7 +894,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found '{'
-//      ╭─[ 0:111:6 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:111:6 ]
 //      │
 //  111 │ args {
 //      │      ┬  
@@ -903,7 +903,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found identifier
-//      ╭─[ 0:112:5 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:112:5 ]
 //      │
 //  112 │     from_text "Test"
 //      │     ────┬────  
@@ -912,7 +912,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found '"'
-//      ╭─[ 0:112:15 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:112:15 ]
 //      │
 //  112 │     from_text "Test"
 //      │               ┬  
@@ -921,7 +921,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found identifier
-//      ╭─[ 0:112:16 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:112:16 ]
 //      │
 //  112 │     from_text "Test"
 //      │                ──┬─  
@@ -930,7 +930,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found '"'
-//      ╭─[ 0:112:20 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:112:20 ]
 //      │
 //  112 │     from_text "Test"
 //      │                    ┬  
@@ -939,7 +939,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found '}'
-//      ╭─[ 0:113:3 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:113:3 ]
 //      │
 //  113 │   }
 //      │   ┬  
@@ -948,7 +948,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Expected top-level declaration, found '}'
-//      ╭─[ 0:114:1 ]
+//      ╭─[ misc_dynamic_types_validation_errors.baml:114:1 ]
 //      │
 //  114 │ }
 //      │ ┬  
@@ -957,7 +957,7 @@ args {
 //      │ Note: Error code: E0010
 // ─────╯
 // Error: Duplicate class 'NonDynamic'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_validation_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 
@@ -968,7 +968,7 @@ args {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate class 'NonDynamic'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_validation_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 
@@ -979,7 +979,7 @@ args {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate class 'DynamicClass'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_validation_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 
@@ -990,7 +990,7 @@ args {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate class 'DynamicClass'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_validation_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 
@@ -1001,7 +1001,7 @@ args {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate class 'DynamicClass'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_validation_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 
@@ -1012,7 +1012,7 @@ args {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate class 'DynamicClass'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_validation_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 
@@ -1023,7 +1023,7 @@ args {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate enum 'DynamicEnum'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_validation_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 
@@ -1034,7 +1034,7 @@ args {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate enum 'DynamicClass'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_validation_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 
@@ -1045,7 +1045,7 @@ args {
 //    │ Note: Error code: E0011
 // ───╯
 // Error: Duplicate type alias 'SomeAlias'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_dynamic_types_validation_errors.baml:1:1 ]
 //    │
 //  1 │ function TypeBuilderFn() -> string {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/return.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/misc/return.baml
@@ -47,7 +47,7 @@ function BadValueReturn(x: int) -> string {
 //----
 //- diagnostics
 // Error: Expected string, found int
-//    ╭─[ 0:1:1 ]
+//    ╭─[ misc_return.baml:1:1 ]
 //    │
 //  1 │ function EarlyReturn(x: int) -> int {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/parens.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/parens.baml
@@ -174,7 +174,7 @@ function foo() -> int {
 //----
 //- diagnostics
 // Error: Expected block after if condition, found if
-//    ╭─[ 0:9:4 ]
+//    ╭─[ parens.baml:9:4 ]
 //    │
 //  9 │    if true) { }
 //    │    ─┬  
@@ -183,7 +183,7 @@ function foo() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected block after if condition, found ')'
-//    ╭─[ 0:9:11 ]
+//    ╭─[ parens.baml:9:11 ]
 //    │
 //  9 │    if true) { }
 //    │           ┬  
@@ -192,7 +192,7 @@ function foo() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected expression, found ')'
-//    ╭─[ 0:9:11 ]
+//    ╭─[ parens.baml:9:11 ]
 //    │
 //  9 │    if true) { }
 //    │           ┬  
@@ -201,7 +201,7 @@ function foo() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected ')', found while
-//     ╭─[ 0:15:4 ]
+//     ╭─[ parens.baml:15:4 ]
 //     │
 //  15 │    while true {}
 //     │    ──┬──  
@@ -210,7 +210,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after if condition, found while
-//     ╭─[ 0:15:4 ]
+//     ╭─[ parens.baml:15:4 ]
 //     │
 //  15 │    while true {}
 //     │    ──┬──  
@@ -219,7 +219,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after while condition, found while
-//     ╭─[ 0:17:4 ]
+//     ╭─[ parens.baml:17:4 ]
 //     │
 //  17 │    while (true {}
 //     │    ──┬──  
@@ -228,7 +228,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected ')', found while
-//     ╭─[ 0:19:4 ]
+//     ╭─[ parens.baml:19:4 ]
 //     │
 //  19 │    while true) {}
 //     │    ──┬──  
@@ -237,7 +237,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after while condition, found while
-//     ╭─[ 0:19:4 ]
+//     ╭─[ parens.baml:19:4 ]
 //     │
 //  19 │    while true) {}
 //     │    ──┬──  
@@ -246,7 +246,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after while condition, found ')'
-//     ╭─[ 0:19:14 ]
+//     ╭─[ parens.baml:19:14 ]
 //     │
 //  19 │    while true) {}
 //     │              ┬  
@@ -255,7 +255,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ')'
-//     ╭─[ 0:19:14 ]
+//     ╭─[ parens.baml:19:14 ]
 //     │
 //  19 │    while true) {}
 //     │              ┬  
@@ -264,7 +264,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected loop variable, found ';'
-//     ╭─[ 0:25:8 ]
+//     ╭─[ parens.baml:25:8 ]
 //     │
 //  25 │    for ;; { }
 //     │        ┬  
@@ -273,7 +273,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected in, found ';'
-//     ╭─[ 0:25:8 ]
+//     ╭─[ parens.baml:25:8 ]
 //     │
 //  25 │    for ;; { }
 //     │        ┬  
@@ -282,7 +282,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ';'
-//     ╭─[ 0:25:8 ]
+//     ╭─[ parens.baml:25:8 ]
 //     │
 //  25 │    for ;; { }
 //     │        ┬  
@@ -291,7 +291,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found ';'
-//     ╭─[ 0:25:9 ]
+//     ╭─[ parens.baml:25:9 ]
 //     │
 //  25 │    for ;; { }
 //     │         ┬  
@@ -300,7 +300,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected ')', found for
-//     ╭─[ 0:29:4 ]
+//     ╭─[ parens.baml:29:4 ]
 //     │
 //  29 │    for ;;) {}
 //     │    ─┬─  
@@ -309,7 +309,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found for
-//     ╭─[ 0:29:4 ]
+//     ╭─[ parens.baml:29:4 ]
 //     │
 //  29 │    for ;;) {}
 //     │    ─┬─  
@@ -318,7 +318,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected loop variable, found ';'
-//     ╭─[ 0:29:8 ]
+//     ╭─[ parens.baml:29:8 ]
 //     │
 //  29 │    for ;;) {}
 //     │        ┬  
@@ -327,7 +327,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected in, found ';'
-//     ╭─[ 0:29:8 ]
+//     ╭─[ parens.baml:29:8 ]
 //     │
 //  29 │    for ;;) {}
 //     │        ┬  
@@ -336,7 +336,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ';'
-//     ╭─[ 0:29:8 ]
+//     ╭─[ parens.baml:29:8 ]
 //     │
 //  29 │    for ;;) {}
 //     │        ┬  
@@ -345,7 +345,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found ';'
-//     ╭─[ 0:29:9 ]
+//     ╭─[ parens.baml:29:9 ]
 //     │
 //  29 │    for ;;) {}
 //     │         ┬  
@@ -354,7 +354,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ')'
-//     ╭─[ 0:29:10 ]
+//     ╭─[ parens.baml:29:10 ]
 //     │
 //  29 │    for ;;) {}
 //     │          ┬  
@@ -363,7 +363,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected ')', found for
-//     ╭─[ 0:39:4 ]
+//     ╭─[ parens.baml:39:4 ]
 //     │
 //  39 │    for ;;i += x) {}
 //     │    ─┬─  
@@ -372,7 +372,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found for
-//     ╭─[ 0:39:4 ]
+//     ╭─[ parens.baml:39:4 ]
 //     │
 //  39 │    for ;;i += x) {}
 //     │    ─┬─  
@@ -381,7 +381,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected loop variable, found ';'
-//     ╭─[ 0:39:8 ]
+//     ╭─[ parens.baml:39:8 ]
 //     │
 //  39 │    for ;;i += x) {}
 //     │        ┬  
@@ -390,7 +390,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected in, found ';'
-//     ╭─[ 0:39:8 ]
+//     ╭─[ parens.baml:39:8 ]
 //     │
 //  39 │    for ;;i += x) {}
 //     │        ┬  
@@ -399,7 +399,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ';'
-//     ╭─[ 0:39:8 ]
+//     ╭─[ parens.baml:39:8 ]
 //     │
 //  39 │    for ;;i += x) {}
 //     │        ┬  
@@ -408,7 +408,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found ';'
-//     ╭─[ 0:39:9 ]
+//     ╭─[ parens.baml:39:9 ]
 //     │
 //  39 │    for ;;i += x) {}
 //     │         ┬  
@@ -417,7 +417,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ')'
-//     ╭─[ 0:39:16 ]
+//     ╭─[ parens.baml:39:16 ]
 //     │
 //  39 │    for ;;i += x) {}
 //     │                ┬  
@@ -426,7 +426,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected loop variable, found ';'
-//     ╭─[ 0:41:8 ]
+//     ╭─[ parens.baml:41:8 ]
 //     │
 //  41 │    for ;;i += x {}
 //     │        ┬  
@@ -435,7 +435,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected in, found ';'
-//     ╭─[ 0:41:8 ]
+//     ╭─[ parens.baml:41:8 ]
 //     │
 //  41 │    for ;;i += x {}
 //     │        ┬  
@@ -444,7 +444,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ';'
-//     ╭─[ 0:41:8 ]
+//     ╭─[ parens.baml:41:8 ]
 //     │
 //  41 │    for ;;i += x {}
 //     │        ┬  
@@ -453,7 +453,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found ';'
-//     ╭─[ 0:41:9 ]
+//     ╭─[ parens.baml:41:9 ]
 //     │
 //  41 │    for ;;i += x {}
 //     │         ┬  
@@ -462,7 +462,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected ')', found for
-//     ╭─[ 0:49:4 ]
+//     ╭─[ parens.baml:49:4 ]
 //     │
 //  49 │    for ;;i = x) {}
 //     │    ─┬─  
@@ -471,7 +471,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found for
-//     ╭─[ 0:49:4 ]
+//     ╭─[ parens.baml:49:4 ]
 //     │
 //  49 │    for ;;i = x) {}
 //     │    ─┬─  
@@ -480,7 +480,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected loop variable, found ';'
-//     ╭─[ 0:49:8 ]
+//     ╭─[ parens.baml:49:8 ]
 //     │
 //  49 │    for ;;i = x) {}
 //     │        ┬  
@@ -489,7 +489,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected in, found ';'
-//     ╭─[ 0:49:8 ]
+//     ╭─[ parens.baml:49:8 ]
 //     │
 //  49 │    for ;;i = x) {}
 //     │        ┬  
@@ -498,7 +498,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ';'
-//     ╭─[ 0:49:8 ]
+//     ╭─[ parens.baml:49:8 ]
 //     │
 //  49 │    for ;;i = x) {}
 //     │        ┬  
@@ -507,7 +507,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found ';'
-//     ╭─[ 0:49:9 ]
+//     ╭─[ parens.baml:49:9 ]
 //     │
 //  49 │    for ;;i = x) {}
 //     │         ┬  
@@ -516,7 +516,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ')'
-//     ╭─[ 0:49:15 ]
+//     ╭─[ parens.baml:49:15 ]
 //     │
 //  49 │    for ;;i = x) {}
 //     │               ┬  
@@ -525,7 +525,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected loop variable, found ';'
-//     ╭─[ 0:51:8 ]
+//     ╭─[ parens.baml:51:8 ]
 //     │
 //  51 │    for ;;i = x {}
 //     │        ┬  
@@ -534,7 +534,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected in, found ';'
-//     ╭─[ 0:51:8 ]
+//     ╭─[ parens.baml:51:8 ]
 //     │
 //  51 │    for ;;i = x {}
 //     │        ┬  
@@ -543,7 +543,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ';'
-//     ╭─[ 0:51:8 ]
+//     ╭─[ parens.baml:51:8 ]
 //     │
 //  51 │    for ;;i = x {}
 //     │        ┬  
@@ -552,7 +552,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found ';'
-//     ╭─[ 0:51:9 ]
+//     ╭─[ parens.baml:51:9 ]
 //     │
 //  51 │    for ;;i = x {}
 //     │         ┬  
@@ -561,7 +561,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected loop variable, found let
-//     ╭─[ 0:55:8 ]
+//     ╭─[ parens.baml:55:8 ]
 //     │
 //  55 │    for let a in as {}
 //     │        ─┬─  
@@ -570,7 +570,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected in, found let
-//     ╭─[ 0:55:8 ]
+//     ╭─[ parens.baml:55:8 ]
 //     │
 //  55 │    for let a in as {}
 //     │        ─┬─  
@@ -579,7 +579,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found let
-//     ╭─[ 0:55:8 ]
+//     ╭─[ parens.baml:55:8 ]
 //     │
 //  55 │    for let a in as {}
 //     │        ─┬─  
@@ -588,7 +588,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found identifier
-//     ╭─[ 0:55:12 ]
+//     ╭─[ parens.baml:55:12 ]
 //     │
 //  55 │    for let a in as {}
 //     │            ┬  
@@ -597,7 +597,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found in
-//     ╭─[ 0:55:14 ]
+//     ╭─[ parens.baml:55:14 ]
 //     │
 //  55 │    for let a in as {}
 //     │              ─┬  
@@ -606,7 +606,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected ')', found for
-//     ╭─[ 0:59:4 ]
+//     ╭─[ parens.baml:59:4 ]
 //     │
 //  59 │    for let a in as) {}
 //     │    ─┬─  
@@ -615,7 +615,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found for
-//     ╭─[ 0:59:4 ]
+//     ╭─[ parens.baml:59:4 ]
 //     │
 //  59 │    for let a in as) {}
 //     │    ─┬─  
@@ -624,7 +624,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected loop variable, found let
-//     ╭─[ 0:59:8 ]
+//     ╭─[ parens.baml:59:8 ]
 //     │
 //  59 │    for let a in as) {}
 //     │        ─┬─  
@@ -633,7 +633,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected in, found let
-//     ╭─[ 0:59:8 ]
+//     ╭─[ parens.baml:59:8 ]
 //     │
 //  59 │    for let a in as) {}
 //     │        ─┬─  
@@ -642,7 +642,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found let
-//     ╭─[ 0:59:8 ]
+//     ╭─[ parens.baml:59:8 ]
 //     │
 //  59 │    for let a in as) {}
 //     │        ─┬─  
@@ -651,7 +651,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected block after for expression, found identifier
-//     ╭─[ 0:59:12 ]
+//     ╭─[ parens.baml:59:12 ]
 //     │
 //  59 │    for let a in as) {}
 //     │            ┬  
@@ -660,7 +660,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found in
-//     ╭─[ 0:59:14 ]
+//     ╭─[ parens.baml:59:14 ]
 //     │
 //  59 │    for let a in as) {}
 //     │              ─┬  
@@ -669,7 +669,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected expression, found ')'
-//     ╭─[ 0:59:19 ]
+//     ╭─[ parens.baml:59:19 ]
 //     │
 //  59 │    for let a in as) {}
 //     │                   ┬  
@@ -678,7 +678,7 @@ function foo() -> int {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:35:11 ]
+//     ╭─[ parens.baml:35:11 ]
 //     │
 //  35 │    for (;;i += x) {}
 //     │           ┬  
@@ -687,7 +687,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable x
-//     ╭─[ 0:35:16 ]
+//     ╭─[ parens.baml:35:16 ]
 //     │
 //  35 │    for (;;i += x) {}
 //     │                ┬  
@@ -696,7 +696,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:37:11 ]
+//     ╭─[ parens.baml:37:11 ]
 //     │
 //  37 │    for (;;i += x {}
 //     │           ┬  
@@ -705,7 +705,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:39:10 ]
+//     ╭─[ parens.baml:39:10 ]
 //     │
 //  39 │    for ;;i += x) {}
 //     │          ┬  
@@ -714,7 +714,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable x
-//     ╭─[ 0:39:15 ]
+//     ╭─[ parens.baml:39:15 ]
 //     │
 //  39 │    for ;;i += x) {}
 //     │               ┬  
@@ -723,7 +723,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:41:10 ]
+//     ╭─[ parens.baml:41:10 ]
 //     │
 //  41 │    for ;;i += x {}
 //     │          ┬  
@@ -732,7 +732,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:45:11 ]
+//     ╭─[ parens.baml:45:11 ]
 //     │
 //  45 │    for (;;i = x) {}
 //     │           ┬  
@@ -741,7 +741,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable x
-//     ╭─[ 0:45:15 ]
+//     ╭─[ parens.baml:45:15 ]
 //     │
 //  45 │    for (;;i = x) {}
 //     │               ┬  
@@ -750,7 +750,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:47:11 ]
+//     ╭─[ parens.baml:47:11 ]
 //     │
 //  47 │    for (;;i = x {}
 //     │           ┬  
@@ -759,7 +759,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:49:10 ]
+//     ╭─[ parens.baml:49:10 ]
 //     │
 //  49 │    for ;;i = x) {}
 //     │          ┬  
@@ -768,7 +768,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable x
-//     ╭─[ 0:49:14 ]
+//     ╭─[ parens.baml:49:14 ]
 //     │
 //  49 │    for ;;i = x) {}
 //     │              ┬  
@@ -777,7 +777,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable i
-//     ╭─[ 0:51:10 ]
+//     ╭─[ parens.baml:51:10 ]
 //     │
 //  51 │    for ;;i = x {}
 //     │          ┬  
@@ -786,7 +786,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable a
-//     ╭─[ 0:55:12 ]
+//     ╭─[ parens.baml:55:12 ]
 //     │
 //  55 │    for let a in as {}
 //     │            ┬  
@@ -795,7 +795,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Type as has no field 'length'
-//    ╭─[ 0:1:1 ]
+//    ╭─[ parens.baml:1:1 ]
 //    │
 //  1 │ function foo() -> int {
 //    │ │ 
@@ -804,7 +804,7 @@ function foo() -> int {
 //    │ Note: Error code: E0007
 // ───╯
 // Error: Type as is not indexable
-//    ╭─[ 0:1:1 ]
+//    ╭─[ parens.baml:1:1 ]
 //    │
 //  1 │ function foo() -> int {
 //    │ │ 
@@ -813,7 +813,7 @@ function foo() -> int {
 //    │ Note: Error code: E0008
 // ───╯
 // Error: Unknown variable a
-//     ╭─[ 0:59:12 ]
+//     ╭─[ parens.baml:59:12 ]
 //     │
 //  59 │    for let a in as) {}
 //     │            ┬  
@@ -822,7 +822,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable as
-//     ╭─[ 0:59:17 ]
+//     ╭─[ parens.baml:59:17 ]
 //     │
 //  59 │    for let a in as) {}
 //     │                 ─┬  
@@ -831,7 +831,7 @@ function foo() -> int {
 //     │ Note: Error code: E0003
 // ────╯
 // Error: Unknown variable as
-//    ╭─[ 0:1:1 ]
+//    ╭─[ parens.baml:1:1 ]
 //    │
 //  1 │ function foo() -> int {
 //    │ │ 
@@ -840,7 +840,7 @@ function foo() -> int {
 //    │ Note: Error code: E0003
 // ───╯
 // Error: Expected int, found void
-//    ╭─[ 0:1:1 ]
+//    ╭─[ parens.baml:1:1 ]
 //    │
 //  1 │ function foo() -> int {
 //    │ │ 

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/streaming/streaming_ok.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/streaming/streaming_ok.baml
@@ -13,7 +13,7 @@ class Foo2 {
 //----
 //- diagnostics
 // Error: Expected Unexpected token in class body, found '.'
-//     ╭─[ 0:10:13 ]
+//     ╭─[ streaming_streaming_ok.baml:10:13 ]
 //     │
 //  10 │     @@stream.done
 //     │             ┬  
@@ -22,7 +22,7 @@ class Foo2 {
 //     │ Note: Error code: E0010
 // ────╯
 // Error: field 'done' is missing a type annotation
-//     ╭─[ 0:10:14 ]
+//     ╭─[ streaming_streaming_ok.baml:10:14 ]
 //     │
 //  10 │     @@stream.done
 //     │              ──┬─  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/template_string/bad_calls.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/template_string/bad_calls.baml
@@ -82,7 +82,7 @@ template_string BadCall4 #"
 //----
 //- diagnostics
 // Error: Expected '(', found '#'
-//    ╭─[ 0:5:26 ]
+//    ╭─[ template_string_bad_calls.baml:5:26 ]
 //    │
 //  5 │ template_string BadCall1 #"
 //    │                          ┬  
@@ -91,7 +91,7 @@ template_string BadCall4 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected parameter name, found '#'
-//    ╭─[ 0:5:26 ]
+//    ╭─[ template_string_bad_calls.baml:5:26 ]
 //    │
 //  5 │ template_string BadCall1 #"
 //    │                          ┬  
@@ -100,7 +100,7 @@ template_string BadCall4 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected type annotation, found '#'
-//    ╭─[ 0:5:26 ]
+//    ╭─[ template_string_bad_calls.baml:5:26 ]
 //    │
 //  5 │ template_string BadCall1 #"
 //    │                          ┬  
@@ -109,7 +109,7 @@ template_string BadCall4 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected ')', found '#'
-//    ╭─[ 0:5:26 ]
+//    ╭─[ template_string_bad_calls.baml:5:26 ]
 //    │
 //  5 │ template_string BadCall1 #"
 //    │                          ┬  
@@ -118,7 +118,7 @@ template_string BadCall4 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected '(', found '#'
-//    ╭─[ 0:9:26 ]
+//    ╭─[ template_string_bad_calls.baml:9:26 ]
 //    │
 //  9 │ template_string BadCall2 #"
 //    │                          ┬  
@@ -127,7 +127,7 @@ template_string BadCall4 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected parameter name, found '#'
-//    ╭─[ 0:9:26 ]
+//    ╭─[ template_string_bad_calls.baml:9:26 ]
 //    │
 //  9 │ template_string BadCall2 #"
 //    │                          ┬  
@@ -136,7 +136,7 @@ template_string BadCall4 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected type annotation, found '#'
-//    ╭─[ 0:9:26 ]
+//    ╭─[ template_string_bad_calls.baml:9:26 ]
 //    │
 //  9 │ template_string BadCall2 #"
 //    │                          ┬  
@@ -145,7 +145,7 @@ template_string BadCall4 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected ')', found '#'
-//    ╭─[ 0:9:26 ]
+//    ╭─[ template_string_bad_calls.baml:9:26 ]
 //    │
 //  9 │ template_string BadCall2 #"
 //    │                          ┬  
@@ -154,7 +154,7 @@ template_string BadCall4 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected '(', found '#'
-//     ╭─[ 0:13:26 ]
+//     ╭─[ template_string_bad_calls.baml:13:26 ]
 //     │
 //  13 │ template_string BadCall3 #"
 //     │                          ┬  
@@ -163,7 +163,7 @@ template_string BadCall4 #"
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected parameter name, found '#'
-//     ╭─[ 0:13:26 ]
+//     ╭─[ template_string_bad_calls.baml:13:26 ]
 //     │
 //  13 │ template_string BadCall3 #"
 //     │                          ┬  
@@ -172,7 +172,7 @@ template_string BadCall4 #"
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected type annotation, found '#'
-//     ╭─[ 0:13:26 ]
+//     ╭─[ template_string_bad_calls.baml:13:26 ]
 //     │
 //  13 │ template_string BadCall3 #"
 //     │                          ┬  
@@ -181,7 +181,7 @@ template_string BadCall4 #"
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected ')', found '#'
-//     ╭─[ 0:13:26 ]
+//     ╭─[ template_string_bad_calls.baml:13:26 ]
 //     │
 //  13 │ template_string BadCall3 #"
 //     │                          ┬  
@@ -190,7 +190,7 @@ template_string BadCall4 #"
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected '(', found '#'
-//     ╭─[ 0:17:26 ]
+//     ╭─[ template_string_bad_calls.baml:17:26 ]
 //     │
 //  17 │ template_string BadCall4 #"
 //     │                          ┬  
@@ -199,7 +199,7 @@ template_string BadCall4 #"
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected parameter name, found '#'
-//     ╭─[ 0:17:26 ]
+//     ╭─[ template_string_bad_calls.baml:17:26 ]
 //     │
 //  17 │ template_string BadCall4 #"
 //     │                          ┬  
@@ -208,7 +208,7 @@ template_string BadCall4 #"
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected type annotation, found '#'
-//     ╭─[ 0:17:26 ]
+//     ╭─[ template_string_bad_calls.baml:17:26 ]
 //     │
 //  17 │ template_string BadCall4 #"
 //     │                          ┬  
@@ -217,7 +217,7 @@ template_string BadCall4 #"
 //     │ Note: Error code: E0010
 // ────╯
 // Error: Expected ')', found '#'
-//     ╭─[ 0:17:26 ]
+//     ╭─[ template_string_bad_calls.baml:17:26 ]
 //     │
 //  17 │ template_string BadCall4 #"
 //     │                          ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/template_string/good_calls.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/template_string/good_calls.baml
@@ -13,7 +13,7 @@ template_string GoodCall2 #"
 //----
 //- diagnostics
 // Error: Expected '(', found '#'
-//    ╭─[ 0:5:27 ]
+//    ╭─[ template_string_good_calls.baml:5:27 ]
 //    │
 //  5 │ template_string GoodCall1 #"
 //    │                           ┬  
@@ -22,7 +22,7 @@ template_string GoodCall2 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected parameter name, found '#'
-//    ╭─[ 0:5:27 ]
+//    ╭─[ template_string_good_calls.baml:5:27 ]
 //    │
 //  5 │ template_string GoodCall1 #"
 //    │                           ┬  
@@ -31,7 +31,7 @@ template_string GoodCall2 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected type annotation, found '#'
-//    ╭─[ 0:5:27 ]
+//    ╭─[ template_string_good_calls.baml:5:27 ]
 //    │
 //  5 │ template_string GoodCall1 #"
 //    │                           ┬  
@@ -40,7 +40,7 @@ template_string GoodCall2 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected ')', found '#'
-//    ╭─[ 0:5:27 ]
+//    ╭─[ template_string_good_calls.baml:5:27 ]
 //    │
 //  5 │ template_string GoodCall1 #"
 //    │                           ┬  
@@ -49,7 +49,7 @@ template_string GoodCall2 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected '(', found '#'
-//    ╭─[ 0:9:27 ]
+//    ╭─[ template_string_good_calls.baml:9:27 ]
 //    │
 //  9 │ template_string GoodCall2 #"
 //    │                           ┬  
@@ -58,7 +58,7 @@ template_string GoodCall2 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected parameter name, found '#'
-//    ╭─[ 0:9:27 ]
+//    ╭─[ template_string_good_calls.baml:9:27 ]
 //    │
 //  9 │ template_string GoodCall2 #"
 //    │                           ┬  
@@ -67,7 +67,7 @@ template_string GoodCall2 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected type annotation, found '#'
-//    ╭─[ 0:9:27 ]
+//    ╭─[ template_string_good_calls.baml:9:27 ]
 //    │
 //  9 │ template_string GoodCall2 #"
 //    │                           ┬  
@@ -76,7 +76,7 @@ template_string GoodCall2 #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected ')', found '#'
-//    ╭─[ 0:9:27 ]
+//    ╭─[ template_string_good_calls.baml:9:27 ]
 //    │
 //  9 │ template_string GoodCall2 #"
 //    │                           ┬  

--- a/baml_language/crates/baml_lsp_tests/test_files/syntax/template_string/valid.baml
+++ b/baml_language/crates/baml_lsp_tests/test_files/syntax/template_string/valid.baml
@@ -9,7 +9,7 @@ template_string WithParams(a: int) #"
 //----
 //- diagnostics
 // Error: Expected '(', found '#'
-//    ╭─[ 0:1:28 ]
+//    ╭─[ template_string_valid.baml:1:28 ]
 //    │
 //  1 │ template_string SomeString #"
 //    │                            ┬  
@@ -18,7 +18,7 @@ template_string WithParams(a: int) #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected parameter name, found '#'
-//    ╭─[ 0:1:28 ]
+//    ╭─[ template_string_valid.baml:1:28 ]
 //    │
 //  1 │ template_string SomeString #"
 //    │                            ┬  
@@ -27,7 +27,7 @@ template_string WithParams(a: int) #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected type annotation, found '#'
-//    ╭─[ 0:1:28 ]
+//    ╭─[ template_string_valid.baml:1:28 ]
 //    │
 //  1 │ template_string SomeString #"
 //    │                            ┬  
@@ -36,7 +36,7 @@ template_string WithParams(a: int) #"
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Expected ')', found '#'
-//    ╭─[ 0:1:28 ]
+//    ╭─[ template_string_valid.baml:1:28 ]
 //    │
 //  1 │ template_string SomeString #"
 //    │                            ┬  

--- a/baml_language/crates/baml_onionskin/src/compiler.rs
+++ b/baml_language/crates/baml_onionskin/src/compiler.rs
@@ -13,8 +13,8 @@ use baml_db::{
     baml_tir, baml_workspace,
 };
 use baml_diagnostics::compiler_error::{
-    CompilerError, HirDiagnostic, ParseError, TypeError, render_hir_diagnostic, render_parse_error,
-    render_type_error,
+    CompilerError, DbSourceCache, HirDiagnostic, ParseError, TypeError, render_hir_diagnostic,
+    render_parse_error, render_type_error,
 };
 use baml_hir::{ItemId, file_lowering, function_body, function_signature};
 use baml_syntax::{
@@ -1114,13 +1114,8 @@ impl CompilerRunner {
         let mut output = String::new();
         let mut output_annotated = Vec::new();
 
-        // Build a source map for error rendering (FileId -> source text)
-        let mut sources: HashMap<FileId, String> = HashMap::new();
-        for source_file in self.source_files.values() {
-            let file_id = source_file.file_id(&self.db);
-            let text = source_file.text(&self.db).clone();
-            sources.insert(file_id, text);
-        }
+        // Create a cache for rendering diagnostics (reused across all errors)
+        let mut cache = DbSourceCache::new(&self.db, self.project_root);
 
         // Group errors by file_id and error type (parse vs type vs hir)
         let mut parse_errors_by_file: HashMap<FileId, Vec<&ParseError>> = HashMap::new();
@@ -1172,7 +1167,7 @@ impl CompilerRunner {
 
                 for error in errors {
                     total_parse_errors += 1;
-                    let rendered = render_parse_error(error, &sources, false);
+                    let rendered = render_parse_error(error, &mut cache, false);
                     for line in rendered.lines() {
                         writeln!(output, "{}", line).ok();
                         output_annotated.push((
@@ -1209,7 +1204,7 @@ impl CompilerRunner {
 
                 for error in errors {
                     total_hir_errors += 1;
-                    let rendered = render_hir_diagnostic(error, &sources, false);
+                    let rendered = render_hir_diagnostic(error, &mut cache, false);
                     for line in rendered.lines() {
                         writeln!(output, "{}", line).ok();
                         output_annotated.push((
@@ -1246,7 +1241,7 @@ impl CompilerRunner {
 
                 for error in errors {
                     total_type_errors += 1;
-                    let rendered = render_type_error(error, &sources, false);
+                    let rendered = render_type_error(error, &mut cache, false);
                     for line in rendered.lines() {
                         writeln!(output, "{}", line).ok();
                         output_annotated.push((

--- a/baml_language/crates/baml_tests/build.rs
+++ b/baml_language/crates/baml_tests/build.rs
@@ -229,7 +229,7 @@ fn generate_project_tests(project: &TestProject, manifest_dir: &str) -> TokenStr
             use baml_hir::{function_body, function_signature};
             use baml_tir::{class_field_types, enum_variants, type_aliases, typing_context};
             use baml_tir::pretty::short_display;
-            use baml_diagnostics::{render_hir_diagnostic, render_name_error, render_parse_error, render_type_error};
+            use baml_diagnostics::{DbSourceCache, render_hir_diagnostic, render_name_error, render_parse_error, render_type_error};
             use std::collections::HashMap;
             use insta::{assert_snapshot, with_settings};
             use std::fmt::Write;
@@ -299,9 +299,9 @@ fn generate_parser_test(baml_file: &BamlFile) -> TokenStream {
             // Normalize line endings for cross-platform compatibility
             let content = content.replace("\r\n", "\n");
             let mut db = RootDatabase::new();
-            let mut sources = HashMap::new();
+            let root = db.set_project_root(std::path::PathBuf::from("."));
             let source_file = db.add_file(#relative_path, &content);
-            sources.insert(source_file.file_id(&db), content.clone());
+            root.set_files(&mut db).to(vec![source_file]);
             let tree = baml_parser::syntax_tree(&db, source_file);
             let errors = baml_parser::parse_errors(&db, source_file);
 
@@ -312,8 +312,9 @@ fn generate_parser_test(baml_file: &BamlFile) -> TokenStream {
             if errors.is_empty() {
                 writeln!(output, "None").unwrap();
             } else {
+                let mut cache = DbSourceCache::new(&db, root);
                 for error in errors.iter() {
-                    writeln!(output, "{}", render_parse_error(error, &sources, false)).unwrap();
+                    writeln!(output, "{}", render_parse_error(error, &mut cache, false)).unwrap();
                 }
             }
 
@@ -542,6 +543,7 @@ fn generate_mir_test(project: &TestProject) -> TokenStream {
 }
 
 fn generate_diagnostics_test(project: &TestProject) -> TokenStream {
+    // File loaders just load files, don't collect errors yet
     let file_loaders: TokenStream = project
         .files
         .iter()
@@ -558,13 +560,7 @@ fn generate_diagnostics_test(project: &TestProject) -> TokenStream {
                         #relative_path,
                         &content,
                     );
-                    sources.insert(source_file.file_id(&db), content.clone());
                     source_files.push(source_file);
-
-                    let errors = baml_parser::parse_errors(&db, source_file);
-                    for error in errors {
-                        all_errors.push(("parse".to_string(), render_parse_error(&error, &sources, false)));
-                    }
                 }
             }
         })
@@ -575,7 +571,6 @@ fn generate_diagnostics_test(project: &TestProject) -> TokenStream {
         fn test_05_diagnostics() {
             let mut db = RootDatabase::new();
             let root = db.set_project_root(std::path::PathBuf::from("."));
-            let mut sources = HashMap::new();
             let mut source_files = Vec::new();
             let mut all_errors = Vec::new();
 
@@ -584,21 +579,32 @@ fn generate_diagnostics_test(project: &TestProject) -> TokenStream {
             // Update project root with the list of files for proper Salsa tracking
             root.set_files(&mut db).to(source_files.clone());
 
+            // Create cache for rendering diagnostics (reused across all errors)
+            let mut cache = DbSourceCache::new(&db, root);
+
+            // Collect parse errors
+            for source_file in &source_files {
+                let errors = baml_parser::parse_errors(&db, *source_file);
+                for error in errors {
+                    all_errors.push(("parse".to_string(), render_parse_error(&error, &mut cache, false)));
+                }
+            }
+
             // Collect HIR lowering diagnostics (per-file validation)
             for source_file in &source_files {
                 let lowering_result = baml_hir::file_lowering(&db, *source_file);
                 for diag in lowering_result.diagnostics(&db) {
-                    all_errors.push(("hir".to_string(), render_hir_diagnostic(diag, &sources, false)));
+                    all_errors.push(("hir".to_string(), render_hir_diagnostic(diag, &mut cache, false)));
                 }
             }
 
             // Check for validation errors (project-wide validation)
             let validation_result = baml_hir::validate_hir(&db, root);
             for diag in validation_result.hir_diagnostics {
-                all_errors.push(("hir".to_string(), render_hir_diagnostic(&diag, &sources, false)));
+                all_errors.push(("hir".to_string(), render_hir_diagnostic(&diag, &mut cache, false)));
             }
             for error in validation_result.name_errors {
-                all_errors.push(("name".to_string(), render_name_error(&error, &sources, false)));
+                all_errors.push(("name".to_string(), render_name_error(&error, &mut cache, false)));
             }
 
             // Build typing context and run type inference
@@ -617,7 +623,7 @@ fn generate_diagnostics_test(project: &TestProject) -> TokenStream {
                         let body = function_body(&db, *func_id);
                         let result = baml_tir::infer_function(&db, &signature, &body, Some(globals.clone()), Some(class_fields.clone()), Some(type_aliases_map.clone()), Some(enum_variants_data.clone()), *func_id);
                         for error in &result.errors {
-                            all_errors.push(("type".to_string(), render_type_error(error, &sources, false)));
+                            all_errors.push(("type".to_string(), render_type_error(error, &mut cache, false)));
                         }
                     }
                 }

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__05_diagnostics.snap
@@ -1,16 +1,16 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [hir] Error: Attribute '@@description' can only be defined once on class 'HasDuplicateDescription'
-   ╭─[ 0:7:5 ]
+   ╭─[ test.baml:7:5 ]
    │
  7 │   @@description("Second description")
    │     ─────┬─────  
    │          ╰─────── duplicate attribute
    │
-   ├─[ 0:7:5 ]
+   ├─[ test.baml:7:5 ]
    │
  5 │   @@description("First description")
    │     ─────┬─────  
@@ -20,13 +20,13 @@ expression: output
 ───╯
 
   [hir] Error: Duplicate field 'name' in class 'HasDuplicateField'
-    ╭─[ 0:13:3 ]
+    ╭─[ test.baml:13:3 ]
     │
  13 │   name int
     │   ──┬─  
     │     ╰─── duplicate definition
     │
-    ├─[ 0:13:3 ]
+    ├─[ test.baml:13:3 ]
     │
  11 │   name string
     │   ──┬─  
@@ -36,7 +36,7 @@ expression: output
 ────╯
 
   [hir] Error: Attribute '@alias' can only be defined once on field 'name' in class 'HasDuplicateFieldAttr'
-    ╭─[ 0:17:49 ]
+    ╭─[ test.baml:17:49 ]
     │
  17 │   name string @alias("n") @description("Name") @alias("nm")
     │                ──┬──                            ──┬──  
@@ -48,13 +48,13 @@ expression: output
 ────╯
 
   [hir] Error: Duplicate variant 'RED' in enum 'HasDuplicateVariant'
-    ╭─[ 0:23:3 ]
+    ╭─[ test.baml:23:3 ]
     │
  23 │   RED
     │   ─┬─  
     │    ╰─── duplicate definition
     │
-    ├─[ 0:23:3 ]
+    ├─[ test.baml:23:3 ]
     │
  21 │   RED
     │   ─┬─  
@@ -64,13 +64,13 @@ expression: output
 ────╯
 
   [hir] Error: Attribute '@@description' can only be defined once on enum 'HasDuplicateEnumAttr'
-    ╭─[ 0:30:5 ]
+    ╭─[ test.baml:30:5 ]
     │
  30 │   @@description("Second")
     │     ─────┬─────  
     │          ╰─────── duplicate attribute
     │
-    ├─[ 0:30:5 ]
+    ├─[ test.baml:30:5 ]
     │
  29 │   @@description("First")
     │     ─────┬─────  
@@ -80,7 +80,7 @@ expression: output
 ────╯
 
   [hir] Error: Attribute '@alias' can only be defined once on field 'ACTIVE' in enum 'HasDuplicateVariantAttr'
-    ╭─[ 0:34:23 ]
+    ╭─[ test.baml:34:23 ]
     │
  34 │   ACTIVE @alias("a") @alias("active")
     │           ──┬──       ──┬──  

--- a/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__02_parser__syntax_errors.snap
+++ b/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__02_parser__syntax_errors.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-a56cff903b8232b2/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -108,7 +108,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected function name, found integer
-   ╭─[ 0:6:10 ]
+   ╭─[ syntax_errors.baml:6:10 ]
    │
  6 │ function 123Invalid() {}
    │          ─┬─  
@@ -118,7 +118,7 @@ Error: Expected function name, found integer
 ───╯
 
 Error: Expected return type (->), found '{'
-   ╭─[ 0:6:23 ]
+   ╭─[ syntax_errors.baml:6:23 ]
    │
  6 │ function 123Invalid() {}
    │                       ┬  
@@ -128,7 +128,7 @@ Error: Expected return type (->), found '{'
 ───╯
 
 Error: Expected '=>' after pattern, found ':'
-    ╭─[ 0:18:19 ]
+    ╭─[ syntax_errors.baml:18:19 ]
     │
  18 │         a: int | b: bool => "bad"
     │                   ┬  
@@ -138,7 +138,7 @@ Error: Expected '=>' after pattern, found ':'
 ────╯
 
 Error: Expected expression, found ':'
-    ╭─[ 0:18:19 ]
+    ╭─[ syntax_errors.baml:18:19 ]
     │
  18 │         a: int | b: bool => "bad"
     │                   ┬  
@@ -148,7 +148,7 @@ Error: Expected expression, found ':'
 ────╯
 
 Error: Expected '}', found EOF
-    ╭─[ 0:27:1 ]
+    ╭─[ syntax_errors.baml:27:1 ]
     │
  27 │ }
     │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [parse] Error: Expected function name, found integer
-   ╭─[ 0:6:10 ]
+   ╭─[ syntax_errors.baml:6:10 ]
    │
  6 │ function 123Invalid() {}
    │          ─┬─  
@@ -14,7 +14,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected return type (->), found '{'
-   ╭─[ 0:6:23 ]
+   ╭─[ syntax_errors.baml:6:23 ]
    │
  6 │ function 123Invalid() {}
    │                       ┬  
@@ -24,7 +24,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected '=>' after pattern, found ':'
-    ╭─[ 0:18:19 ]
+    ╭─[ syntax_errors.baml:18:19 ]
     │
  18 │         a: int | b: bool => "bad"
     │                   ┬  
@@ -34,7 +34,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected expression, found ':'
-    ╭─[ 0:18:19 ]
+    ╭─[ syntax_errors.baml:18:19 ]
     │
  18 │         a: int | b: bool => "bad"
     │                   ┬  
@@ -44,7 +44,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected '}', found EOF
-    ╭─[ 0:27:1 ]
+    ╭─[ syntax_errors.baml:27:1 ]
     │
  27 │ }
     │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__02_parser__valid_generator.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__02_parser__valid_generator.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -104,7 +104,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected client name, found '<'
-    ╭─[ 0:21:11 ]
+    ╭─[ valid_generator.baml:21:11 ]
     │
  21 │     client<llm> MyClient
     │           ┬  
@@ -114,7 +114,7 @@ Error: Expected client name, found '<'
 ────╯
 
 Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '<', found '<'
-    ╭─[ 0:21:11 ]
+    ╭─[ valid_generator.baml:21:11 ]
     │
  21 │     client<llm> MyClient
     │           ┬  
@@ -124,7 +124,7 @@ Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '<', f
 ────╯
 
 Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'llm', found identifier
-    ╭─[ 0:21:12 ]
+    ╭─[ valid_generator.baml:21:12 ]
     │
  21 │     client<llm> MyClient
     │            ─┬─  
@@ -134,7 +134,7 @@ Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'llm',
 ────╯
 
 Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '>', found '>'
-    ╭─[ 0:21:15 ]
+    ╭─[ valid_generator.baml:21:15 ]
     │
  21 │     client<llm> MyClient
     │               ┬  
@@ -144,7 +144,7 @@ Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '>', f
 ────╯
 
 Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'MyClient', found identifier
-    ╭─[ 0:21:17 ]
+    ╭─[ valid_generator.baml:21:17 ]
     │
  21 │     client<llm> MyClient
     │                 ────┬───  

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [parse] Error: Expected client name, found '<'
-    ╭─[ 0:21:11 ]
+    ╭─[ valid_generator.baml:21:11 ]
     │
  21 │     client<llm> MyClient
     │           ┬  
@@ -14,7 +14,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '<', found '<'
-    ╭─[ 0:21:11 ]
+    ╭─[ valid_generator.baml:21:11 ]
     │
  21 │     client<llm> MyClient
     │           ┬  
@@ -24,7 +24,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'llm', found identifier
-    ╭─[ 0:21:12 ]
+    ╭─[ valid_generator.baml:21:12 ]
     │
  21 │     client<llm> MyClient
     │            ─┬─  
@@ -34,7 +34,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected Only 'client' and 'prompt' allowed in LLM function, found '>', found '>'
-    ╭─[ 0:21:15 ]
+    ╭─[ valid_generator.baml:21:15 ]
     │
  21 │     client<llm> MyClient
     │               ┬  
@@ -44,7 +44,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'MyClient', found identifier
-    ╭─[ 0:21:17 ]
+    ╭─[ valid_generator.baml:21:17 ]
     │
  21 │     client<llm> MyClient
     │                 ────┬───  

--- a/baml_language/crates/baml_tests/snapshots/generics/baml_tests__generics__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/generics/baml_tests__generics__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-eb448e436f8a003a/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [type] Error: Unknown variable baml
-    ╭─[ 0:10:16 ]
+    ╭─[ fetch_as.baml:10:16 ]
     │
  10 │         method: baml.HttpMethod.Get,
     │                ──────────┬─────────  

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__02_parser__test.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__02_parser__test.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -95,7 +95,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Header comments (//#) are not allowed inside LLM functions
-    ╭─[ 0:13:5 ]
+    ╭─[ test.baml:13:5 ]
     │
  13 │     //# collect source material
     │     ─────────────┬─────────────  

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [parse] Error: Header comments (//#) are not allowed inside LLM functions
-    ╭─[ 0:13:5 ]
+    ╭─[ test.baml:13:5 ]
     │
  13 │     //# collect source material
     │     ─────────────┬─────────────  

--- a/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [type] Error: Expected string, found int
-   ╭─[ 0:1:1 ]
+   ╭─[ edge_cases.baml:1:1 ]
    │
  1 │ // Edge cases for MDX headers
    │ │ 

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-1e9ee45736f74339/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:478:34 ]
+     ╭─[ match_exhaustiveness.baml:478:34 ]
      │
  478 │ ╭─▶         Status.Active => "first",
  479 │ ├─▶         Status.Active => "second",
@@ -15,7 +15,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type bool not fully covered. Missing: true, false
-     ╭─[ 0:744:58 ]
+     ╭─[ match_exhaustiveness.baml:744:58 ]
      │
  744 │ ╭─▶ function WrongLiteralTypeBoolWithInt(b: bool) -> string {
      ┆ ┆   
@@ -27,7 +27,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-    ╭─[ 0:26:26 ]
+    ╭─[ match_exhaustiveness.baml:26:26 ]
     │
  26 │ ╭─▶         _ => "catch all",
  27 │ ├─▶         n: int => "unreachable 1",
@@ -38,7 +38,7 @@ expression: output
 ────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-    ╭─[ 0:27:35 ]
+    ╭─[ match_exhaustiveness.baml:27:35 ]
     │
  27 │ ╭─▶         n: int => "unreachable 1",
  28 │ ├─▶         m: int => "unreachable 2"
@@ -49,7 +49,7 @@ expression: output
 ────╯
 
   [type] Error: Non-exhaustive match: type bool not fully covered. Missing: true
-     ╭─[ 0:250:59 ]
+     ╭─[ match_exhaustiveness.baml:250:59 ]
      │
  250 │ ╭─▶ function NonExhaustiveBoolMissingTrue(b: bool) -> string {
      ┆ ┆   
@@ -61,7 +61,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:732:35 ]
+     ╭─[ match_exhaustiveness.baml:732:35 ]
      │
  732 │ ╭─▶         x: Status => "any status",
  733 │ ├─▶         Status.Active => "unreachable"
@@ -72,7 +72,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:792:31 ]
+     ╭─[ match_exhaustiveness.baml:792:31 ]
      │
  792 │ ╭─▶         x: bool => "any bool",
  793 │ ├─▶         true => "unreachable"
@@ -83,7 +83,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:488:26 ]
+     ╭─[ match_exhaustiveness.baml:488:26 ]
      │
  488 │ ╭─▶         1 => "first one",
  489 │ ├─▶         1 => "second one",
@@ -94,7 +94,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type Status? not fully covered. Missing: null
-     ╭─[ 0:671:70 ]
+     ╭─[ match_exhaustiveness.baml:671:70 ]
      │
  671 │ ╭─▶ function NonExhaustiveNullableEnumMissingNull(s: Status?) -> string {
      ┆ ┆   
@@ -106,7 +106,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type Result not fully covered. Missing: Failure
-     ╭─[ 0:620:65 ]
+     ╭─[ match_exhaustiveness.baml:620:65 ]
      │
  620 │ ╭─▶ function NonExhaustiveTypeAliasMissingOne(r: Result) -> string {
      ┆ ┆   
@@ -118,7 +118,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type DoubleMaybe not fully covered. Missing: null
-     ╭─[ 0:607:74 ]
+     ╭─[ match_exhaustiveness.baml:607:74 ]
      │
  607 │ ╭─▶ function NonExhaustiveDoubleMaybeMissingNull(dm: DoubleMaybe) -> string {
      ┆ ┆   
@@ -130,7 +130,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type int not fully covered. Missing: int
-    ╭─[ 0:59:51 ]
+    ╭─[ match_exhaustiveness.baml:59:51 ]
     │
  59 │ ╭─▶ function GuardedOnlyNonExhaustive(x: int) -> int {
     ┆ ┆   
@@ -142,7 +142,7 @@ expression: output
 ────╯
 
   [type] Error: Non-exhaustive match: type bool not fully covered. Missing: false
-     ╭─[ 0:243:60 ]
+     ╭─[ match_exhaustiveness.baml:243:60 ]
      │
  243 │ ╭─▶ function NonExhaustiveBoolMissingFalse(b: bool) -> string {
      ┆ ┆   
@@ -154,7 +154,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:865:35 ]
+     ╭─[ match_exhaustiveness.baml:865:35 ]
      │
  865 │ ╭─▶         Status.Active => "active",
  866 │ ├─▶         Status.Active => "duplicate 1",
@@ -165,7 +165,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:867:39 ]
+     ╭─[ match_exhaustiveness.baml:867:39 ]
      │
  867 │ ╭─▶         Status.Inactive => "inactive",
  868 │ ├─▶         Status.Active => "duplicate 2",
@@ -176,7 +176,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:854:35 ]
+     ╭─[ match_exhaustiveness.baml:854:35 ]
      │
  854 │ ╭─▶             false => "zero false",
  855 │ ├─▶             true => "unreachable nested"
@@ -187,7 +187,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type MaybeOk not fully covered. Missing: 200
-     ╭─[ 0:536:70 ]
+     ╭─[ match_exhaustiveness.baml:536:70 ]
      │
  536 │ ╭─▶ function NonExhaustiveOptionalMissingValue(code: MaybeOk) -> string {
      ┆ ┆   
@@ -199,7 +199,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type MaybeOk not fully covered. Missing: null
-     ╭─[ 0:529:69 ]
+     ╭─[ match_exhaustiveness.baml:529:69 ]
      │
  529 │ ╭─▶ function NonExhaustiveOptionalMissingNull(code: MaybeOk) -> string {
      ┆ ┆   
@@ -211,7 +211,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type AlwaysTrue not fully covered. Missing: true
-     ╭─[ 0:295:70 ]
+     ╭─[ match_exhaustiveness.baml:295:70 ]
      │
  295 │ ╭─▶ function NonExhaustiveTrueTypeWrongLiteral(t: AlwaysTrue) -> string {
      ┆ ┆   
@@ -223,7 +223,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type OkOrCreated not fully covered. Missing: 201
-     ╭─[ 0:583:69 ]
+     ╭─[ match_exhaustiveness.baml:583:69 ]
      │
  583 │ ╭─▶ function NonExhaustiveAliasOfLiterals(code: OkOrCreated) -> string {
      ┆ ┆   
@@ -235,7 +235,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type int not fully covered. Missing: int
-     ╭─[ 0:751:59 ]
+     ╭─[ match_exhaustiveness.baml:751:59 ]
      │
  751 │ ╭─▶ function WrongLiteralTypeIntWithString(x: int) -> string {
      ┆ ┆   
@@ -247,7 +247,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type Status not fully covered. Missing: Status.Inactive, Status.Pending
-     ╭─[ 0:875:60 ]
+     ╭─[ match_exhaustiveness.baml:875:60 ]
      │
  875 │ ╭─▶ function HighLineNumberNonExhaustive(s: Status) -> string {
      ┆ ┆   
@@ -259,7 +259,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type Status? not fully covered. Missing: Status.Pending
-     ╭─[ 0:680:73 ]
+     ╭─[ match_exhaustiveness.baml:680:73 ]
      │
  680 │ ╭─▶ function NonExhaustiveNullableEnumMissingVariant(s: Status?) -> string {
      ┆ ┆   
@@ -271,7 +271,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type FullResult not fully covered. Missing: Pending
-     ╭─[ 0:627:70 ]
+     ╭─[ match_exhaustiveness.baml:627:70 ]
      │
  627 │ ╭─▶ function NonExhaustiveFullResultMissingOne(r: FullResult) -> string {
      ┆ ┆   
@@ -283,7 +283,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type SuccessOr200 not fully covered. Missing: 200
-     ╭─[ 0:704:82 ]
+     ╭─[ match_exhaustiveness.baml:704:82 ]
      │
  704 │ ╭─▶ function NonExhaustiveClassPlusLiteralMissingLiteral(x: SuccessOr200) -> string {
      ┆ ┆   
@@ -295,7 +295,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:506:32 ]
+     ╭─[ match_exhaustiveness.baml:506:32 ]
      │
  506 │ ╭─▶         "user" => "first user",
  507 │ ├─▶         "user" => "second user",
@@ -306,7 +306,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type Status not fully covered. Missing: Status.Pending
-     ╭─[ 0:456:60 ]
+     ╭─[ match_exhaustiveness.baml:456:60 ]
      │
  456 │ ╭─▶ function NonExhaustiveEnumMissingOne(s: Status) -> string {
      ┆ ┆   
@@ -318,7 +318,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type CustomBool not fully covered. Missing: false
-     ╭─[ 0:302:67 ]
+     ╭─[ match_exhaustiveness.baml:302:67 ]
      │
  302 │ ╭─▶ function NonExhaustiveCustomBoolMissing(b: CustomBool) -> string {
      ┆ ┆   
@@ -330,7 +330,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type MixedLiterals not fully covered. Missing: true
-     ╭─[ 0:559:66 ]
+     ╭─[ match_exhaustiveness.baml:559:66 ]
      │
  559 │ ╭─▶ function NonExhaustiveMixedLiterals(x: MixedLiterals) -> string {
      ┆ ┆   
@@ -342,7 +342,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type SuccessOr200 not fully covered. Missing: Success
-     ╭─[ 0:711:80 ]
+     ╭─[ match_exhaustiveness.baml:711:80 ]
      │
  711 │ ╭─▶ function NonExhaustiveClassPlusLiteralMissingClass(x: SuccessOr200) -> string {
      ┆ ┆   
@@ -354,7 +354,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-    ╭─[ 0:18:26 ]
+    ╭─[ match_exhaustiveness.baml:18:26 ]
     │
  18 │ ╭─▶         _ => "catch all",
  19 │ ├─▶         n: int => "never reached"
@@ -365,7 +365,7 @@ expression: output
 ────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:497:30 ]
+     ╭─[ match_exhaustiveness.baml:497:30 ]
      │
  497 │ ╭─▶         true => "first true",
  498 │ ├─▶         true => "second true",
@@ -376,7 +376,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:642:35 ]
+     ╭─[ match_exhaustiveness.baml:642:35 ]
      │
  642 │ ╭─▶         x: string => "any string",
  643 │ ├─▶         "hello" => "unreachable"
@@ -387,7 +387,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type FullResult not fully covered. Missing: Pending
-     ╭─[ 0:763:64 ]
+     ╭─[ match_exhaustiveness.baml:763:64 ]
      │
  763 │ ╭─▶ function PartialUnionPatternCoverage(r: FullResult) -> string {
      ┆ ┆   
@@ -399,7 +399,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type Role not fully covered. Missing: "system"
-     ╭─[ 0:355:60 ]
+     ╭─[ match_exhaustiveness.baml:355:60 ]
      │
  355 │ ╭─▶ function NonExhaustiveStringLiteral(role: Role) -> string {
      ┆ ┆   
@@ -411,7 +411,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type Status not fully covered. Missing: Status.Inactive, Status.Pending
-     ╭─[ 0:464:65 ]
+     ╭─[ match_exhaustiveness.baml:464:65 ]
      │
  464 │ ╭─▶ function NonExhaustiveEnumMissingMultiple(s: Status) -> string {
      ┆ ┆   
@@ -423,7 +423,7 @@ expression: output
 ─────╯
 
   [type] Error: Non-exhaustive match: type SuccessCode not fully covered. Missing: 204
-     ╭─[ 0:396:64 ]
+     ╭─[ match_exhaustiveness.baml:396:64 ]
      │
  396 │ ╭─▶ function NonExhaustiveIntLiteral(code: SuccessCode) -> string {
      ┆ ┆   
@@ -435,7 +435,7 @@ expression: output
 ─────╯
 
   [type] Error: Unreachable match arm: previous arms already cover all cases
-     ╭─[ 0:784:25 ]
+     ╭─[ match_exhaustiveness.baml:784:25 ]
      │
  784 │ ╭─▶         n: int => "int",
  785 │ ├─▶         42 => "unreachable"

--- a/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__05_diagnostics.snap
@@ -1,16 +1,16 @@
 ---
-source: target/debug/build/baml_tests-eb448e436f8a003a/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [name] Error: Duplicate class 'Point'
-   ╭─[ 1:1:1 ]
+   ╭─[ class_constructor.baml:1:1 ]
    │
  1 │ class Point {
    │ │ 
    │ ╰─ class 'Point' defined in class_constructor.baml
    │
-   ├─[ 0:1:1 ]
+   ├─[ array_constructor.baml:1:1 ]
    │
  1 │ class Point {
    │ │ 

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__invalid_syntax.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__invalid_syntax.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -41,7 +41,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected class name, found integer
-   ╭─[ 0:1:7 ]
+   ╭─[ invalid_syntax.baml:1:7 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │       ─┬─  
@@ -51,7 +51,7 @@ Error: Expected class name, found integer
 ───╯
 
 Error: Expected '{', found integer
-   ╭─[ 0:1:7 ]
+   ╭─[ invalid_syntax.baml:1:7 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │       ─┬─  
@@ -61,7 +61,7 @@ Error: Expected '{', found integer
 ───╯
 
 Error: Expected top-level declaration, found integer
-   ╭─[ 0:1:7 ]
+   ╭─[ invalid_syntax.baml:1:7 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │       ─┬─  
@@ -71,7 +71,7 @@ Error: Expected top-level declaration, found integer
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:1:10 ]
+   ╭─[ invalid_syntax.baml:1:10 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │          ───┬───  
@@ -81,7 +81,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found '{'
-   ╭─[ 0:1:18 ]
+   ╭─[ invalid_syntax.baml:1:18 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │                  ┬  
@@ -91,7 +91,7 @@ Error: Expected top-level declaration, found '{'
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:2:3 ]
+   ╭─[ invalid_syntax.baml:2:3 ]
    │
  2 │   field string
    │   ──┬──  
@@ -101,7 +101,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:2:9 ]
+   ╭─[ invalid_syntax.baml:2:9 ]
    │
  2 │   field string
    │         ───┬──  
@@ -111,7 +111,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found '}'
-   ╭─[ 0:3:1 ]
+   ╭─[ invalid_syntax.baml:3:1 ]
    │
  3 │ }
    │ ┬  
@@ -121,7 +121,7 @@ Error: Expected top-level declaration, found '}'
 ───╯
 
 Error: Expected type, found '{'
-    ╭─[ 0:10:19 ]
+    ╭─[ invalid_syntax.baml:10:19 ]
     │
  10 │ function Foo() -> {  // Missing return type
     │                   ┬  
@@ -131,7 +131,7 @@ Error: Expected type, found '{'
 ────╯
 
 Error: Expected LLM function missing 'prompt' field, found '}'
-    ╭─[ 0:12:1 ]
+    ╭─[ invalid_syntax.baml:12:1 ]
     │
  12 │ }
     │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__missing_braces.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__missing_braces.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -24,7 +24,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected '}', found class
-   ╭─[ 0:5:1 ]
+   ╭─[ missing_braces.baml:5:1 ]
    │
  5 │ class Another {  // Should still parse this class
    │ ──┬──  

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__partial_input.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__partial_input.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -83,7 +83,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: field 'field2' is missing a type annotation
-   ╭─[ 0:4:3 ]
+   ╭─[ partial_input.baml:4:3 ]
    │
  4 │   field2  // Missing type entirely
    │   ───┬──  
@@ -93,7 +93,7 @@ Error: field 'field2' is missing a type annotation
 ───╯
 
 Error: field 'string' is missing a type annotation
-   ╭─[ 0:6:10 ]
+   ╭─[ partial_input.baml:6:10 ]
    │
  6 │   field4 string @alias(  // Unclosed attribute
    │          ───┬──  
@@ -103,7 +103,7 @@ Error: field 'string' is missing a type annotation
 ───╯
 
 Error: Expected Unexpected token in class body, found '@'
-   ╭─[ 0:6:17 ]
+   ╭─[ partial_input.baml:6:17 ]
    │
  6 │   field4 string @alias(  // Unclosed attribute
    │                 ┬  
@@ -113,7 +113,7 @@ Error: Expected Unexpected token in class body, found '@'
 ───╯
 
 Error: Expected ')', found identifier
-   ╭─[ 0:7:10 ]
+   ╭─[ partial_input.baml:7:10 ]
    │
  7 │   field5 string  // This should parse correctly
    │          ───┬──  
@@ -123,7 +123,7 @@ Error: Expected ')', found identifier
 ───╯
 
 Error: field 'string' is missing a type annotation
-   ╭─[ 0:7:10 ]
+   ╭─[ partial_input.baml:7:10 ]
    │
  7 │   field5 string  // This should parse correctly
    │          ───┬──  
@@ -133,7 +133,7 @@ Error: field 'string' is missing a type annotation
 ───╯
 
 Error: Expected ')', found function
-    ╭─[ 0:13:1 ]
+    ╭─[ partial_input.baml:13:1 ]
     │
  13 │ function NextFunction() -> string {  // Should still parse this
     │ ────┬───  
@@ -143,7 +143,7 @@ Error: Expected ')', found function
 ────╯
 
 Error: Expected return type (->), found function
-    ╭─[ 0:13:1 ]
+    ╭─[ partial_input.baml:13:1 ]
     │
  13 │ function NextFunction() -> string {  // Should still parse this
     │ ────┬───  
@@ -153,7 +153,7 @@ Error: Expected return type (->), found function
 ────╯
 
 Error: Expected function body, found function
-    ╭─[ 0:13:1 ]
+    ╭─[ partial_input.baml:13:1 ]
     │
  13 │ function NextFunction() -> string {  // Should still parse this
     │ ────┬───  
@@ -163,7 +163,7 @@ Error: Expected function body, found function
 ────╯
 
 Error: Expected '{', found identifier
-    ╭─[ 0:19:3 ]
+    ╭─[ partial_input.baml:19:3 ]
     │
  19 │   VALUE2
     │   ───┬──  
@@ -173,7 +173,7 @@ Error: Expected '{', found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:19:3 ]
+    ╭─[ partial_input.baml:19:3 ]
     │
  19 │   VALUE2
     │   ───┬──  
@@ -183,7 +183,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:20:1 ]
+    ╭─[ partial_input.baml:20:1 ]
     │
  20 │ }
     │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__unclosed_string.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__unclosed_string.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -64,7 +64,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected ')', found identifier
-   ╭─[ 0:4:25 ]
+   ╭─[ unclosed_string.baml:4:25 ]
    │
  4 │   field3 string @alias("another closed string")  // Should still parse this
    │                         ───┬───  
@@ -74,7 +74,7 @@ Error: Expected ')', found identifier
 ───╯
 
 Error: Expected Unclosed string literal, found EOF
-   ╭─[ 0:5:2 ]
+   ╭─[ unclosed_string.baml:5:2 ]
    │
  5 │ }
    │  ┬  
@@ -84,7 +84,7 @@ Error: Expected Unclosed string literal, found EOF
 ───╯
 
 Error: Expected '}', found EOF
-   ╭─[ 0:5:2 ]
+   ╭─[ unclosed_string.baml:5:2 ]
    │
  5 │ }
    │  ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [parse] Error: Expected class name, found integer
-   ╭─[ 0:1:7 ]
+   ╭─[ invalid_syntax.baml:1:7 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │       ─┬─  
@@ -14,7 +14,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected '{', found integer
-   ╭─[ 0:1:7 ]
+   ╭─[ invalid_syntax.baml:1:7 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │       ─┬─  
@@ -24,7 +24,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found integer
-   ╭─[ 0:1:7 ]
+   ╭─[ invalid_syntax.baml:1:7 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │       ─┬─  
@@ -34,7 +34,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 0:1:10 ]
+   ╭─[ invalid_syntax.baml:1:10 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │          ───┬───  
@@ -44,7 +44,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found '{'
-   ╭─[ 0:1:18 ]
+   ╭─[ invalid_syntax.baml:1:18 ]
    │
  1 │ class 123Invalid {  // Invalid class name
    │                  ┬  
@@ -54,7 +54,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 0:2:3 ]
+   ╭─[ invalid_syntax.baml:2:3 ]
    │
  2 │   field string
    │   ──┬──  
@@ -64,7 +64,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 0:2:9 ]
+   ╭─[ invalid_syntax.baml:2:9 ]
    │
  2 │   field string
    │         ───┬──  
@@ -74,7 +74,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found '}'
-   ╭─[ 0:3:1 ]
+   ╭─[ invalid_syntax.baml:3:1 ]
    │
  3 │ }
    │ ┬  
@@ -84,7 +84,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected type, found '{'
-    ╭─[ 0:10:19 ]
+    ╭─[ invalid_syntax.baml:10:19 ]
     │
  10 │ function Foo() -> {  // Missing return type
     │                   ┬  
@@ -94,7 +94,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected LLM function missing 'prompt' field, found '}'
-    ╭─[ 0:12:1 ]
+    ╭─[ invalid_syntax.baml:12:1 ]
     │
  12 │ }
     │ ┬  
@@ -104,7 +104,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected '}', found class
-   ╭─[ 1:5:1 ]
+   ╭─[ missing_braces.baml:5:1 ]
    │
  5 │ class Another {  // Should still parse this class
    │ ──┬──  
@@ -114,7 +114,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'field2' is missing a type annotation
-   ╭─[ 2:4:3 ]
+   ╭─[ partial_input.baml:4:3 ]
    │
  4 │   field2  // Missing type entirely
    │   ───┬──  
@@ -124,7 +124,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'string' is missing a type annotation
-   ╭─[ 2:6:10 ]
+   ╭─[ partial_input.baml:6:10 ]
    │
  6 │   field4 string @alias(  // Unclosed attribute
    │          ───┬──  
@@ -134,7 +134,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '@'
-   ╭─[ 2:6:17 ]
+   ╭─[ partial_input.baml:6:17 ]
    │
  6 │   field4 string @alias(  // Unclosed attribute
    │                 ┬  
@@ -144,7 +144,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected ')', found identifier
-   ╭─[ 2:7:10 ]
+   ╭─[ partial_input.baml:7:10 ]
    │
  7 │   field5 string  // This should parse correctly
    │          ───┬──  
@@ -154,7 +154,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'string' is missing a type annotation
-   ╭─[ 2:7:10 ]
+   ╭─[ partial_input.baml:7:10 ]
    │
  7 │   field5 string  // This should parse correctly
    │          ───┬──  
@@ -164,7 +164,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected ')', found function
-    ╭─[ 2:13:1 ]
+    ╭─[ partial_input.baml:13:1 ]
     │
  13 │ function NextFunction() -> string {  // Should still parse this
     │ ────┬───  
@@ -174,7 +174,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected return type (->), found function
-    ╭─[ 2:13:1 ]
+    ╭─[ partial_input.baml:13:1 ]
     │
  13 │ function NextFunction() -> string {  // Should still parse this
     │ ────┬───  
@@ -184,7 +184,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected function body, found function
-    ╭─[ 2:13:1 ]
+    ╭─[ partial_input.baml:13:1 ]
     │
  13 │ function NextFunction() -> string {  // Should still parse this
     │ ────┬───  
@@ -194,7 +194,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected '{', found identifier
-    ╭─[ 2:19:3 ]
+    ╭─[ partial_input.baml:19:3 ]
     │
  19 │   VALUE2
     │   ───┬──  
@@ -204,7 +204,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 2:19:3 ]
+    ╭─[ partial_input.baml:19:3 ]
     │
  19 │   VALUE2
     │   ───┬──  
@@ -214,7 +214,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 2:20:1 ]
+    ╭─[ partial_input.baml:20:1 ]
     │
  20 │ }
     │ ┬  
@@ -224,7 +224,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected ')', found identifier
-   ╭─[ 3:4:25 ]
+   ╭─[ unclosed_string.baml:4:25 ]
    │
  4 │   field3 string @alias("another closed string")  // Should still parse this
    │                         ───┬───  
@@ -234,7 +234,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unclosed string literal, found EOF
-   ╭─[ 3:5:2 ]
+   ╭─[ unclosed_string.baml:5:2 ]
    │
  5 │ }
    │  ┬  
@@ -244,7 +244,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected '}', found EOF
-   ╭─[ 3:5:2 ]
+   ╭─[ unclosed_string.baml:5:2 ]
    │
  5 │ }
    │  ┬  
@@ -254,13 +254,13 @@ expression: output
 ───╯
 
   [hir] Error: Duplicate field 'string' in class 'Partial'
-   ╭─[ 2:7:10 ]
+   ╭─[ partial_input.baml:7:10 ]
    │
  7 │   field5 string  // This should parse correctly
    │          ───┬──  
    │             ╰──── duplicate definition
    │
-   ├─[ 2:7:10 ]
+   ├─[ partial_input.baml:7:10 ]
    │
  6 │   field4 string @alias(  // Unclosed attribute
    │          ───┬──  

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__02_parser__ambiguous_function.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__02_parser__ambiguous_function.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -58,7 +58,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected LLM function missing 'prompt' field, found '}'
-   ╭─[ 0:5:1 ]
+   ╭─[ ambiguous_function.baml:5:1 ]
    │
  5 │ }
    │ ┬  
@@ -68,7 +68,7 @@ Error: Expected LLM function missing 'prompt' field, found '}'
 ───╯
 
 Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'clent', found identifier
-   ╭─[ 0:9:3 ]
+   ╭─[ ambiguous_function.baml:9:3 ]
    │
  9 │   clent GPT4  // Typo in "client"
    │   ──┬──  
@@ -78,7 +78,7 @@ Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'clent
 ───╯
 
 Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'GPT4', found identifier
-   ╭─[ 0:9:9 ]
+   ╭─[ ambiguous_function.baml:9:9 ]
    │
  9 │   clent GPT4  // Typo in "client"
    │         ──┬─  
@@ -88,7 +88,7 @@ Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'GPT4'
 ───╯
 
 Error: Expected LLM function missing 'client' field, found '}'
-    ╭─[ 0:11:1 ]
+    ╭─[ ambiguous_function.baml:11:1 ]
     │
  11 │ }
     │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [parse] Error: Expected LLM function missing 'prompt' field, found '}'
-   ╭─[ 0:5:1 ]
+   ╭─[ ambiguous_function.baml:5:1 ]
    │
  5 │ }
    │ ┬  
@@ -14,7 +14,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'clent', found identifier
-   ╭─[ 0:9:3 ]
+   ╭─[ ambiguous_function.baml:9:3 ]
    │
  9 │   clent GPT4  // Typo in "client"
    │   ──┬──  
@@ -24,7 +24,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Only 'client' and 'prompt' allowed in LLM function, found 'GPT4', found identifier
-   ╭─[ 0:9:9 ]
+   ╭─[ ambiguous_function.baml:9:9 ]
    │
  9 │   clent GPT4  // Typo in "client"
    │         ──┬─  
@@ -34,7 +34,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected LLM function missing 'client' field, found '}'
-    ╭─[ 0:11:1 ]
+    ╭─[ ambiguous_function.baml:11:1 ]
     │
  11 │ }
     │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__deeply_nested.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__deeply_nested.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -165,7 +165,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected '>', found '>>'
-    ╭─[ 0:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -175,7 +175,7 @@ Error: Expected '>', found '>>'
 ────╯
 
 Error: Expected '>', found '>>'
-    ╭─[ 0:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -185,7 +185,7 @@ Error: Expected '>', found '>>'
 ────╯
 
 Error: Expected '>', found '>>'
-    ╭─[ 0:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -195,7 +195,7 @@ Error: Expected '>', found '>>'
 ────╯
 
 Error: Expected function body, found '>>'
-    ╭─[ 0:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -205,7 +205,7 @@ Error: Expected function body, found '>>'
 ────╯
 
 Error: Expected top-level declaration, found '>>'
-    ╭─[ 0:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -215,7 +215,7 @@ Error: Expected top-level declaration, found '>>'
 ────╯
 
 Error: Expected top-level declaration, found '>'
-    ╭─[ 0:28:71 ]
+    ╭─[ deeply_nested.baml:28:71 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                       ┬  
@@ -225,7 +225,7 @@ Error: Expected top-level declaration, found '>'
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:28:73 ]
+    ╭─[ deeply_nested.baml:28:73 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                         ┬  
@@ -235,7 +235,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found return
-    ╭─[ 0:30:3 ]
+    ╭─[ deeply_nested.baml:30:3 ]
     │
  30 │   return {}
     │   ───┬──  
@@ -245,7 +245,7 @@ Error: Expected top-level declaration, found return
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:30:10 ]
+    ╭─[ deeply_nested.baml:30:10 ]
     │
  30 │   return {}
     │          ┬  
@@ -255,7 +255,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:30:11 ]
+    ╭─[ deeply_nested.baml:30:11 ]
     │
  30 │   return {}
     │           ┬  
@@ -265,7 +265,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:31:1 ]
+    ╭─[ deeply_nested.baml:31:1 ]
     │
  31 │ }
     │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__rust.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__rust.snap
@@ -1421,7 +1421,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:7:1 ]
+   ╭─[ rust.baml:7:1 ]
    │
  7 │ use rowan::ast::AstNode;
    │ ─┬─  
@@ -1431,7 +1431,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:7:5 ]
+   ╭─[ rust.baml:7:5 ]
    │
  7 │ use rowan::ast::AstNode;
    │     ──┬──  
@@ -1441,7 +1441,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found '::'
-   ╭─[ 0:7:10 ]
+   ╭─[ rust.baml:7:10 ]
    │
  7 │ use rowan::ast::AstNode;
    │          ─┬  
@@ -1451,7 +1451,7 @@ Error: Expected top-level declaration, found '::'
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:7:12 ]
+   ╭─[ rust.baml:7:12 ]
    │
  7 │ use rowan::ast::AstNode;
    │            ─┬─  
@@ -1461,7 +1461,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found '::'
-   ╭─[ 0:7:15 ]
+   ╭─[ rust.baml:7:15 ]
    │
  7 │ use rowan::ast::AstNode;
    │               ─┬  
@@ -1471,7 +1471,7 @@ Error: Expected top-level declaration, found '::'
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:7:17 ]
+   ╭─[ rust.baml:7:17 ]
    │
  7 │ use rowan::ast::AstNode;
    │                 ───┬───  
@@ -1481,7 +1481,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found ';'
-   ╭─[ 0:7:24 ]
+   ╭─[ rust.baml:7:24 ]
    │
  7 │ use rowan::ast::AstNode;
    │                        ┬  
@@ -1491,7 +1491,7 @@ Error: Expected top-level declaration, found ';'
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:9:1 ]
+   ╭─[ rust.baml:9:1 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │ ─┬─  
@@ -1501,7 +1501,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:9:5 ]
+   ╭─[ rust.baml:9:5 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │     ──┬──  
@@ -1511,7 +1511,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found '::'
-   ╭─[ 0:9:10 ]
+   ╭─[ rust.baml:9:10 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │          ─┬  
@@ -1521,7 +1521,7 @@ Error: Expected top-level declaration, found '::'
 ───╯
 
 Error: Expected top-level declaration, found '{'
-   ╭─[ 0:9:12 ]
+   ╭─[ rust.baml:9:12 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │            ┬  
@@ -1531,7 +1531,7 @@ Error: Expected top-level declaration, found '{'
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:9:13 ]
+   ╭─[ rust.baml:9:13 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │             ─────┬────  
@@ -1541,7 +1541,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found ','
-   ╭─[ 0:9:23 ]
+   ╭─[ rust.baml:9:23 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                       ┬  
@@ -1551,7 +1551,7 @@ Error: Expected top-level declaration, found ','
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:9:25 ]
+   ╭─[ rust.baml:9:25 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                         ─────┬────  
@@ -1561,7 +1561,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found ','
-   ╭─[ 0:9:35 ]
+   ╭─[ rust.baml:9:35 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                                   ┬  
@@ -1571,7 +1571,7 @@ Error: Expected top-level declaration, found ','
 ───╯
 
 Error: Expected top-level declaration, found identifier
-   ╭─[ 0:9:37 ]
+   ╭─[ rust.baml:9:37 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                                     ─────┬─────  
@@ -1581,7 +1581,7 @@ Error: Expected top-level declaration, found identifier
 ───╯
 
 Error: Expected top-level declaration, found '}'
-   ╭─[ 0:9:48 ]
+   ╭─[ rust.baml:9:48 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                                                ┬  
@@ -1591,7 +1591,7 @@ Error: Expected top-level declaration, found '}'
 ───╯
 
 Error: Expected top-level declaration, found ';'
-   ╭─[ 0:9:49 ]
+   ╭─[ rust.baml:9:49 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                                                 ┬  
@@ -1601,7 +1601,7 @@ Error: Expected top-level declaration, found ';'
 ───╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:12:1 ]
+    ╭─[ rust.baml:12:1 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │ ─┬─  
@@ -1611,7 +1611,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:12:5 ]
+    ╭─[ rust.baml:12:5 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │     ──┬──  
@@ -1621,7 +1621,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:12:11 ]
+    ╭─[ rust.baml:12:11 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │           ─────┬─────  
@@ -1631,7 +1631,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ':'
-    ╭─[ 0:12:22 ]
+    ╭─[ rust.baml:12:22 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                      ┬  
@@ -1641,7 +1641,7 @@ Error: Expected top-level declaration, found ':'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:12:24 ]
+    ╭─[ rust.baml:12:24 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                        ───┬───  
@@ -1651,7 +1651,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '<'
-    ╭─[ 0:12:31 ]
+    ╭─[ rust.baml:12:31 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                               ┬  
@@ -1661,7 +1661,7 @@ Error: Expected top-level declaration, found '<'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:12:32 ]
+    ╭─[ rust.baml:12:32 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                ────┬───  
@@ -1671,7 +1671,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '='
-    ╭─[ 0:12:41 ]
+    ╭─[ rust.baml:12:41 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                         ┬  
@@ -1681,7 +1681,7 @@ Error: Expected top-level declaration, found '='
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:12:43 ]
+    ╭─[ rust.baml:12:43 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                           ──┬──  
@@ -1691,7 +1691,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:12:48 ]
+    ╭─[ rust.baml:12:48 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                                ─┬  
@@ -1701,7 +1701,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:12:50 ]
+    ╭─[ rust.baml:12:50 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                                  ──────┬─────  
@@ -1711,7 +1711,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '>'
-    ╭─[ 0:12:62 ]
+    ╭─[ rust.baml:12:62 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                                              ┬  
@@ -1721,7 +1721,7 @@ Error: Expected top-level declaration, found '>'
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:12:64 ]
+    ╭─[ rust.baml:12:64 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                                                ┬  
@@ -1731,7 +1731,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:14:5 ]
+    ╭─[ rust.baml:14:5 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │     ─┬  
@@ -1741,7 +1741,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:14:8 ]
+    ╭─[ rust.baml:14:8 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │        ──┬─  
@@ -1751,7 +1751,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:14:12 ]
+    ╭─[ rust.baml:14:12 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │            ┬  
@@ -1761,7 +1761,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found '&'
-    ╭─[ 0:14:13 ]
+    ╭─[ rust.baml:14:13 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │             ┬  
@@ -1771,7 +1771,7 @@ Error: Expected top-level declaration, found '&'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:14:14 ]
+    ╭─[ rust.baml:14:14 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │              ──┬─  
@@ -1781,7 +1781,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:14:18 ]
+    ╭─[ rust.baml:14:18 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │                  ┬  
@@ -1791,7 +1791,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '->'
-    ╭─[ 0:14:20 ]
+    ╭─[ rust.baml:14:20 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │                    ─┬  
@@ -1801,7 +1801,7 @@ Error: Expected top-level declaration, found '->'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:14:23 ]
+    ╭─[ rust.baml:14:23 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │                       ─────┬────  
@@ -1811,7 +1811,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:14:34 ]
+    ╭─[ rust.baml:14:34 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │                                  ┬  
@@ -1821,7 +1821,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:15:9 ]
+    ╭─[ rust.baml:15:9 ]
     │
  15 │         self.syntax().kind()
     │         ──┬─  
@@ -1831,7 +1831,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:15:13 ]
+    ╭─[ rust.baml:15:13 ]
     │
  15 │         self.syntax().kind()
     │             ┬  
@@ -1841,7 +1841,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:15:14 ]
+    ╭─[ rust.baml:15:14 ]
     │
  15 │         self.syntax().kind()
     │              ───┬──  
@@ -1851,7 +1851,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:15:20 ]
+    ╭─[ rust.baml:15:20 ]
     │
  15 │         self.syntax().kind()
     │                    ┬  
@@ -1861,7 +1861,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:15:21 ]
+    ╭─[ rust.baml:15:21 ]
     │
  15 │         self.syntax().kind()
     │                     ┬  
@@ -1871,7 +1871,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:15:22 ]
+    ╭─[ rust.baml:15:22 ]
     │
  15 │         self.syntax().kind()
     │                      ┬  
@@ -1881,7 +1881,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:15:23 ]
+    ╭─[ rust.baml:15:23 ]
     │
  15 │         self.syntax().kind()
     │                       ──┬─  
@@ -1891,7 +1891,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:15:27 ]
+    ╭─[ rust.baml:15:27 ]
     │
  15 │         self.syntax().kind()
     │                           ┬  
@@ -1901,7 +1901,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:15:28 ]
+    ╭─[ rust.baml:15:28 ]
     │
  15 │         self.syntax().kind()
     │                            ┬  
@@ -1911,7 +1911,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:16:5 ]
+    ╭─[ rust.baml:16:5 ]
     │
  16 │     }
     │     ┬  
@@ -1921,7 +1921,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:17:1 ]
+    ╭─[ rust.baml:17:1 ]
     │
  17 │ }
     │ ┬  
@@ -1931,7 +1931,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:20:1 ]
+    ╭─[ rust.baml:20:1 ]
     │
  20 │ macro_rules! ast_node {
     │ ─────┬─────  
@@ -1941,7 +1941,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:20:12 ]
+    ╭─[ rust.baml:20:12 ]
     │
  20 │ macro_rules! ast_node {
     │            ┬  
@@ -1951,7 +1951,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:20:14 ]
+    ╭─[ rust.baml:20:14 ]
     │
  20 │ macro_rules! ast_node {
     │              ────┬───  
@@ -1961,7 +1961,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:20:23 ]
+    ╭─[ rust.baml:20:23 ]
     │
  20 │ macro_rules! ast_node {
     │                       ┬  
@@ -1971,7 +1971,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:21:5 ]
+    ╭─[ rust.baml:21:5 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │     ┬  
@@ -1981,7 +1981,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:21:6 ]
+    ╭─[ rust.baml:21:6 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │      ──┬──  
@@ -1991,7 +1991,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ':'
-    ╭─[ 0:21:11 ]
+    ╭─[ rust.baml:21:11 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │           ┬  
@@ -2001,7 +2001,7 @@ Error: Expected top-level declaration, found ':'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:21:12 ]
+    ╭─[ rust.baml:21:12 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │            ──┬──  
@@ -2011,7 +2011,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:21:17 ]
+    ╭─[ rust.baml:21:17 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                 ┬  
@@ -2021,7 +2021,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:21:19 ]
+    ╭─[ rust.baml:21:19 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                   ──┬──  
@@ -2031,7 +2031,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ':'
-    ╭─[ 0:21:24 ]
+    ╭─[ rust.baml:21:24 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                        ┬  
@@ -2041,7 +2041,7 @@ Error: Expected top-level declaration, found ':'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:21:25 ]
+    ╭─[ rust.baml:21:25 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                         ──┬──  
@@ -2051,7 +2051,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:21:30 ]
+    ╭─[ rust.baml:21:30 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                              ┬  
@@ -2061,7 +2061,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '=>'
-    ╭─[ 0:21:32 ]
+    ╭─[ rust.baml:21:32 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                                ─┬  
@@ -2071,7 +2071,7 @@ Error: Expected top-level declaration, found '=>'
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:21:35 ]
+    ╭─[ rust.baml:21:35 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                                   ┬  
@@ -2081,7 +2081,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found '#'
-    ╭─[ 0:22:9 ]
+    ╭─[ rust.baml:22:9 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │         ┬  
@@ -2091,7 +2091,7 @@ Error: Expected top-level declaration, found '#'
 ────╯
 
 Error: Expected top-level declaration, found '['
-    ╭─[ 0:22:10 ]
+    ╭─[ rust.baml:22:10 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │          ┬  
@@ -2101,7 +2101,7 @@ Error: Expected top-level declaration, found '['
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:22:11 ]
+    ╭─[ rust.baml:22:11 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │           ───┬──  
@@ -2111,7 +2111,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:22:17 ]
+    ╭─[ rust.baml:22:17 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                 ┬  
@@ -2121,7 +2121,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:22:18 ]
+    ╭─[ rust.baml:22:18 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                  ──┬──  
@@ -2131,7 +2131,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:22:23 ]
+    ╭─[ rust.baml:22:23 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                       ┬  
@@ -2141,7 +2141,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:22:25 ]
+    ╭─[ rust.baml:22:25 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                         ──┬──  
@@ -2151,7 +2151,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:22:30 ]
+    ╭─[ rust.baml:22:30 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                              ┬  
@@ -2161,7 +2161,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:22:32 ]
+    ╭─[ rust.baml:22:32 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                ────┬────  
@@ -2171,7 +2171,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:22:41 ]
+    ╭─[ rust.baml:22:41 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                         ┬  
@@ -2181,7 +2181,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:22:43 ]
+    ╭─[ rust.baml:22:43 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                           ─┬  
@@ -2191,7 +2191,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:22:45 ]
+    ╭─[ rust.baml:22:45 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                             ┬  
@@ -2201,7 +2201,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:22:47 ]
+    ╭─[ rust.baml:22:47 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                               ──┬─  
@@ -2211,7 +2211,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:22:51 ]
+    ╭─[ rust.baml:22:51 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                                   ┬  
@@ -2221,7 +2221,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ']'
-    ╭─[ 0:22:52 ]
+    ╭─[ rust.baml:22:52 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                                    ┬  
@@ -2231,7 +2231,7 @@ Error: Expected top-level declaration, found ']'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:23:9 ]
+    ╭─[ rust.baml:23:9 ]
     │
  23 │         pub struct $name {
     │         ─┬─  
@@ -2241,7 +2241,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:23:13 ]
+    ╭─[ rust.baml:23:13 ]
     │
  23 │         pub struct $name {
     │             ───┬──  
@@ -2251,7 +2251,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:23:20 ]
+    ╭─[ rust.baml:23:20 ]
     │
  23 │         pub struct $name {
     │                    ──┬──  
@@ -2261,7 +2261,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:23:26 ]
+    ╭─[ rust.baml:23:26 ]
     │
  23 │         pub struct $name {
     │                          ┬  
@@ -2271,7 +2271,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:24:13 ]
+    ╭─[ rust.baml:24:13 ]
     │
  24 │             syntax: SyntaxNode,
     │             ───┬──  
@@ -2281,7 +2281,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ':'
-    ╭─[ 0:24:19 ]
+    ╭─[ rust.baml:24:19 ]
     │
  24 │             syntax: SyntaxNode,
     │                   ┬  
@@ -2291,7 +2291,7 @@ Error: Expected top-level declaration, found ':'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:24:21 ]
+    ╭─[ rust.baml:24:21 ]
     │
  24 │             syntax: SyntaxNode,
     │                     ─────┬────  
@@ -2301,7 +2301,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:24:31 ]
+    ╭─[ rust.baml:24:31 ]
     │
  24 │             syntax: SyntaxNode,
     │                               ┬  
@@ -2311,7 +2311,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:25:9 ]
+    ╭─[ rust.baml:25:9 ]
     │
  25 │         }
     │         ┬  
@@ -2321,7 +2321,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:27:9 ]
+    ╭─[ rust.baml:27:9 ]
     │
  27 │         impl BamlAstNode for $name {}
     │         ──┬─  
@@ -2331,7 +2331,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:27:14 ]
+    ╭─[ rust.baml:27:14 ]
     │
  27 │         impl BamlAstNode for $name {}
     │              ─────┬─────  
@@ -2341,7 +2341,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found for
-    ╭─[ 0:27:26 ]
+    ╭─[ rust.baml:27:26 ]
     │
  27 │         impl BamlAstNode for $name {}
     │                          ─┬─  
@@ -2351,7 +2351,7 @@ Error: Expected top-level declaration, found for
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:27:30 ]
+    ╭─[ rust.baml:27:30 ]
     │
  27 │         impl BamlAstNode for $name {}
     │                              ──┬──  
@@ -2361,7 +2361,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:27:36 ]
+    ╭─[ rust.baml:27:36 ]
     │
  27 │         impl BamlAstNode for $name {}
     │                                    ┬  
@@ -2371,7 +2371,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:27:37 ]
+    ╭─[ rust.baml:27:37 ]
     │
  27 │         impl BamlAstNode for $name {}
     │                                     ┬  
@@ -2381,7 +2381,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:29:9 ]
+    ╭─[ rust.baml:29:9 ]
     │
  29 │         impl AstNode for $name {
     │         ──┬─  
@@ -2391,7 +2391,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:29:14 ]
+    ╭─[ rust.baml:29:14 ]
     │
  29 │         impl AstNode for $name {
     │              ───┬───  
@@ -2401,7 +2401,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found for
-    ╭─[ 0:29:22 ]
+    ╭─[ rust.baml:29:22 ]
     │
  29 │         impl AstNode for $name {
     │                      ─┬─  
@@ -2411,7 +2411,7 @@ Error: Expected top-level declaration, found for
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:29:26 ]
+    ╭─[ rust.baml:29:26 ]
     │
  29 │         impl AstNode for $name {
     │                          ──┬──  
@@ -2421,7 +2421,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:29:32 ]
+    ╭─[ rust.baml:29:32 ]
     │
  29 │         impl AstNode for $name {
     │                                ┬  
@@ -2431,7 +2431,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:30:34 ]
+    ╭─[ rust.baml:30:34 ]
     │
  30 │             type Language = crate::BamlLanguage;
     │                                  ─┬  
@@ -2441,7 +2441,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:30:36 ]
+    ╭─[ rust.baml:30:36 ]
     │
  30 │             type Language = crate::BamlLanguage;
     │                                    ──────┬─────  
@@ -2451,7 +2451,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:30:48 ]
+    ╭─[ rust.baml:30:48 ]
     │
  30 │             type Language = crate::BamlLanguage;
     │                                                ┬  
@@ -2461,7 +2461,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:13 ]
+    ╭─[ rust.baml:32:13 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │             ─┬  
@@ -2471,7 +2471,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:16 ]
+    ╭─[ rust.baml:32:16 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                ────┬───  
@@ -2481,7 +2481,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:32:24 ]
+    ╭─[ rust.baml:32:24 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                        ┬  
@@ -2491,7 +2491,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:25 ]
+    ╭─[ rust.baml:32:25 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                         ──┬─  
@@ -2501,7 +2501,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ':'
-    ╭─[ 0:32:29 ]
+    ╭─[ rust.baml:32:29 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                             ┬  
@@ -2511,7 +2511,7 @@ Error: Expected top-level declaration, found ':'
 ────╯
 
 Error: Expected top-level declaration, found '<'
-    ╭─[ 0:32:31 ]
+    ╭─[ rust.baml:32:31 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                               ┬  
@@ -2521,7 +2521,7 @@ Error: Expected top-level declaration, found '<'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:32 ]
+    ╭─[ rust.baml:32:32 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                ──┬─  
@@ -2531,7 +2531,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:32:36 ]
+    ╭─[ rust.baml:32:36 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                    ─┬  
@@ -2541,7 +2541,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:38 ]
+    ╭─[ rust.baml:32:38 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                      ────┬───  
@@ -2551,7 +2551,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:47 ]
+    ╭─[ rust.baml:32:47 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                               ─┬  
@@ -2561,7 +2561,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:50 ]
+    ╭─[ rust.baml:32:50 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                  ──┬──  
@@ -2571,7 +2571,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:32:55 ]
+    ╭─[ rust.baml:32:55 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                       ─┬  
@@ -2581,7 +2581,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:57 ]
+    ╭─[ rust.baml:32:57 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                         ────┬───  
@@ -2591,7 +2591,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '>'
-    ╭─[ 0:32:65 ]
+    ╭─[ rust.baml:32:65 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                 ┬  
@@ -2601,7 +2601,7 @@ Error: Expected top-level declaration, found '>'
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:32:66 ]
+    ╭─[ rust.baml:32:66 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                  ─┬  
@@ -2611,7 +2611,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:68 ]
+    ╭─[ rust.baml:32:68 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                    ──┬─  
@@ -2621,7 +2621,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:32:72 ]
+    ╭─[ rust.baml:32:72 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                        ┬  
@@ -2631,7 +2631,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '->'
-    ╭─[ 0:32:74 ]
+    ╭─[ rust.baml:32:74 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                          ─┬  
@@ -2641,7 +2641,7 @@ Error: Expected top-level declaration, found '->'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:32:77 ]
+    ╭─[ rust.baml:32:77 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                             ──┬─  
@@ -2651,7 +2651,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:32:82 ]
+    ╭─[ rust.baml:32:82 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                                  ┬  
@@ -2661,7 +2661,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:33:17 ]
+    ╭─[ rust.baml:33:17 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                 ──┬─  
@@ -2671,7 +2671,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '=='
-    ╭─[ 0:33:22 ]
+    ╭─[ rust.baml:33:22 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                      ─┬  
@@ -2681,7 +2681,7 @@ Error: Expected top-level declaration, found '=='
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:33:25 ]
+    ╭─[ rust.baml:33:25 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                         ─────┬────  
@@ -2691,7 +2691,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:33:35 ]
+    ╭─[ rust.baml:33:35 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                   ─┬  
@@ -2701,7 +2701,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:33:37 ]
+    ╭─[ rust.baml:33:37 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                     ──┬──  
@@ -2711,7 +2711,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:33:42 ]
+    ╭─[ rust.baml:33:42 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                          ┬  
@@ -2721,7 +2721,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:33:43 ]
+    ╭─[ rust.baml:33:43 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                           ──┬─  
@@ -2731,7 +2731,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:33:47 ]
+    ╭─[ rust.baml:33:47 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                               ┬  
@@ -2741,7 +2741,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:33:48 ]
+    ╭─[ rust.baml:33:48 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                                ┬  
@@ -2751,7 +2751,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:34:13 ]
+    ╭─[ rust.baml:34:13 ]
     │
  34 │             }
     │             ┬  
@@ -2761,7 +2761,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:36:13 ]
+    ╭─[ rust.baml:36:13 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │             ─┬  
@@ -2771,7 +2771,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:36:16 ]
+    ╭─[ rust.baml:36:16 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                ──┬─  
@@ -2781,7 +2781,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:36:20 ]
+    ╭─[ rust.baml:36:20 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                    ┬  
@@ -2791,7 +2791,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:36:21 ]
+    ╭─[ rust.baml:36:21 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                     ───┬──  
@@ -2801,7 +2801,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ':'
-    ╭─[ 0:36:27 ]
+    ╭─[ rust.baml:36:27 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                           ┬  
@@ -2811,7 +2811,7 @@ Error: Expected top-level declaration, found ':'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:36:29 ]
+    ╭─[ rust.baml:36:29 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                             ─────┬────  
@@ -2821,7 +2821,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:36:39 ]
+    ╭─[ rust.baml:36:39 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                       ┬  
@@ -2831,7 +2831,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '->'
-    ╭─[ 0:36:41 ]
+    ╭─[ rust.baml:36:41 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                         ─┬  
@@ -2841,7 +2841,7 @@ Error: Expected top-level declaration, found '->'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:36:44 ]
+    ╭─[ rust.baml:36:44 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                            ───┬──  
@@ -2851,7 +2851,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '<'
-    ╭─[ 0:36:50 ]
+    ╭─[ rust.baml:36:50 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                                  ┬  
@@ -2861,7 +2861,7 @@ Error: Expected top-level declaration, found '<'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:36:51 ]
+    ╭─[ rust.baml:36:51 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                                   ──┬─  
@@ -2871,7 +2871,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '>'
-    ╭─[ 0:36:55 ]
+    ╭─[ rust.baml:36:55 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                                       ┬  
@@ -2881,7 +2881,7 @@ Error: Expected top-level declaration, found '>'
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:36:57 ]
+    ╭─[ rust.baml:36:57 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                                         ┬  
@@ -2891,7 +2891,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found if
-    ╭─[ 0:37:17 ]
+    ╭─[ rust.baml:37:17 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                 ─┬  
@@ -2901,7 +2901,7 @@ Error: Expected top-level declaration, found if
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:37:20 ]
+    ╭─[ rust.baml:37:20 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                    ──┬─  
@@ -2911,7 +2911,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:37:24 ]
+    ╭─[ rust.baml:37:24 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                        ─┬  
@@ -2921,7 +2921,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:37:26 ]
+    ╭─[ rust.baml:37:26 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                          ────┬───  
@@ -2931,7 +2931,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:37:34 ]
+    ╭─[ rust.baml:37:34 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                  ┬  
@@ -2941,7 +2941,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:37:35 ]
+    ╭─[ rust.baml:37:35 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                   ───┬──  
@@ -2951,7 +2951,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:37:41 ]
+    ╭─[ rust.baml:37:41 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                         ┬  
@@ -2961,7 +2961,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:37:42 ]
+    ╭─[ rust.baml:37:42 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                          ──┬─  
@@ -2971,7 +2971,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:37:46 ]
+    ╭─[ rust.baml:37:46 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                              ┬  
@@ -2981,7 +2981,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:37:47 ]
+    ╭─[ rust.baml:37:47 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                               ┬  
@@ -2991,7 +2991,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:37:48 ]
+    ╭─[ rust.baml:37:48 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                                ┬  
@@ -3001,7 +3001,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:37:50 ]
+    ╭─[ rust.baml:37:50 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                                  ┬  
@@ -3011,7 +3011,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:38:21 ]
+    ╭─[ rust.baml:38:21 ]
     │
  38 │                     Some(Self { syntax })
     │                     ──┬─  
@@ -3021,7 +3021,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:38:25 ]
+    ╭─[ rust.baml:38:25 ]
     │
  38 │                     Some(Self { syntax })
     │                         ┬  
@@ -3031,7 +3031,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:38:26 ]
+    ╭─[ rust.baml:38:26 ]
     │
  38 │                     Some(Self { syntax })
     │                          ──┬─  
@@ -3041,7 +3041,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:38:31 ]
+    ╭─[ rust.baml:38:31 ]
     │
  38 │                     Some(Self { syntax })
     │                               ┬  
@@ -3051,7 +3051,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:38:33 ]
+    ╭─[ rust.baml:38:33 ]
     │
  38 │                     Some(Self { syntax })
     │                                 ───┬──  
@@ -3061,7 +3061,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:38:40 ]
+    ╭─[ rust.baml:38:40 ]
     │
  38 │                     Some(Self { syntax })
     │                                        ┬  
@@ -3071,7 +3071,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:38:41 ]
+    ╭─[ rust.baml:38:41 ]
     │
  38 │                     Some(Self { syntax })
     │                                         ┬  
@@ -3081,7 +3081,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:39:17 ]
+    ╭─[ rust.baml:39:17 ]
     │
  39 │                 } else {
     │                 ┬  
@@ -3091,7 +3091,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found else
-    ╭─[ 0:39:19 ]
+    ╭─[ rust.baml:39:19 ]
     │
  39 │                 } else {
     │                   ──┬─  
@@ -3101,7 +3101,7 @@ Error: Expected top-level declaration, found else
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:39:24 ]
+    ╭─[ rust.baml:39:24 ]
     │
  39 │                 } else {
     │                        ┬  
@@ -3111,7 +3111,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:40:21 ]
+    ╭─[ rust.baml:40:21 ]
     │
  40 │                     None
     │                     ──┬─  
@@ -3121,7 +3121,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:41:17 ]
+    ╭─[ rust.baml:41:17 ]
     │
  41 │                 }
     │                 ┬  
@@ -3131,7 +3131,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:42:13 ]
+    ╭─[ rust.baml:42:13 ]
     │
  42 │             }
     │             ┬  
@@ -3141,7 +3141,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:44:13 ]
+    ╭─[ rust.baml:44:13 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │             ─┬  
@@ -3151,7 +3151,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:44:16 ]
+    ╭─[ rust.baml:44:16 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                ───┬──  
@@ -3161,7 +3161,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:44:22 ]
+    ╭─[ rust.baml:44:22 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                      ┬  
@@ -3171,7 +3171,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found '&'
-    ╭─[ 0:44:23 ]
+    ╭─[ rust.baml:44:23 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                       ┬  
@@ -3181,7 +3181,7 @@ Error: Expected top-level declaration, found '&'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:44:24 ]
+    ╭─[ rust.baml:44:24 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                        ──┬─  
@@ -3191,7 +3191,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:44:28 ]
+    ╭─[ rust.baml:44:28 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                            ┬  
@@ -3201,7 +3201,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '->'
-    ╭─[ 0:44:30 ]
+    ╭─[ rust.baml:44:30 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                              ─┬  
@@ -3211,7 +3211,7 @@ Error: Expected top-level declaration, found '->'
 ────╯
 
 Error: Expected top-level declaration, found '&'
-    ╭─[ 0:44:33 ]
+    ╭─[ rust.baml:44:33 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                                 ┬  
@@ -3221,7 +3221,7 @@ Error: Expected top-level declaration, found '&'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:44:34 ]
+    ╭─[ rust.baml:44:34 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                                  ─────┬────  
@@ -3231,7 +3231,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:44:45 ]
+    ╭─[ rust.baml:44:45 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                                             ┬  
@@ -3241,7 +3241,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found '&'
-    ╭─[ 0:45:17 ]
+    ╭─[ rust.baml:45:17 ]
     │
  45 │                 &self.syntax
     │                 ┬  
@@ -3251,7 +3251,7 @@ Error: Expected top-level declaration, found '&'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:45:18 ]
+    ╭─[ rust.baml:45:18 ]
     │
  45 │                 &self.syntax
     │                  ──┬─  
@@ -3261,7 +3261,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:45:22 ]
+    ╭─[ rust.baml:45:22 ]
     │
  45 │                 &self.syntax
     │                      ┬  
@@ -3271,7 +3271,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:45:23 ]
+    ╭─[ rust.baml:45:23 ]
     │
  45 │                 &self.syntax
     │                       ───┬──  
@@ -3281,7 +3281,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:46:13 ]
+    ╭─[ rust.baml:46:13 ]
     │
  46 │             }
     │             ┬  
@@ -3291,7 +3291,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:47:9 ]
+    ╭─[ rust.baml:47:9 ]
     │
  47 │         }
     │         ┬  
@@ -3301,7 +3301,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:48:5 ]
+    ╭─[ rust.baml:48:5 ]
     │
  48 │     };
     │     ┬  
@@ -3311,7 +3311,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:48:6 ]
+    ╭─[ rust.baml:48:6 ]
     │
  48 │     };
     │      ┬  
@@ -3321,7 +3321,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:49:1 ]
+    ╭─[ rust.baml:49:1 ]
     │
  49 │ }
     │ ┬  
@@ -3331,7 +3331,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:52:1 ]
+    ╭─[ rust.baml:52:1 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │ ────┬───  
@@ -3341,7 +3341,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:52:9 ]
+    ╭─[ rust.baml:52:9 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │         ┬  
@@ -3351,7 +3351,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:52:10 ]
+    ╭─[ rust.baml:52:10 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │          ┬  
@@ -3361,7 +3361,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:52:11 ]
+    ╭─[ rust.baml:52:11 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │           ─────┬────  
@@ -3371,7 +3371,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:52:21 ]
+    ╭─[ rust.baml:52:21 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │                     ┬  
@@ -3381,7 +3381,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:52:23 ]
+    ╭─[ rust.baml:52:23 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │                       ─────┬─────  
@@ -3391,7 +3391,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:52:34 ]
+    ╭─[ rust.baml:52:34 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │                                  ┬  
@@ -3401,7 +3401,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:52:35 ]
+    ╭─[ rust.baml:52:35 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │                                   ┬  
@@ -3411,7 +3411,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:53:1 ]
+    ╭─[ rust.baml:53:1 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │ ────┬───  
@@ -3421,7 +3421,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:53:9 ]
+    ╭─[ rust.baml:53:9 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │         ┬  
@@ -3431,7 +3431,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:53:10 ]
+    ╭─[ rust.baml:53:10 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │          ┬  
@@ -3441,7 +3441,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:53:11 ]
+    ╭─[ rust.baml:53:11 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │           ─────┬─────  
@@ -3451,7 +3451,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:53:22 ]
+    ╭─[ rust.baml:53:22 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │                      ┬  
@@ -3461,7 +3461,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:53:24 ]
+    ╭─[ rust.baml:53:24 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │                        ──────┬─────  
@@ -3471,7 +3471,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:53:36 ]
+    ╭─[ rust.baml:53:36 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │                                    ┬  
@@ -3481,7 +3481,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:53:37 ]
+    ╭─[ rust.baml:53:37 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │                                     ┬  
@@ -3491,7 +3491,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:54:1 ]
+    ╭─[ rust.baml:54:1 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │ ────┬───  
@@ -3501,7 +3501,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:54:9 ]
+    ╭─[ rust.baml:54:9 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │         ┬  
@@ -3511,7 +3511,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:54:10 ]
+    ╭─[ rust.baml:54:10 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │          ┬  
@@ -3521,7 +3521,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:54:11 ]
+    ╭─[ rust.baml:54:11 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │           ────┬───  
@@ -3531,7 +3531,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:54:19 ]
+    ╭─[ rust.baml:54:19 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │                   ┬  
@@ -3541,7 +3541,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:54:21 ]
+    ╭─[ rust.baml:54:21 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │                     ────┬────  
@@ -3551,7 +3551,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:54:30 ]
+    ╭─[ rust.baml:54:30 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │                              ┬  
@@ -3561,7 +3561,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:54:31 ]
+    ╭─[ rust.baml:54:31 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │                               ┬  
@@ -3571,7 +3571,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:55:1 ]
+    ╭─[ rust.baml:55:1 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │ ────┬───  
@@ -3581,7 +3581,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:55:9 ]
+    ╭─[ rust.baml:55:9 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │         ┬  
@@ -3591,7 +3591,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:55:10 ]
+    ╭─[ rust.baml:55:10 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │          ┬  
@@ -3601,7 +3601,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:55:11 ]
+    ╭─[ rust.baml:55:11 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │           ───┬───  
@@ -3611,7 +3611,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:55:18 ]
+    ╭─[ rust.baml:55:18 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │                  ┬  
@@ -3621,7 +3621,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:55:20 ]
+    ╭─[ rust.baml:55:20 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │                    ────┬───  
@@ -3631,7 +3631,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:55:28 ]
+    ╭─[ rust.baml:55:28 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │                            ┬  
@@ -3641,7 +3641,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:55:29 ]
+    ╭─[ rust.baml:55:29 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │                             ┬  
@@ -3651,7 +3651,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:56:1 ]
+    ╭─[ rust.baml:56:1 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │ ────┬───  
@@ -3661,7 +3661,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:56:9 ]
+    ╭─[ rust.baml:56:9 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │         ┬  
@@ -3671,7 +3671,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:56:10 ]
+    ╭─[ rust.baml:56:10 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │          ┬  
@@ -3681,7 +3681,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:56:11 ]
+    ╭─[ rust.baml:56:11 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │           ────┬────  
@@ -3691,7 +3691,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:56:20 ]
+    ╭─[ rust.baml:56:20 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │                    ┬  
@@ -3701,7 +3701,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:56:22 ]
+    ╭─[ rust.baml:56:22 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │                      ─────┬────  
@@ -3711,7 +3711,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:56:32 ]
+    ╭─[ rust.baml:56:32 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │                                ┬  
@@ -3721,7 +3721,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:56:33 ]
+    ╭─[ rust.baml:56:33 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │                                 ┬  
@@ -3731,7 +3731,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:57:1 ]
+    ╭─[ rust.baml:57:1 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │ ────┬───  
@@ -3741,7 +3741,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:57:9 ]
+    ╭─[ rust.baml:57:9 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │         ┬  
@@ -3751,7 +3751,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:57:10 ]
+    ╭─[ rust.baml:57:10 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │          ┬  
@@ -3761,7 +3761,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:57:11 ]
+    ╭─[ rust.baml:57:11 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │           ───┬───  
@@ -3771,7 +3771,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:57:18 ]
+    ╭─[ rust.baml:57:18 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │                  ┬  
@@ -3781,7 +3781,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:57:20 ]
+    ╭─[ rust.baml:57:20 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │                    ────┬───  
@@ -3791,7 +3791,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:57:28 ]
+    ╭─[ rust.baml:57:28 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │                            ┬  
@@ -3801,7 +3801,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:57:29 ]
+    ╭─[ rust.baml:57:29 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │                             ┬  
@@ -3811,7 +3811,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:58:1 ]
+    ╭─[ rust.baml:58:1 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │ ────┬───  
@@ -3821,7 +3821,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:58:9 ]
+    ╭─[ rust.baml:58:9 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │         ┬  
@@ -3831,7 +3831,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:58:10 ]
+    ╭─[ rust.baml:58:10 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │          ┬  
@@ -3841,7 +3841,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:58:11 ]
+    ╭─[ rust.baml:58:11 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │           ───────┬──────  
@@ -3851,7 +3851,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:58:25 ]
+    ╭─[ rust.baml:58:25 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │                         ┬  
@@ -3861,7 +3861,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:58:27 ]
+    ╭─[ rust.baml:58:27 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │                           ────────┬───────  
@@ -3871,7 +3871,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:58:43 ]
+    ╭─[ rust.baml:58:43 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │                                           ┬  
@@ -3881,7 +3881,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:58:44 ]
+    ╭─[ rust.baml:58:44 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │                                            ┬  
@@ -3891,7 +3891,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:59:1 ]
+    ╭─[ rust.baml:59:1 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │ ────┬───  
@@ -3901,7 +3901,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:59:9 ]
+    ╭─[ rust.baml:59:9 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │         ┬  
@@ -3911,7 +3911,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:59:10 ]
+    ╭─[ rust.baml:59:10 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │          ┬  
@@ -3921,7 +3921,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:59:11 ]
+    ╭─[ rust.baml:59:11 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │           ────────┬────────  
@@ -3931,7 +3931,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:59:28 ]
+    ╭─[ rust.baml:59:28 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │                            ┬  
@@ -3941,7 +3941,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:59:30 ]
+    ╭─[ rust.baml:59:30 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │                              ─────────┬─────────  
@@ -3951,7 +3951,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:59:49 ]
+    ╭─[ rust.baml:59:49 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │                                                 ┬  
@@ -3961,7 +3961,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:59:50 ]
+    ╭─[ rust.baml:59:50 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │                                                  ┬  
@@ -3971,7 +3971,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:60:1 ]
+    ╭─[ rust.baml:60:1 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │ ────┬───  
@@ -3981,7 +3981,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:60:9 ]
+    ╭─[ rust.baml:60:9 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │         ┬  
@@ -3991,7 +3991,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:60:10 ]
+    ╭─[ rust.baml:60:10 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │          ┬  
@@ -4001,7 +4001,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:60:11 ]
+    ╭─[ rust.baml:60:11 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │           ──────┬─────  
@@ -4011,7 +4011,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:60:23 ]
+    ╭─[ rust.baml:60:23 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │                       ┬  
@@ -4021,7 +4021,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:60:25 ]
+    ╭─[ rust.baml:60:25 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │                         ───────┬──────  
@@ -4031,7 +4031,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:60:39 ]
+    ╭─[ rust.baml:60:39 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │                                       ┬  
@@ -4041,7 +4041,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:60:40 ]
+    ╭─[ rust.baml:60:40 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │                                        ┬  
@@ -4051,7 +4051,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:62:1 ]
+    ╭─[ rust.baml:62:1 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │ ────┬───  
@@ -4061,7 +4061,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:62:9 ]
+    ╭─[ rust.baml:62:9 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │         ┬  
@@ -4071,7 +4071,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:62:10 ]
+    ╭─[ rust.baml:62:10 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │          ┬  
@@ -4081,7 +4081,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:62:11 ]
+    ╭─[ rust.baml:62:11 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │           ──────┬──────  
@@ -4091,7 +4091,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:62:24 ]
+    ╭─[ rust.baml:62:24 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │                        ┬  
@@ -4101,7 +4101,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:62:26 ]
+    ╭─[ rust.baml:62:26 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │                          ───────┬──────  
@@ -4111,7 +4111,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:62:40 ]
+    ╭─[ rust.baml:62:40 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │                                        ┬  
@@ -4121,7 +4121,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:62:41 ]
+    ╭─[ rust.baml:62:41 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │                                         ┬  
@@ -4131,7 +4131,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:63:1 ]
+    ╭─[ rust.baml:63:1 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │ ────┬───  
@@ -4141,7 +4141,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:63:9 ]
+    ╭─[ rust.baml:63:9 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │         ┬  
@@ -4151,7 +4151,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:63:10 ]
+    ╭─[ rust.baml:63:10 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │          ┬  
@@ -4161,7 +4161,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:63:11 ]
+    ╭─[ rust.baml:63:11 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │           ────┬────  
@@ -4171,7 +4171,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:63:20 ]
+    ╭─[ rust.baml:63:20 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │                    ┬  
@@ -4181,7 +4181,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:63:22 ]
+    ╭─[ rust.baml:63:22 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │                      ────┬────  
@@ -4191,7 +4191,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:63:31 ]
+    ╭─[ rust.baml:63:31 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │                               ┬  
@@ -4201,7 +4201,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:63:32 ]
+    ╭─[ rust.baml:63:32 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │                                ┬  
@@ -4211,7 +4211,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:64:1 ]
+    ╭─[ rust.baml:64:1 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │ ────┬───  
@@ -4221,7 +4221,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:64:9 ]
+    ╭─[ rust.baml:64:9 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │         ┬  
@@ -4231,7 +4231,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:64:10 ]
+    ╭─[ rust.baml:64:10 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │          ┬  
@@ -4241,7 +4241,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:64:11 ]
+    ╭─[ rust.baml:64:11 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │           ──────┬─────  
@@ -4251,7 +4251,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:64:23 ]
+    ╭─[ rust.baml:64:23 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │                       ┬  
@@ -4261,7 +4261,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:64:25 ]
+    ╭─[ rust.baml:64:25 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │                         ──────┬──────  
@@ -4271,7 +4271,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:64:38 ]
+    ╭─[ rust.baml:64:38 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │                                      ┬  
@@ -4281,7 +4281,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:64:39 ]
+    ╭─[ rust.baml:64:39 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │                                       ┬  
@@ -4291,7 +4291,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:65:1 ]
+    ╭─[ rust.baml:65:1 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │ ────┬───  
@@ -4301,7 +4301,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:65:9 ]
+    ╭─[ rust.baml:65:9 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │         ┬  
@@ -4311,7 +4311,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:65:10 ]
+    ╭─[ rust.baml:65:10 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │          ┬  
@@ -4321,7 +4321,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:65:11 ]
+    ╭─[ rust.baml:65:11 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │           ───────┬───────  
@@ -4331,7 +4331,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:65:26 ]
+    ╭─[ rust.baml:65:26 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │                          ┬  
@@ -4341,7 +4341,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:65:28 ]
+    ╭─[ rust.baml:65:28 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │                            ────────┬────────  
@@ -4351,7 +4351,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:65:45 ]
+    ╭─[ rust.baml:65:45 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │                                             ┬  
@@ -4361,7 +4361,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:65:46 ]
+    ╭─[ rust.baml:65:46 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │                                              ┬  
@@ -4371,7 +4371,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:66:1 ]
+    ╭─[ rust.baml:66:1 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │ ────┬───  
@@ -4381,7 +4381,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:66:9 ]
+    ╭─[ rust.baml:66:9 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │         ┬  
@@ -4391,7 +4391,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:66:10 ]
+    ╭─[ rust.baml:66:10 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │          ┬  
@@ -4401,7 +4401,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:66:11 ]
+    ╭─[ rust.baml:66:11 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │           ────────┬───────  
@@ -4411,7 +4411,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:66:27 ]
+    ╭─[ rust.baml:66:27 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │                           ┬  
@@ -4421,7 +4421,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:66:29 ]
+    ╭─[ rust.baml:66:29 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │                             ─────────┬────────  
@@ -4431,7 +4431,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:66:47 ]
+    ╭─[ rust.baml:66:47 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │                                               ┬  
@@ -4441,7 +4441,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:66:48 ]
+    ╭─[ rust.baml:66:48 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │                                                ┬  
@@ -4451,7 +4451,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:67:1 ]
+    ╭─[ rust.baml:67:1 ]
     │
  67 │ ast_node!(Field, FIELD);
     │ ────┬───  
@@ -4461,7 +4461,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:67:9 ]
+    ╭─[ rust.baml:67:9 ]
     │
  67 │ ast_node!(Field, FIELD);
     │         ┬  
@@ -4471,7 +4471,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:67:10 ]
+    ╭─[ rust.baml:67:10 ]
     │
  67 │ ast_node!(Field, FIELD);
     │          ┬  
@@ -4481,7 +4481,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:67:11 ]
+    ╭─[ rust.baml:67:11 ]
     │
  67 │ ast_node!(Field, FIELD);
     │           ──┬──  
@@ -4491,7 +4491,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:67:16 ]
+    ╭─[ rust.baml:67:16 ]
     │
  67 │ ast_node!(Field, FIELD);
     │                ┬  
@@ -4501,7 +4501,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:67:18 ]
+    ╭─[ rust.baml:67:18 ]
     │
  67 │ ast_node!(Field, FIELD);
     │                  ──┬──  
@@ -4511,7 +4511,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:67:23 ]
+    ╭─[ rust.baml:67:23 ]
     │
  67 │ ast_node!(Field, FIELD);
     │                       ┬  
@@ -4521,7 +4521,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:67:24 ]
+    ╭─[ rust.baml:67:24 ]
     │
  67 │ ast_node!(Field, FIELD);
     │                        ┬  
@@ -4531,7 +4531,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:68:1 ]
+    ╭─[ rust.baml:68:1 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │ ────┬───  
@@ -4541,7 +4541,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:68:9 ]
+    ╭─[ rust.baml:68:9 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │         ┬  
@@ -4551,7 +4551,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:68:10 ]
+    ╭─[ rust.baml:68:10 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │          ┬  
@@ -4561,7 +4561,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:68:11 ]
+    ╭─[ rust.baml:68:11 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │           ─────┬─────  
@@ -4571,7 +4571,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:68:22 ]
+    ╭─[ rust.baml:68:22 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │                      ┬  
@@ -4581,7 +4581,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:68:24 ]
+    ╭─[ rust.baml:68:24 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │                        ──────┬─────  
@@ -4591,7 +4591,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:68:36 ]
+    ╭─[ rust.baml:68:36 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │                                    ┬  
@@ -4601,7 +4601,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:68:37 ]
+    ╭─[ rust.baml:68:37 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │                                     ┬  
@@ -4611,7 +4611,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:69:1 ]
+    ╭─[ rust.baml:69:1 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │ ────┬───  
@@ -4621,7 +4621,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:69:9 ]
+    ╭─[ rust.baml:69:9 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │         ┬  
@@ -4631,7 +4631,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:69:10 ]
+    ╭─[ rust.baml:69:10 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │          ┬  
@@ -4641,7 +4641,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:69:11 ]
+    ╭─[ rust.baml:69:11 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │           ─────┬─────  
@@ -4651,7 +4651,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:69:22 ]
+    ╭─[ rust.baml:69:22 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │                      ┬  
@@ -4661,7 +4661,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:69:24 ]
+    ╭─[ rust.baml:69:24 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │                        ──────┬─────  
@@ -4671,7 +4671,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:69:36 ]
+    ╭─[ rust.baml:69:36 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │                                    ┬  
@@ -4681,7 +4681,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:69:37 ]
+    ╭─[ rust.baml:69:37 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │                                     ┬  
@@ -4691,7 +4691,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:70:1 ]
+    ╭─[ rust.baml:70:1 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │ ────┬───  
@@ -4701,7 +4701,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:70:9 ]
+    ╭─[ rust.baml:70:9 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │         ┬  
@@ -4711,7 +4711,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:70:10 ]
+    ╭─[ rust.baml:70:10 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │          ┬  
@@ -4721,7 +4721,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:70:11 ]
+    ╭─[ rust.baml:70:11 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │           ─────┬────  
@@ -4731,7 +4731,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:70:21 ]
+    ╭─[ rust.baml:70:21 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │                     ┬  
@@ -4741,7 +4741,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:70:23 ]
+    ╭─[ rust.baml:70:23 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │                       ─────┬─────  
@@ -4751,7 +4751,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:70:34 ]
+    ╭─[ rust.baml:70:34 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │                                  ┬  
@@ -4761,7 +4761,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:70:35 ]
+    ╭─[ rust.baml:70:35 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │                                   ┬  
@@ -4771,7 +4771,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:72:1 ]
+    ╭─[ rust.baml:72:1 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │ ────┬───  
@@ -4781,7 +4781,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:72:9 ]
+    ╭─[ rust.baml:72:9 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │         ┬  
@@ -4791,7 +4791,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:72:10 ]
+    ╭─[ rust.baml:72:10 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │          ┬  
@@ -4801,7 +4801,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:72:11 ]
+    ╭─[ rust.baml:72:11 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │           ────┬───  
@@ -4811,7 +4811,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:72:19 ]
+    ╭─[ rust.baml:72:19 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │                   ┬  
@@ -4821,7 +4821,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:72:21 ]
+    ╭─[ rust.baml:72:21 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │                     ────┬────  
@@ -4831,7 +4831,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:72:30 ]
+    ╭─[ rust.baml:72:30 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │                              ┬  
@@ -4841,7 +4841,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:72:31 ]
+    ╭─[ rust.baml:72:31 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │                               ┬  
@@ -4851,7 +4851,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:73:1 ]
+    ╭─[ rust.baml:73:1 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │ ────┬───  
@@ -4861,7 +4861,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:73:9 ]
+    ╭─[ rust.baml:73:9 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │         ┬  
@@ -4871,7 +4871,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:73:10 ]
+    ╭─[ rust.baml:73:10 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │          ┬  
@@ -4881,7 +4881,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:73:11 ]
+    ╭─[ rust.baml:73:11 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │           ────┬────  
@@ -4891,7 +4891,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:73:20 ]
+    ╭─[ rust.baml:73:20 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │                    ┬  
@@ -4901,7 +4901,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:73:22 ]
+    ╭─[ rust.baml:73:22 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │                      ────┬────  
@@ -4911,7 +4911,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:73:31 ]
+    ╭─[ rust.baml:73:31 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │                               ┬  
@@ -4921,7 +4921,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:73:32 ]
+    ╭─[ rust.baml:73:32 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │                                ┬  
@@ -4931,7 +4931,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:74:1 ]
+    ╭─[ rust.baml:74:1 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │ ────┬───  
@@ -4941,7 +4941,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:74:9 ]
+    ╭─[ rust.baml:74:9 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │         ┬  
@@ -4951,7 +4951,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:74:10 ]
+    ╭─[ rust.baml:74:10 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │          ┬  
@@ -4961,7 +4961,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:74:11 ]
+    ╭─[ rust.baml:74:11 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │           ───────┬──────  
@@ -4971,7 +4971,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:74:25 ]
+    ╭─[ rust.baml:74:25 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │                         ┬  
@@ -4981,7 +4981,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:74:27 ]
+    ╭─[ rust.baml:74:27 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │                           ───────┬───────  
@@ -4991,7 +4991,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:74:42 ]
+    ╭─[ rust.baml:74:42 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │                                          ┬  
@@ -5001,7 +5001,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:74:43 ]
+    ╭─[ rust.baml:74:43 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │                                           ┬  
@@ -5011,7 +5011,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:76:1 ]
+    ╭─[ rust.baml:76:1 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │ ────┬───  
@@ -5021,7 +5021,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:76:9 ]
+    ╭─[ rust.baml:76:9 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │         ┬  
@@ -5031,7 +5031,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:76:10 ]
+    ╭─[ rust.baml:76:10 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │          ┬  
@@ -5041,7 +5041,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:76:11 ]
+    ╭─[ rust.baml:76:11 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │           ──┬─  
@@ -5051,7 +5051,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:76:15 ]
+    ╭─[ rust.baml:76:15 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │               ┬  
@@ -5061,7 +5061,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:76:17 ]
+    ╭─[ rust.baml:76:17 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │                 ──┬─  
@@ -5071,7 +5071,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:76:21 ]
+    ╭─[ rust.baml:76:21 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │                     ┬  
@@ -5081,7 +5081,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:76:22 ]
+    ╭─[ rust.baml:76:22 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │                      ┬  
@@ -5091,7 +5091,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:77:1 ]
+    ╭─[ rust.baml:77:1 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │ ────┬───  
@@ -5101,7 +5101,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:77:9 ]
+    ╭─[ rust.baml:77:9 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │         ┬  
@@ -5111,7 +5111,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:77:10 ]
+    ╭─[ rust.baml:77:10 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │          ┬  
@@ -5121,7 +5121,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:77:11 ]
+    ╭─[ rust.baml:77:11 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │           ───┬───  
@@ -5131,7 +5131,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:77:18 ]
+    ╭─[ rust.baml:77:18 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │                  ┬  
@@ -5141,7 +5141,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:77:20 ]
+    ╭─[ rust.baml:77:20 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │                    ────┬───  
@@ -5151,7 +5151,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:77:28 ]
+    ╭─[ rust.baml:77:28 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │                            ┬  
@@ -5161,7 +5161,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:77:29 ]
+    ╭─[ rust.baml:77:29 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │                             ┬  
@@ -5171,7 +5171,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:78:1 ]
+    ╭─[ rust.baml:78:1 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │ ────┬───  
@@ -5181,7 +5181,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:78:9 ]
+    ╭─[ rust.baml:78:9 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │         ┬  
@@ -5191,7 +5191,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:78:10 ]
+    ╭─[ rust.baml:78:10 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │          ┬  
@@ -5201,7 +5201,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:78:11 ]
+    ╭─[ rust.baml:78:11 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │           ───┬──  
@@ -5211,7 +5211,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:78:17 ]
+    ╭─[ rust.baml:78:17 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │                 ┬  
@@ -5221,7 +5221,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:78:19 ]
+    ╭─[ rust.baml:78:19 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │                   ───┬───  
@@ -5231,7 +5231,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:78:26 ]
+    ╭─[ rust.baml:78:26 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │                          ┬  
@@ -5241,7 +5241,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:78:27 ]
+    ╭─[ rust.baml:78:27 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │                           ┬  
@@ -5251,7 +5251,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:79:1 ]
+    ╭─[ rust.baml:79:1 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │ ────┬───  
@@ -5261,7 +5261,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:79:9 ]
+    ╭─[ rust.baml:79:9 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │         ┬  
@@ -5271,7 +5271,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:79:10 ]
+    ╭─[ rust.baml:79:10 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │          ┬  
@@ -5281,7 +5281,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:79:11 ]
+    ╭─[ rust.baml:79:11 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │           ────┬────  
@@ -5291,7 +5291,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:79:20 ]
+    ╭─[ rust.baml:79:20 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │                    ┬  
@@ -5301,7 +5301,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:79:22 ]
+    ╭─[ rust.baml:79:22 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │                      ─────┬────  
@@ -5311,7 +5311,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:79:32 ]
+    ╭─[ rust.baml:79:32 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │                                ┬  
@@ -5321,7 +5321,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:79:33 ]
+    ╭─[ rust.baml:79:33 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │                                 ┬  
@@ -5331,7 +5331,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:80:1 ]
+    ╭─[ rust.baml:80:1 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │ ────┬───  
@@ -5341,7 +5341,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:80:9 ]
+    ╭─[ rust.baml:80:9 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │         ┬  
@@ -5351,7 +5351,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:80:10 ]
+    ╭─[ rust.baml:80:10 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │          ┬  
@@ -5361,7 +5361,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:80:11 ]
+    ╭─[ rust.baml:80:11 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │           ───┬───  
@@ -5371,7 +5371,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:80:18 ]
+    ╭─[ rust.baml:80:18 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │                  ┬  
@@ -5381,7 +5381,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:80:20 ]
+    ╭─[ rust.baml:80:20 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │                    ────┬───  
@@ -5391,7 +5391,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:80:28 ]
+    ╭─[ rust.baml:80:28 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │                            ┬  
@@ -5401,7 +5401,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:80:29 ]
+    ╭─[ rust.baml:80:29 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │                             ┬  
@@ -5411,7 +5411,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:81:1 ]
+    ╭─[ rust.baml:81:1 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │ ────┬───  
@@ -5421,7 +5421,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '!'
-    ╭─[ 0:81:9 ]
+    ╭─[ rust.baml:81:9 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │         ┬  
@@ -5431,7 +5431,7 @@ Error: Expected top-level declaration, found '!'
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:81:10 ]
+    ╭─[ rust.baml:81:10 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │          ┬  
@@ -5441,7 +5441,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:81:11 ]
+    ╭─[ rust.baml:81:11 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │           ────┬────  
@@ -5451,7 +5451,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ','
-    ╭─[ 0:81:20 ]
+    ╭─[ rust.baml:81:20 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │                    ┬  
@@ -5461,7 +5461,7 @@ Error: Expected top-level declaration, found ','
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:81:22 ]
+    ╭─[ rust.baml:81:22 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │                      ─────┬────  
@@ -5471,7 +5471,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:81:32 ]
+    ╭─[ rust.baml:81:32 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │                                ┬  
@@ -5481,7 +5481,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ';'
-    ╭─[ 0:81:33 ]
+    ╭─[ rust.baml:81:33 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │                                 ┬  
@@ -5491,7 +5491,7 @@ Error: Expected top-level declaration, found ';'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:84:1 ]
+    ╭─[ rust.baml:84:1 ]
     │
  84 │ impl SourceFile {
     │ ──┬─  
@@ -5501,7 +5501,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:84:6 ]
+    ╭─[ rust.baml:84:6 ]
     │
  84 │ impl SourceFile {
     │      ─────┬────  
@@ -5511,7 +5511,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:84:17 ]
+    ╭─[ rust.baml:84:17 ]
     │
  84 │ impl SourceFile {
     │                 ┬  
@@ -5521,7 +5521,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:86:5 ]
+    ╭─[ rust.baml:86:5 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │     ─┬─  
@@ -5531,7 +5531,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:86:9 ]
+    ╭─[ rust.baml:86:9 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │         ─┬  
@@ -5541,7 +5541,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:86:12 ]
+    ╭─[ rust.baml:86:12 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │            ──┬──  
@@ -5551,7 +5551,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:86:17 ]
+    ╭─[ rust.baml:86:17 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                 ┬  
@@ -5561,7 +5561,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found '&'
-    ╭─[ 0:86:18 ]
+    ╭─[ rust.baml:86:18 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                  ┬  
@@ -5571,7 +5571,7 @@ Error: Expected top-level declaration, found '&'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:86:19 ]
+    ╭─[ rust.baml:86:19 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                   ──┬─  
@@ -5581,7 +5581,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:86:23 ]
+    ╭─[ rust.baml:86:23 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                       ┬  
@@ -5591,7 +5591,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '->'
-    ╭─[ 0:86:25 ]
+    ╭─[ rust.baml:86:25 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                         ─┬  
@@ -5601,7 +5601,7 @@ Error: Expected top-level declaration, found '->'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:86:28 ]
+    ╭─[ rust.baml:86:28 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                            ──┬─  
@@ -5611,7 +5611,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:86:33 ]
+    ╭─[ rust.baml:86:33 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                 ────┬───  
@@ -5621,7 +5621,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '<'
-    ╭─[ 0:86:41 ]
+    ╭─[ rust.baml:86:41 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                         ┬  
@@ -5631,7 +5631,7 @@ Error: Expected top-level declaration, found '<'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:86:42 ]
+    ╭─[ rust.baml:86:42 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                          ──┬─  
@@ -5641,7 +5641,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '='
-    ╭─[ 0:86:47 ]
+    ╭─[ rust.baml:86:47 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                               ┬  
@@ -5651,7 +5651,7 @@ Error: Expected top-level declaration, found '='
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:86:49 ]
+    ╭─[ rust.baml:86:49 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                                 ──┬─  
@@ -5661,7 +5661,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '>'
-    ╭─[ 0:86:53 ]
+    ╭─[ rust.baml:86:53 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                                     ┬  
@@ -5671,7 +5671,7 @@ Error: Expected top-level declaration, found '>'
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:86:55 ]
+    ╭─[ rust.baml:86:55 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                                       ┬  
@@ -5681,7 +5681,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:87:9 ]
+    ╭─[ rust.baml:87:9 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │         ──┬─  
@@ -5691,7 +5691,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:87:13 ]
+    ╭─[ rust.baml:87:13 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │             ┬  
@@ -5701,7 +5701,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:87:14 ]
+    ╭─[ rust.baml:87:14 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │              ───┬──  
@@ -5711,7 +5711,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:87:20 ]
+    ╭─[ rust.baml:87:20 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                    ┬  
@@ -5721,7 +5721,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:87:21 ]
+    ╭─[ rust.baml:87:21 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                     ────┬───  
@@ -5731,7 +5731,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:87:29 ]
+    ╭─[ rust.baml:87:29 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                             ┬  
@@ -5741,7 +5741,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:87:30 ]
+    ╭─[ rust.baml:87:30 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                              ┬  
@@ -5751,7 +5751,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:87:31 ]
+    ╭─[ rust.baml:87:31 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                               ┬  
@@ -5761,7 +5761,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:87:32 ]
+    ╭─[ rust.baml:87:32 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                ─────┬────  
@@ -5771,7 +5771,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:87:42 ]
+    ╭─[ rust.baml:87:42 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                          ┬  
@@ -5781,7 +5781,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:87:43 ]
+    ╭─[ rust.baml:87:43 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                           ──┬─  
@@ -5791,7 +5791,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:87:47 ]
+    ╭─[ rust.baml:87:47 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                               ─┬  
@@ -5801,7 +5801,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:87:49 ]
+    ╭─[ rust.baml:87:49 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                                 ──┬─  
@@ -5811,7 +5811,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:87:53 ]
+    ╭─[ rust.baml:87:53 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                                     ┬  
@@ -5821,7 +5821,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:88:5 ]
+    ╭─[ rust.baml:88:5 ]
     │
  88 │     }
     │     ┬  
@@ -5831,7 +5831,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:89:1 ]
+    ╭─[ rust.baml:89:1 ]
     │
  89 │ }
     │ ┬  
@@ -5841,7 +5841,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:91:1 ]
+    ╭─[ rust.baml:91:1 ]
     │
  91 │ impl FunctionDef {
     │ ──┬─  
@@ -5851,7 +5851,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:91:6 ]
+    ╭─[ rust.baml:91:6 ]
     │
  91 │ impl FunctionDef {
     │      ─────┬─────  
@@ -5861,7 +5861,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:91:18 ]
+    ╭─[ rust.baml:91:18 ]
     │
  91 │ impl FunctionDef {
     │                  ┬  
@@ -5871,7 +5871,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:93:5 ]
+    ╭─[ rust.baml:93:5 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │     ─┬─  
@@ -5881,7 +5881,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:93:9 ]
+    ╭─[ rust.baml:93:9 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │         ─┬  
@@ -5891,7 +5891,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:93:12 ]
+    ╭─[ rust.baml:93:12 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │            ──┬─  
@@ -5901,7 +5901,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:93:16 ]
+    ╭─[ rust.baml:93:16 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                ┬  
@@ -5911,7 +5911,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found '&'
-    ╭─[ 0:93:17 ]
+    ╭─[ rust.baml:93:17 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                 ┬  
@@ -5921,7 +5921,7 @@ Error: Expected top-level declaration, found '&'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:93:18 ]
+    ╭─[ rust.baml:93:18 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                  ──┬─  
@@ -5931,7 +5931,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:93:22 ]
+    ╭─[ rust.baml:93:22 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                      ┬  
@@ -5941,7 +5941,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '->'
-    ╭─[ 0:93:24 ]
+    ╭─[ rust.baml:93:24 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                        ─┬  
@@ -5951,7 +5951,7 @@ Error: Expected top-level declaration, found '->'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:93:27 ]
+    ╭─[ rust.baml:93:27 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                           ───┬──  
@@ -5961,7 +5961,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '<'
-    ╭─[ 0:93:33 ]
+    ╭─[ rust.baml:93:33 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                                 ┬  
@@ -5971,7 +5971,7 @@ Error: Expected top-level declaration, found '<'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:93:34 ]
+    ╭─[ rust.baml:93:34 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                                  ─────┬─────  
@@ -5981,7 +5981,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '>'
-    ╭─[ 0:93:45 ]
+    ╭─[ rust.baml:93:45 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                                             ┬  
@@ -5991,7 +5991,7 @@ Error: Expected top-level declaration, found '>'
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:93:47 ]
+    ╭─[ rust.baml:93:47 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                                               ┬  
@@ -6001,7 +6001,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:94:9 ]
+    ╭─[ rust.baml:94:9 ]
     │
  94 │         self.syntax
     │         ──┬─  
@@ -6011,7 +6011,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:94:13 ]
+    ╭─[ rust.baml:94:13 ]
     │
  94 │         self.syntax
     │             ┬  
@@ -6021,7 +6021,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:94:14 ]
+    ╭─[ rust.baml:94:14 ]
     │
  94 │         self.syntax
     │              ───┬──  
@@ -6031,7 +6031,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:95:13 ]
+    ╭─[ rust.baml:95:13 ]
     │
  95 │             .children_with_tokens()
     │             ┬  
@@ -6041,7 +6041,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:95:14 ]
+    ╭─[ rust.baml:95:14 ]
     │
  95 │             .children_with_tokens()
     │              ──────────┬─────────  
@@ -6051,7 +6051,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:95:34 ]
+    ╭─[ rust.baml:95:34 ]
     │
  95 │             .children_with_tokens()
     │                                  ┬  
@@ -6061,7 +6061,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:95:35 ]
+    ╭─[ rust.baml:95:35 ]
     │
  95 │             .children_with_tokens()
     │                                   ┬  
@@ -6071,7 +6071,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:96:13 ]
+    ╭─[ rust.baml:96:13 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │             ┬  
@@ -6081,7 +6081,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:96:14 ]
+    ╭─[ rust.baml:96:14 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │              ─────┬────  
@@ -6091,7 +6091,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:96:24 ]
+    ╭─[ rust.baml:96:24 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                        ┬  
@@ -6101,7 +6101,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:96:25 ]
+    ╭─[ rust.baml:96:25 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                         ──┬──  
@@ -6111,7 +6111,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:96:30 ]
+    ╭─[ rust.baml:96:30 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                              ─┬  
@@ -6121,7 +6121,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:96:32 ]
+    ╭─[ rust.baml:96:32 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                                ─────┬─────  
@@ -6131,7 +6131,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:96:43 ]
+    ╭─[ rust.baml:96:43 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                                           ─┬  
@@ -6141,7 +6141,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:96:45 ]
+    ╭─[ rust.baml:96:45 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                                             ─────┬────  
@@ -6151,7 +6151,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:96:55 ]
+    ╭─[ rust.baml:96:55 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                                                       ┬  
@@ -6161,7 +6161,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:97:13 ]
+    ╭─[ rust.baml:97:13 ]
     │
  97 │             .filter(|token| {
     │             ┬  
@@ -6171,7 +6171,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:97:14 ]
+    ╭─[ rust.baml:97:14 ]
     │
  97 │             .filter(|token| {
     │              ───┬──  
@@ -6181,7 +6181,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:97:20 ]
+    ╭─[ rust.baml:97:20 ]
     │
  97 │             .filter(|token| {
     │                    ┬  
@@ -6191,7 +6191,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found '|'
-    ╭─[ 0:97:21 ]
+    ╭─[ rust.baml:97:21 ]
     │
  97 │             .filter(|token| {
     │                     ┬  
@@ -6201,7 +6201,7 @@ Error: Expected top-level declaration, found '|'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:97:22 ]
+    ╭─[ rust.baml:97:22 ]
     │
  97 │             .filter(|token| {
     │                      ──┬──  
@@ -6211,7 +6211,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '|'
-    ╭─[ 0:97:27 ]
+    ╭─[ rust.baml:97:27 ]
     │
  97 │             .filter(|token| {
     │                           ┬  
@@ -6221,7 +6221,7 @@ Error: Expected top-level declaration, found '|'
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:97:29 ]
+    ╭─[ rust.baml:97:29 ]
     │
  97 │             .filter(|token| {
     │                             ┬  
@@ -6231,7 +6231,7 @@ Error: Expected top-level declaration, found '{'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:17 ]
+    ╭─[ rust.baml:98:17 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                 ──┬──  
@@ -6241,7 +6241,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:98:22 ]
+    ╭─[ rust.baml:98:22 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                      ┬  
@@ -6251,7 +6251,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:23 ]
+    ╭─[ rust.baml:98:23 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                       ──┬─  
@@ -6261,7 +6261,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:98:27 ]
+    ╭─[ rust.baml:98:27 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                           ┬  
@@ -6271,7 +6271,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:98:28 ]
+    ╭─[ rust.baml:98:28 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                            ┬  
@@ -6281,7 +6281,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '=='
-    ╭─[ 0:98:30 ]
+    ╭─[ rust.baml:98:30 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                              ─┬  
@@ -6291,7 +6291,7 @@ Error: Expected top-level declaration, found '=='
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:33 ]
+    ╭─[ rust.baml:98:33 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                 ─────┬────  
@@ -6301,7 +6301,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '::'
-    ╭─[ 0:98:43 ]
+    ╭─[ rust.baml:98:43 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                           ─┬  
@@ -6311,7 +6311,7 @@ Error: Expected top-level declaration, found '::'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:45 ]
+    ╭─[ rust.baml:98:45 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                             ──┬─  
@@ -6321,7 +6321,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '&&'
-    ╭─[ 0:98:50 ]
+    ╭─[ rust.baml:98:50 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                  ─┬  
@@ -6331,7 +6331,7 @@ Error: Expected top-level declaration, found '&&'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:53 ]
+    ╭─[ rust.baml:98:53 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                     ──┬──  
@@ -6341,7 +6341,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:98:58 ]
+    ╭─[ rust.baml:98:58 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                          ┬  
@@ -6351,7 +6351,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:59 ]
+    ╭─[ rust.baml:98:59 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                           ───┬──  
@@ -6361,7 +6361,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:98:65 ]
+    ╭─[ rust.baml:98:65 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                 ┬  
@@ -6371,7 +6371,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:98:66 ]
+    ╭─[ rust.baml:98:66 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                  ┬  
@@ -6381,7 +6381,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '=='
-    ╭─[ 0:98:68 ]
+    ╭─[ rust.baml:98:68 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                    ─┬  
@@ -6391,7 +6391,7 @@ Error: Expected top-level declaration, found '=='
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:71 ]
+    ╭─[ rust.baml:98:71 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                       ──┬─  
@@ -6401,7 +6401,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:98:75 ]
+    ╭─[ rust.baml:98:75 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                           ┬  
@@ -6411,7 +6411,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:76 ]
+    ╭─[ rust.baml:98:76 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                            ──┬─  
@@ -6421,7 +6421,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:98:80 ]
+    ╭─[ rust.baml:98:80 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                ┬  
@@ -6431,7 +6431,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:81 ]
+    ╭─[ rust.baml:98:81 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                 ───┬──  
@@ -6441,7 +6441,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '.'
-    ╭─[ 0:98:87 ]
+    ╭─[ rust.baml:98:87 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                       ┬  
@@ -6451,7 +6451,7 @@ Error: Expected top-level declaration, found '.'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:98:88 ]
+    ╭─[ rust.baml:98:88 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                        ──┬──  
@@ -6461,7 +6461,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '('
-    ╭─[ 0:98:93 ]
+    ╭─[ rust.baml:98:93 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                             ┬  
@@ -6471,7 +6471,7 @@ Error: Expected top-level declaration, found '('
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:98:94 ]
+    ╭─[ rust.baml:98:94 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                              ┬  
@@ -6481,7 +6481,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:98:95 ]
+    ╭─[ rust.baml:98:95 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                               ┬  
@@ -6491,7 +6491,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '}'
-    ╭─[ 0:99:13 ]
+    ╭─[ rust.baml:99:13 ]
     │
  99 │             })
     │             ┬  
@@ -6501,7 +6501,7 @@ Error: Expected top-level declaration, found '}'
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:99:14 ]
+    ╭─[ rust.baml:99:14 ]
     │
  99 │             })
     │              ┬  
@@ -6511,7 +6511,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:100:13 ]
+     ╭─[ rust.baml:100:13 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │             ┬  
@@ -6521,7 +6521,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:100:14 ]
+     ╭─[ rust.baml:100:14 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │              ─┬─  
@@ -6531,7 +6531,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:100:17 ]
+     ╭─[ rust.baml:100:17 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │                 ┬  
@@ -6541,7 +6541,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found integer
-     ╭─[ 0:100:18 ]
+     ╭─[ rust.baml:100:18 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │                  ┬  
@@ -6551,7 +6551,7 @@ Error: Expected top-level declaration, found integer
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:100:19 ]
+     ╭─[ rust.baml:100:19 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │                   ┬  
@@ -6561,7 +6561,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:101:5 ]
+     ╭─[ rust.baml:101:5 ]
      │
  101 │     }
      │     ┬  
@@ -6571,7 +6571,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:104:5 ]
+     ╭─[ rust.baml:104:5 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │     ─┬─  
@@ -6581,7 +6581,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:104:9 ]
+     ╭─[ rust.baml:104:9 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │         ─┬  
@@ -6591,7 +6591,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:104:12 ]
+     ╭─[ rust.baml:104:12 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │            ─────┬────  
@@ -6601,7 +6601,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:104:22 ]
+     ╭─[ rust.baml:104:22 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                      ┬  
@@ -6611,7 +6611,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:104:23 ]
+     ╭─[ rust.baml:104:23 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                       ┬  
@@ -6621,7 +6621,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:104:24 ]
+     ╭─[ rust.baml:104:24 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                        ──┬─  
@@ -6631,7 +6631,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:104:28 ]
+     ╭─[ rust.baml:104:28 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                            ┬  
@@ -6641,7 +6641,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:104:30 ]
+     ╭─[ rust.baml:104:30 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                              ─┬  
@@ -6651,7 +6651,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:104:33 ]
+     ╭─[ rust.baml:104:33 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                 ───┬──  
@@ -6661,7 +6661,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:104:39 ]
+     ╭─[ rust.baml:104:39 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                       ┬  
@@ -6671,7 +6671,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:104:40 ]
+     ╭─[ rust.baml:104:40 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                        ──────┬──────  
@@ -6681,7 +6681,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:104:53 ]
+     ╭─[ rust.baml:104:53 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                                     ┬  
@@ -6691,7 +6691,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:104:55 ]
+     ╭─[ rust.baml:104:55 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                                       ┬  
@@ -6701,7 +6701,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:105:9 ]
+     ╭─[ rust.baml:105:9 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │         ──┬─  
@@ -6711,7 +6711,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:105:13 ]
+     ╭─[ rust.baml:105:13 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │             ┬  
@@ -6721,7 +6721,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:105:14 ]
+     ╭─[ rust.baml:105:14 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │              ───┬──  
@@ -6731,7 +6731,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:105:20 ]
+     ╭─[ rust.baml:105:20 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                    ┬  
@@ -6741,7 +6741,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:105:21 ]
+     ╭─[ rust.baml:105:21 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                     ────┬───  
@@ -6751,7 +6751,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:105:29 ]
+     ╭─[ rust.baml:105:29 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                             ┬  
@@ -6761,7 +6761,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:105:30 ]
+     ╭─[ rust.baml:105:30 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                              ┬  
@@ -6771,7 +6771,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:105:31 ]
+     ╭─[ rust.baml:105:31 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                               ┬  
@@ -6781,7 +6781,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:105:32 ]
+     ╭─[ rust.baml:105:32 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                ────┬───  
@@ -6791,7 +6791,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:105:40 ]
+     ╭─[ rust.baml:105:40 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                        ┬  
@@ -6801,7 +6801,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:105:41 ]
+     ╭─[ rust.baml:105:41 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                         ──────┬──────  
@@ -6811,7 +6811,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:105:54 ]
+     ╭─[ rust.baml:105:54 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                                      ─┬  
@@ -6821,7 +6821,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:105:56 ]
+     ╭─[ rust.baml:105:56 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                                        ──┬─  
@@ -6831,7 +6831,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:105:60 ]
+     ╭─[ rust.baml:105:60 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                                            ┬  
@@ -6841,7 +6841,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:106:5 ]
+     ╭─[ rust.baml:106:5 ]
      │
  106 │     }
      │     ┬  
@@ -6851,7 +6851,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:109:5 ]
+     ╭─[ rust.baml:109:5 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │     ─┬─  
@@ -6861,7 +6861,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:109:9 ]
+     ╭─[ rust.baml:109:9 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │         ─┬  
@@ -6871,7 +6871,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:109:12 ]
+     ╭─[ rust.baml:109:12 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │            ─────┬─────  
@@ -6881,7 +6881,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:109:23 ]
+     ╭─[ rust.baml:109:23 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                       ┬  
@@ -6891,7 +6891,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:109:24 ]
+     ╭─[ rust.baml:109:24 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                        ┬  
@@ -6901,7 +6901,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:109:25 ]
+     ╭─[ rust.baml:109:25 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                         ──┬─  
@@ -6911,7 +6911,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:109:29 ]
+     ╭─[ rust.baml:109:29 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                             ┬  
@@ -6921,7 +6921,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:109:31 ]
+     ╭─[ rust.baml:109:31 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                               ─┬  
@@ -6931,7 +6931,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:109:34 ]
+     ╭─[ rust.baml:109:34 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                  ───┬──  
@@ -6941,7 +6941,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:109:40 ]
+     ╭─[ rust.baml:109:40 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                        ┬  
@@ -6951,7 +6951,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:109:41 ]
+     ╭─[ rust.baml:109:41 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                         ────┬───  
@@ -6961,7 +6961,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:109:49 ]
+     ╭─[ rust.baml:109:49 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                                 ┬  
@@ -6971,7 +6971,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:109:51 ]
+     ╭─[ rust.baml:109:51 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                                   ┬  
@@ -6981,7 +6981,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:110:9 ]
+     ╭─[ rust.baml:110:9 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │         ──┬─  
@@ -6991,7 +6991,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:110:13 ]
+     ╭─[ rust.baml:110:13 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │             ┬  
@@ -7001,7 +7001,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:110:14 ]
+     ╭─[ rust.baml:110:14 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │              ───┬──  
@@ -7011,7 +7011,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:110:20 ]
+     ╭─[ rust.baml:110:20 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                    ┬  
@@ -7021,7 +7021,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:110:21 ]
+     ╭─[ rust.baml:110:21 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                     ────┬───  
@@ -7031,7 +7031,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:110:29 ]
+     ╭─[ rust.baml:110:29 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                             ┬  
@@ -7041,7 +7041,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:110:30 ]
+     ╭─[ rust.baml:110:30 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                              ┬  
@@ -7051,7 +7051,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:110:31 ]
+     ╭─[ rust.baml:110:31 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                               ┬  
@@ -7061,7 +7061,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:110:32 ]
+     ╭─[ rust.baml:110:32 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                ────┬───  
@@ -7071,7 +7071,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:110:40 ]
+     ╭─[ rust.baml:110:40 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                        ┬  
@@ -7081,7 +7081,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:110:41 ]
+     ╭─[ rust.baml:110:41 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                         ────┬───  
@@ -7091,7 +7091,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:110:49 ]
+     ╭─[ rust.baml:110:49 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                 ─┬  
@@ -7101,7 +7101,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:110:51 ]
+     ╭─[ rust.baml:110:51 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                   ──┬─  
@@ -7111,7 +7111,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:110:55 ]
+     ╭─[ rust.baml:110:55 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                       ┬  
@@ -7121,7 +7121,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:111:5 ]
+     ╭─[ rust.baml:111:5 ]
      │
  111 │     }
      │     ┬  
@@ -7131,7 +7131,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:114:5 ]
+     ╭─[ rust.baml:114:5 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │     ─┬─  
@@ -7141,7 +7141,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:114:9 ]
+     ╭─[ rust.baml:114:9 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │         ─┬  
@@ -7151,7 +7151,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:114:12 ]
+     ╭─[ rust.baml:114:12 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │            ──┬─  
@@ -7161,7 +7161,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:114:16 ]
+     ╭─[ rust.baml:114:16 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                ┬  
@@ -7171,7 +7171,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:114:17 ]
+     ╭─[ rust.baml:114:17 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                 ┬  
@@ -7181,7 +7181,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:114:18 ]
+     ╭─[ rust.baml:114:18 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                  ──┬─  
@@ -7191,7 +7191,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:114:22 ]
+     ╭─[ rust.baml:114:22 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                      ┬  
@@ -7201,7 +7201,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:114:24 ]
+     ╭─[ rust.baml:114:24 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                        ─┬  
@@ -7211,7 +7211,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:114:27 ]
+     ╭─[ rust.baml:114:27 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                           ───┬──  
@@ -7221,7 +7221,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:114:33 ]
+     ╭─[ rust.baml:114:33 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                                 ┬  
@@ -7231,7 +7231,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:114:34 ]
+     ╭─[ rust.baml:114:34 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                                  ──────┬─────  
@@ -7241,7 +7241,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:114:46 ]
+     ╭─[ rust.baml:114:46 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                                              ┬  
@@ -7251,7 +7251,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:114:48 ]
+     ╭─[ rust.baml:114:48 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                                                ┬  
@@ -7261,7 +7261,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:115:9 ]
+     ╭─[ rust.baml:115:9 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │         ──┬─  
@@ -7271,7 +7271,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:115:13 ]
+     ╭─[ rust.baml:115:13 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │             ┬  
@@ -7281,7 +7281,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:115:14 ]
+     ╭─[ rust.baml:115:14 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │              ───┬──  
@@ -7291,7 +7291,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:115:20 ]
+     ╭─[ rust.baml:115:20 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                    ┬  
@@ -7301,7 +7301,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:115:21 ]
+     ╭─[ rust.baml:115:21 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                     ────┬───  
@@ -7311,7 +7311,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:115:29 ]
+     ╭─[ rust.baml:115:29 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                             ┬  
@@ -7321,7 +7321,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:115:30 ]
+     ╭─[ rust.baml:115:30 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                              ┬  
@@ -7331,7 +7331,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:115:31 ]
+     ╭─[ rust.baml:115:31 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                               ┬  
@@ -7341,7 +7341,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:115:32 ]
+     ╭─[ rust.baml:115:32 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                ────┬───  
@@ -7351,7 +7351,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:115:40 ]
+     ╭─[ rust.baml:115:40 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                        ┬  
@@ -7361,7 +7361,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:115:41 ]
+     ╭─[ rust.baml:115:41 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                         ──────┬─────  
@@ -7371,7 +7371,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:115:53 ]
+     ╭─[ rust.baml:115:53 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                                     ─┬  
@@ -7381,7 +7381,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:115:55 ]
+     ╭─[ rust.baml:115:55 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                                       ──┬─  
@@ -7391,7 +7391,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:115:59 ]
+     ╭─[ rust.baml:115:59 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                                           ┬  
@@ -7401,7 +7401,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:116:5 ]
+     ╭─[ rust.baml:116:5 ]
      │
  116 │     }
      │     ┬  
@@ -7411,7 +7411,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:119:5 ]
+     ╭─[ rust.baml:119:5 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │     ─┬─  
@@ -7421,7 +7421,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:119:9 ]
+     ╭─[ rust.baml:119:9 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │         ─┬  
@@ -7431,7 +7431,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:119:12 ]
+     ╭─[ rust.baml:119:12 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │            ────┬───  
@@ -7441,7 +7441,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:119:20 ]
+     ╭─[ rust.baml:119:20 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                    ┬  
@@ -7451,7 +7451,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:119:21 ]
+     ╭─[ rust.baml:119:21 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                     ┬  
@@ -7461,7 +7461,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:119:22 ]
+     ╭─[ rust.baml:119:22 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                      ──┬─  
@@ -7471,7 +7471,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:119:26 ]
+     ╭─[ rust.baml:119:26 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                          ┬  
@@ -7481,7 +7481,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:119:28 ]
+     ╭─[ rust.baml:119:28 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                            ─┬  
@@ -7491,7 +7491,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:119:31 ]
+     ╭─[ rust.baml:119:31 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                               ───┬──  
@@ -7501,7 +7501,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:119:37 ]
+     ╭─[ rust.baml:119:37 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                                     ┬  
@@ -7511,7 +7511,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:119:38 ]
+     ╭─[ rust.baml:119:38 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                                      ───────┬───────  
@@ -7521,7 +7521,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:119:53 ]
+     ╭─[ rust.baml:119:53 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                                                     ┬  
@@ -7531,7 +7531,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:119:55 ]
+     ╭─[ rust.baml:119:55 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                                                       ┬  
@@ -7541,7 +7541,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:120:9 ]
+     ╭─[ rust.baml:120:9 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │         ──┬─  
@@ -7551,7 +7551,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:120:13 ]
+     ╭─[ rust.baml:120:13 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │             ┬  
@@ -7561,7 +7561,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:120:14 ]
+     ╭─[ rust.baml:120:14 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │              ───┬──  
@@ -7571,7 +7571,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:120:20 ]
+     ╭─[ rust.baml:120:20 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                    ┬  
@@ -7581,7 +7581,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:120:21 ]
+     ╭─[ rust.baml:120:21 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                     ────┬───  
@@ -7591,7 +7591,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:120:29 ]
+     ╭─[ rust.baml:120:29 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                             ┬  
@@ -7601,7 +7601,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:120:30 ]
+     ╭─[ rust.baml:120:30 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                              ┬  
@@ -7611,7 +7611,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:120:31 ]
+     ╭─[ rust.baml:120:31 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                               ┬  
@@ -7621,7 +7621,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:120:32 ]
+     ╭─[ rust.baml:120:32 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                ────┬───  
@@ -7631,7 +7631,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:120:40 ]
+     ╭─[ rust.baml:120:40 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                        ┬  
@@ -7641,7 +7641,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:120:41 ]
+     ╭─[ rust.baml:120:41 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                         ───────┬───────  
@@ -7651,7 +7651,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:120:56 ]
+     ╭─[ rust.baml:120:56 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                                        ─┬  
@@ -7661,7 +7661,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:120:58 ]
+     ╭─[ rust.baml:120:58 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                                          ──┬─  
@@ -7671,7 +7671,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:120:62 ]
+     ╭─[ rust.baml:120:62 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                                              ┬  
@@ -7681,7 +7681,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:121:5 ]
+     ╭─[ rust.baml:121:5 ]
      │
  121 │     }
      │     ┬  
@@ -7691,7 +7691,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:124:5 ]
+     ╭─[ rust.baml:124:5 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │     ─┬─  
@@ -7701,7 +7701,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:124:9 ]
+     ╭─[ rust.baml:124:9 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │         ─┬  
@@ -7711,7 +7711,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:124:12 ]
+     ╭─[ rust.baml:124:12 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │            ────┬────  
@@ -7721,7 +7721,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:124:21 ]
+     ╭─[ rust.baml:124:21 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                     ┬  
@@ -7731,7 +7731,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:124:22 ]
+     ╭─[ rust.baml:124:22 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                      ┬  
@@ -7741,7 +7741,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:124:23 ]
+     ╭─[ rust.baml:124:23 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                       ──┬─  
@@ -7751,7 +7751,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:124:27 ]
+     ╭─[ rust.baml:124:27 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                           ┬  
@@ -7761,7 +7761,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:124:29 ]
+     ╭─[ rust.baml:124:29 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                             ─┬  
@@ -7771,7 +7771,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:124:32 ]
+     ╭─[ rust.baml:124:32 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                ───┬──  
@@ -7781,7 +7781,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:124:38 ]
+     ╭─[ rust.baml:124:38 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                      ┬  
@@ -7791,7 +7791,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:124:39 ]
+     ╭─[ rust.baml:124:39 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                       ────────┬───────  
@@ -7801,7 +7801,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:124:55 ]
+     ╭─[ rust.baml:124:55 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                                       ┬  
@@ -7811,7 +7811,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:124:57 ]
+     ╭─[ rust.baml:124:57 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                                         ┬  
@@ -7821,7 +7821,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:125:9 ]
+     ╭─[ rust.baml:125:9 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │         ──┬─  
@@ -7831,7 +7831,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:125:13 ]
+     ╭─[ rust.baml:125:13 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │             ┬  
@@ -7841,7 +7841,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:125:14 ]
+     ╭─[ rust.baml:125:14 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │              ───┬──  
@@ -7851,7 +7851,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:125:20 ]
+     ╭─[ rust.baml:125:20 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                    ┬  
@@ -7861,7 +7861,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:125:21 ]
+     ╭─[ rust.baml:125:21 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                     ────┬───  
@@ -7871,7 +7871,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:125:29 ]
+     ╭─[ rust.baml:125:29 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                             ┬  
@@ -7881,7 +7881,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:125:30 ]
+     ╭─[ rust.baml:125:30 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                              ┬  
@@ -7891,7 +7891,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:125:31 ]
+     ╭─[ rust.baml:125:31 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                               ┬  
@@ -7901,7 +7901,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:125:32 ]
+     ╭─[ rust.baml:125:32 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                ────┬───  
@@ -7911,7 +7911,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:125:40 ]
+     ╭─[ rust.baml:125:40 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                        ┬  
@@ -7921,7 +7921,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:125:41 ]
+     ╭─[ rust.baml:125:41 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                         ────────┬───────  
@@ -7931,7 +7931,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:125:57 ]
+     ╭─[ rust.baml:125:57 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                                         ─┬  
@@ -7941,7 +7941,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:125:59 ]
+     ╭─[ rust.baml:125:59 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                                           ──┬─  
@@ -7951,7 +7951,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:125:63 ]
+     ╭─[ rust.baml:125:63 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                                               ┬  
@@ -7961,7 +7961,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:126:5 ]
+     ╭─[ rust.baml:126:5 ]
      │
  126 │     }
      │     ┬  
@@ -7971,7 +7971,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:129:5 ]
+     ╭─[ rust.baml:129:5 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │     ─┬─  
@@ -7981,7 +7981,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:129:9 ]
+     ╭─[ rust.baml:129:9 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │         ─┬  
@@ -7991,7 +7991,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:129:12 ]
+     ╭─[ rust.baml:129:12 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │            ───────┬───────  
@@ -8001,7 +8001,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:129:27 ]
+     ╭─[ rust.baml:129:27 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                           ┬  
@@ -8011,7 +8011,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:129:28 ]
+     ╭─[ rust.baml:129:28 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                            ┬  
@@ -8021,7 +8021,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:129:29 ]
+     ╭─[ rust.baml:129:29 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                             ──┬─  
@@ -8031,7 +8031,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:129:33 ]
+     ╭─[ rust.baml:129:33 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                                 ┬  
@@ -8041,7 +8041,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:129:35 ]
+     ╭─[ rust.baml:129:35 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                                   ─┬  
@@ -8051,7 +8051,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:129:38 ]
+     ╭─[ rust.baml:129:38 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                                      ──┬─  
@@ -8061,7 +8061,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:129:43 ]
+     ╭─[ rust.baml:129:43 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                                           ┬  
@@ -8071,7 +8071,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:130:9 ]
+     ╭─[ rust.baml:130:9 ]
      │
  130 │         self.llm_body().is_some()
      │         ──┬─  
@@ -8081,7 +8081,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:130:13 ]
+     ╭─[ rust.baml:130:13 ]
      │
  130 │         self.llm_body().is_some()
      │             ┬  
@@ -8091,7 +8091,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:130:14 ]
+     ╭─[ rust.baml:130:14 ]
      │
  130 │         self.llm_body().is_some()
      │              ────┬───  
@@ -8101,7 +8101,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:130:22 ]
+     ╭─[ rust.baml:130:22 ]
      │
  130 │         self.llm_body().is_some()
      │                      ┬  
@@ -8111,7 +8111,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:130:23 ]
+     ╭─[ rust.baml:130:23 ]
      │
  130 │         self.llm_body().is_some()
      │                       ┬  
@@ -8121,7 +8121,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:130:24 ]
+     ╭─[ rust.baml:130:24 ]
      │
  130 │         self.llm_body().is_some()
      │                        ┬  
@@ -8131,7 +8131,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:130:25 ]
+     ╭─[ rust.baml:130:25 ]
      │
  130 │         self.llm_body().is_some()
      │                         ───┬───  
@@ -8141,7 +8141,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:130:32 ]
+     ╭─[ rust.baml:130:32 ]
      │
  130 │         self.llm_body().is_some()
      │                                ┬  
@@ -8151,7 +8151,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:130:33 ]
+     ╭─[ rust.baml:130:33 ]
      │
  130 │         self.llm_body().is_some()
      │                                 ┬  
@@ -8161,7 +8161,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:131:5 ]
+     ╭─[ rust.baml:131:5 ]
      │
  131 │     }
      │     ┬  
@@ -8171,7 +8171,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:134:5 ]
+     ╭─[ rust.baml:134:5 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │     ─┬─  
@@ -8181,7 +8181,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:134:9 ]
+     ╭─[ rust.baml:134:9 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │         ─┬  
@@ -8191,7 +8191,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:134:12 ]
+     ╭─[ rust.baml:134:12 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │            ────────┬───────  
@@ -8201,7 +8201,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:134:28 ]
+     ╭─[ rust.baml:134:28 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                            ┬  
@@ -8211,7 +8211,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:134:29 ]
+     ╭─[ rust.baml:134:29 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                             ┬  
@@ -8221,7 +8221,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:134:30 ]
+     ╭─[ rust.baml:134:30 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                              ──┬─  
@@ -8231,7 +8231,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:134:34 ]
+     ╭─[ rust.baml:134:34 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                                  ┬  
@@ -8241,7 +8241,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:134:36 ]
+     ╭─[ rust.baml:134:36 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                                    ─┬  
@@ -8251,7 +8251,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:134:39 ]
+     ╭─[ rust.baml:134:39 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                                       ──┬─  
@@ -8261,7 +8261,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:134:44 ]
+     ╭─[ rust.baml:134:44 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                                            ┬  
@@ -8271,7 +8271,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:135:9 ]
+     ╭─[ rust.baml:135:9 ]
      │
  135 │         self.expr_body().is_some()
      │         ──┬─  
@@ -8281,7 +8281,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:135:13 ]
+     ╭─[ rust.baml:135:13 ]
      │
  135 │         self.expr_body().is_some()
      │             ┬  
@@ -8291,7 +8291,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:135:14 ]
+     ╭─[ rust.baml:135:14 ]
      │
  135 │         self.expr_body().is_some()
      │              ────┬────  
@@ -8301,7 +8301,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:135:23 ]
+     ╭─[ rust.baml:135:23 ]
      │
  135 │         self.expr_body().is_some()
      │                       ┬  
@@ -8311,7 +8311,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:135:24 ]
+     ╭─[ rust.baml:135:24 ]
      │
  135 │         self.expr_body().is_some()
      │                        ┬  
@@ -8321,7 +8321,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:135:25 ]
+     ╭─[ rust.baml:135:25 ]
      │
  135 │         self.expr_body().is_some()
      │                         ┬  
@@ -8331,7 +8331,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:135:26 ]
+     ╭─[ rust.baml:135:26 ]
      │
  135 │         self.expr_body().is_some()
      │                          ───┬───  
@@ -8341,7 +8341,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:135:33 ]
+     ╭─[ rust.baml:135:33 ]
      │
  135 │         self.expr_body().is_some()
      │                                 ┬  
@@ -8351,7 +8351,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:135:34 ]
+     ╭─[ rust.baml:135:34 ]
      │
  135 │         self.expr_body().is_some()
      │                                  ┬  
@@ -8361,7 +8361,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:136:5 ]
+     ╭─[ rust.baml:136:5 ]
      │
  136 │     }
      │     ┬  
@@ -8371,7 +8371,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:137:1 ]
+     ╭─[ rust.baml:137:1 ]
      │
  137 │ }
      │ ┬  
@@ -8381,7 +8381,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:139:1 ]
+     ╭─[ rust.baml:139:1 ]
      │
  139 │ impl ParameterList {
      │ ──┬─  
@@ -8391,7 +8391,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:139:6 ]
+     ╭─[ rust.baml:139:6 ]
      │
  139 │ impl ParameterList {
      │      ──────┬──────  
@@ -8401,7 +8401,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:139:20 ]
+     ╭─[ rust.baml:139:20 ]
      │
  139 │ impl ParameterList {
      │                    ┬  
@@ -8411,7 +8411,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:141:5 ]
+     ╭─[ rust.baml:141:5 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │     ─┬─  
@@ -8421,7 +8421,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:141:9 ]
+     ╭─[ rust.baml:141:9 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │         ─┬  
@@ -8431,7 +8431,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:141:12 ]
+     ╭─[ rust.baml:141:12 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │            ───┬──  
@@ -8441,7 +8441,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:141:18 ]
+     ╭─[ rust.baml:141:18 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                  ┬  
@@ -8451,7 +8451,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:141:19 ]
+     ╭─[ rust.baml:141:19 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                   ┬  
@@ -8461,7 +8461,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:141:20 ]
+     ╭─[ rust.baml:141:20 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                    ──┬─  
@@ -8471,7 +8471,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:141:24 ]
+     ╭─[ rust.baml:141:24 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                        ┬  
@@ -8481,7 +8481,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:141:26 ]
+     ╭─[ rust.baml:141:26 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                          ─┬  
@@ -8491,7 +8491,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:141:29 ]
+     ╭─[ rust.baml:141:29 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                             ──┬─  
@@ -8501,7 +8501,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:141:34 ]
+     ╭─[ rust.baml:141:34 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                  ────┬───  
@@ -8511,7 +8511,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:141:42 ]
+     ╭─[ rust.baml:141:42 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                          ┬  
@@ -8521,7 +8521,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:141:43 ]
+     ╭─[ rust.baml:141:43 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                           ──┬─  
@@ -8531,7 +8531,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '='
-     ╭─[ 0:141:48 ]
+     ╭─[ rust.baml:141:48 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                                ┬  
@@ -8541,7 +8541,7 @@ Error: Expected top-level declaration, found '='
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:141:50 ]
+     ╭─[ rust.baml:141:50 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                                  ────┬────  
@@ -8551,7 +8551,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:141:59 ]
+     ╭─[ rust.baml:141:59 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                                           ┬  
@@ -8561,7 +8561,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:141:61 ]
+     ╭─[ rust.baml:141:61 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                                             ┬  
@@ -8571,7 +8571,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:142:9 ]
+     ╭─[ rust.baml:142:9 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │         ──┬─  
@@ -8581,7 +8581,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:142:13 ]
+     ╭─[ rust.baml:142:13 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │             ┬  
@@ -8591,7 +8591,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:142:14 ]
+     ╭─[ rust.baml:142:14 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │              ───┬──  
@@ -8601,7 +8601,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:142:20 ]
+     ╭─[ rust.baml:142:20 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                    ┬  
@@ -8611,7 +8611,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:142:21 ]
+     ╭─[ rust.baml:142:21 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                     ────┬───  
@@ -8621,7 +8621,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:142:29 ]
+     ╭─[ rust.baml:142:29 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                             ┬  
@@ -8631,7 +8631,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:142:30 ]
+     ╭─[ rust.baml:142:30 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                              ┬  
@@ -8641,7 +8641,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:142:31 ]
+     ╭─[ rust.baml:142:31 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                               ┬  
@@ -8651,7 +8651,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:142:32 ]
+     ╭─[ rust.baml:142:32 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                ─────┬────  
@@ -8661,7 +8661,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:142:42 ]
+     ╭─[ rust.baml:142:42 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                          ┬  
@@ -8671,7 +8671,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:142:43 ]
+     ╭─[ rust.baml:142:43 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                           ────┬────  
@@ -8681,7 +8681,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:142:52 ]
+     ╭─[ rust.baml:142:52 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                                    ─┬  
@@ -8691,7 +8691,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:142:54 ]
+     ╭─[ rust.baml:142:54 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                                      ──┬─  
@@ -8701,7 +8701,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:142:58 ]
+     ╭─[ rust.baml:142:58 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                                          ┬  
@@ -8711,7 +8711,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:143:5 ]
+     ╭─[ rust.baml:143:5 ]
      │
  143 │     }
      │     ┬  
@@ -8721,7 +8721,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:144:1 ]
+     ╭─[ rust.baml:144:1 ]
      │
  144 │ }
      │ ┬  
@@ -8731,7 +8731,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:146:1 ]
+     ╭─[ rust.baml:146:1 ]
      │
  146 │ impl ClassDef {
      │ ──┬─  
@@ -8741,7 +8741,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:146:6 ]
+     ╭─[ rust.baml:146:6 ]
      │
  146 │ impl ClassDef {
      │      ────┬───  
@@ -8751,7 +8751,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:146:15 ]
+     ╭─[ rust.baml:146:15 ]
      │
  146 │ impl ClassDef {
      │               ┬  
@@ -8761,7 +8761,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:148:5 ]
+     ╭─[ rust.baml:148:5 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │     ─┬─  
@@ -8771,7 +8771,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:148:9 ]
+     ╭─[ rust.baml:148:9 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │         ─┬  
@@ -8781,7 +8781,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:148:12 ]
+     ╭─[ rust.baml:148:12 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │            ──┬─  
@@ -8791,7 +8791,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:148:16 ]
+     ╭─[ rust.baml:148:16 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                ┬  
@@ -8801,7 +8801,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:148:17 ]
+     ╭─[ rust.baml:148:17 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                 ┬  
@@ -8811,7 +8811,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:148:18 ]
+     ╭─[ rust.baml:148:18 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                  ──┬─  
@@ -8821,7 +8821,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:148:22 ]
+     ╭─[ rust.baml:148:22 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                      ┬  
@@ -8831,7 +8831,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:148:24 ]
+     ╭─[ rust.baml:148:24 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                        ─┬  
@@ -8841,7 +8841,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:148:27 ]
+     ╭─[ rust.baml:148:27 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                           ───┬──  
@@ -8851,7 +8851,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:148:33 ]
+     ╭─[ rust.baml:148:33 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                 ┬  
@@ -8861,7 +8861,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:148:34 ]
+     ╭─[ rust.baml:148:34 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                  ─────┬─────  
@@ -8871,7 +8871,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:148:45 ]
+     ╭─[ rust.baml:148:45 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                             ┬  
@@ -8881,7 +8881,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:148:47 ]
+     ╭─[ rust.baml:148:47 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                               ┬  
@@ -8891,7 +8891,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:149:9 ]
+     ╭─[ rust.baml:149:9 ]
      │
  149 │         self.syntax
      │         ──┬─  
@@ -8901,7 +8901,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:149:13 ]
+     ╭─[ rust.baml:149:13 ]
      │
  149 │         self.syntax
      │             ┬  
@@ -8911,7 +8911,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:149:14 ]
+     ╭─[ rust.baml:149:14 ]
      │
  149 │         self.syntax
      │              ───┬──  
@@ -8921,7 +8921,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:150:13 ]
+     ╭─[ rust.baml:150:13 ]
      │
  150 │             .children_with_tokens()
      │             ┬  
@@ -8931,7 +8931,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:150:14 ]
+     ╭─[ rust.baml:150:14 ]
      │
  150 │             .children_with_tokens()
      │              ──────────┬─────────  
@@ -8941,7 +8941,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:150:34 ]
+     ╭─[ rust.baml:150:34 ]
      │
  150 │             .children_with_tokens()
      │                                  ┬  
@@ -8951,7 +8951,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:150:35 ]
+     ╭─[ rust.baml:150:35 ]
      │
  150 │             .children_with_tokens()
      │                                   ┬  
@@ -8961,7 +8961,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:151:13 ]
+     ╭─[ rust.baml:151:13 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │             ┬  
@@ -8971,7 +8971,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:151:14 ]
+     ╭─[ rust.baml:151:14 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │              ─────┬────  
@@ -8981,7 +8981,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:151:24 ]
+     ╭─[ rust.baml:151:24 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                        ┬  
@@ -8991,7 +8991,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:151:25 ]
+     ╭─[ rust.baml:151:25 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                         ──┬──  
@@ -9001,7 +9001,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:151:30 ]
+     ╭─[ rust.baml:151:30 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                              ─┬  
@@ -9011,7 +9011,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:151:32 ]
+     ╭─[ rust.baml:151:32 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                ─────┬─────  
@@ -9021,7 +9021,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:151:43 ]
+     ╭─[ rust.baml:151:43 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                           ─┬  
@@ -9031,7 +9031,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:151:45 ]
+     ╭─[ rust.baml:151:45 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                             ─────┬────  
@@ -9041,7 +9041,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:151:55 ]
+     ╭─[ rust.baml:151:55 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                                       ┬  
@@ -9051,7 +9051,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:152:13 ]
+     ╭─[ rust.baml:152:13 ]
      │
  152 │             .filter(|token| {
      │             ┬  
@@ -9061,7 +9061,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:152:14 ]
+     ╭─[ rust.baml:152:14 ]
      │
  152 │             .filter(|token| {
      │              ───┬──  
@@ -9071,7 +9071,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:152:20 ]
+     ╭─[ rust.baml:152:20 ]
      │
  152 │             .filter(|token| {
      │                    ┬  
@@ -9081,7 +9081,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:152:21 ]
+     ╭─[ rust.baml:152:21 ]
      │
  152 │             .filter(|token| {
      │                     ┬  
@@ -9091,7 +9091,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:152:22 ]
+     ╭─[ rust.baml:152:22 ]
      │
  152 │             .filter(|token| {
      │                      ──┬──  
@@ -9101,7 +9101,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:152:27 ]
+     ╭─[ rust.baml:152:27 ]
      │
  152 │             .filter(|token| {
      │                           ┬  
@@ -9111,7 +9111,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:152:29 ]
+     ╭─[ rust.baml:152:29 ]
      │
  152 │             .filter(|token| {
      │                             ┬  
@@ -9121,7 +9121,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:17 ]
+     ╭─[ rust.baml:153:17 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                 ──┬──  
@@ -9131,7 +9131,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:153:22 ]
+     ╭─[ rust.baml:153:22 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                      ┬  
@@ -9141,7 +9141,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:23 ]
+     ╭─[ rust.baml:153:23 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                       ──┬─  
@@ -9151,7 +9151,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:153:27 ]
+     ╭─[ rust.baml:153:27 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                           ┬  
@@ -9161,7 +9161,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:153:28 ]
+     ╭─[ rust.baml:153:28 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                            ┬  
@@ -9171,7 +9171,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=='
-     ╭─[ 0:153:30 ]
+     ╭─[ rust.baml:153:30 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                              ─┬  
@@ -9181,7 +9181,7 @@ Error: Expected top-level declaration, found '=='
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:33 ]
+     ╭─[ rust.baml:153:33 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                 ─────┬────  
@@ -9191,7 +9191,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:153:43 ]
+     ╭─[ rust.baml:153:43 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                           ─┬  
@@ -9201,7 +9201,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:45 ]
+     ╭─[ rust.baml:153:45 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                             ──┬─  
@@ -9211,7 +9211,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '&&'
-     ╭─[ 0:153:50 ]
+     ╭─[ rust.baml:153:50 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                  ─┬  
@@ -9221,7 +9221,7 @@ Error: Expected top-level declaration, found '&&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:53 ]
+     ╭─[ rust.baml:153:53 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                     ──┬──  
@@ -9231,7 +9231,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:153:58 ]
+     ╭─[ rust.baml:153:58 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                          ┬  
@@ -9241,7 +9241,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:59 ]
+     ╭─[ rust.baml:153:59 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                           ───┬──  
@@ -9251,7 +9251,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:153:65 ]
+     ╭─[ rust.baml:153:65 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                 ┬  
@@ -9261,7 +9261,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:153:66 ]
+     ╭─[ rust.baml:153:66 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                  ┬  
@@ -9271,7 +9271,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=='
-     ╭─[ 0:153:68 ]
+     ╭─[ rust.baml:153:68 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                    ─┬  
@@ -9281,7 +9281,7 @@ Error: Expected top-level declaration, found '=='
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:71 ]
+     ╭─[ rust.baml:153:71 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                       ──┬─  
@@ -9291,7 +9291,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:153:75 ]
+     ╭─[ rust.baml:153:75 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                           ┬  
@@ -9301,7 +9301,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:76 ]
+     ╭─[ rust.baml:153:76 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                            ──┬─  
@@ -9311,7 +9311,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:153:80 ]
+     ╭─[ rust.baml:153:80 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                ┬  
@@ -9321,7 +9321,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:81 ]
+     ╭─[ rust.baml:153:81 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                 ───┬──  
@@ -9331,7 +9331,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:153:87 ]
+     ╭─[ rust.baml:153:87 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                       ┬  
@@ -9341,7 +9341,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:153:88 ]
+     ╭─[ rust.baml:153:88 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                        ──┬──  
@@ -9351,7 +9351,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:153:93 ]
+     ╭─[ rust.baml:153:93 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                             ┬  
@@ -9361,7 +9361,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:153:94 ]
+     ╭─[ rust.baml:153:94 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                              ┬  
@@ -9371,7 +9371,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:153:95 ]
+     ╭─[ rust.baml:153:95 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                               ┬  
@@ -9381,7 +9381,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:154:13 ]
+     ╭─[ rust.baml:154:13 ]
      │
  154 │             })
      │             ┬  
@@ -9391,7 +9391,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:154:14 ]
+     ╭─[ rust.baml:154:14 ]
      │
  154 │             })
      │              ┬  
@@ -9401,7 +9401,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:155:13 ]
+     ╭─[ rust.baml:155:13 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │             ┬  
@@ -9411,7 +9411,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:155:14 ]
+     ╭─[ rust.baml:155:14 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │              ─┬─  
@@ -9421,7 +9421,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:155:17 ]
+     ╭─[ rust.baml:155:17 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │                 ┬  
@@ -9431,7 +9431,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found integer
-     ╭─[ 0:155:18 ]
+     ╭─[ rust.baml:155:18 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │                  ┬  
@@ -9441,7 +9441,7 @@ Error: Expected top-level declaration, found integer
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:155:19 ]
+     ╭─[ rust.baml:155:19 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │                   ┬  
@@ -9451,7 +9451,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:156:5 ]
+     ╭─[ rust.baml:156:5 ]
      │
  156 │     }
      │     ┬  
@@ -9461,7 +9461,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:159:5 ]
+     ╭─[ rust.baml:159:5 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │     ─┬─  
@@ -9471,7 +9471,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:159:9 ]
+     ╭─[ rust.baml:159:9 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │         ─┬  
@@ -9481,7 +9481,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:159:12 ]
+     ╭─[ rust.baml:159:12 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │            ───┬──  
@@ -9491,7 +9491,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:159:18 ]
+     ╭─[ rust.baml:159:18 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                  ┬  
@@ -9501,7 +9501,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:159:19 ]
+     ╭─[ rust.baml:159:19 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                   ┬  
@@ -9511,7 +9511,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:159:20 ]
+     ╭─[ rust.baml:159:20 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                    ──┬─  
@@ -9521,7 +9521,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:159:24 ]
+     ╭─[ rust.baml:159:24 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                        ┬  
@@ -9531,7 +9531,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:159:26 ]
+     ╭─[ rust.baml:159:26 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                          ─┬  
@@ -9541,7 +9541,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:159:29 ]
+     ╭─[ rust.baml:159:29 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                             ──┬─  
@@ -9551,7 +9551,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:159:34 ]
+     ╭─[ rust.baml:159:34 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                  ────┬───  
@@ -9561,7 +9561,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:159:42 ]
+     ╭─[ rust.baml:159:42 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                          ┬  
@@ -9571,7 +9571,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:159:43 ]
+     ╭─[ rust.baml:159:43 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                           ──┬─  
@@ -9581,7 +9581,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '='
-     ╭─[ 0:159:48 ]
+     ╭─[ rust.baml:159:48 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                                ┬  
@@ -9591,7 +9591,7 @@ Error: Expected top-level declaration, found '='
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:159:50 ]
+     ╭─[ rust.baml:159:50 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                                  ──┬──  
@@ -9601,7 +9601,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:159:55 ]
+     ╭─[ rust.baml:159:55 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                                       ┬  
@@ -9611,7 +9611,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:159:57 ]
+     ╭─[ rust.baml:159:57 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                                         ┬  
@@ -9621,7 +9621,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:160:9 ]
+     ╭─[ rust.baml:160:9 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │         ──┬─  
@@ -9631,7 +9631,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:160:13 ]
+     ╭─[ rust.baml:160:13 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │             ┬  
@@ -9641,7 +9641,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:160:14 ]
+     ╭─[ rust.baml:160:14 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │              ───┬──  
@@ -9651,7 +9651,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:160:20 ]
+     ╭─[ rust.baml:160:20 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                    ┬  
@@ -9661,7 +9661,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:160:21 ]
+     ╭─[ rust.baml:160:21 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                     ────┬───  
@@ -9671,7 +9671,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:160:29 ]
+     ╭─[ rust.baml:160:29 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                             ┬  
@@ -9681,7 +9681,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:160:30 ]
+     ╭─[ rust.baml:160:30 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                              ┬  
@@ -9691,7 +9691,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:160:31 ]
+     ╭─[ rust.baml:160:31 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                               ┬  
@@ -9701,7 +9701,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:160:32 ]
+     ╭─[ rust.baml:160:32 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                ─────┬────  
@@ -9711,7 +9711,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:160:42 ]
+     ╭─[ rust.baml:160:42 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                          ┬  
@@ -9721,7 +9721,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:160:43 ]
+     ╭─[ rust.baml:160:43 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                           ──┬──  
@@ -9731,7 +9731,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:160:48 ]
+     ╭─[ rust.baml:160:48 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                                ─┬  
@@ -9741,7 +9741,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:160:50 ]
+     ╭─[ rust.baml:160:50 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                                  ──┬─  
@@ -9751,7 +9751,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:160:54 ]
+     ╭─[ rust.baml:160:54 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                                      ┬  
@@ -9761,7 +9761,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:161:5 ]
+     ╭─[ rust.baml:161:5 ]
      │
  161 │     }
      │     ┬  
@@ -9771,7 +9771,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:164:5 ]
+     ╭─[ rust.baml:164:5 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │     ─┬─  
@@ -9781,7 +9781,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:164:9 ]
+     ╭─[ rust.baml:164:9 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │         ─┬  
@@ -9791,7 +9791,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:164:12 ]
+     ╭─[ rust.baml:164:12 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │            ────────┬───────  
@@ -9801,7 +9801,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:164:28 ]
+     ╭─[ rust.baml:164:28 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                            ┬  
@@ -9811,7 +9811,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:164:29 ]
+     ╭─[ rust.baml:164:29 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                             ┬  
@@ -9821,7 +9821,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:164:30 ]
+     ╭─[ rust.baml:164:30 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                              ──┬─  
@@ -9831,7 +9831,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:164:34 ]
+     ╭─[ rust.baml:164:34 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                  ┬  
@@ -9841,7 +9841,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:164:36 ]
+     ╭─[ rust.baml:164:36 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                    ─┬  
@@ -9851,7 +9851,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:164:39 ]
+     ╭─[ rust.baml:164:39 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                       ──┬─  
@@ -9861,7 +9861,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:164:44 ]
+     ╭─[ rust.baml:164:44 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                            ────┬───  
@@ -9871,7 +9871,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:164:52 ]
+     ╭─[ rust.baml:164:52 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                    ┬  
@@ -9881,7 +9881,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:164:53 ]
+     ╭─[ rust.baml:164:53 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                     ──┬─  
@@ -9891,7 +9891,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '='
-     ╭─[ 0:164:58 ]
+     ╭─[ rust.baml:164:58 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                          ┬  
@@ -9901,7 +9901,7 @@ Error: Expected top-level declaration, found '='
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:164:60 ]
+     ╭─[ rust.baml:164:60 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                            ───────┬──────  
@@ -9911,7 +9911,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:164:74 ]
+     ╭─[ rust.baml:164:74 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                                          ┬  
@@ -9921,7 +9921,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:164:76 ]
+     ╭─[ rust.baml:164:76 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                                            ┬  
@@ -9931,7 +9931,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:165:9 ]
+     ╭─[ rust.baml:165:9 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │         ──┬─  
@@ -9941,7 +9941,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:165:13 ]
+     ╭─[ rust.baml:165:13 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │             ┬  
@@ -9951,7 +9951,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:165:14 ]
+     ╭─[ rust.baml:165:14 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │              ───┬──  
@@ -9961,7 +9961,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:165:20 ]
+     ╭─[ rust.baml:165:20 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                    ┬  
@@ -9971,7 +9971,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:165:21 ]
+     ╭─[ rust.baml:165:21 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                     ────┬───  
@@ -9981,7 +9981,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:165:29 ]
+     ╭─[ rust.baml:165:29 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                             ┬  
@@ -9991,7 +9991,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:165:30 ]
+     ╭─[ rust.baml:165:30 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                              ┬  
@@ -10001,7 +10001,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:165:31 ]
+     ╭─[ rust.baml:165:31 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                               ┬  
@@ -10011,7 +10011,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:165:32 ]
+     ╭─[ rust.baml:165:32 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                ─────┬────  
@@ -10021,7 +10021,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:165:42 ]
+     ╭─[ rust.baml:165:42 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                          ┬  
@@ -10031,7 +10031,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:165:43 ]
+     ╭─[ rust.baml:165:43 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                           ───────┬──────  
@@ -10041,7 +10041,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:165:57 ]
+     ╭─[ rust.baml:165:57 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                                         ─┬  
@@ -10051,7 +10051,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:165:59 ]
+     ╭─[ rust.baml:165:59 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                                           ──┬─  
@@ -10061,7 +10061,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:165:63 ]
+     ╭─[ rust.baml:165:63 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                                               ┬  
@@ -10071,7 +10071,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:166:5 ]
+     ╭─[ rust.baml:166:5 ]
      │
  166 │     }
      │     ┬  
@@ -10081,7 +10081,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:167:1 ]
+     ╭─[ rust.baml:167:1 ]
      │
  167 │ }
      │ ┬  
@@ -10091,7 +10091,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:169:1 ]
+     ╭─[ rust.baml:169:1 ]
      │
  169 │ impl Field {
      │ ──┬─  
@@ -10101,7 +10101,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:169:6 ]
+     ╭─[ rust.baml:169:6 ]
      │
  169 │ impl Field {
      │      ──┬──  
@@ -10111,7 +10111,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:169:12 ]
+     ╭─[ rust.baml:169:12 ]
      │
  169 │ impl Field {
      │            ┬  
@@ -10121,7 +10121,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:171:5 ]
+     ╭─[ rust.baml:171:5 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │     ─┬─  
@@ -10131,7 +10131,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:171:9 ]
+     ╭─[ rust.baml:171:9 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │         ─┬  
@@ -10141,7 +10141,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:171:12 ]
+     ╭─[ rust.baml:171:12 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │            ──┬─  
@@ -10151,7 +10151,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:171:16 ]
+     ╭─[ rust.baml:171:16 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                ┬  
@@ -10161,7 +10161,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:171:17 ]
+     ╭─[ rust.baml:171:17 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                 ┬  
@@ -10171,7 +10171,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:171:18 ]
+     ╭─[ rust.baml:171:18 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                  ──┬─  
@@ -10181,7 +10181,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:171:22 ]
+     ╭─[ rust.baml:171:22 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                      ┬  
@@ -10191,7 +10191,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:171:24 ]
+     ╭─[ rust.baml:171:24 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                        ─┬  
@@ -10201,7 +10201,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:171:27 ]
+     ╭─[ rust.baml:171:27 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                           ───┬──  
@@ -10211,7 +10211,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:171:33 ]
+     ╭─[ rust.baml:171:33 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                 ┬  
@@ -10221,7 +10221,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:171:34 ]
+     ╭─[ rust.baml:171:34 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                  ─────┬─────  
@@ -10231,7 +10231,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:171:45 ]
+     ╭─[ rust.baml:171:45 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                             ┬  
@@ -10241,7 +10241,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:171:47 ]
+     ╭─[ rust.baml:171:47 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                               ┬  
@@ -10251,7 +10251,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:172:9 ]
+     ╭─[ rust.baml:172:9 ]
      │
  172 │         self.syntax
      │         ──┬─  
@@ -10261,7 +10261,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:172:13 ]
+     ╭─[ rust.baml:172:13 ]
      │
  172 │         self.syntax
      │             ┬  
@@ -10271,7 +10271,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:172:14 ]
+     ╭─[ rust.baml:172:14 ]
      │
  172 │         self.syntax
      │              ───┬──  
@@ -10281,7 +10281,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:173:13 ]
+     ╭─[ rust.baml:173:13 ]
      │
  173 │             .children_with_tokens()
      │             ┬  
@@ -10291,7 +10291,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:173:14 ]
+     ╭─[ rust.baml:173:14 ]
      │
  173 │             .children_with_tokens()
      │              ──────────┬─────────  
@@ -10301,7 +10301,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:173:34 ]
+     ╭─[ rust.baml:173:34 ]
      │
  173 │             .children_with_tokens()
      │                                  ┬  
@@ -10311,7 +10311,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:173:35 ]
+     ╭─[ rust.baml:173:35 ]
      │
  173 │             .children_with_tokens()
      │                                   ┬  
@@ -10321,7 +10321,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:174:13 ]
+     ╭─[ rust.baml:174:13 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │             ┬  
@@ -10331,7 +10331,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:174:14 ]
+     ╭─[ rust.baml:174:14 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │              ─────┬────  
@@ -10341,7 +10341,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:174:24 ]
+     ╭─[ rust.baml:174:24 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                        ┬  
@@ -10351,7 +10351,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:174:25 ]
+     ╭─[ rust.baml:174:25 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                         ──┬──  
@@ -10361,7 +10361,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:174:30 ]
+     ╭─[ rust.baml:174:30 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                              ─┬  
@@ -10371,7 +10371,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:174:32 ]
+     ╭─[ rust.baml:174:32 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                ─────┬─────  
@@ -10381,7 +10381,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:174:43 ]
+     ╭─[ rust.baml:174:43 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                           ─┬  
@@ -10391,7 +10391,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:174:45 ]
+     ╭─[ rust.baml:174:45 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                             ─────┬────  
@@ -10401,7 +10401,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:174:55 ]
+     ╭─[ rust.baml:174:55 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                                       ┬  
@@ -10411,7 +10411,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:175:13 ]
+     ╭─[ rust.baml:175:13 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │             ┬  
@@ -10421,7 +10421,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:175:14 ]
+     ╭─[ rust.baml:175:14 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │              ──┬─  
@@ -10431,7 +10431,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:175:18 ]
+     ╭─[ rust.baml:175:18 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                  ┬  
@@ -10441,7 +10441,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:175:19 ]
+     ╭─[ rust.baml:175:19 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                   ┬  
@@ -10451,7 +10451,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:175:20 ]
+     ╭─[ rust.baml:175:20 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                    ──┬──  
@@ -10461,7 +10461,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:175:25 ]
+     ╭─[ rust.baml:175:25 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                         ┬  
@@ -10471,7 +10471,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:175:27 ]
+     ╭─[ rust.baml:175:27 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                           ──┬──  
@@ -10481,7 +10481,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:175:32 ]
+     ╭─[ rust.baml:175:32 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                ┬  
@@ -10491,7 +10491,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:175:33 ]
+     ╭─[ rust.baml:175:33 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                 ──┬─  
@@ -10501,7 +10501,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:175:37 ]
+     ╭─[ rust.baml:175:37 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                     ┬  
@@ -10511,7 +10511,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:175:38 ]
+     ╭─[ rust.baml:175:38 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                      ┬  
@@ -10521,7 +10521,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=='
-     ╭─[ 0:175:40 ]
+     ╭─[ rust.baml:175:40 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                        ─┬  
@@ -10531,7 +10531,7 @@ Error: Expected top-level declaration, found '=='
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:175:43 ]
+     ╭─[ rust.baml:175:43 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                           ─────┬────  
@@ -10541,7 +10541,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:175:53 ]
+     ╭─[ rust.baml:175:53 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                                     ─┬  
@@ -10551,7 +10551,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:175:55 ]
+     ╭─[ rust.baml:175:55 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                                       ──┬─  
@@ -10561,7 +10561,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:175:59 ]
+     ╭─[ rust.baml:175:59 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                                           ┬  
@@ -10571,7 +10571,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:176:5 ]
+     ╭─[ rust.baml:176:5 ]
      │
  176 │     }
      │     ┬  
@@ -10581,7 +10581,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:179:5 ]
+     ╭─[ rust.baml:179:5 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │     ─┬─  
@@ -10591,7 +10591,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:179:9 ]
+     ╭─[ rust.baml:179:9 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │         ─┬  
@@ -10601,7 +10601,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:179:12 ]
+     ╭─[ rust.baml:179:12 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │            ─┬  
@@ -10611,7 +10611,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:179:14 ]
+     ╭─[ rust.baml:179:14 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │              ┬  
@@ -10621,7 +10621,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:179:15 ]
+     ╭─[ rust.baml:179:15 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │               ┬  
@@ -10631,7 +10631,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:179:16 ]
+     ╭─[ rust.baml:179:16 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                ──┬─  
@@ -10641,7 +10641,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:179:20 ]
+     ╭─[ rust.baml:179:20 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                    ┬  
@@ -10651,7 +10651,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:179:22 ]
+     ╭─[ rust.baml:179:22 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                      ─┬  
@@ -10661,7 +10661,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:179:25 ]
+     ╭─[ rust.baml:179:25 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                         ───┬──  
@@ -10671,7 +10671,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:179:31 ]
+     ╭─[ rust.baml:179:31 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                               ┬  
@@ -10681,7 +10681,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:179:32 ]
+     ╭─[ rust.baml:179:32 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                                ────┬───  
@@ -10691,7 +10691,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:179:40 ]
+     ╭─[ rust.baml:179:40 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                                        ┬  
@@ -10701,7 +10701,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:179:42 ]
+     ╭─[ rust.baml:179:42 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                                          ┬  
@@ -10711,7 +10711,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:180:9 ]
+     ╭─[ rust.baml:180:9 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │         ──┬─  
@@ -10721,7 +10721,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:180:13 ]
+     ╭─[ rust.baml:180:13 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │             ┬  
@@ -10731,7 +10731,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:180:14 ]
+     ╭─[ rust.baml:180:14 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │              ───┬──  
@@ -10741,7 +10741,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:180:20 ]
+     ╭─[ rust.baml:180:20 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                    ┬  
@@ -10751,7 +10751,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:180:21 ]
+     ╭─[ rust.baml:180:21 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                     ────┬───  
@@ -10761,7 +10761,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:180:29 ]
+     ╭─[ rust.baml:180:29 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                             ┬  
@@ -10771,7 +10771,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:180:30 ]
+     ╭─[ rust.baml:180:30 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                              ┬  
@@ -10781,7 +10781,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:180:31 ]
+     ╭─[ rust.baml:180:31 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                               ┬  
@@ -10791,7 +10791,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:180:32 ]
+     ╭─[ rust.baml:180:32 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                ────┬───  
@@ -10801,7 +10801,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:180:40 ]
+     ╭─[ rust.baml:180:40 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                        ┬  
@@ -10811,7 +10811,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:180:41 ]
+     ╭─[ rust.baml:180:41 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                         ────┬───  
@@ -10821,7 +10821,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:180:49 ]
+     ╭─[ rust.baml:180:49 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                 ─┬  
@@ -10831,7 +10831,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:180:51 ]
+     ╭─[ rust.baml:180:51 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                   ──┬─  
@@ -10841,7 +10841,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:180:55 ]
+     ╭─[ rust.baml:180:55 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                       ┬  
@@ -10851,7 +10851,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:181:5 ]
+     ╭─[ rust.baml:181:5 ]
      │
  181 │     }
      │     ┬  
@@ -10861,7 +10861,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:184:5 ]
+     ╭─[ rust.baml:184:5 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │     ─┬─  
@@ -10871,7 +10871,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:184:9 ]
+     ╭─[ rust.baml:184:9 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │         ─┬  
@@ -10881,7 +10881,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:184:12 ]
+     ╭─[ rust.baml:184:12 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │            ─────┬────  
@@ -10891,7 +10891,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:184:22 ]
+     ╭─[ rust.baml:184:22 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                      ┬  
@@ -10901,7 +10901,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:184:23 ]
+     ╭─[ rust.baml:184:23 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                       ┬  
@@ -10911,7 +10911,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:184:24 ]
+     ╭─[ rust.baml:184:24 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                        ──┬─  
@@ -10921,7 +10921,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:184:28 ]
+     ╭─[ rust.baml:184:28 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                            ┬  
@@ -10931,7 +10931,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:184:30 ]
+     ╭─[ rust.baml:184:30 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                              ─┬  
@@ -10941,7 +10941,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:184:33 ]
+     ╭─[ rust.baml:184:33 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                 ──┬─  
@@ -10951,7 +10951,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:184:38 ]
+     ╭─[ rust.baml:184:38 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                      ────┬───  
@@ -10961,7 +10961,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:184:46 ]
+     ╭─[ rust.baml:184:46 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                              ┬  
@@ -10971,7 +10971,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:184:47 ]
+     ╭─[ rust.baml:184:47 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                               ──┬─  
@@ -10981,7 +10981,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '='
-     ╭─[ 0:184:52 ]
+     ╭─[ rust.baml:184:52 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                                    ┬  
@@ -10991,7 +10991,7 @@ Error: Expected top-level declaration, found '='
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:184:54 ]
+     ╭─[ rust.baml:184:54 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                                      ────┬────  
@@ -11001,7 +11001,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:184:63 ]
+     ╭─[ rust.baml:184:63 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                                               ┬  
@@ -11011,7 +11011,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:184:65 ]
+     ╭─[ rust.baml:184:65 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                                                 ┬  
@@ -11021,7 +11021,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:185:9 ]
+     ╭─[ rust.baml:185:9 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │         ──┬─  
@@ -11031,7 +11031,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:185:13 ]
+     ╭─[ rust.baml:185:13 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │             ┬  
@@ -11041,7 +11041,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:185:14 ]
+     ╭─[ rust.baml:185:14 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │              ───┬──  
@@ -11051,7 +11051,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:185:20 ]
+     ╭─[ rust.baml:185:20 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                    ┬  
@@ -11061,7 +11061,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:185:21 ]
+     ╭─[ rust.baml:185:21 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                     ────┬───  
@@ -11071,7 +11071,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:185:29 ]
+     ╭─[ rust.baml:185:29 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                             ┬  
@@ -11081,7 +11081,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:185:30 ]
+     ╭─[ rust.baml:185:30 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                              ┬  
@@ -11091,7 +11091,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:185:31 ]
+     ╭─[ rust.baml:185:31 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                               ┬  
@@ -11101,7 +11101,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:185:32 ]
+     ╭─[ rust.baml:185:32 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                ─────┬────  
@@ -11111,7 +11111,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:185:42 ]
+     ╭─[ rust.baml:185:42 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                          ┬  
@@ -11121,7 +11121,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:185:43 ]
+     ╭─[ rust.baml:185:43 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                           ────┬────  
@@ -11131,7 +11131,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:185:52 ]
+     ╭─[ rust.baml:185:52 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                                    ─┬  
@@ -11141,7 +11141,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:185:54 ]
+     ╭─[ rust.baml:185:54 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                                      ──┬─  
@@ -11151,7 +11151,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:185:58 ]
+     ╭─[ rust.baml:185:58 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                                          ┬  
@@ -11161,7 +11161,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:186:5 ]
+     ╭─[ rust.baml:186:5 ]
      │
  186 │     }
      │     ┬  
@@ -11171,7 +11171,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:187:1 ]
+     ╭─[ rust.baml:187:1 ]
      │
  187 │ }
      │ ┬  
@@ -11181,7 +11181,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found '#'
-     ╭─[ 0:190:1 ]
+     ╭─[ rust.baml:190:1 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │ ┬  
@@ -11191,7 +11191,7 @@ Error: Expected top-level declaration, found '#'
 ─────╯
 
 Error: Expected top-level declaration, found '['
-     ╭─[ 0:190:2 ]
+     ╭─[ rust.baml:190:2 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │  ┬  
@@ -11201,7 +11201,7 @@ Error: Expected top-level declaration, found '['
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:190:3 ]
+     ╭─[ rust.baml:190:3 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │   ───┬──  
@@ -11211,7 +11211,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:190:9 ]
+     ╭─[ rust.baml:190:9 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │         ┬  
@@ -11221,7 +11221,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:190:10 ]
+     ╭─[ rust.baml:190:10 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │          ──┬──  
@@ -11231,7 +11231,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:190:15 ]
+     ╭─[ rust.baml:190:15 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │               ┬  
@@ -11241,7 +11241,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:190:17 ]
+     ╭─[ rust.baml:190:17 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                 ──┬──  
@@ -11251,7 +11251,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:190:22 ]
+     ╭─[ rust.baml:190:22 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                      ┬  
@@ -11261,7 +11261,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:190:24 ]
+     ╭─[ rust.baml:190:24 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                        ────┬────  
@@ -11271,7 +11271,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:190:33 ]
+     ╭─[ rust.baml:190:33 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                 ┬  
@@ -11281,7 +11281,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:190:35 ]
+     ╭─[ rust.baml:190:35 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                   ─┬  
@@ -11291,7 +11291,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:190:37 ]
+     ╭─[ rust.baml:190:37 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                     ┬  
@@ -11301,7 +11301,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:190:39 ]
+     ╭─[ rust.baml:190:39 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                       ──┬─  
@@ -11311,7 +11311,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:190:43 ]
+     ╭─[ rust.baml:190:43 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                           ┬  
@@ -11321,7 +11321,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ']'
-     ╭─[ 0:190:44 ]
+     ╭─[ rust.baml:190:44 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                            ┬  
@@ -11331,7 +11331,7 @@ Error: Expected top-level declaration, found ']'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:191:1 ]
+     ╭─[ rust.baml:191:1 ]
      │
  191 │ pub enum Item {
      │ ─┬─  
@@ -11341,7 +11341,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 0:192:13 ]
+     ╭─[ rust.baml:192:13 ]
      │
  192 │     Function(FunctionDef),
      │             ┬  
@@ -11351,7 +11351,7 @@ Error: Expected Unexpected token in enum body, found '('
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 0:192:25 ]
+     ╭─[ rust.baml:192:25 ]
      │
  192 │     Function(FunctionDef),
      │                         ┬  
@@ -11361,7 +11361,7 @@ Error: Expected Unexpected token in enum body, found ')'
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 0:192:26 ]
+     ╭─[ rust.baml:192:26 ]
      │
  192 │     Function(FunctionDef),
      │                          ┬  
@@ -11371,7 +11371,7 @@ Error: Expected Unexpected token in enum body, found ','
 ─────╯
 
 Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 0:193:10 ]
+     ╭─[ rust.baml:193:10 ]
      │
  193 │     Class(ClassDef),
      │          ┬  
@@ -11381,7 +11381,7 @@ Error: Expected Unexpected token in enum body, found '('
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 0:193:19 ]
+     ╭─[ rust.baml:193:19 ]
      │
  193 │     Class(ClassDef),
      │                   ┬  
@@ -11391,7 +11391,7 @@ Error: Expected Unexpected token in enum body, found ')'
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 0:193:20 ]
+     ╭─[ rust.baml:193:20 ]
      │
  193 │     Class(ClassDef),
      │                    ┬  
@@ -11401,7 +11401,7 @@ Error: Expected Unexpected token in enum body, found ','
 ─────╯
 
 Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 0:194:9 ]
+     ╭─[ rust.baml:194:9 ]
      │
  194 │     Enum(EnumDef),
      │         ┬  
@@ -11411,7 +11411,7 @@ Error: Expected Unexpected token in enum body, found '('
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 0:194:17 ]
+     ╭─[ rust.baml:194:17 ]
      │
  194 │     Enum(EnumDef),
      │                 ┬  
@@ -11421,7 +11421,7 @@ Error: Expected Unexpected token in enum body, found ')'
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 0:194:18 ]
+     ╭─[ rust.baml:194:18 ]
      │
  194 │     Enum(EnumDef),
      │                  ┬  
@@ -11431,7 +11431,7 @@ Error: Expected Unexpected token in enum body, found ','
 ─────╯
 
 Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 0:195:11 ]
+     ╭─[ rust.baml:195:11 ]
      │
  195 │     Client(ClientDef),
      │           ┬  
@@ -11441,7 +11441,7 @@ Error: Expected Unexpected token in enum body, found '('
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 0:195:21 ]
+     ╭─[ rust.baml:195:21 ]
      │
  195 │     Client(ClientDef),
      │                     ┬  
@@ -11451,7 +11451,7 @@ Error: Expected Unexpected token in enum body, found ')'
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 0:195:22 ]
+     ╭─[ rust.baml:195:22 ]
      │
  195 │     Client(ClientDef),
      │                      ┬  
@@ -11461,7 +11461,7 @@ Error: Expected Unexpected token in enum body, found ','
 ─────╯
 
 Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 0:196:9 ]
+     ╭─[ rust.baml:196:9 ]
      │
  196 │     Test(TestDef),
      │         ┬  
@@ -11471,7 +11471,7 @@ Error: Expected Unexpected token in enum body, found '('
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 0:196:17 ]
+     ╭─[ rust.baml:196:17 ]
      │
  196 │     Test(TestDef),
      │                 ┬  
@@ -11481,7 +11481,7 @@ Error: Expected Unexpected token in enum body, found ')'
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 0:196:18 ]
+     ╭─[ rust.baml:196:18 ]
      │
  196 │     Test(TestDef),
      │                  ┬  
@@ -11491,7 +11491,7 @@ Error: Expected Unexpected token in enum body, found ','
 ─────╯
 
 Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 0:197:16 ]
+     ╭─[ rust.baml:197:16 ]
      │
  197 │     RetryPolicy(RetryPolicyDef),
      │                ┬  
@@ -11501,7 +11501,7 @@ Error: Expected Unexpected token in enum body, found '('
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 0:197:31 ]
+     ╭─[ rust.baml:197:31 ]
      │
  197 │     RetryPolicy(RetryPolicyDef),
      │                               ┬  
@@ -11511,7 +11511,7 @@ Error: Expected Unexpected token in enum body, found ')'
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 0:197:32 ]
+     ╭─[ rust.baml:197:32 ]
      │
  197 │     RetryPolicy(RetryPolicyDef),
      │                                ┬  
@@ -11521,7 +11521,7 @@ Error: Expected Unexpected token in enum body, found ','
 ─────╯
 
 Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 0:198:19 ]
+     ╭─[ rust.baml:198:19 ]
      │
  198 │     TemplateString(TemplateStringDef),
      │                   ┬  
@@ -11531,7 +11531,7 @@ Error: Expected Unexpected token in enum body, found '('
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 0:198:37 ]
+     ╭─[ rust.baml:198:37 ]
      │
  198 │     TemplateString(TemplateStringDef),
      │                                     ┬  
@@ -11541,7 +11541,7 @@ Error: Expected Unexpected token in enum body, found ')'
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 0:198:38 ]
+     ╭─[ rust.baml:198:38 ]
      │
  198 │     TemplateString(TemplateStringDef),
      │                                      ┬  
@@ -11551,7 +11551,7 @@ Error: Expected Unexpected token in enum body, found ','
 ─────╯
 
 Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 0:199:14 ]
+     ╭─[ rust.baml:199:14 ]
      │
  199 │     TypeAlias(TypeAliasDef),
      │              ┬  
@@ -11561,7 +11561,7 @@ Error: Expected Unexpected token in enum body, found '('
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 0:199:27 ]
+     ╭─[ rust.baml:199:27 ]
      │
  199 │     TypeAlias(TypeAliasDef),
      │                           ┬  
@@ -11571,7 +11571,7 @@ Error: Expected Unexpected token in enum body, found ')'
 ─────╯
 
 Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 0:199:28 ]
+     ╭─[ rust.baml:199:28 ]
      │
  199 │     TypeAlias(TypeAliasDef),
      │                            ┬  
@@ -11581,7 +11581,7 @@ Error: Expected Unexpected token in enum body, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:202:1 ]
+     ╭─[ rust.baml:202:1 ]
      │
  202 │ impl AstNode for Item {
      │ ──┬─  
@@ -11591,7 +11591,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:202:6 ]
+     ╭─[ rust.baml:202:6 ]
      │
  202 │ impl AstNode for Item {
      │      ───┬───  
@@ -11601,7 +11601,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found for
-     ╭─[ 0:202:14 ]
+     ╭─[ rust.baml:202:14 ]
      │
  202 │ impl AstNode for Item {
      │              ─┬─  
@@ -11611,7 +11611,7 @@ Error: Expected top-level declaration, found for
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:202:18 ]
+     ╭─[ rust.baml:202:18 ]
      │
  202 │ impl AstNode for Item {
      │                  ──┬─  
@@ -11621,7 +11621,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:202:23 ]
+     ╭─[ rust.baml:202:23 ]
      │
  202 │ impl AstNode for Item {
      │                       ┬  
@@ -11631,7 +11631,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:203:26 ]
+     ╭─[ rust.baml:203:26 ]
      │
  203 │     type Language = crate::BamlLanguage;
      │                          ─┬  
@@ -11641,7 +11641,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:203:28 ]
+     ╭─[ rust.baml:203:28 ]
      │
  203 │     type Language = crate::BamlLanguage;
      │                            ──────┬─────  
@@ -11651,7 +11651,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ';'
-     ╭─[ 0:203:40 ]
+     ╭─[ rust.baml:203:40 ]
      │
  203 │     type Language = crate::BamlLanguage;
      │                                        ┬  
@@ -11661,7 +11661,7 @@ Error: Expected top-level declaration, found ';'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:5 ]
+     ╭─[ rust.baml:205:5 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │     ─┬  
@@ -11671,7 +11671,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:8 ]
+     ╭─[ rust.baml:205:8 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │        ────┬───  
@@ -11681,7 +11681,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:205:16 ]
+     ╭─[ rust.baml:205:16 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                ┬  
@@ -11691,7 +11691,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:17 ]
+     ╭─[ rust.baml:205:17 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                 ──┬─  
@@ -11701,7 +11701,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ':'
-     ╭─[ 0:205:21 ]
+     ╭─[ rust.baml:205:21 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                     ┬  
@@ -11711,7 +11711,7 @@ Error: Expected top-level declaration, found ':'
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:205:23 ]
+     ╭─[ rust.baml:205:23 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                       ┬  
@@ -11721,7 +11721,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:24 ]
+     ╭─[ rust.baml:205:24 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                        ──┬─  
@@ -11731,7 +11731,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:205:28 ]
+     ╭─[ rust.baml:205:28 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                            ─┬  
@@ -11741,7 +11741,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:30 ]
+     ╭─[ rust.baml:205:30 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                              ────┬───  
@@ -11751,7 +11751,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:39 ]
+     ╭─[ rust.baml:205:39 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                       ─┬  
@@ -11761,7 +11761,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:42 ]
+     ╭─[ rust.baml:205:42 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                          ──┬──  
@@ -11771,7 +11771,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:205:47 ]
+     ╭─[ rust.baml:205:47 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                               ─┬  
@@ -11781,7 +11781,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:49 ]
+     ╭─[ rust.baml:205:49 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                 ────┬───  
@@ -11791,7 +11791,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:205:57 ]
+     ╭─[ rust.baml:205:57 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                         ┬  
@@ -11801,7 +11801,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:205:58 ]
+     ╭─[ rust.baml:205:58 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                          ─┬  
@@ -11811,7 +11811,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:60 ]
+     ╭─[ rust.baml:205:60 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                            ──┬─  
@@ -11821,7 +11821,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:205:64 ]
+     ╭─[ rust.baml:205:64 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                                ┬  
@@ -11831,7 +11831,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:205:66 ]
+     ╭─[ rust.baml:205:66 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                                  ─┬  
@@ -11841,7 +11841,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:205:69 ]
+     ╭─[ rust.baml:205:69 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                                     ──┬─  
@@ -11851,7 +11851,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:205:74 ]
+     ╭─[ rust.baml:205:74 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                                          ┬  
@@ -11861,7 +11861,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:206:9 ]
+     ╭─[ rust.baml:206:9 ]
      │
  206 │         matches!(
      │         ───┬───  
@@ -11871,7 +11871,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '!'
-     ╭─[ 0:206:16 ]
+     ╭─[ rust.baml:206:16 ]
      │
  206 │         matches!(
      │                ┬  
@@ -11881,7 +11881,7 @@ Error: Expected top-level declaration, found '!'
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:206:17 ]
+     ╭─[ rust.baml:206:17 ]
      │
  206 │         matches!(
      │                 ┬  
@@ -11891,7 +11891,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:207:13 ]
+     ╭─[ rust.baml:207:13 ]
      │
  207 │             kind,
      │             ──┬─  
@@ -11901,7 +11901,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:207:17 ]
+     ╭─[ rust.baml:207:17 ]
      │
  207 │             kind,
      │                 ┬  
@@ -11911,7 +11911,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:208:13 ]
+     ╭─[ rust.baml:208:13 ]
      │
  208 │             SyntaxKind::FUNCTION_DEF
      │             ─────┬────  
@@ -11921,7 +11921,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:208:23 ]
+     ╭─[ rust.baml:208:23 ]
      │
  208 │             SyntaxKind::FUNCTION_DEF
      │                       ─┬  
@@ -11931,7 +11931,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:208:25 ]
+     ╭─[ rust.baml:208:25 ]
      │
  208 │             SyntaxKind::FUNCTION_DEF
      │                         ──────┬─────  
@@ -11941,7 +11941,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:209:17 ]
+     ╭─[ rust.baml:209:17 ]
      │
  209 │                 | SyntaxKind::CLASS_DEF
      │                 ┬  
@@ -11951,7 +11951,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:209:19 ]
+     ╭─[ rust.baml:209:19 ]
      │
  209 │                 | SyntaxKind::CLASS_DEF
      │                   ─────┬────  
@@ -11961,7 +11961,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:209:29 ]
+     ╭─[ rust.baml:209:29 ]
      │
  209 │                 | SyntaxKind::CLASS_DEF
      │                             ─┬  
@@ -11971,7 +11971,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:209:31 ]
+     ╭─[ rust.baml:209:31 ]
      │
  209 │                 | SyntaxKind::CLASS_DEF
      │                               ────┬────  
@@ -11981,7 +11981,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:210:17 ]
+     ╭─[ rust.baml:210:17 ]
      │
  210 │                 | SyntaxKind::ENUM_DEF
      │                 ┬  
@@ -11991,7 +11991,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:210:19 ]
+     ╭─[ rust.baml:210:19 ]
      │
  210 │                 | SyntaxKind::ENUM_DEF
      │                   ─────┬────  
@@ -12001,7 +12001,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:210:29 ]
+     ╭─[ rust.baml:210:29 ]
      │
  210 │                 | SyntaxKind::ENUM_DEF
      │                             ─┬  
@@ -12011,7 +12011,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:210:31 ]
+     ╭─[ rust.baml:210:31 ]
      │
  210 │                 | SyntaxKind::ENUM_DEF
      │                               ────┬───  
@@ -12021,7 +12021,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:211:17 ]
+     ╭─[ rust.baml:211:17 ]
      │
  211 │                 | SyntaxKind::CLIENT_DEF
      │                 ┬  
@@ -12031,7 +12031,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:211:19 ]
+     ╭─[ rust.baml:211:19 ]
      │
  211 │                 | SyntaxKind::CLIENT_DEF
      │                   ─────┬────  
@@ -12041,7 +12041,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:211:29 ]
+     ╭─[ rust.baml:211:29 ]
      │
  211 │                 | SyntaxKind::CLIENT_DEF
      │                             ─┬  
@@ -12051,7 +12051,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:211:31 ]
+     ╭─[ rust.baml:211:31 ]
      │
  211 │                 | SyntaxKind::CLIENT_DEF
      │                               ─────┬────  
@@ -12061,7 +12061,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:212:17 ]
+     ╭─[ rust.baml:212:17 ]
      │
  212 │                 | SyntaxKind::TEST_DEF
      │                 ┬  
@@ -12071,7 +12071,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:212:19 ]
+     ╭─[ rust.baml:212:19 ]
      │
  212 │                 | SyntaxKind::TEST_DEF
      │                   ─────┬────  
@@ -12081,7 +12081,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:212:29 ]
+     ╭─[ rust.baml:212:29 ]
      │
  212 │                 | SyntaxKind::TEST_DEF
      │                             ─┬  
@@ -12091,7 +12091,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:212:31 ]
+     ╭─[ rust.baml:212:31 ]
      │
  212 │                 | SyntaxKind::TEST_DEF
      │                               ────┬───  
@@ -12101,7 +12101,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:213:17 ]
+     ╭─[ rust.baml:213:17 ]
      │
  213 │                 | SyntaxKind::RETRY_POLICY_DEF
      │                 ┬  
@@ -12111,7 +12111,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:213:19 ]
+     ╭─[ rust.baml:213:19 ]
      │
  213 │                 | SyntaxKind::RETRY_POLICY_DEF
      │                   ─────┬────  
@@ -12121,7 +12121,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:213:29 ]
+     ╭─[ rust.baml:213:29 ]
      │
  213 │                 | SyntaxKind::RETRY_POLICY_DEF
      │                             ─┬  
@@ -12131,7 +12131,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:213:31 ]
+     ╭─[ rust.baml:213:31 ]
      │
  213 │                 | SyntaxKind::RETRY_POLICY_DEF
      │                               ────────┬───────  
@@ -12141,7 +12141,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:214:17 ]
+     ╭─[ rust.baml:214:17 ]
      │
  214 │                 | SyntaxKind::TEMPLATE_STRING_DEF
      │                 ┬  
@@ -12151,7 +12151,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:214:19 ]
+     ╭─[ rust.baml:214:19 ]
      │
  214 │                 | SyntaxKind::TEMPLATE_STRING_DEF
      │                   ─────┬────  
@@ -12161,7 +12161,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:214:29 ]
+     ╭─[ rust.baml:214:29 ]
      │
  214 │                 | SyntaxKind::TEMPLATE_STRING_DEF
      │                             ─┬  
@@ -12171,7 +12171,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:214:31 ]
+     ╭─[ rust.baml:214:31 ]
      │
  214 │                 | SyntaxKind::TEMPLATE_STRING_DEF
      │                               ─────────┬─────────  
@@ -12181,7 +12181,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '|'
-     ╭─[ 0:215:17 ]
+     ╭─[ rust.baml:215:17 ]
      │
  215 │                 | SyntaxKind::TYPE_ALIAS_DEF
      │                 ┬  
@@ -12191,7 +12191,7 @@ Error: Expected top-level declaration, found '|'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:215:19 ]
+     ╭─[ rust.baml:215:19 ]
      │
  215 │                 | SyntaxKind::TYPE_ALIAS_DEF
      │                   ─────┬────  
@@ -12201,7 +12201,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:215:29 ]
+     ╭─[ rust.baml:215:29 ]
      │
  215 │                 | SyntaxKind::TYPE_ALIAS_DEF
      │                             ─┬  
@@ -12211,7 +12211,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:215:31 ]
+     ╭─[ rust.baml:215:31 ]
      │
  215 │                 | SyntaxKind::TYPE_ALIAS_DEF
      │                               ───────┬──────  
@@ -12221,7 +12221,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:216:9 ]
+     ╭─[ rust.baml:216:9 ]
      │
  216 │         )
      │         ┬  
@@ -12231,7 +12231,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:217:5 ]
+     ╭─[ rust.baml:217:5 ]
      │
  217 │     }
      │     ┬  
@@ -12241,7 +12241,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:219:5 ]
+     ╭─[ rust.baml:219:5 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │     ─┬  
@@ -12251,7 +12251,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:219:8 ]
+     ╭─[ rust.baml:219:8 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │        ──┬─  
@@ -12261,7 +12261,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:219:12 ]
+     ╭─[ rust.baml:219:12 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │            ┬  
@@ -12271,7 +12271,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:219:13 ]
+     ╭─[ rust.baml:219:13 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │             ───┬──  
@@ -12281,7 +12281,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ':'
-     ╭─[ 0:219:19 ]
+     ╭─[ rust.baml:219:19 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                   ┬  
@@ -12291,7 +12291,7 @@ Error: Expected top-level declaration, found ':'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:219:21 ]
+     ╭─[ rust.baml:219:21 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                     ─────┬────  
@@ -12301,7 +12301,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:219:31 ]
+     ╭─[ rust.baml:219:31 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                               ┬  
@@ -12311,7 +12311,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:219:33 ]
+     ╭─[ rust.baml:219:33 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                 ─┬  
@@ -12321,7 +12321,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:219:36 ]
+     ╭─[ rust.baml:219:36 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                    ───┬──  
@@ -12331,7 +12331,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '<'
-     ╭─[ 0:219:42 ]
+     ╭─[ rust.baml:219:42 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                          ┬  
@@ -12341,7 +12341,7 @@ Error: Expected top-level declaration, found '<'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:219:43 ]
+     ╭─[ rust.baml:219:43 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                           ──┬─  
@@ -12351,7 +12351,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '>'
-     ╭─[ 0:219:47 ]
+     ╭─[ rust.baml:219:47 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                               ┬  
@@ -12361,7 +12361,7 @@ Error: Expected top-level declaration, found '>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:219:49 ]
+     ╭─[ rust.baml:219:49 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                                 ┬  
@@ -12371,7 +12371,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found match
-     ╭─[ 0:220:9 ]
+     ╭─[ rust.baml:220:9 ]
      │
  220 │         match syntax.kind() {
      │         ──┬──  
@@ -12381,7 +12381,7 @@ Error: Expected top-level declaration, found match
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:220:15 ]
+     ╭─[ rust.baml:220:15 ]
      │
  220 │         match syntax.kind() {
      │               ───┬──  
@@ -12391,7 +12391,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:220:21 ]
+     ╭─[ rust.baml:220:21 ]
      │
  220 │         match syntax.kind() {
      │                     ┬  
@@ -12401,7 +12401,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:220:22 ]
+     ╭─[ rust.baml:220:22 ]
      │
  220 │         match syntax.kind() {
      │                      ──┬─  
@@ -12411,7 +12411,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:220:26 ]
+     ╭─[ rust.baml:220:26 ]
      │
  220 │         match syntax.kind() {
      │                          ┬  
@@ -12421,7 +12421,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:220:27 ]
+     ╭─[ rust.baml:220:27 ]
      │
  220 │         match syntax.kind() {
      │                           ┬  
@@ -12431,7 +12431,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:220:29 ]
+     ╭─[ rust.baml:220:29 ]
      │
  220 │         match syntax.kind() {
      │                             ┬  
@@ -12441,7 +12441,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:221:13 ]
+     ╭─[ rust.baml:221:13 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │             ─────┬────  
@@ -12451,7 +12451,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:221:23 ]
+     ╭─[ rust.baml:221:23 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                       ─┬  
@@ -12461,7 +12461,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:221:25 ]
+     ╭─[ rust.baml:221:25 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                         ──────┬─────  
@@ -12471,7 +12471,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:221:38 ]
+     ╭─[ rust.baml:221:38 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                      ─┬  
@@ -12481,7 +12481,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:221:41 ]
+     ╭─[ rust.baml:221:41 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                         ──┬─  
@@ -12491,7 +12491,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:221:45 ]
+     ╭─[ rust.baml:221:45 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                             ┬  
@@ -12501,7 +12501,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:221:46 ]
+     ╭─[ rust.baml:221:46 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                              ──┬─  
@@ -12511,7 +12511,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:221:50 ]
+     ╭─[ rust.baml:221:50 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                  ─┬  
@@ -12521,7 +12521,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:221:52 ]
+     ╭─[ rust.baml:221:52 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                    ────┬───  
@@ -12531,7 +12531,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:221:60 ]
+     ╭─[ rust.baml:221:60 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                            ┬  
@@ -12541,7 +12541,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:221:61 ]
+     ╭─[ rust.baml:221:61 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                             ─────┬─────  
@@ -12551,7 +12551,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:221:73 ]
+     ╭─[ rust.baml:221:73 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                         ┬  
@@ -12561,7 +12561,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:221:75 ]
+     ╭─[ rust.baml:221:75 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                           ───┬──  
@@ -12571,7 +12571,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:221:82 ]
+     ╭─[ rust.baml:221:82 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                                  ┬  
@@ -12581,7 +12581,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:221:83 ]
+     ╭─[ rust.baml:221:83 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                                   ┬  
@@ -12591,7 +12591,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:221:84 ]
+     ╭─[ rust.baml:221:84 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                                    ┬  
@@ -12601,7 +12601,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:221:85 ]
+     ╭─[ rust.baml:221:85 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                                     ┬  
@@ -12611,7 +12611,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:222:13 ]
+     ╭─[ rust.baml:222:13 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │             ─────┬────  
@@ -12621,7 +12621,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:222:23 ]
+     ╭─[ rust.baml:222:23 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                       ─┬  
@@ -12631,7 +12631,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:222:25 ]
+     ╭─[ rust.baml:222:25 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                         ────┬────  
@@ -12641,7 +12641,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:222:35 ]
+     ╭─[ rust.baml:222:35 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                   ─┬  
@@ -12651,7 +12651,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:222:38 ]
+     ╭─[ rust.baml:222:38 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                      ──┬─  
@@ -12661,7 +12661,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:222:42 ]
+     ╭─[ rust.baml:222:42 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                          ┬  
@@ -12671,7 +12671,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:222:43 ]
+     ╭─[ rust.baml:222:43 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                           ──┬─  
@@ -12681,7 +12681,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:222:47 ]
+     ╭─[ rust.baml:222:47 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                               ─┬  
@@ -12691,7 +12691,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:222:49 ]
+     ╭─[ rust.baml:222:49 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                 ──┬──  
@@ -12701,7 +12701,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:222:54 ]
+     ╭─[ rust.baml:222:54 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                      ┬  
@@ -12711,7 +12711,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:222:55 ]
+     ╭─[ rust.baml:222:55 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                       ────┬───  
@@ -12721,7 +12721,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:222:64 ]
+     ╭─[ rust.baml:222:64 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                ┬  
@@ -12731,7 +12731,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:222:66 ]
+     ╭─[ rust.baml:222:66 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                  ───┬──  
@@ -12741,7 +12741,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:222:73 ]
+     ╭─[ rust.baml:222:73 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                         ┬  
@@ -12751,7 +12751,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:222:74 ]
+     ╭─[ rust.baml:222:74 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                          ┬  
@@ -12761,7 +12761,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:222:75 ]
+     ╭─[ rust.baml:222:75 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                           ┬  
@@ -12771,7 +12771,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:222:76 ]
+     ╭─[ rust.baml:222:76 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                            ┬  
@@ -12781,7 +12781,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:223:13 ]
+     ╭─[ rust.baml:223:13 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │             ─────┬────  
@@ -12791,7 +12791,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:223:23 ]
+     ╭─[ rust.baml:223:23 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                       ─┬  
@@ -12801,7 +12801,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:223:25 ]
+     ╭─[ rust.baml:223:25 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                         ────┬───  
@@ -12811,7 +12811,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:223:34 ]
+     ╭─[ rust.baml:223:34 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                  ─┬  
@@ -12821,7 +12821,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:223:37 ]
+     ╭─[ rust.baml:223:37 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                     ──┬─  
@@ -12831,7 +12831,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:223:41 ]
+     ╭─[ rust.baml:223:41 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                         ┬  
@@ -12841,7 +12841,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:223:42 ]
+     ╭─[ rust.baml:223:42 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                          ──┬─  
@@ -12851,7 +12851,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:223:46 ]
+     ╭─[ rust.baml:223:46 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                              ─┬  
@@ -12861,7 +12861,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:223:48 ]
+     ╭─[ rust.baml:223:48 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                ──┬─  
@@ -12871,7 +12871,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:223:52 ]
+     ╭─[ rust.baml:223:52 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                    ┬  
@@ -12881,7 +12881,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:223:53 ]
+     ╭─[ rust.baml:223:53 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                     ───┬───  
@@ -12891,7 +12891,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:223:61 ]
+     ╭─[ rust.baml:223:61 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                             ┬  
@@ -12901,7 +12901,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:223:63 ]
+     ╭─[ rust.baml:223:63 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                               ───┬──  
@@ -12911,7 +12911,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:223:70 ]
+     ╭─[ rust.baml:223:70 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                                      ┬  
@@ -12921,7 +12921,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:223:71 ]
+     ╭─[ rust.baml:223:71 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                                       ┬  
@@ -12931,7 +12931,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:223:72 ]
+     ╭─[ rust.baml:223:72 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                                        ┬  
@@ -12941,7 +12941,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:223:73 ]
+     ╭─[ rust.baml:223:73 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                                         ┬  
@@ -12951,7 +12951,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:224:13 ]
+     ╭─[ rust.baml:224:13 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │             ─────┬────  
@@ -12961,7 +12961,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:224:23 ]
+     ╭─[ rust.baml:224:23 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                       ─┬  
@@ -12971,7 +12971,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:224:25 ]
+     ╭─[ rust.baml:224:25 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                         ─────┬────  
@@ -12981,7 +12981,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:224:36 ]
+     ╭─[ rust.baml:224:36 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                    ─┬  
@@ -12991,7 +12991,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:224:39 ]
+     ╭─[ rust.baml:224:39 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                       ──┬─  
@@ -13001,7 +13001,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:224:43 ]
+     ╭─[ rust.baml:224:43 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                           ┬  
@@ -13011,7 +13011,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:224:44 ]
+     ╭─[ rust.baml:224:44 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                            ──┬─  
@@ -13021,7 +13021,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:224:48 ]
+     ╭─[ rust.baml:224:48 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                ─┬  
@@ -13031,7 +13031,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:224:50 ]
+     ╭─[ rust.baml:224:50 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                  ───┬──  
@@ -13041,7 +13041,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:224:56 ]
+     ╭─[ rust.baml:224:56 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                        ┬  
@@ -13051,7 +13051,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:224:57 ]
+     ╭─[ rust.baml:224:57 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                         ────┬────  
@@ -13061,7 +13061,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:224:67 ]
+     ╭─[ rust.baml:224:67 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                   ┬  
@@ -13071,7 +13071,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:224:69 ]
+     ╭─[ rust.baml:224:69 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                     ───┬──  
@@ -13081,7 +13081,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:224:76 ]
+     ╭─[ rust.baml:224:76 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                            ┬  
@@ -13091,7 +13091,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:224:77 ]
+     ╭─[ rust.baml:224:77 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                             ┬  
@@ -13101,7 +13101,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:224:78 ]
+     ╭─[ rust.baml:224:78 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                              ┬  
@@ -13111,7 +13111,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:224:79 ]
+     ╭─[ rust.baml:224:79 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                               ┬  
@@ -13121,7 +13121,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:225:13 ]
+     ╭─[ rust.baml:225:13 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │             ─────┬────  
@@ -13131,7 +13131,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:225:23 ]
+     ╭─[ rust.baml:225:23 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                       ─┬  
@@ -13141,7 +13141,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:225:25 ]
+     ╭─[ rust.baml:225:25 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                         ────┬───  
@@ -13151,7 +13151,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:225:34 ]
+     ╭─[ rust.baml:225:34 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                  ─┬  
@@ -13161,7 +13161,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:225:37 ]
+     ╭─[ rust.baml:225:37 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                     ──┬─  
@@ -13171,7 +13171,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:225:41 ]
+     ╭─[ rust.baml:225:41 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                         ┬  
@@ -13181,7 +13181,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:225:42 ]
+     ╭─[ rust.baml:225:42 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                          ──┬─  
@@ -13191,7 +13191,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:225:46 ]
+     ╭─[ rust.baml:225:46 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                              ─┬  
@@ -13201,7 +13201,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:225:48 ]
+     ╭─[ rust.baml:225:48 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                ──┬─  
@@ -13211,7 +13211,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:225:52 ]
+     ╭─[ rust.baml:225:52 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                    ┬  
@@ -13221,7 +13221,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:225:53 ]
+     ╭─[ rust.baml:225:53 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                     ───┬───  
@@ -13231,7 +13231,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:225:61 ]
+     ╭─[ rust.baml:225:61 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                             ┬  
@@ -13241,7 +13241,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:225:63 ]
+     ╭─[ rust.baml:225:63 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                               ───┬──  
@@ -13251,7 +13251,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:225:70 ]
+     ╭─[ rust.baml:225:70 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                                      ┬  
@@ -13261,7 +13261,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:225:71 ]
+     ╭─[ rust.baml:225:71 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                                       ┬  
@@ -13271,7 +13271,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:225:72 ]
+     ╭─[ rust.baml:225:72 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                                        ┬  
@@ -13281,7 +13281,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:225:73 ]
+     ╭─[ rust.baml:225:73 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                                         ┬  
@@ -13291,7 +13291,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:226:13 ]
+     ╭─[ rust.baml:226:13 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │             ─────┬────  
@@ -13301,7 +13301,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:226:23 ]
+     ╭─[ rust.baml:226:23 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                       ─┬  
@@ -13311,7 +13311,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:226:25 ]
+     ╭─[ rust.baml:226:25 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                         ────────┬───────  
@@ -13321,7 +13321,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:226:42 ]
+     ╭─[ rust.baml:226:42 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                          ─┬  
@@ -13331,7 +13331,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:226:45 ]
+     ╭─[ rust.baml:226:45 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                             ──┬─  
@@ -13341,7 +13341,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:226:49 ]
+     ╭─[ rust.baml:226:49 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                 ┬  
@@ -13351,7 +13351,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:226:50 ]
+     ╭─[ rust.baml:226:50 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                  ──┬─  
@@ -13361,7 +13361,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:226:54 ]
+     ╭─[ rust.baml:226:54 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                      ─┬  
@@ -13371,7 +13371,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:226:56 ]
+     ╭─[ rust.baml:226:56 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                        ─────┬─────  
@@ -13381,7 +13381,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:226:67 ]
+     ╭─[ rust.baml:226:67 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                   ┬  
@@ -13391,7 +13391,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:226:68 ]
+     ╭─[ rust.baml:226:68 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                    ───────┬──────  
@@ -13401,7 +13401,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:226:83 ]
+     ╭─[ rust.baml:226:83 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                   ┬  
@@ -13411,7 +13411,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:226:85 ]
+     ╭─[ rust.baml:226:85 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                     ───┬──  
@@ -13421,7 +13421,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:226:92 ]
+     ╭─[ rust.baml:226:92 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                            ┬  
@@ -13431,7 +13431,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:226:93 ]
+     ╭─[ rust.baml:226:93 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                             ┬  
@@ -13441,7 +13441,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:226:94 ]
+     ╭─[ rust.baml:226:94 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                              ┬  
@@ -13451,7 +13451,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:226:95 ]
+     ╭─[ rust.baml:226:95 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                               ┬  
@@ -13461,7 +13461,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:227:13 ]
+     ╭─[ rust.baml:227:13 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │             ─────┬────  
@@ -13471,7 +13471,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:227:23 ]
+     ╭─[ rust.baml:227:23 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │                       ─┬  
@@ -13481,7 +13481,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:227:25 ]
+     ╭─[ rust.baml:227:25 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │                         ─────────┬─────────  
@@ -13491,7 +13491,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:227:45 ]
+     ╭─[ rust.baml:227:45 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │                                             ─┬  
@@ -13501,7 +13501,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:227:48 ]
+     ╭─[ rust.baml:227:48 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │                                                ┬  
@@ -13511,7 +13511,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:228:17 ]
+     ╭─[ rust.baml:228:17 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                 ──┬─  
@@ -13521,7 +13521,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:228:21 ]
+     ╭─[ rust.baml:228:21 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                     ┬  
@@ -13531,7 +13531,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:228:22 ]
+     ╭─[ rust.baml:228:22 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                      ──┬─  
@@ -13541,7 +13541,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:228:26 ]
+     ╭─[ rust.baml:228:26 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                          ─┬  
@@ -13551,7 +13551,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:228:28 ]
+     ╭─[ rust.baml:228:28 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                            ───────┬──────  
@@ -13561,7 +13561,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:228:42 ]
+     ╭─[ rust.baml:228:42 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                          ┬  
@@ -13571,7 +13571,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:228:43 ]
+     ╭─[ rust.baml:228:43 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                           ────────┬────────  
@@ -13581,7 +13581,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:228:61 ]
+     ╭─[ rust.baml:228:61 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                             ┬  
@@ -13591,7 +13591,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:228:63 ]
+     ╭─[ rust.baml:228:63 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                               ───┬──  
@@ -13601,7 +13601,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:228:70 ]
+     ╭─[ rust.baml:228:70 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                                      ┬  
@@ -13611,7 +13611,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:228:71 ]
+     ╭─[ rust.baml:228:71 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                                       ┬  
@@ -13621,7 +13621,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:228:72 ]
+     ╭─[ rust.baml:228:72 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                                        ┬  
@@ -13631,7 +13631,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:229:13 ]
+     ╭─[ rust.baml:229:13 ]
      │
  229 │             }
      │             ┬  
@@ -13641,7 +13641,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:230:13 ]
+     ╭─[ rust.baml:230:13 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │             ─────┬────  
@@ -13651,7 +13651,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:230:23 ]
+     ╭─[ rust.baml:230:23 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                       ─┬  
@@ -13661,7 +13661,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:230:25 ]
+     ╭─[ rust.baml:230:25 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                         ───────┬──────  
@@ -13671,7 +13671,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:230:40 ]
+     ╭─[ rust.baml:230:40 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                        ─┬  
@@ -13681,7 +13681,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:230:43 ]
+     ╭─[ rust.baml:230:43 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                           ──┬─  
@@ -13691,7 +13691,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:230:47 ]
+     ╭─[ rust.baml:230:47 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                               ┬  
@@ -13701,7 +13701,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:230:48 ]
+     ╭─[ rust.baml:230:48 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                ──┬─  
@@ -13711,7 +13711,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:230:52 ]
+     ╭─[ rust.baml:230:52 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                    ─┬  
@@ -13721,7 +13721,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:230:54 ]
+     ╭─[ rust.baml:230:54 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                      ────┬────  
@@ -13731,7 +13731,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:230:63 ]
+     ╭─[ rust.baml:230:63 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                               ┬  
@@ -13741,7 +13741,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:230:64 ]
+     ╭─[ rust.baml:230:64 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                ──────┬─────  
@@ -13751,7 +13751,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:230:77 ]
+     ╭─[ rust.baml:230:77 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                             ┬  
@@ -13761,7 +13761,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:230:79 ]
+     ╭─[ rust.baml:230:79 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                               ───┬──  
@@ -13771,7 +13771,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:230:86 ]
+     ╭─[ rust.baml:230:86 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                                      ┬  
@@ -13781,7 +13781,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:230:87 ]
+     ╭─[ rust.baml:230:87 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                                       ┬  
@@ -13791,7 +13791,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:230:88 ]
+     ╭─[ rust.baml:230:88 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                                        ┬  
@@ -13801,7 +13801,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:230:89 ]
+     ╭─[ rust.baml:230:89 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                                         ┬  
@@ -13811,7 +13811,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:231:13 ]
+     ╭─[ rust.baml:231:13 ]
      │
  231 │             _ => None,
      │             ┬  
@@ -13821,7 +13821,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:231:15 ]
+     ╭─[ rust.baml:231:15 ]
      │
  231 │             _ => None,
      │               ─┬  
@@ -13831,7 +13831,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:231:18 ]
+     ╭─[ rust.baml:231:18 ]
      │
  231 │             _ => None,
      │                  ──┬─  
@@ -13841,7 +13841,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:231:22 ]
+     ╭─[ rust.baml:231:22 ]
      │
  231 │             _ => None,
      │                      ┬  
@@ -13851,7 +13851,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:232:9 ]
+     ╭─[ rust.baml:232:9 ]
      │
  232 │         }
      │         ┬  
@@ -13861,7 +13861,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:233:5 ]
+     ╭─[ rust.baml:233:5 ]
      │
  233 │     }
      │     ┬  
@@ -13871,7 +13871,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:235:5 ]
+     ╭─[ rust.baml:235:5 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │     ─┬  
@@ -13881,7 +13881,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:235:8 ]
+     ╭─[ rust.baml:235:8 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │        ───┬──  
@@ -13891,7 +13891,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:235:14 ]
+     ╭─[ rust.baml:235:14 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │              ┬  
@@ -13901,7 +13901,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:235:15 ]
+     ╭─[ rust.baml:235:15 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │               ┬  
@@ -13911,7 +13911,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:235:16 ]
+     ╭─[ rust.baml:235:16 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                ──┬─  
@@ -13921,7 +13921,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:235:20 ]
+     ╭─[ rust.baml:235:20 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                    ┬  
@@ -13931,7 +13931,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '->'
-     ╭─[ 0:235:22 ]
+     ╭─[ rust.baml:235:22 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                      ─┬  
@@ -13941,7 +13941,7 @@ Error: Expected top-level declaration, found '->'
 ─────╯
 
 Error: Expected top-level declaration, found '&'
-     ╭─[ 0:235:25 ]
+     ╭─[ rust.baml:235:25 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                         ┬  
@@ -13951,7 +13951,7 @@ Error: Expected top-level declaration, found '&'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:235:26 ]
+     ╭─[ rust.baml:235:26 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                          ─────┬────  
@@ -13961,7 +13961,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:235:37 ]
+     ╭─[ rust.baml:235:37 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                                     ┬  
@@ -13971,7 +13971,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found match
-     ╭─[ 0:236:9 ]
+     ╭─[ rust.baml:236:9 ]
      │
  236 │         match self {
      │         ──┬──  
@@ -13981,7 +13981,7 @@ Error: Expected top-level declaration, found match
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:236:15 ]
+     ╭─[ rust.baml:236:15 ]
      │
  236 │         match self {
      │               ──┬─  
@@ -13991,7 +13991,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '{'
-     ╭─[ 0:236:20 ]
+     ╭─[ rust.baml:236:20 ]
      │
  236 │         match self {
      │                    ┬  
@@ -14001,7 +14001,7 @@ Error: Expected top-level declaration, found '{'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:237:13 ]
+     ╭─[ rust.baml:237:13 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │             ──┬─  
@@ -14011,7 +14011,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:237:17 ]
+     ╭─[ rust.baml:237:17 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                 ─┬  
@@ -14021,7 +14021,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:237:19 ]
+     ╭─[ rust.baml:237:19 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                   ────┬───  
@@ -14031,7 +14031,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:237:27 ]
+     ╭─[ rust.baml:237:27 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                           ┬  
@@ -14041,7 +14041,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:237:28 ]
+     ╭─[ rust.baml:237:28 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                            ─┬  
@@ -14051,7 +14051,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:237:30 ]
+     ╭─[ rust.baml:237:30 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                              ┬  
@@ -14061,7 +14061,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:237:32 ]
+     ╭─[ rust.baml:237:32 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                ─┬  
@@ -14071,7 +14071,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:237:35 ]
+     ╭─[ rust.baml:237:35 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                   ─┬  
@@ -14081,7 +14081,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:237:37 ]
+     ╭─[ rust.baml:237:37 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                     ┬  
@@ -14091,7 +14091,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:237:38 ]
+     ╭─[ rust.baml:237:38 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                      ───┬──  
@@ -14101,7 +14101,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:237:44 ]
+     ╭─[ rust.baml:237:44 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                            ┬  
@@ -14111,7 +14111,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:237:45 ]
+     ╭─[ rust.baml:237:45 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                             ┬  
@@ -14121,7 +14121,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:237:46 ]
+     ╭─[ rust.baml:237:46 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                              ┬  
@@ -14131,7 +14131,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:238:13 ]
+     ╭─[ rust.baml:238:13 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │             ──┬─  
@@ -14141,7 +14141,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:238:17 ]
+     ╭─[ rust.baml:238:17 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                 ─┬  
@@ -14151,7 +14151,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:238:19 ]
+     ╭─[ rust.baml:238:19 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                   ──┬──  
@@ -14161,7 +14161,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:238:24 ]
+     ╭─[ rust.baml:238:24 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                        ┬  
@@ -14171,7 +14171,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:238:25 ]
+     ╭─[ rust.baml:238:25 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                         ─┬  
@@ -14181,7 +14181,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:238:27 ]
+     ╭─[ rust.baml:238:27 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                           ┬  
@@ -14191,7 +14191,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:238:29 ]
+     ╭─[ rust.baml:238:29 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                             ─┬  
@@ -14201,7 +14201,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:238:32 ]
+     ╭─[ rust.baml:238:32 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                ─┬  
@@ -14211,7 +14211,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:238:34 ]
+     ╭─[ rust.baml:238:34 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                  ┬  
@@ -14221,7 +14221,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:238:35 ]
+     ╭─[ rust.baml:238:35 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                   ───┬──  
@@ -14231,7 +14231,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:238:41 ]
+     ╭─[ rust.baml:238:41 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                         ┬  
@@ -14241,7 +14241,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:238:42 ]
+     ╭─[ rust.baml:238:42 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                          ┬  
@@ -14251,7 +14251,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:238:43 ]
+     ╭─[ rust.baml:238:43 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                           ┬  
@@ -14261,7 +14261,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:239:13 ]
+     ╭─[ rust.baml:239:13 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │             ──┬─  
@@ -14271,7 +14271,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:239:17 ]
+     ╭─[ rust.baml:239:17 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                 ─┬  
@@ -14281,7 +14281,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:239:19 ]
+     ╭─[ rust.baml:239:19 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                   ──┬─  
@@ -14291,7 +14291,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:239:23 ]
+     ╭─[ rust.baml:239:23 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                       ┬  
@@ -14301,7 +14301,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:239:24 ]
+     ╭─[ rust.baml:239:24 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                        ─┬  
@@ -14311,7 +14311,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:239:26 ]
+     ╭─[ rust.baml:239:26 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                          ┬  
@@ -14321,7 +14321,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:239:28 ]
+     ╭─[ rust.baml:239:28 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                            ─┬  
@@ -14331,7 +14331,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:239:31 ]
+     ╭─[ rust.baml:239:31 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                               ─┬  
@@ -14341,7 +14341,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:239:33 ]
+     ╭─[ rust.baml:239:33 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                 ┬  
@@ -14351,7 +14351,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:239:34 ]
+     ╭─[ rust.baml:239:34 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                  ───┬──  
@@ -14361,7 +14361,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:239:40 ]
+     ╭─[ rust.baml:239:40 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                        ┬  
@@ -14371,7 +14371,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:239:41 ]
+     ╭─[ rust.baml:239:41 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                         ┬  
@@ -14381,7 +14381,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:239:42 ]
+     ╭─[ rust.baml:239:42 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                          ┬  
@@ -14391,7 +14391,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:240:13 ]
+     ╭─[ rust.baml:240:13 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │             ──┬─  
@@ -14401,7 +14401,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:240:17 ]
+     ╭─[ rust.baml:240:17 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                 ─┬  
@@ -14411,7 +14411,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:240:19 ]
+     ╭─[ rust.baml:240:19 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                   ───┬──  
@@ -14421,7 +14421,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:240:25 ]
+     ╭─[ rust.baml:240:25 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                         ┬  
@@ -14431,7 +14431,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:240:26 ]
+     ╭─[ rust.baml:240:26 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                          ─┬  
@@ -14441,7 +14441,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:240:28 ]
+     ╭─[ rust.baml:240:28 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                            ┬  
@@ -14451,7 +14451,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:240:30 ]
+     ╭─[ rust.baml:240:30 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                              ─┬  
@@ -14461,7 +14461,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:240:33 ]
+     ╭─[ rust.baml:240:33 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                 ─┬  
@@ -14471,7 +14471,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:240:35 ]
+     ╭─[ rust.baml:240:35 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                   ┬  
@@ -14481,7 +14481,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:240:36 ]
+     ╭─[ rust.baml:240:36 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                    ───┬──  
@@ -14491,7 +14491,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:240:42 ]
+     ╭─[ rust.baml:240:42 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                          ┬  
@@ -14501,7 +14501,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:240:43 ]
+     ╭─[ rust.baml:240:43 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                           ┬  
@@ -14511,7 +14511,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:240:44 ]
+     ╭─[ rust.baml:240:44 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                            ┬  
@@ -14521,7 +14521,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:241:13 ]
+     ╭─[ rust.baml:241:13 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │             ──┬─  
@@ -14531,7 +14531,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:241:17 ]
+     ╭─[ rust.baml:241:17 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                 ─┬  
@@ -14541,7 +14541,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:241:19 ]
+     ╭─[ rust.baml:241:19 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                   ──┬─  
@@ -14551,7 +14551,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:241:23 ]
+     ╭─[ rust.baml:241:23 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                       ┬  
@@ -14561,7 +14561,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:241:24 ]
+     ╭─[ rust.baml:241:24 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                        ─┬  
@@ -14571,7 +14571,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:241:26 ]
+     ╭─[ rust.baml:241:26 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                          ┬  
@@ -14581,7 +14581,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:241:28 ]
+     ╭─[ rust.baml:241:28 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                            ─┬  
@@ -14591,7 +14591,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:241:31 ]
+     ╭─[ rust.baml:241:31 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                               ─┬  
@@ -14601,7 +14601,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:241:33 ]
+     ╭─[ rust.baml:241:33 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                 ┬  
@@ -14611,7 +14611,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:241:34 ]
+     ╭─[ rust.baml:241:34 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                  ───┬──  
@@ -14621,7 +14621,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:241:40 ]
+     ╭─[ rust.baml:241:40 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                        ┬  
@@ -14631,7 +14631,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:241:41 ]
+     ╭─[ rust.baml:241:41 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                         ┬  
@@ -14641,7 +14641,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:241:42 ]
+     ╭─[ rust.baml:241:42 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                          ┬  
@@ -14651,7 +14651,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:242:13 ]
+     ╭─[ rust.baml:242:13 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │             ──┬─  
@@ -14661,7 +14661,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:242:17 ]
+     ╭─[ rust.baml:242:17 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                 ─┬  
@@ -14671,7 +14671,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:242:19 ]
+     ╭─[ rust.baml:242:19 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                   ─────┬─────  
@@ -14681,7 +14681,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:242:30 ]
+     ╭─[ rust.baml:242:30 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                              ┬  
@@ -14691,7 +14691,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:242:31 ]
+     ╭─[ rust.baml:242:31 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                               ─┬  
@@ -14701,7 +14701,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:242:33 ]
+     ╭─[ rust.baml:242:33 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                 ┬  
@@ -14711,7 +14711,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:242:35 ]
+     ╭─[ rust.baml:242:35 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                   ─┬  
@@ -14721,7 +14721,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:242:38 ]
+     ╭─[ rust.baml:242:38 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                      ─┬  
@@ -14731,7 +14731,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:242:40 ]
+     ╭─[ rust.baml:242:40 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                        ┬  
@@ -14741,7 +14741,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:242:41 ]
+     ╭─[ rust.baml:242:41 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                         ───┬──  
@@ -14751,7 +14751,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:242:47 ]
+     ╭─[ rust.baml:242:47 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                               ┬  
@@ -14761,7 +14761,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:242:48 ]
+     ╭─[ rust.baml:242:48 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                                ┬  
@@ -14771,7 +14771,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:242:49 ]
+     ╭─[ rust.baml:242:49 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                                 ┬  
@@ -14781,7 +14781,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:243:13 ]
+     ╭─[ rust.baml:243:13 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │             ──┬─  
@@ -14791,7 +14791,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:243:17 ]
+     ╭─[ rust.baml:243:17 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                 ─┬  
@@ -14801,7 +14801,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:243:19 ]
+     ╭─[ rust.baml:243:19 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                   ───────┬──────  
@@ -14811,7 +14811,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:243:33 ]
+     ╭─[ rust.baml:243:33 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                 ┬  
@@ -14821,7 +14821,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:243:34 ]
+     ╭─[ rust.baml:243:34 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                  ─┬  
@@ -14831,7 +14831,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:243:36 ]
+     ╭─[ rust.baml:243:36 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                    ┬  
@@ -14841,7 +14841,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:243:38 ]
+     ╭─[ rust.baml:243:38 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                      ─┬  
@@ -14851,7 +14851,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:243:41 ]
+     ╭─[ rust.baml:243:41 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                         ─┬  
@@ -14861,7 +14861,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:243:43 ]
+     ╭─[ rust.baml:243:43 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                           ┬  
@@ -14871,7 +14871,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:243:44 ]
+     ╭─[ rust.baml:243:44 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                            ───┬──  
@@ -14881,7 +14881,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:243:50 ]
+     ╭─[ rust.baml:243:50 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                                  ┬  
@@ -14891,7 +14891,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:243:51 ]
+     ╭─[ rust.baml:243:51 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                                   ┬  
@@ -14901,7 +14901,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:243:52 ]
+     ╭─[ rust.baml:243:52 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                                    ┬  
@@ -14911,7 +14911,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:244:13 ]
+     ╭─[ rust.baml:244:13 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │             ──┬─  
@@ -14921,7 +14921,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '::'
-     ╭─[ 0:244:17 ]
+     ╭─[ rust.baml:244:17 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                 ─┬  
@@ -14931,7 +14931,7 @@ Error: Expected top-level declaration, found '::'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:244:19 ]
+     ╭─[ rust.baml:244:19 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                   ────┬────  
@@ -14941,7 +14941,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:244:28 ]
+     ╭─[ rust.baml:244:28 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                            ┬  
@@ -14951,7 +14951,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:244:29 ]
+     ╭─[ rust.baml:244:29 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                             ─┬  
@@ -14961,7 +14961,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:244:31 ]
+     ╭─[ rust.baml:244:31 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                               ┬  
@@ -14971,7 +14971,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found '=>'
-     ╭─[ 0:244:33 ]
+     ╭─[ rust.baml:244:33 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                 ─┬  
@@ -14981,7 +14981,7 @@ Error: Expected top-level declaration, found '=>'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:244:36 ]
+     ╭─[ rust.baml:244:36 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                    ─┬  
@@ -14991,7 +14991,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '.'
-     ╭─[ 0:244:38 ]
+     ╭─[ rust.baml:244:38 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                      ┬  
@@ -15001,7 +15001,7 @@ Error: Expected top-level declaration, found '.'
 ─────╯
 
 Error: Expected top-level declaration, found identifier
-     ╭─[ 0:244:39 ]
+     ╭─[ rust.baml:244:39 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                       ───┬──  
@@ -15011,7 +15011,7 @@ Error: Expected top-level declaration, found identifier
 ─────╯
 
 Error: Expected top-level declaration, found '('
-     ╭─[ 0:244:45 ]
+     ╭─[ rust.baml:244:45 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                             ┬  
@@ -15021,7 +15021,7 @@ Error: Expected top-level declaration, found '('
 ─────╯
 
 Error: Expected top-level declaration, found ')'
-     ╭─[ 0:244:46 ]
+     ╭─[ rust.baml:244:46 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                              ┬  
@@ -15031,7 +15031,7 @@ Error: Expected top-level declaration, found ')'
 ─────╯
 
 Error: Expected top-level declaration, found ','
-     ╭─[ 0:244:47 ]
+     ╭─[ rust.baml:244:47 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                               ┬  
@@ -15041,7 +15041,7 @@ Error: Expected top-level declaration, found ','
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:245:9 ]
+     ╭─[ rust.baml:245:9 ]
      │
  245 │         }
      │         ┬  
@@ -15051,7 +15051,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:246:5 ]
+     ╭─[ rust.baml:246:5 ]
      │
  246 │     }
      │     ┬  
@@ -15061,7 +15061,7 @@ Error: Expected top-level declaration, found '}'
 ─────╯
 
 Error: Expected top-level declaration, found '}'
-     ╭─[ 0:247:1 ]
+     ╭─[ rust.baml:247:1 ]
      │
  247 │ }
      │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__very_invalid.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__very_invalid.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-a56cff903b8232b2/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -37,7 +37,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected expression, found error
-   ╭─[ 0:6:11 ]
+   ╭─[ very_invalid.baml:6:11 ]
    │
  6 │   let x = ¿;
    │           ─┬  
@@ -47,7 +47,7 @@ Error: Expected expression, found error
 ───╯
 
 Error: Expected expression, found error
-   ╭─[ 0:8:10 ]
+   ╭─[ very_invalid.baml:8:10 ]
    │
  8 │   while \ {
    │          ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__05_diagnostics.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 === DIAGNOSTICS ===
   [parse] Error: Expected '>', found '>>'
-    ╭─[ 1:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -14,7 +14,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected '>', found '>>'
-    ╭─[ 1:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -24,7 +24,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected '>', found '>>'
-    ╭─[ 1:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -34,7 +34,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected function body, found '>>'
-    ╭─[ 1:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -44,7 +44,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '>>'
-    ╭─[ 1:28:69 ]
+    ╭─[ deeply_nested.baml:28:69 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                     ─┬  
@@ -54,7 +54,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-    ╭─[ 1:28:71 ]
+    ╭─[ deeply_nested.baml:28:71 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                       ┬  
@@ -64,7 +64,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 1:28:73 ]
+    ╭─[ deeply_nested.baml:28:73 ]
     │
  28 │ function ComplexType() -> map<string, map<string, map<string, int[]?>>> {
     │                                                                         ┬  
@@ -74,7 +74,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found return
-    ╭─[ 1:30:3 ]
+    ╭─[ deeply_nested.baml:30:3 ]
     │
  30 │   return {}
     │   ───┬──  
@@ -84,7 +84,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 1:30:10 ]
+    ╭─[ deeply_nested.baml:30:10 ]
     │
  30 │   return {}
     │          ┬  
@@ -94,7 +94,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 1:30:11 ]
+    ╭─[ deeply_nested.baml:30:11 ]
     │
  30 │   return {}
     │           ┬  
@@ -104,7 +104,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 1:31:1 ]
+    ╭─[ deeply_nested.baml:31:1 ]
     │
  31 │ }
     │ ┬  
@@ -114,7 +114,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 3:7:1 ]
+   ╭─[ rust.baml:7:1 ]
    │
  7 │ use rowan::ast::AstNode;
    │ ─┬─  
@@ -124,7 +124,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 3:7:5 ]
+   ╭─[ rust.baml:7:5 ]
    │
  7 │ use rowan::ast::AstNode;
    │     ──┬──  
@@ -134,7 +134,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found '::'
-   ╭─[ 3:7:10 ]
+   ╭─[ rust.baml:7:10 ]
    │
  7 │ use rowan::ast::AstNode;
    │          ─┬  
@@ -144,7 +144,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 3:7:12 ]
+   ╭─[ rust.baml:7:12 ]
    │
  7 │ use rowan::ast::AstNode;
    │            ─┬─  
@@ -154,7 +154,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found '::'
-   ╭─[ 3:7:15 ]
+   ╭─[ rust.baml:7:15 ]
    │
  7 │ use rowan::ast::AstNode;
    │               ─┬  
@@ -164,7 +164,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 3:7:17 ]
+   ╭─[ rust.baml:7:17 ]
    │
  7 │ use rowan::ast::AstNode;
    │                 ───┬───  
@@ -174,7 +174,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found ';'
-   ╭─[ 3:7:24 ]
+   ╭─[ rust.baml:7:24 ]
    │
  7 │ use rowan::ast::AstNode;
    │                        ┬  
@@ -184,7 +184,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 3:9:1 ]
+   ╭─[ rust.baml:9:1 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │ ─┬─  
@@ -194,7 +194,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 3:9:5 ]
+   ╭─[ rust.baml:9:5 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │     ──┬──  
@@ -204,7 +204,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found '::'
-   ╭─[ 3:9:10 ]
+   ╭─[ rust.baml:9:10 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │          ─┬  
@@ -214,7 +214,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found '{'
-   ╭─[ 3:9:12 ]
+   ╭─[ rust.baml:9:12 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │            ┬  
@@ -224,7 +224,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 3:9:13 ]
+   ╭─[ rust.baml:9:13 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │             ─────┬────  
@@ -234,7 +234,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found ','
-   ╭─[ 3:9:23 ]
+   ╭─[ rust.baml:9:23 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                       ┬  
@@ -244,7 +244,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 3:9:25 ]
+   ╭─[ rust.baml:9:25 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                         ─────┬────  
@@ -254,7 +254,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found ','
-   ╭─[ 3:9:35 ]
+   ╭─[ rust.baml:9:35 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                                   ┬  
@@ -264,7 +264,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-   ╭─[ 3:9:37 ]
+   ╭─[ rust.baml:9:37 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                                     ─────┬─────  
@@ -274,7 +274,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found '}'
-   ╭─[ 3:9:48 ]
+   ╭─[ rust.baml:9:48 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                                                ┬  
@@ -284,7 +284,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found ';'
-   ╭─[ 3:9:49 ]
+   ╭─[ rust.baml:9:49 ]
    │
  9 │ use crate::{SyntaxKind, SyntaxNode, SyntaxToken};
    │                                                 ┬  
@@ -294,7 +294,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:12:1 ]
+    ╭─[ rust.baml:12:1 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │ ─┬─  
@@ -304,7 +304,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:12:5 ]
+    ╭─[ rust.baml:12:5 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │     ──┬──  
@@ -314,7 +314,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:12:11 ]
+    ╭─[ rust.baml:12:11 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │           ─────┬─────  
@@ -324,7 +324,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ':'
-    ╭─[ 3:12:22 ]
+    ╭─[ rust.baml:12:22 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                      ┬  
@@ -334,7 +334,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:12:24 ]
+    ╭─[ rust.baml:12:24 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                        ───┬───  
@@ -344,7 +344,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-    ╭─[ 3:12:31 ]
+    ╭─[ rust.baml:12:31 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                               ┬  
@@ -354,7 +354,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:12:32 ]
+    ╭─[ rust.baml:12:32 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                ────┬───  
@@ -364,7 +364,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '='
-    ╭─[ 3:12:41 ]
+    ╭─[ rust.baml:12:41 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                         ┬  
@@ -374,7 +374,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:12:43 ]
+    ╭─[ rust.baml:12:43 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                           ──┬──  
@@ -384,7 +384,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:12:48 ]
+    ╭─[ rust.baml:12:48 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                                ─┬  
@@ -394,7 +394,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:12:50 ]
+    ╭─[ rust.baml:12:50 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                                  ──────┬─────  
@@ -404,7 +404,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-    ╭─[ 3:12:62 ]
+    ╭─[ rust.baml:12:62 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                                              ┬  
@@ -414,7 +414,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:12:64 ]
+    ╭─[ rust.baml:12:64 ]
     │
  12 │ pub trait BamlAstNode: AstNode<Language = crate::BamlLanguage> {
     │                                                                ┬  
@@ -424,7 +424,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:14:5 ]
+    ╭─[ rust.baml:14:5 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │     ─┬  
@@ -434,7 +434,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:14:8 ]
+    ╭─[ rust.baml:14:8 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │        ──┬─  
@@ -444,7 +444,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:14:12 ]
+    ╭─[ rust.baml:14:12 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │            ┬  
@@ -454,7 +454,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-    ╭─[ 3:14:13 ]
+    ╭─[ rust.baml:14:13 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │             ┬  
@@ -464,7 +464,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:14:14 ]
+    ╭─[ rust.baml:14:14 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │              ──┬─  
@@ -474,7 +474,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:14:18 ]
+    ╭─[ rust.baml:14:18 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │                  ┬  
@@ -484,7 +484,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-    ╭─[ 3:14:20 ]
+    ╭─[ rust.baml:14:20 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │                    ─┬  
@@ -494,7 +494,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:14:23 ]
+    ╭─[ rust.baml:14:23 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │                       ─────┬────  
@@ -504,7 +504,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:14:34 ]
+    ╭─[ rust.baml:14:34 ]
     │
  14 │     fn kind(&self) -> SyntaxKind {
     │                                  ┬  
@@ -514,7 +514,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:15:9 ]
+    ╭─[ rust.baml:15:9 ]
     │
  15 │         self.syntax().kind()
     │         ──┬─  
@@ -524,7 +524,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:15:13 ]
+    ╭─[ rust.baml:15:13 ]
     │
  15 │         self.syntax().kind()
     │             ┬  
@@ -534,7 +534,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:15:14 ]
+    ╭─[ rust.baml:15:14 ]
     │
  15 │         self.syntax().kind()
     │              ───┬──  
@@ -544,7 +544,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:15:20 ]
+    ╭─[ rust.baml:15:20 ]
     │
  15 │         self.syntax().kind()
     │                    ┬  
@@ -554,7 +554,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:15:21 ]
+    ╭─[ rust.baml:15:21 ]
     │
  15 │         self.syntax().kind()
     │                     ┬  
@@ -564,7 +564,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:15:22 ]
+    ╭─[ rust.baml:15:22 ]
     │
  15 │         self.syntax().kind()
     │                      ┬  
@@ -574,7 +574,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:15:23 ]
+    ╭─[ rust.baml:15:23 ]
     │
  15 │         self.syntax().kind()
     │                       ──┬─  
@@ -584,7 +584,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:15:27 ]
+    ╭─[ rust.baml:15:27 ]
     │
  15 │         self.syntax().kind()
     │                           ┬  
@@ -594,7 +594,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:15:28 ]
+    ╭─[ rust.baml:15:28 ]
     │
  15 │         self.syntax().kind()
     │                            ┬  
@@ -604,7 +604,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:16:5 ]
+    ╭─[ rust.baml:16:5 ]
     │
  16 │     }
     │     ┬  
@@ -614,7 +614,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:17:1 ]
+    ╭─[ rust.baml:17:1 ]
     │
  17 │ }
     │ ┬  
@@ -624,7 +624,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:20:1 ]
+    ╭─[ rust.baml:20:1 ]
     │
  20 │ macro_rules! ast_node {
     │ ─────┬─────  
@@ -634,7 +634,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:20:12 ]
+    ╭─[ rust.baml:20:12 ]
     │
  20 │ macro_rules! ast_node {
     │            ┬  
@@ -644,7 +644,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:20:14 ]
+    ╭─[ rust.baml:20:14 ]
     │
  20 │ macro_rules! ast_node {
     │              ────┬───  
@@ -654,7 +654,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:20:23 ]
+    ╭─[ rust.baml:20:23 ]
     │
  20 │ macro_rules! ast_node {
     │                       ┬  
@@ -664,7 +664,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:21:5 ]
+    ╭─[ rust.baml:21:5 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │     ┬  
@@ -674,7 +674,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:21:6 ]
+    ╭─[ rust.baml:21:6 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │      ──┬──  
@@ -684,7 +684,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ':'
-    ╭─[ 3:21:11 ]
+    ╭─[ rust.baml:21:11 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │           ┬  
@@ -694,7 +694,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:21:12 ]
+    ╭─[ rust.baml:21:12 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │            ──┬──  
@@ -704,7 +704,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:21:17 ]
+    ╭─[ rust.baml:21:17 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                 ┬  
@@ -714,7 +714,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:21:19 ]
+    ╭─[ rust.baml:21:19 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                   ──┬──  
@@ -724,7 +724,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ':'
-    ╭─[ 3:21:24 ]
+    ╭─[ rust.baml:21:24 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                        ┬  
@@ -734,7 +734,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:21:25 ]
+    ╭─[ rust.baml:21:25 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                         ──┬──  
@@ -744,7 +744,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:21:30 ]
+    ╭─[ rust.baml:21:30 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                              ┬  
@@ -754,7 +754,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-    ╭─[ 3:21:32 ]
+    ╭─[ rust.baml:21:32 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                                ─┬  
@@ -764,7 +764,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:21:35 ]
+    ╭─[ rust.baml:21:35 ]
     │
  21 │     ($name:ident, $kind:ident) => {
     │                                   ┬  
@@ -774,7 +774,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '#'
-    ╭─[ 3:22:9 ]
+    ╭─[ rust.baml:22:9 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │         ┬  
@@ -784,7 +784,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '['
-    ╭─[ 3:22:10 ]
+    ╭─[ rust.baml:22:10 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │          ┬  
@@ -794,7 +794,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:22:11 ]
+    ╭─[ rust.baml:22:11 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │           ───┬──  
@@ -804,7 +804,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:22:17 ]
+    ╭─[ rust.baml:22:17 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                 ┬  
@@ -814,7 +814,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:22:18 ]
+    ╭─[ rust.baml:22:18 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                  ──┬──  
@@ -824,7 +824,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:22:23 ]
+    ╭─[ rust.baml:22:23 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                       ┬  
@@ -834,7 +834,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:22:25 ]
+    ╭─[ rust.baml:22:25 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                         ──┬──  
@@ -844,7 +844,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:22:30 ]
+    ╭─[ rust.baml:22:30 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                              ┬  
@@ -854,7 +854,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:22:32 ]
+    ╭─[ rust.baml:22:32 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                ────┬────  
@@ -864,7 +864,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:22:41 ]
+    ╭─[ rust.baml:22:41 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                         ┬  
@@ -874,7 +874,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:22:43 ]
+    ╭─[ rust.baml:22:43 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                           ─┬  
@@ -884,7 +884,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:22:45 ]
+    ╭─[ rust.baml:22:45 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                             ┬  
@@ -894,7 +894,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:22:47 ]
+    ╭─[ rust.baml:22:47 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                               ──┬─  
@@ -904,7 +904,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:22:51 ]
+    ╭─[ rust.baml:22:51 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                                   ┬  
@@ -914,7 +914,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ']'
-    ╭─[ 3:22:52 ]
+    ╭─[ rust.baml:22:52 ]
     │
  22 │         #[derive(Debug, Clone, PartialEq, Eq, Hash)]
     │                                                    ┬  
@@ -924,7 +924,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:23:9 ]
+    ╭─[ rust.baml:23:9 ]
     │
  23 │         pub struct $name {
     │         ─┬─  
@@ -934,7 +934,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:23:13 ]
+    ╭─[ rust.baml:23:13 ]
     │
  23 │         pub struct $name {
     │             ───┬──  
@@ -944,7 +944,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:23:20 ]
+    ╭─[ rust.baml:23:20 ]
     │
  23 │         pub struct $name {
     │                    ──┬──  
@@ -954,7 +954,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:23:26 ]
+    ╭─[ rust.baml:23:26 ]
     │
  23 │         pub struct $name {
     │                          ┬  
@@ -964,7 +964,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:24:13 ]
+    ╭─[ rust.baml:24:13 ]
     │
  24 │             syntax: SyntaxNode,
     │             ───┬──  
@@ -974,7 +974,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ':'
-    ╭─[ 3:24:19 ]
+    ╭─[ rust.baml:24:19 ]
     │
  24 │             syntax: SyntaxNode,
     │                   ┬  
@@ -984,7 +984,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:24:21 ]
+    ╭─[ rust.baml:24:21 ]
     │
  24 │             syntax: SyntaxNode,
     │                     ─────┬────  
@@ -994,7 +994,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:24:31 ]
+    ╭─[ rust.baml:24:31 ]
     │
  24 │             syntax: SyntaxNode,
     │                               ┬  
@@ -1004,7 +1004,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:25:9 ]
+    ╭─[ rust.baml:25:9 ]
     │
  25 │         }
     │         ┬  
@@ -1014,7 +1014,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:27:9 ]
+    ╭─[ rust.baml:27:9 ]
     │
  27 │         impl BamlAstNode for $name {}
     │         ──┬─  
@@ -1024,7 +1024,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:27:14 ]
+    ╭─[ rust.baml:27:14 ]
     │
  27 │         impl BamlAstNode for $name {}
     │              ─────┬─────  
@@ -1034,7 +1034,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found for
-    ╭─[ 3:27:26 ]
+    ╭─[ rust.baml:27:26 ]
     │
  27 │         impl BamlAstNode for $name {}
     │                          ─┬─  
@@ -1044,7 +1044,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:27:30 ]
+    ╭─[ rust.baml:27:30 ]
     │
  27 │         impl BamlAstNode for $name {}
     │                              ──┬──  
@@ -1054,7 +1054,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:27:36 ]
+    ╭─[ rust.baml:27:36 ]
     │
  27 │         impl BamlAstNode for $name {}
     │                                    ┬  
@@ -1064,7 +1064,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:27:37 ]
+    ╭─[ rust.baml:27:37 ]
     │
  27 │         impl BamlAstNode for $name {}
     │                                     ┬  
@@ -1074,7 +1074,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:29:9 ]
+    ╭─[ rust.baml:29:9 ]
     │
  29 │         impl AstNode for $name {
     │         ──┬─  
@@ -1084,7 +1084,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:29:14 ]
+    ╭─[ rust.baml:29:14 ]
     │
  29 │         impl AstNode for $name {
     │              ───┬───  
@@ -1094,7 +1094,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found for
-    ╭─[ 3:29:22 ]
+    ╭─[ rust.baml:29:22 ]
     │
  29 │         impl AstNode for $name {
     │                      ─┬─  
@@ -1104,7 +1104,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:29:26 ]
+    ╭─[ rust.baml:29:26 ]
     │
  29 │         impl AstNode for $name {
     │                          ──┬──  
@@ -1114,7 +1114,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:29:32 ]
+    ╭─[ rust.baml:29:32 ]
     │
  29 │         impl AstNode for $name {
     │                                ┬  
@@ -1124,7 +1124,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:30:34 ]
+    ╭─[ rust.baml:30:34 ]
     │
  30 │             type Language = crate::BamlLanguage;
     │                                  ─┬  
@@ -1134,7 +1134,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:30:36 ]
+    ╭─[ rust.baml:30:36 ]
     │
  30 │             type Language = crate::BamlLanguage;
     │                                    ──────┬─────  
@@ -1144,7 +1144,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:30:48 ]
+    ╭─[ rust.baml:30:48 ]
     │
  30 │             type Language = crate::BamlLanguage;
     │                                                ┬  
@@ -1154,7 +1154,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:13 ]
+    ╭─[ rust.baml:32:13 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │             ─┬  
@@ -1164,7 +1164,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:16 ]
+    ╭─[ rust.baml:32:16 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                ────┬───  
@@ -1174,7 +1174,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:32:24 ]
+    ╭─[ rust.baml:32:24 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                        ┬  
@@ -1184,7 +1184,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:25 ]
+    ╭─[ rust.baml:32:25 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                         ──┬─  
@@ -1194,7 +1194,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ':'
-    ╭─[ 3:32:29 ]
+    ╭─[ rust.baml:32:29 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                             ┬  
@@ -1204,7 +1204,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-    ╭─[ 3:32:31 ]
+    ╭─[ rust.baml:32:31 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                               ┬  
@@ -1214,7 +1214,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:32 ]
+    ╭─[ rust.baml:32:32 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                ──┬─  
@@ -1224,7 +1224,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:32:36 ]
+    ╭─[ rust.baml:32:36 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                    ─┬  
@@ -1234,7 +1234,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:38 ]
+    ╭─[ rust.baml:32:38 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                      ────┬───  
@@ -1244,7 +1244,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:47 ]
+    ╭─[ rust.baml:32:47 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                               ─┬  
@@ -1254,7 +1254,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:50 ]
+    ╭─[ rust.baml:32:50 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                  ──┬──  
@@ -1264,7 +1264,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:32:55 ]
+    ╭─[ rust.baml:32:55 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                       ─┬  
@@ -1274,7 +1274,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:57 ]
+    ╭─[ rust.baml:32:57 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                         ────┬───  
@@ -1284,7 +1284,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-    ╭─[ 3:32:65 ]
+    ╭─[ rust.baml:32:65 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                 ┬  
@@ -1294,7 +1294,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:32:66 ]
+    ╭─[ rust.baml:32:66 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                  ─┬  
@@ -1304,7 +1304,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:68 ]
+    ╭─[ rust.baml:32:68 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                    ──┬─  
@@ -1314,7 +1314,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:32:72 ]
+    ╭─[ rust.baml:32:72 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                        ┬  
@@ -1324,7 +1324,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-    ╭─[ 3:32:74 ]
+    ╭─[ rust.baml:32:74 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                          ─┬  
@@ -1334,7 +1334,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:32:77 ]
+    ╭─[ rust.baml:32:77 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                             ──┬─  
@@ -1344,7 +1344,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:32:82 ]
+    ╭─[ rust.baml:32:82 ]
     │
  32 │             fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
     │                                                                                  ┬  
@@ -1354,7 +1354,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:33:17 ]
+    ╭─[ rust.baml:33:17 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                 ──┬─  
@@ -1364,7 +1364,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '=='
-    ╭─[ 3:33:22 ]
+    ╭─[ rust.baml:33:22 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                      ─┬  
@@ -1374,7 +1374,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:33:25 ]
+    ╭─[ rust.baml:33:25 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                         ─────┬────  
@@ -1384,7 +1384,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:33:35 ]
+    ╭─[ rust.baml:33:35 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                   ─┬  
@@ -1394,7 +1394,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:33:37 ]
+    ╭─[ rust.baml:33:37 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                     ──┬──  
@@ -1404,7 +1404,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:33:42 ]
+    ╭─[ rust.baml:33:42 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                          ┬  
@@ -1414,7 +1414,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:33:43 ]
+    ╭─[ rust.baml:33:43 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                           ──┬─  
@@ -1424,7 +1424,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:33:47 ]
+    ╭─[ rust.baml:33:47 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                               ┬  
@@ -1434,7 +1434,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:33:48 ]
+    ╭─[ rust.baml:33:48 ]
     │
  33 │                 kind == SyntaxKind::$kind.into()
     │                                                ┬  
@@ -1444,7 +1444,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:34:13 ]
+    ╭─[ rust.baml:34:13 ]
     │
  34 │             }
     │             ┬  
@@ -1454,7 +1454,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:36:13 ]
+    ╭─[ rust.baml:36:13 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │             ─┬  
@@ -1464,7 +1464,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:36:16 ]
+    ╭─[ rust.baml:36:16 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                ──┬─  
@@ -1474,7 +1474,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:36:20 ]
+    ╭─[ rust.baml:36:20 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                    ┬  
@@ -1484,7 +1484,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:36:21 ]
+    ╭─[ rust.baml:36:21 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                     ───┬──  
@@ -1494,7 +1494,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ':'
-    ╭─[ 3:36:27 ]
+    ╭─[ rust.baml:36:27 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                           ┬  
@@ -1504,7 +1504,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:36:29 ]
+    ╭─[ rust.baml:36:29 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                             ─────┬────  
@@ -1514,7 +1514,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:36:39 ]
+    ╭─[ rust.baml:36:39 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                       ┬  
@@ -1524,7 +1524,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-    ╭─[ 3:36:41 ]
+    ╭─[ rust.baml:36:41 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                         ─┬  
@@ -1534,7 +1534,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:36:44 ]
+    ╭─[ rust.baml:36:44 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                            ───┬──  
@@ -1544,7 +1544,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-    ╭─[ 3:36:50 ]
+    ╭─[ rust.baml:36:50 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                                  ┬  
@@ -1554,7 +1554,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:36:51 ]
+    ╭─[ rust.baml:36:51 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                                   ──┬─  
@@ -1564,7 +1564,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-    ╭─[ 3:36:55 ]
+    ╭─[ rust.baml:36:55 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                                       ┬  
@@ -1574,7 +1574,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:36:57 ]
+    ╭─[ rust.baml:36:57 ]
     │
  36 │             fn cast(syntax: SyntaxNode) -> Option<Self> {
     │                                                         ┬  
@@ -1584,7 +1584,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found if
-    ╭─[ 3:37:17 ]
+    ╭─[ rust.baml:37:17 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                 ─┬  
@@ -1594,7 +1594,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:37:20 ]
+    ╭─[ rust.baml:37:20 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                    ──┬─  
@@ -1604,7 +1604,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:37:24 ]
+    ╭─[ rust.baml:37:24 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                        ─┬  
@@ -1614,7 +1614,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:37:26 ]
+    ╭─[ rust.baml:37:26 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                          ────┬───  
@@ -1624,7 +1624,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:37:34 ]
+    ╭─[ rust.baml:37:34 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                  ┬  
@@ -1634,7 +1634,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:37:35 ]
+    ╭─[ rust.baml:37:35 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                   ───┬──  
@@ -1644,7 +1644,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:37:41 ]
+    ╭─[ rust.baml:37:41 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                         ┬  
@@ -1654,7 +1654,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:37:42 ]
+    ╭─[ rust.baml:37:42 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                          ──┬─  
@@ -1664,7 +1664,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:37:46 ]
+    ╭─[ rust.baml:37:46 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                              ┬  
@@ -1674,7 +1674,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:37:47 ]
+    ╭─[ rust.baml:37:47 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                               ┬  
@@ -1684,7 +1684,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:37:48 ]
+    ╭─[ rust.baml:37:48 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                                ┬  
@@ -1694,7 +1694,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:37:50 ]
+    ╭─[ rust.baml:37:50 ]
     │
  37 │                 if Self::can_cast(syntax.kind()) {
     │                                                  ┬  
@@ -1704,7 +1704,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:38:21 ]
+    ╭─[ rust.baml:38:21 ]
     │
  38 │                     Some(Self { syntax })
     │                     ──┬─  
@@ -1714,7 +1714,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:38:25 ]
+    ╭─[ rust.baml:38:25 ]
     │
  38 │                     Some(Self { syntax })
     │                         ┬  
@@ -1724,7 +1724,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:38:26 ]
+    ╭─[ rust.baml:38:26 ]
     │
  38 │                     Some(Self { syntax })
     │                          ──┬─  
@@ -1734,7 +1734,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:38:31 ]
+    ╭─[ rust.baml:38:31 ]
     │
  38 │                     Some(Self { syntax })
     │                               ┬  
@@ -1744,7 +1744,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:38:33 ]
+    ╭─[ rust.baml:38:33 ]
     │
  38 │                     Some(Self { syntax })
     │                                 ───┬──  
@@ -1754,7 +1754,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:38:40 ]
+    ╭─[ rust.baml:38:40 ]
     │
  38 │                     Some(Self { syntax })
     │                                        ┬  
@@ -1764,7 +1764,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:38:41 ]
+    ╭─[ rust.baml:38:41 ]
     │
  38 │                     Some(Self { syntax })
     │                                         ┬  
@@ -1774,7 +1774,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:39:17 ]
+    ╭─[ rust.baml:39:17 ]
     │
  39 │                 } else {
     │                 ┬  
@@ -1784,7 +1784,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found else
-    ╭─[ 3:39:19 ]
+    ╭─[ rust.baml:39:19 ]
     │
  39 │                 } else {
     │                   ──┬─  
@@ -1794,7 +1794,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:39:24 ]
+    ╭─[ rust.baml:39:24 ]
     │
  39 │                 } else {
     │                        ┬  
@@ -1804,7 +1804,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:40:21 ]
+    ╭─[ rust.baml:40:21 ]
     │
  40 │                     None
     │                     ──┬─  
@@ -1814,7 +1814,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:41:17 ]
+    ╭─[ rust.baml:41:17 ]
     │
  41 │                 }
     │                 ┬  
@@ -1824,7 +1824,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:42:13 ]
+    ╭─[ rust.baml:42:13 ]
     │
  42 │             }
     │             ┬  
@@ -1834,7 +1834,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:44:13 ]
+    ╭─[ rust.baml:44:13 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │             ─┬  
@@ -1844,7 +1844,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:44:16 ]
+    ╭─[ rust.baml:44:16 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                ───┬──  
@@ -1854,7 +1854,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:44:22 ]
+    ╭─[ rust.baml:44:22 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                      ┬  
@@ -1864,7 +1864,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-    ╭─[ 3:44:23 ]
+    ╭─[ rust.baml:44:23 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                       ┬  
@@ -1874,7 +1874,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:44:24 ]
+    ╭─[ rust.baml:44:24 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                        ──┬─  
@@ -1884,7 +1884,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:44:28 ]
+    ╭─[ rust.baml:44:28 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                            ┬  
@@ -1894,7 +1894,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-    ╭─[ 3:44:30 ]
+    ╭─[ rust.baml:44:30 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                              ─┬  
@@ -1904,7 +1904,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-    ╭─[ 3:44:33 ]
+    ╭─[ rust.baml:44:33 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                                 ┬  
@@ -1914,7 +1914,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:44:34 ]
+    ╭─[ rust.baml:44:34 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                                  ─────┬────  
@@ -1924,7 +1924,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:44:45 ]
+    ╭─[ rust.baml:44:45 ]
     │
  44 │             fn syntax(&self) -> &SyntaxNode {
     │                                             ┬  
@@ -1934,7 +1934,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-    ╭─[ 3:45:17 ]
+    ╭─[ rust.baml:45:17 ]
     │
  45 │                 &self.syntax
     │                 ┬  
@@ -1944,7 +1944,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:45:18 ]
+    ╭─[ rust.baml:45:18 ]
     │
  45 │                 &self.syntax
     │                  ──┬─  
@@ -1954,7 +1954,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:45:22 ]
+    ╭─[ rust.baml:45:22 ]
     │
  45 │                 &self.syntax
     │                      ┬  
@@ -1964,7 +1964,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:45:23 ]
+    ╭─[ rust.baml:45:23 ]
     │
  45 │                 &self.syntax
     │                       ───┬──  
@@ -1974,7 +1974,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:46:13 ]
+    ╭─[ rust.baml:46:13 ]
     │
  46 │             }
     │             ┬  
@@ -1984,7 +1984,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:47:9 ]
+    ╭─[ rust.baml:47:9 ]
     │
  47 │         }
     │         ┬  
@@ -1994,7 +1994,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:48:5 ]
+    ╭─[ rust.baml:48:5 ]
     │
  48 │     };
     │     ┬  
@@ -2004,7 +2004,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:48:6 ]
+    ╭─[ rust.baml:48:6 ]
     │
  48 │     };
     │      ┬  
@@ -2014,7 +2014,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:49:1 ]
+    ╭─[ rust.baml:49:1 ]
     │
  49 │ }
     │ ┬  
@@ -2024,7 +2024,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:52:1 ]
+    ╭─[ rust.baml:52:1 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │ ────┬───  
@@ -2034,7 +2034,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:52:9 ]
+    ╭─[ rust.baml:52:9 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │         ┬  
@@ -2044,7 +2044,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:52:10 ]
+    ╭─[ rust.baml:52:10 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │          ┬  
@@ -2054,7 +2054,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:52:11 ]
+    ╭─[ rust.baml:52:11 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │           ─────┬────  
@@ -2064,7 +2064,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:52:21 ]
+    ╭─[ rust.baml:52:21 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │                     ┬  
@@ -2074,7 +2074,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:52:23 ]
+    ╭─[ rust.baml:52:23 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │                       ─────┬─────  
@@ -2084,7 +2084,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:52:34 ]
+    ╭─[ rust.baml:52:34 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │                                  ┬  
@@ -2094,7 +2094,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:52:35 ]
+    ╭─[ rust.baml:52:35 ]
     │
  52 │ ast_node!(SourceFile, SOURCE_FILE);
     │                                   ┬  
@@ -2104,7 +2104,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:53:1 ]
+    ╭─[ rust.baml:53:1 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │ ────┬───  
@@ -2114,7 +2114,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:53:9 ]
+    ╭─[ rust.baml:53:9 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │         ┬  
@@ -2124,7 +2124,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:53:10 ]
+    ╭─[ rust.baml:53:10 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │          ┬  
@@ -2134,7 +2134,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:53:11 ]
+    ╭─[ rust.baml:53:11 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │           ─────┬─────  
@@ -2144,7 +2144,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:53:22 ]
+    ╭─[ rust.baml:53:22 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │                      ┬  
@@ -2154,7 +2154,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:53:24 ]
+    ╭─[ rust.baml:53:24 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │                        ──────┬─────  
@@ -2164,7 +2164,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:53:36 ]
+    ╭─[ rust.baml:53:36 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │                                    ┬  
@@ -2174,7 +2174,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:53:37 ]
+    ╭─[ rust.baml:53:37 ]
     │
  53 │ ast_node!(FunctionDef, FUNCTION_DEF);
     │                                     ┬  
@@ -2184,7 +2184,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:54:1 ]
+    ╭─[ rust.baml:54:1 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │ ────┬───  
@@ -2194,7 +2194,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:54:9 ]
+    ╭─[ rust.baml:54:9 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │         ┬  
@@ -2204,7 +2204,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:54:10 ]
+    ╭─[ rust.baml:54:10 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │          ┬  
@@ -2214,7 +2214,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:54:11 ]
+    ╭─[ rust.baml:54:11 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │           ────┬───  
@@ -2224,7 +2224,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:54:19 ]
+    ╭─[ rust.baml:54:19 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │                   ┬  
@@ -2234,7 +2234,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:54:21 ]
+    ╭─[ rust.baml:54:21 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │                     ────┬────  
@@ -2244,7 +2244,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:54:30 ]
+    ╭─[ rust.baml:54:30 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │                              ┬  
@@ -2254,7 +2254,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:54:31 ]
+    ╭─[ rust.baml:54:31 ]
     │
  54 │ ast_node!(ClassDef, CLASS_DEF);
     │                               ┬  
@@ -2264,7 +2264,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:55:1 ]
+    ╭─[ rust.baml:55:1 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │ ────┬───  
@@ -2274,7 +2274,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:55:9 ]
+    ╭─[ rust.baml:55:9 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │         ┬  
@@ -2284,7 +2284,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:55:10 ]
+    ╭─[ rust.baml:55:10 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │          ┬  
@@ -2294,7 +2294,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:55:11 ]
+    ╭─[ rust.baml:55:11 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │           ───┬───  
@@ -2304,7 +2304,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:55:18 ]
+    ╭─[ rust.baml:55:18 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │                  ┬  
@@ -2314,7 +2314,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:55:20 ]
+    ╭─[ rust.baml:55:20 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │                    ────┬───  
@@ -2324,7 +2324,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:55:28 ]
+    ╭─[ rust.baml:55:28 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │                            ┬  
@@ -2334,7 +2334,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:55:29 ]
+    ╭─[ rust.baml:55:29 ]
     │
  55 │ ast_node!(EnumDef, ENUM_DEF);
     │                             ┬  
@@ -2344,7 +2344,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:56:1 ]
+    ╭─[ rust.baml:56:1 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │ ────┬───  
@@ -2354,7 +2354,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:56:9 ]
+    ╭─[ rust.baml:56:9 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │         ┬  
@@ -2364,7 +2364,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:56:10 ]
+    ╭─[ rust.baml:56:10 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │          ┬  
@@ -2374,7 +2374,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:56:11 ]
+    ╭─[ rust.baml:56:11 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │           ────┬────  
@@ -2384,7 +2384,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:56:20 ]
+    ╭─[ rust.baml:56:20 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │                    ┬  
@@ -2394,7 +2394,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:56:22 ]
+    ╭─[ rust.baml:56:22 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │                      ─────┬────  
@@ -2404,7 +2404,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:56:32 ]
+    ╭─[ rust.baml:56:32 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │                                ┬  
@@ -2414,7 +2414,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:56:33 ]
+    ╭─[ rust.baml:56:33 ]
     │
  56 │ ast_node!(ClientDef, CLIENT_DEF);
     │                                 ┬  
@@ -2424,7 +2424,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:57:1 ]
+    ╭─[ rust.baml:57:1 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │ ────┬───  
@@ -2434,7 +2434,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:57:9 ]
+    ╭─[ rust.baml:57:9 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │         ┬  
@@ -2444,7 +2444,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:57:10 ]
+    ╭─[ rust.baml:57:10 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │          ┬  
@@ -2454,7 +2454,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:57:11 ]
+    ╭─[ rust.baml:57:11 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │           ───┬───  
@@ -2464,7 +2464,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:57:18 ]
+    ╭─[ rust.baml:57:18 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │                  ┬  
@@ -2474,7 +2474,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:57:20 ]
+    ╭─[ rust.baml:57:20 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │                    ────┬───  
@@ -2484,7 +2484,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:57:28 ]
+    ╭─[ rust.baml:57:28 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │                            ┬  
@@ -2494,7 +2494,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:57:29 ]
+    ╭─[ rust.baml:57:29 ]
     │
  57 │ ast_node!(TestDef, TEST_DEF);
     │                             ┬  
@@ -2504,7 +2504,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:58:1 ]
+    ╭─[ rust.baml:58:1 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │ ────┬───  
@@ -2514,7 +2514,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:58:9 ]
+    ╭─[ rust.baml:58:9 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │         ┬  
@@ -2524,7 +2524,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:58:10 ]
+    ╭─[ rust.baml:58:10 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │          ┬  
@@ -2534,7 +2534,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:58:11 ]
+    ╭─[ rust.baml:58:11 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │           ───────┬──────  
@@ -2544,7 +2544,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:58:25 ]
+    ╭─[ rust.baml:58:25 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │                         ┬  
@@ -2554,7 +2554,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:58:27 ]
+    ╭─[ rust.baml:58:27 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │                           ────────┬───────  
@@ -2564,7 +2564,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:58:43 ]
+    ╭─[ rust.baml:58:43 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │                                           ┬  
@@ -2574,7 +2574,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:58:44 ]
+    ╭─[ rust.baml:58:44 ]
     │
  58 │ ast_node!(RetryPolicyDef, RETRY_POLICY_DEF);
     │                                            ┬  
@@ -2584,7 +2584,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:59:1 ]
+    ╭─[ rust.baml:59:1 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │ ────┬───  
@@ -2594,7 +2594,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:59:9 ]
+    ╭─[ rust.baml:59:9 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │         ┬  
@@ -2604,7 +2604,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:59:10 ]
+    ╭─[ rust.baml:59:10 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │          ┬  
@@ -2614,7 +2614,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:59:11 ]
+    ╭─[ rust.baml:59:11 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │           ────────┬────────  
@@ -2624,7 +2624,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:59:28 ]
+    ╭─[ rust.baml:59:28 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │                            ┬  
@@ -2634,7 +2634,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:59:30 ]
+    ╭─[ rust.baml:59:30 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │                              ─────────┬─────────  
@@ -2644,7 +2644,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:59:49 ]
+    ╭─[ rust.baml:59:49 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │                                                 ┬  
@@ -2654,7 +2654,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:59:50 ]
+    ╭─[ rust.baml:59:50 ]
     │
  59 │ ast_node!(TemplateStringDef, TEMPLATE_STRING_DEF);
     │                                                  ┬  
@@ -2664,7 +2664,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:60:1 ]
+    ╭─[ rust.baml:60:1 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │ ────┬───  
@@ -2674,7 +2674,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:60:9 ]
+    ╭─[ rust.baml:60:9 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │         ┬  
@@ -2684,7 +2684,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:60:10 ]
+    ╭─[ rust.baml:60:10 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │          ┬  
@@ -2694,7 +2694,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:60:11 ]
+    ╭─[ rust.baml:60:11 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │           ──────┬─────  
@@ -2704,7 +2704,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:60:23 ]
+    ╭─[ rust.baml:60:23 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │                       ┬  
@@ -2714,7 +2714,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:60:25 ]
+    ╭─[ rust.baml:60:25 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │                         ───────┬──────  
@@ -2724,7 +2724,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:60:39 ]
+    ╭─[ rust.baml:60:39 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │                                       ┬  
@@ -2734,7 +2734,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:60:40 ]
+    ╭─[ rust.baml:60:40 ]
     │
  60 │ ast_node!(TypeAliasDef, TYPE_ALIAS_DEF);
     │                                        ┬  
@@ -2744,7 +2744,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:62:1 ]
+    ╭─[ rust.baml:62:1 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │ ────┬───  
@@ -2754,7 +2754,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:62:9 ]
+    ╭─[ rust.baml:62:9 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │         ┬  
@@ -2764,7 +2764,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:62:10 ]
+    ╭─[ rust.baml:62:10 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │          ┬  
@@ -2774,7 +2774,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:62:11 ]
+    ╭─[ rust.baml:62:11 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │           ──────┬──────  
@@ -2784,7 +2784,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:62:24 ]
+    ╭─[ rust.baml:62:24 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │                        ┬  
@@ -2794,7 +2794,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:62:26 ]
+    ╭─[ rust.baml:62:26 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │                          ───────┬──────  
@@ -2804,7 +2804,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:62:40 ]
+    ╭─[ rust.baml:62:40 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │                                        ┬  
@@ -2814,7 +2814,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:62:41 ]
+    ╭─[ rust.baml:62:41 ]
     │
  62 │ ast_node!(ParameterList, PARAMETER_LIST);
     │                                         ┬  
@@ -2824,7 +2824,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:63:1 ]
+    ╭─[ rust.baml:63:1 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │ ────┬───  
@@ -2834,7 +2834,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:63:9 ]
+    ╭─[ rust.baml:63:9 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │         ┬  
@@ -2844,7 +2844,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:63:10 ]
+    ╭─[ rust.baml:63:10 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │          ┬  
@@ -2854,7 +2854,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:63:11 ]
+    ╭─[ rust.baml:63:11 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │           ────┬────  
@@ -2864,7 +2864,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:63:20 ]
+    ╭─[ rust.baml:63:20 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │                    ┬  
@@ -2874,7 +2874,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:63:22 ]
+    ╭─[ rust.baml:63:22 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │                      ────┬────  
@@ -2884,7 +2884,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:63:31 ]
+    ╭─[ rust.baml:63:31 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │                               ┬  
@@ -2894,7 +2894,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:63:32 ]
+    ╭─[ rust.baml:63:32 ]
     │
  63 │ ast_node!(Parameter, PARAMETER);
     │                                ┬  
@@ -2904,7 +2904,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:64:1 ]
+    ╭─[ rust.baml:64:1 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │ ────┬───  
@@ -2914,7 +2914,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:64:9 ]
+    ╭─[ rust.baml:64:9 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │         ┬  
@@ -2924,7 +2924,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:64:10 ]
+    ╭─[ rust.baml:64:10 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │          ┬  
@@ -2934,7 +2934,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:64:11 ]
+    ╭─[ rust.baml:64:11 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │           ──────┬─────  
@@ -2944,7 +2944,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:64:23 ]
+    ╭─[ rust.baml:64:23 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │                       ┬  
@@ -2954,7 +2954,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:64:25 ]
+    ╭─[ rust.baml:64:25 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │                         ──────┬──────  
@@ -2964,7 +2964,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:64:38 ]
+    ╭─[ rust.baml:64:38 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │                                      ┬  
@@ -2974,7 +2974,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:64:39 ]
+    ╭─[ rust.baml:64:39 ]
     │
  64 │ ast_node!(FunctionBody, FUNCTION_BODY);
     │                                       ┬  
@@ -2984,7 +2984,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:65:1 ]
+    ╭─[ rust.baml:65:1 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │ ────┬───  
@@ -2994,7 +2994,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:65:9 ]
+    ╭─[ rust.baml:65:9 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │         ┬  
@@ -3004,7 +3004,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:65:10 ]
+    ╭─[ rust.baml:65:10 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │          ┬  
@@ -3014,7 +3014,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:65:11 ]
+    ╭─[ rust.baml:65:11 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │           ───────┬───────  
@@ -3024,7 +3024,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:65:26 ]
+    ╭─[ rust.baml:65:26 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │                          ┬  
@@ -3034,7 +3034,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:65:28 ]
+    ╭─[ rust.baml:65:28 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │                            ────────┬────────  
@@ -3044,7 +3044,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:65:45 ]
+    ╭─[ rust.baml:65:45 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │                                             ┬  
@@ -3054,7 +3054,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:65:46 ]
+    ╭─[ rust.baml:65:46 ]
     │
  65 │ ast_node!(LlmFunctionBody, LLM_FUNCTION_BODY);
     │                                              ┬  
@@ -3064,7 +3064,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:66:1 ]
+    ╭─[ rust.baml:66:1 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │ ────┬───  
@@ -3074,7 +3074,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:66:9 ]
+    ╭─[ rust.baml:66:9 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │         ┬  
@@ -3084,7 +3084,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:66:10 ]
+    ╭─[ rust.baml:66:10 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │          ┬  
@@ -3094,7 +3094,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:66:11 ]
+    ╭─[ rust.baml:66:11 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │           ────────┬───────  
@@ -3104,7 +3104,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:66:27 ]
+    ╭─[ rust.baml:66:27 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │                           ┬  
@@ -3114,7 +3114,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:66:29 ]
+    ╭─[ rust.baml:66:29 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │                             ─────────┬────────  
@@ -3124,7 +3124,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:66:47 ]
+    ╭─[ rust.baml:66:47 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │                                               ┬  
@@ -3134,7 +3134,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:66:48 ]
+    ╭─[ rust.baml:66:48 ]
     │
  66 │ ast_node!(ExprFunctionBody, EXPR_FUNCTION_BODY);
     │                                                ┬  
@@ -3144,7 +3144,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:67:1 ]
+    ╭─[ rust.baml:67:1 ]
     │
  67 │ ast_node!(Field, FIELD);
     │ ────┬───  
@@ -3154,7 +3154,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:67:9 ]
+    ╭─[ rust.baml:67:9 ]
     │
  67 │ ast_node!(Field, FIELD);
     │         ┬  
@@ -3164,7 +3164,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:67:10 ]
+    ╭─[ rust.baml:67:10 ]
     │
  67 │ ast_node!(Field, FIELD);
     │          ┬  
@@ -3174,7 +3174,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:67:11 ]
+    ╭─[ rust.baml:67:11 ]
     │
  67 │ ast_node!(Field, FIELD);
     │           ──┬──  
@@ -3184,7 +3184,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:67:16 ]
+    ╭─[ rust.baml:67:16 ]
     │
  67 │ ast_node!(Field, FIELD);
     │                ┬  
@@ -3194,7 +3194,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:67:18 ]
+    ╭─[ rust.baml:67:18 ]
     │
  67 │ ast_node!(Field, FIELD);
     │                  ──┬──  
@@ -3204,7 +3204,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:67:23 ]
+    ╭─[ rust.baml:67:23 ]
     │
  67 │ ast_node!(Field, FIELD);
     │                       ┬  
@@ -3214,7 +3214,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:67:24 ]
+    ╭─[ rust.baml:67:24 ]
     │
  67 │ ast_node!(Field, FIELD);
     │                        ┬  
@@ -3224,7 +3224,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:68:1 ]
+    ╭─[ rust.baml:68:1 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │ ────┬───  
@@ -3234,7 +3234,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:68:9 ]
+    ╭─[ rust.baml:68:9 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │         ┬  
@@ -3244,7 +3244,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:68:10 ]
+    ╭─[ rust.baml:68:10 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │          ┬  
@@ -3254,7 +3254,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:68:11 ]
+    ╭─[ rust.baml:68:11 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │           ─────┬─────  
@@ -3264,7 +3264,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:68:22 ]
+    ╭─[ rust.baml:68:22 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │                      ┬  
@@ -3274,7 +3274,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:68:24 ]
+    ╭─[ rust.baml:68:24 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │                        ──────┬─────  
@@ -3284,7 +3284,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:68:36 ]
+    ╭─[ rust.baml:68:36 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │                                    ┬  
@@ -3294,7 +3294,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:68:37 ]
+    ╭─[ rust.baml:68:37 ]
     │
  68 │ ast_node!(EnumVariant, ENUM_VARIANT);
     │                                     ┬  
@@ -3304,7 +3304,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:69:1 ]
+    ╭─[ rust.baml:69:1 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │ ────┬───  
@@ -3314,7 +3314,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:69:9 ]
+    ╭─[ rust.baml:69:9 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │         ┬  
@@ -3324,7 +3324,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:69:10 ]
+    ╭─[ rust.baml:69:10 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │          ┬  
@@ -3334,7 +3334,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:69:11 ]
+    ╭─[ rust.baml:69:11 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │           ─────┬─────  
@@ -3344,7 +3344,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:69:22 ]
+    ╭─[ rust.baml:69:22 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │                      ┬  
@@ -3354,7 +3354,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:69:24 ]
+    ╭─[ rust.baml:69:24 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │                        ──────┬─────  
@@ -3364,7 +3364,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:69:36 ]
+    ╭─[ rust.baml:69:36 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │                                    ┬  
@@ -3374,7 +3374,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:69:37 ]
+    ╭─[ rust.baml:69:37 ]
     │
  69 │ ast_node!(ConfigBlock, CONFIG_BLOCK);
     │                                     ┬  
@@ -3384,7 +3384,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:70:1 ]
+    ╭─[ rust.baml:70:1 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │ ────┬───  
@@ -3394,7 +3394,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:70:9 ]
+    ╭─[ rust.baml:70:9 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │         ┬  
@@ -3404,7 +3404,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:70:10 ]
+    ╭─[ rust.baml:70:10 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │          ┬  
@@ -3414,7 +3414,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:70:11 ]
+    ╭─[ rust.baml:70:11 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │           ─────┬────  
@@ -3424,7 +3424,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:70:21 ]
+    ╭─[ rust.baml:70:21 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │                     ┬  
@@ -3434,7 +3434,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:70:23 ]
+    ╭─[ rust.baml:70:23 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │                       ─────┬─────  
@@ -3444,7 +3444,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:70:34 ]
+    ╭─[ rust.baml:70:34 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │                                  ┬  
@@ -3454,7 +3454,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:70:35 ]
+    ╭─[ rust.baml:70:35 ]
     │
  70 │ ast_node!(ConfigItem, CONFIG_ITEM);
     │                                   ┬  
@@ -3464,7 +3464,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:72:1 ]
+    ╭─[ rust.baml:72:1 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │ ────┬───  
@@ -3474,7 +3474,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:72:9 ]
+    ╭─[ rust.baml:72:9 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │         ┬  
@@ -3484,7 +3484,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:72:10 ]
+    ╭─[ rust.baml:72:10 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │          ┬  
@@ -3494,7 +3494,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:72:11 ]
+    ╭─[ rust.baml:72:11 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │           ────┬───  
@@ -3504,7 +3504,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:72:19 ]
+    ╭─[ rust.baml:72:19 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │                   ┬  
@@ -3514,7 +3514,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:72:21 ]
+    ╭─[ rust.baml:72:21 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │                     ────┬────  
@@ -3524,7 +3524,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:72:30 ]
+    ╭─[ rust.baml:72:30 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │                              ┬  
@@ -3534,7 +3534,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:72:31 ]
+    ╭─[ rust.baml:72:31 ]
     │
  72 │ ast_node!(TypeExpr, TYPE_EXPR);
     │                               ┬  
@@ -3544,7 +3544,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:73:1 ]
+    ╭─[ rust.baml:73:1 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │ ────┬───  
@@ -3554,7 +3554,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:73:9 ]
+    ╭─[ rust.baml:73:9 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │         ┬  
@@ -3564,7 +3564,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:73:10 ]
+    ╭─[ rust.baml:73:10 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │          ┬  
@@ -3574,7 +3574,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:73:11 ]
+    ╭─[ rust.baml:73:11 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │           ────┬────  
@@ -3584,7 +3584,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:73:20 ]
+    ╭─[ rust.baml:73:20 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │                    ┬  
@@ -3594,7 +3594,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:73:22 ]
+    ╭─[ rust.baml:73:22 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │                      ────┬────  
@@ -3604,7 +3604,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:73:31 ]
+    ╭─[ rust.baml:73:31 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │                               ┬  
@@ -3614,7 +3614,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:73:32 ]
+    ╭─[ rust.baml:73:32 ]
     │
  73 │ ast_node!(Attribute, ATTRIBUTE);
     │                                ┬  
@@ -3624,7 +3624,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:74:1 ]
+    ╭─[ rust.baml:74:1 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │ ────┬───  
@@ -3634,7 +3634,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:74:9 ]
+    ╭─[ rust.baml:74:9 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │         ┬  
@@ -3644,7 +3644,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:74:10 ]
+    ╭─[ rust.baml:74:10 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │          ┬  
@@ -3654,7 +3654,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:74:11 ]
+    ╭─[ rust.baml:74:11 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │           ───────┬──────  
@@ -3664,7 +3664,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:74:25 ]
+    ╭─[ rust.baml:74:25 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │                         ┬  
@@ -3674,7 +3674,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:74:27 ]
+    ╭─[ rust.baml:74:27 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │                           ───────┬───────  
@@ -3684,7 +3684,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:74:42 ]
+    ╭─[ rust.baml:74:42 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │                                          ┬  
@@ -3694,7 +3694,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:74:43 ]
+    ╭─[ rust.baml:74:43 ]
     │
  74 │ ast_node!(BlockAttribute, BLOCK_ATTRIBUTE);
     │                                           ┬  
@@ -3704,7 +3704,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:76:1 ]
+    ╭─[ rust.baml:76:1 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │ ────┬───  
@@ -3714,7 +3714,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:76:9 ]
+    ╭─[ rust.baml:76:9 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │         ┬  
@@ -3724,7 +3724,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:76:10 ]
+    ╭─[ rust.baml:76:10 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │          ┬  
@@ -3734,7 +3734,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:76:11 ]
+    ╭─[ rust.baml:76:11 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │           ──┬─  
@@ -3744,7 +3744,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:76:15 ]
+    ╭─[ rust.baml:76:15 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │               ┬  
@@ -3754,7 +3754,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:76:17 ]
+    ╭─[ rust.baml:76:17 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │                 ──┬─  
@@ -3764,7 +3764,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:76:21 ]
+    ╭─[ rust.baml:76:21 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │                     ┬  
@@ -3774,7 +3774,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:76:22 ]
+    ╭─[ rust.baml:76:22 ]
     │
  76 │ ast_node!(Expr, EXPR);
     │                      ┬  
@@ -3784,7 +3784,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:77:1 ]
+    ╭─[ rust.baml:77:1 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │ ────┬───  
@@ -3794,7 +3794,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:77:9 ]
+    ╭─[ rust.baml:77:9 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │         ┬  
@@ -3804,7 +3804,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:77:10 ]
+    ╭─[ rust.baml:77:10 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │          ┬  
@@ -3814,7 +3814,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:77:11 ]
+    ╭─[ rust.baml:77:11 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │           ───┬───  
@@ -3824,7 +3824,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:77:18 ]
+    ╭─[ rust.baml:77:18 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │                  ┬  
@@ -3834,7 +3834,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:77:20 ]
+    ╭─[ rust.baml:77:20 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │                    ────┬───  
@@ -3844,7 +3844,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:77:28 ]
+    ╭─[ rust.baml:77:28 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │                            ┬  
@@ -3854,7 +3854,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:77:29 ]
+    ╭─[ rust.baml:77:29 ]
     │
  77 │ ast_node!(LetStmt, LET_STMT);
     │                             ┬  
@@ -3864,7 +3864,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:78:1 ]
+    ╭─[ rust.baml:78:1 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │ ────┬───  
@@ -3874,7 +3874,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:78:9 ]
+    ╭─[ rust.baml:78:9 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │         ┬  
@@ -3884,7 +3884,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:78:10 ]
+    ╭─[ rust.baml:78:10 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │          ┬  
@@ -3894,7 +3894,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:78:11 ]
+    ╭─[ rust.baml:78:11 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │           ───┬──  
@@ -3904,7 +3904,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:78:17 ]
+    ╭─[ rust.baml:78:17 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │                 ┬  
@@ -3914,7 +3914,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:78:19 ]
+    ╭─[ rust.baml:78:19 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │                   ───┬───  
@@ -3924,7 +3924,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:78:26 ]
+    ╭─[ rust.baml:78:26 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │                          ┬  
@@ -3934,7 +3934,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:78:27 ]
+    ╭─[ rust.baml:78:27 ]
     │
  78 │ ast_node!(IfExpr, IF_EXPR);
     │                           ┬  
@@ -3944,7 +3944,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:79:1 ]
+    ╭─[ rust.baml:79:1 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │ ────┬───  
@@ -3954,7 +3954,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:79:9 ]
+    ╭─[ rust.baml:79:9 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │         ┬  
@@ -3964,7 +3964,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:79:10 ]
+    ╭─[ rust.baml:79:10 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │          ┬  
@@ -3974,7 +3974,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:79:11 ]
+    ╭─[ rust.baml:79:11 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │           ────┬────  
@@ -3984,7 +3984,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:79:20 ]
+    ╭─[ rust.baml:79:20 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │                    ┬  
@@ -3994,7 +3994,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:79:22 ]
+    ╭─[ rust.baml:79:22 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │                      ─────┬────  
@@ -4004,7 +4004,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:79:32 ]
+    ╭─[ rust.baml:79:32 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │                                ┬  
@@ -4014,7 +4014,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:79:33 ]
+    ╭─[ rust.baml:79:33 ]
     │
  79 │ ast_node!(WhileStmt, WHILE_STMT);
     │                                 ┬  
@@ -4024,7 +4024,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:80:1 ]
+    ╭─[ rust.baml:80:1 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │ ────┬───  
@@ -4034,7 +4034,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:80:9 ]
+    ╭─[ rust.baml:80:9 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │         ┬  
@@ -4044,7 +4044,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:80:10 ]
+    ╭─[ rust.baml:80:10 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │          ┬  
@@ -4054,7 +4054,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:80:11 ]
+    ╭─[ rust.baml:80:11 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │           ───┬───  
@@ -4064,7 +4064,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:80:18 ]
+    ╭─[ rust.baml:80:18 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │                  ┬  
@@ -4074,7 +4074,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:80:20 ]
+    ╭─[ rust.baml:80:20 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │                    ────┬───  
@@ -4084,7 +4084,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:80:28 ]
+    ╭─[ rust.baml:80:28 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │                            ┬  
@@ -4094,7 +4094,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:80:29 ]
+    ╭─[ rust.baml:80:29 ]
     │
  80 │ ast_node!(ForExpr, FOR_EXPR);
     │                             ┬  
@@ -4104,7 +4104,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:81:1 ]
+    ╭─[ rust.baml:81:1 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │ ────┬───  
@@ -4114,7 +4114,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-    ╭─[ 3:81:9 ]
+    ╭─[ rust.baml:81:9 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │         ┬  
@@ -4124,7 +4124,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:81:10 ]
+    ╭─[ rust.baml:81:10 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │          ┬  
@@ -4134,7 +4134,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:81:11 ]
+    ╭─[ rust.baml:81:11 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │           ────┬────  
@@ -4144,7 +4144,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ','
-    ╭─[ 3:81:20 ]
+    ╭─[ rust.baml:81:20 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │                    ┬  
@@ -4154,7 +4154,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:81:22 ]
+    ╭─[ rust.baml:81:22 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │                      ─────┬────  
@@ -4164,7 +4164,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:81:32 ]
+    ╭─[ rust.baml:81:32 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │                                ┬  
@@ -4174,7 +4174,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-    ╭─[ 3:81:33 ]
+    ╭─[ rust.baml:81:33 ]
     │
  81 │ ast_node!(BlockExpr, BLOCK_EXPR);
     │                                 ┬  
@@ -4184,7 +4184,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:84:1 ]
+    ╭─[ rust.baml:84:1 ]
     │
  84 │ impl SourceFile {
     │ ──┬─  
@@ -4194,7 +4194,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:84:6 ]
+    ╭─[ rust.baml:84:6 ]
     │
  84 │ impl SourceFile {
     │      ─────┬────  
@@ -4204,7 +4204,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:84:17 ]
+    ╭─[ rust.baml:84:17 ]
     │
  84 │ impl SourceFile {
     │                 ┬  
@@ -4214,7 +4214,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:86:5 ]
+    ╭─[ rust.baml:86:5 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │     ─┬─  
@@ -4224,7 +4224,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:86:9 ]
+    ╭─[ rust.baml:86:9 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │         ─┬  
@@ -4234,7 +4234,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:86:12 ]
+    ╭─[ rust.baml:86:12 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │            ──┬──  
@@ -4244,7 +4244,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:86:17 ]
+    ╭─[ rust.baml:86:17 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                 ┬  
@@ -4254,7 +4254,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-    ╭─[ 3:86:18 ]
+    ╭─[ rust.baml:86:18 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                  ┬  
@@ -4264,7 +4264,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:86:19 ]
+    ╭─[ rust.baml:86:19 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                   ──┬─  
@@ -4274,7 +4274,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:86:23 ]
+    ╭─[ rust.baml:86:23 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                       ┬  
@@ -4284,7 +4284,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-    ╭─[ 3:86:25 ]
+    ╭─[ rust.baml:86:25 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                         ─┬  
@@ -4294,7 +4294,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:86:28 ]
+    ╭─[ rust.baml:86:28 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                            ──┬─  
@@ -4304,7 +4304,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:86:33 ]
+    ╭─[ rust.baml:86:33 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                 ────┬───  
@@ -4314,7 +4314,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-    ╭─[ 3:86:41 ]
+    ╭─[ rust.baml:86:41 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                         ┬  
@@ -4324,7 +4324,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:86:42 ]
+    ╭─[ rust.baml:86:42 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                          ──┬─  
@@ -4334,7 +4334,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '='
-    ╭─[ 3:86:47 ]
+    ╭─[ rust.baml:86:47 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                               ┬  
@@ -4344,7 +4344,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:86:49 ]
+    ╭─[ rust.baml:86:49 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                                 ──┬─  
@@ -4354,7 +4354,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-    ╭─[ 3:86:53 ]
+    ╭─[ rust.baml:86:53 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                                     ┬  
@@ -4364,7 +4364,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:86:55 ]
+    ╭─[ rust.baml:86:55 ]
     │
  86 │     pub fn items(&self) -> impl Iterator<Item = Item> {
     │                                                       ┬  
@@ -4374,7 +4374,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:87:9 ]
+    ╭─[ rust.baml:87:9 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │         ──┬─  
@@ -4384,7 +4384,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:87:13 ]
+    ╭─[ rust.baml:87:13 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │             ┬  
@@ -4394,7 +4394,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:87:14 ]
+    ╭─[ rust.baml:87:14 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │              ───┬──  
@@ -4404,7 +4404,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:87:20 ]
+    ╭─[ rust.baml:87:20 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                    ┬  
@@ -4414,7 +4414,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:87:21 ]
+    ╭─[ rust.baml:87:21 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                     ────┬───  
@@ -4424,7 +4424,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:87:29 ]
+    ╭─[ rust.baml:87:29 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                             ┬  
@@ -4434,7 +4434,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:87:30 ]
+    ╭─[ rust.baml:87:30 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                              ┬  
@@ -4444,7 +4444,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:87:31 ]
+    ╭─[ rust.baml:87:31 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                               ┬  
@@ -4454,7 +4454,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:87:32 ]
+    ╭─[ rust.baml:87:32 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                ─────┬────  
@@ -4464,7 +4464,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:87:42 ]
+    ╭─[ rust.baml:87:42 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                          ┬  
@@ -4474,7 +4474,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:87:43 ]
+    ╭─[ rust.baml:87:43 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                           ──┬─  
@@ -4484,7 +4484,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:87:47 ]
+    ╭─[ rust.baml:87:47 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                               ─┬  
@@ -4494,7 +4494,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:87:49 ]
+    ╭─[ rust.baml:87:49 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                                 ──┬─  
@@ -4504,7 +4504,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:87:53 ]
+    ╭─[ rust.baml:87:53 ]
     │
  87 │         self.syntax.children().filter_map(Item::cast)
     │                                                     ┬  
@@ -4514,7 +4514,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:88:5 ]
+    ╭─[ rust.baml:88:5 ]
     │
  88 │     }
     │     ┬  
@@ -4524,7 +4524,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:89:1 ]
+    ╭─[ rust.baml:89:1 ]
     │
  89 │ }
     │ ┬  
@@ -4534,7 +4534,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:91:1 ]
+    ╭─[ rust.baml:91:1 ]
     │
  91 │ impl FunctionDef {
     │ ──┬─  
@@ -4544,7 +4544,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:91:6 ]
+    ╭─[ rust.baml:91:6 ]
     │
  91 │ impl FunctionDef {
     │      ─────┬─────  
@@ -4554,7 +4554,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:91:18 ]
+    ╭─[ rust.baml:91:18 ]
     │
  91 │ impl FunctionDef {
     │                  ┬  
@@ -4564,7 +4564,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:93:5 ]
+    ╭─[ rust.baml:93:5 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │     ─┬─  
@@ -4574,7 +4574,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:93:9 ]
+    ╭─[ rust.baml:93:9 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │         ─┬  
@@ -4584,7 +4584,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:93:12 ]
+    ╭─[ rust.baml:93:12 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │            ──┬─  
@@ -4594,7 +4594,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:93:16 ]
+    ╭─[ rust.baml:93:16 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                ┬  
@@ -4604,7 +4604,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-    ╭─[ 3:93:17 ]
+    ╭─[ rust.baml:93:17 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                 ┬  
@@ -4614,7 +4614,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:93:18 ]
+    ╭─[ rust.baml:93:18 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                  ──┬─  
@@ -4624,7 +4624,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:93:22 ]
+    ╭─[ rust.baml:93:22 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                      ┬  
@@ -4634,7 +4634,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-    ╭─[ 3:93:24 ]
+    ╭─[ rust.baml:93:24 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                        ─┬  
@@ -4644,7 +4644,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:93:27 ]
+    ╭─[ rust.baml:93:27 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                           ───┬──  
@@ -4654,7 +4654,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-    ╭─[ 3:93:33 ]
+    ╭─[ rust.baml:93:33 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                                 ┬  
@@ -4664,7 +4664,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:93:34 ]
+    ╭─[ rust.baml:93:34 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                                  ─────┬─────  
@@ -4674,7 +4674,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-    ╭─[ 3:93:45 ]
+    ╭─[ rust.baml:93:45 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                                             ┬  
@@ -4684,7 +4684,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:93:47 ]
+    ╭─[ rust.baml:93:47 ]
     │
  93 │     pub fn name(&self) -> Option<SyntaxToken> {
     │                                               ┬  
@@ -4694,7 +4694,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:94:9 ]
+    ╭─[ rust.baml:94:9 ]
     │
  94 │         self.syntax
     │         ──┬─  
@@ -4704,7 +4704,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:94:13 ]
+    ╭─[ rust.baml:94:13 ]
     │
  94 │         self.syntax
     │             ┬  
@@ -4714,7 +4714,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:94:14 ]
+    ╭─[ rust.baml:94:14 ]
     │
  94 │         self.syntax
     │              ───┬──  
@@ -4724,7 +4724,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:95:13 ]
+    ╭─[ rust.baml:95:13 ]
     │
  95 │             .children_with_tokens()
     │             ┬  
@@ -4734,7 +4734,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:95:14 ]
+    ╭─[ rust.baml:95:14 ]
     │
  95 │             .children_with_tokens()
     │              ──────────┬─────────  
@@ -4744,7 +4744,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:95:34 ]
+    ╭─[ rust.baml:95:34 ]
     │
  95 │             .children_with_tokens()
     │                                  ┬  
@@ -4754,7 +4754,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:95:35 ]
+    ╭─[ rust.baml:95:35 ]
     │
  95 │             .children_with_tokens()
     │                                   ┬  
@@ -4764,7 +4764,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:96:13 ]
+    ╭─[ rust.baml:96:13 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │             ┬  
@@ -4774,7 +4774,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:96:14 ]
+    ╭─[ rust.baml:96:14 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │              ─────┬────  
@@ -4784,7 +4784,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:96:24 ]
+    ╭─[ rust.baml:96:24 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                        ┬  
@@ -4794,7 +4794,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:96:25 ]
+    ╭─[ rust.baml:96:25 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                         ──┬──  
@@ -4804,7 +4804,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:96:30 ]
+    ╭─[ rust.baml:96:30 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                              ─┬  
@@ -4814,7 +4814,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:96:32 ]
+    ╭─[ rust.baml:96:32 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                                ─────┬─────  
@@ -4824,7 +4824,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:96:43 ]
+    ╭─[ rust.baml:96:43 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                                           ─┬  
@@ -4834,7 +4834,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:96:45 ]
+    ╭─[ rust.baml:96:45 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                                             ─────┬────  
@@ -4844,7 +4844,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:96:55 ]
+    ╭─[ rust.baml:96:55 ]
     │
  96 │             .filter_map(rowan::NodeOrToken::into_token)
     │                                                       ┬  
@@ -4854,7 +4854,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:97:13 ]
+    ╭─[ rust.baml:97:13 ]
     │
  97 │             .filter(|token| {
     │             ┬  
@@ -4864,7 +4864,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:97:14 ]
+    ╭─[ rust.baml:97:14 ]
     │
  97 │             .filter(|token| {
     │              ───┬──  
@@ -4874,7 +4874,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:97:20 ]
+    ╭─[ rust.baml:97:20 ]
     │
  97 │             .filter(|token| {
     │                    ┬  
@@ -4884,7 +4884,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-    ╭─[ 3:97:21 ]
+    ╭─[ rust.baml:97:21 ]
     │
  97 │             .filter(|token| {
     │                     ┬  
@@ -4894,7 +4894,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:97:22 ]
+    ╭─[ rust.baml:97:22 ]
     │
  97 │             .filter(|token| {
     │                      ──┬──  
@@ -4904,7 +4904,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-    ╭─[ 3:97:27 ]
+    ╭─[ rust.baml:97:27 ]
     │
  97 │             .filter(|token| {
     │                           ┬  
@@ -4914,7 +4914,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:97:29 ]
+    ╭─[ rust.baml:97:29 ]
     │
  97 │             .filter(|token| {
     │                             ┬  
@@ -4924,7 +4924,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:17 ]
+    ╭─[ rust.baml:98:17 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                 ──┬──  
@@ -4934,7 +4934,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:98:22 ]
+    ╭─[ rust.baml:98:22 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                      ┬  
@@ -4944,7 +4944,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:23 ]
+    ╭─[ rust.baml:98:23 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                       ──┬─  
@@ -4954,7 +4954,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:98:27 ]
+    ╭─[ rust.baml:98:27 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                           ┬  
@@ -4964,7 +4964,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:98:28 ]
+    ╭─[ rust.baml:98:28 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                            ┬  
@@ -4974,7 +4974,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '=='
-    ╭─[ 3:98:30 ]
+    ╭─[ rust.baml:98:30 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                              ─┬  
@@ -4984,7 +4984,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:33 ]
+    ╭─[ rust.baml:98:33 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                 ─────┬────  
@@ -4994,7 +4994,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-    ╭─[ 3:98:43 ]
+    ╭─[ rust.baml:98:43 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                           ─┬  
@@ -5004,7 +5004,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:45 ]
+    ╭─[ rust.baml:98:45 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                             ──┬─  
@@ -5014,7 +5014,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '&&'
-    ╭─[ 3:98:50 ]
+    ╭─[ rust.baml:98:50 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                  ─┬  
@@ -5024,7 +5024,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:53 ]
+    ╭─[ rust.baml:98:53 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                     ──┬──  
@@ -5034,7 +5034,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:98:58 ]
+    ╭─[ rust.baml:98:58 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                          ┬  
@@ -5044,7 +5044,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:59 ]
+    ╭─[ rust.baml:98:59 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                           ───┬──  
@@ -5054,7 +5054,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:98:65 ]
+    ╭─[ rust.baml:98:65 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                 ┬  
@@ -5064,7 +5064,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:98:66 ]
+    ╭─[ rust.baml:98:66 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                  ┬  
@@ -5074,7 +5074,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '=='
-    ╭─[ 3:98:68 ]
+    ╭─[ rust.baml:98:68 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                    ─┬  
@@ -5084,7 +5084,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:71 ]
+    ╭─[ rust.baml:98:71 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                       ──┬─  
@@ -5094,7 +5094,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:98:75 ]
+    ╭─[ rust.baml:98:75 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                           ┬  
@@ -5104,7 +5104,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:76 ]
+    ╭─[ rust.baml:98:76 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                            ──┬─  
@@ -5114,7 +5114,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:98:80 ]
+    ╭─[ rust.baml:98:80 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                ┬  
@@ -5124,7 +5124,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:81 ]
+    ╭─[ rust.baml:98:81 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                 ───┬──  
@@ -5134,7 +5134,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-    ╭─[ 3:98:87 ]
+    ╭─[ rust.baml:98:87 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                       ┬  
@@ -5144,7 +5144,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:98:88 ]
+    ╭─[ rust.baml:98:88 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                        ──┬──  
@@ -5154,7 +5154,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '('
-    ╭─[ 3:98:93 ]
+    ╭─[ rust.baml:98:93 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                             ┬  
@@ -5164,7 +5164,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:98:94 ]
+    ╭─[ rust.baml:98:94 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                              ┬  
@@ -5174,7 +5174,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:98:95 ]
+    ╭─[ rust.baml:98:95 ]
     │
  98 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
     │                                                                                               ┬  
@@ -5184,7 +5184,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-    ╭─[ 3:99:13 ]
+    ╭─[ rust.baml:99:13 ]
     │
  99 │             })
     │             ┬  
@@ -5194,7 +5194,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:99:14 ]
+    ╭─[ rust.baml:99:14 ]
     │
  99 │             })
     │              ┬  
@@ -5204,7 +5204,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:100:13 ]
+     ╭─[ rust.baml:100:13 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │             ┬  
@@ -5214,7 +5214,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:100:14 ]
+     ╭─[ rust.baml:100:14 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │              ─┬─  
@@ -5224,7 +5224,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:100:17 ]
+     ╭─[ rust.baml:100:17 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │                 ┬  
@@ -5234,7 +5234,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found integer
-     ╭─[ 3:100:18 ]
+     ╭─[ rust.baml:100:18 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │                  ┬  
@@ -5244,7 +5244,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:100:19 ]
+     ╭─[ rust.baml:100:19 ]
      │
  100 │             .nth(1) // Skip the "function" keyword, get the second WORD
      │                   ┬  
@@ -5254,7 +5254,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:101:5 ]
+     ╭─[ rust.baml:101:5 ]
      │
  101 │     }
      │     ┬  
@@ -5264,7 +5264,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:104:5 ]
+     ╭─[ rust.baml:104:5 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │     ─┬─  
@@ -5274,7 +5274,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:104:9 ]
+     ╭─[ rust.baml:104:9 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │         ─┬  
@@ -5284,7 +5284,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:104:12 ]
+     ╭─[ rust.baml:104:12 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │            ─────┬────  
@@ -5294,7 +5294,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:104:22 ]
+     ╭─[ rust.baml:104:22 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                      ┬  
@@ -5304,7 +5304,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:104:23 ]
+     ╭─[ rust.baml:104:23 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                       ┬  
@@ -5314,7 +5314,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:104:24 ]
+     ╭─[ rust.baml:104:24 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                        ──┬─  
@@ -5324,7 +5324,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:104:28 ]
+     ╭─[ rust.baml:104:28 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                            ┬  
@@ -5334,7 +5334,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:104:30 ]
+     ╭─[ rust.baml:104:30 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                              ─┬  
@@ -5344,7 +5344,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:104:33 ]
+     ╭─[ rust.baml:104:33 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                 ───┬──  
@@ -5354,7 +5354,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:104:39 ]
+     ╭─[ rust.baml:104:39 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                       ┬  
@@ -5364,7 +5364,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:104:40 ]
+     ╭─[ rust.baml:104:40 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                        ──────┬──────  
@@ -5374,7 +5374,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:104:53 ]
+     ╭─[ rust.baml:104:53 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                                     ┬  
@@ -5384,7 +5384,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:104:55 ]
+     ╭─[ rust.baml:104:55 ]
      │
  104 │     pub fn param_list(&self) -> Option<ParameterList> {
      │                                                       ┬  
@@ -5394,7 +5394,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:105:9 ]
+     ╭─[ rust.baml:105:9 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │         ──┬─  
@@ -5404,7 +5404,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:105:13 ]
+     ╭─[ rust.baml:105:13 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │             ┬  
@@ -5414,7 +5414,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:105:14 ]
+     ╭─[ rust.baml:105:14 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │              ───┬──  
@@ -5424,7 +5424,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:105:20 ]
+     ╭─[ rust.baml:105:20 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                    ┬  
@@ -5434,7 +5434,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:105:21 ]
+     ╭─[ rust.baml:105:21 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                     ────┬───  
@@ -5444,7 +5444,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:105:29 ]
+     ╭─[ rust.baml:105:29 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                             ┬  
@@ -5454,7 +5454,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:105:30 ]
+     ╭─[ rust.baml:105:30 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                              ┬  
@@ -5464,7 +5464,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:105:31 ]
+     ╭─[ rust.baml:105:31 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                               ┬  
@@ -5474,7 +5474,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:105:32 ]
+     ╭─[ rust.baml:105:32 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                ────┬───  
@@ -5484,7 +5484,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:105:40 ]
+     ╭─[ rust.baml:105:40 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                        ┬  
@@ -5494,7 +5494,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:105:41 ]
+     ╭─[ rust.baml:105:41 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                         ──────┬──────  
@@ -5504,7 +5504,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:105:54 ]
+     ╭─[ rust.baml:105:54 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                                      ─┬  
@@ -5514,7 +5514,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:105:56 ]
+     ╭─[ rust.baml:105:56 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                                        ──┬─  
@@ -5524,7 +5524,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:105:60 ]
+     ╭─[ rust.baml:105:60 ]
      │
  105 │         self.syntax.children().find_map(ParameterList::cast)
      │                                                            ┬  
@@ -5534,7 +5534,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:106:5 ]
+     ╭─[ rust.baml:106:5 ]
      │
  106 │     }
      │     ┬  
@@ -5544,7 +5544,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:109:5 ]
+     ╭─[ rust.baml:109:5 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │     ─┬─  
@@ -5554,7 +5554,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:109:9 ]
+     ╭─[ rust.baml:109:9 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │         ─┬  
@@ -5564,7 +5564,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:109:12 ]
+     ╭─[ rust.baml:109:12 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │            ─────┬─────  
@@ -5574,7 +5574,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:109:23 ]
+     ╭─[ rust.baml:109:23 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                       ┬  
@@ -5584,7 +5584,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:109:24 ]
+     ╭─[ rust.baml:109:24 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                        ┬  
@@ -5594,7 +5594,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:109:25 ]
+     ╭─[ rust.baml:109:25 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                         ──┬─  
@@ -5604,7 +5604,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:109:29 ]
+     ╭─[ rust.baml:109:29 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                             ┬  
@@ -5614,7 +5614,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:109:31 ]
+     ╭─[ rust.baml:109:31 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                               ─┬  
@@ -5624,7 +5624,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:109:34 ]
+     ╭─[ rust.baml:109:34 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                  ───┬──  
@@ -5634,7 +5634,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:109:40 ]
+     ╭─[ rust.baml:109:40 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                        ┬  
@@ -5644,7 +5644,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:109:41 ]
+     ╭─[ rust.baml:109:41 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                         ────┬───  
@@ -5654,7 +5654,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:109:49 ]
+     ╭─[ rust.baml:109:49 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                                 ┬  
@@ -5664,7 +5664,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:109:51 ]
+     ╭─[ rust.baml:109:51 ]
      │
  109 │     pub fn return_type(&self) -> Option<TypeExpr> {
      │                                                   ┬  
@@ -5674,7 +5674,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:110:9 ]
+     ╭─[ rust.baml:110:9 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │         ──┬─  
@@ -5684,7 +5684,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:110:13 ]
+     ╭─[ rust.baml:110:13 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │             ┬  
@@ -5694,7 +5694,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:110:14 ]
+     ╭─[ rust.baml:110:14 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │              ───┬──  
@@ -5704,7 +5704,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:110:20 ]
+     ╭─[ rust.baml:110:20 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                    ┬  
@@ -5714,7 +5714,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:110:21 ]
+     ╭─[ rust.baml:110:21 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                     ────┬───  
@@ -5724,7 +5724,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:110:29 ]
+     ╭─[ rust.baml:110:29 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                             ┬  
@@ -5734,7 +5734,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:110:30 ]
+     ╭─[ rust.baml:110:30 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                              ┬  
@@ -5744,7 +5744,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:110:31 ]
+     ╭─[ rust.baml:110:31 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                               ┬  
@@ -5754,7 +5754,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:110:32 ]
+     ╭─[ rust.baml:110:32 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                ────┬───  
@@ -5764,7 +5764,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:110:40 ]
+     ╭─[ rust.baml:110:40 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                        ┬  
@@ -5774,7 +5774,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:110:41 ]
+     ╭─[ rust.baml:110:41 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                         ────┬───  
@@ -5784,7 +5784,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:110:49 ]
+     ╭─[ rust.baml:110:49 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                 ─┬  
@@ -5794,7 +5794,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:110:51 ]
+     ╭─[ rust.baml:110:51 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                   ──┬─  
@@ -5804,7 +5804,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:110:55 ]
+     ╭─[ rust.baml:110:55 ]
      │
  110 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                       ┬  
@@ -5814,7 +5814,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:111:5 ]
+     ╭─[ rust.baml:111:5 ]
      │
  111 │     }
      │     ┬  
@@ -5824,7 +5824,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:114:5 ]
+     ╭─[ rust.baml:114:5 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │     ─┬─  
@@ -5834,7 +5834,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:114:9 ]
+     ╭─[ rust.baml:114:9 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │         ─┬  
@@ -5844,7 +5844,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:114:12 ]
+     ╭─[ rust.baml:114:12 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │            ──┬─  
@@ -5854,7 +5854,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:114:16 ]
+     ╭─[ rust.baml:114:16 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                ┬  
@@ -5864,7 +5864,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:114:17 ]
+     ╭─[ rust.baml:114:17 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                 ┬  
@@ -5874,7 +5874,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:114:18 ]
+     ╭─[ rust.baml:114:18 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                  ──┬─  
@@ -5884,7 +5884,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:114:22 ]
+     ╭─[ rust.baml:114:22 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                      ┬  
@@ -5894,7 +5894,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:114:24 ]
+     ╭─[ rust.baml:114:24 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                        ─┬  
@@ -5904,7 +5904,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:114:27 ]
+     ╭─[ rust.baml:114:27 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                           ───┬──  
@@ -5914,7 +5914,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:114:33 ]
+     ╭─[ rust.baml:114:33 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                                 ┬  
@@ -5924,7 +5924,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:114:34 ]
+     ╭─[ rust.baml:114:34 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                                  ──────┬─────  
@@ -5934,7 +5934,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:114:46 ]
+     ╭─[ rust.baml:114:46 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                                              ┬  
@@ -5944,7 +5944,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:114:48 ]
+     ╭─[ rust.baml:114:48 ]
      │
  114 │     pub fn body(&self) -> Option<FunctionBody> {
      │                                                ┬  
@@ -5954,7 +5954,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:115:9 ]
+     ╭─[ rust.baml:115:9 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │         ──┬─  
@@ -5964,7 +5964,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:115:13 ]
+     ╭─[ rust.baml:115:13 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │             ┬  
@@ -5974,7 +5974,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:115:14 ]
+     ╭─[ rust.baml:115:14 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │              ───┬──  
@@ -5984,7 +5984,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:115:20 ]
+     ╭─[ rust.baml:115:20 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                    ┬  
@@ -5994,7 +5994,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:115:21 ]
+     ╭─[ rust.baml:115:21 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                     ────┬───  
@@ -6004,7 +6004,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:115:29 ]
+     ╭─[ rust.baml:115:29 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                             ┬  
@@ -6014,7 +6014,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:115:30 ]
+     ╭─[ rust.baml:115:30 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                              ┬  
@@ -6024,7 +6024,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:115:31 ]
+     ╭─[ rust.baml:115:31 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                               ┬  
@@ -6034,7 +6034,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:115:32 ]
+     ╭─[ rust.baml:115:32 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                ────┬───  
@@ -6044,7 +6044,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:115:40 ]
+     ╭─[ rust.baml:115:40 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                        ┬  
@@ -6054,7 +6054,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:115:41 ]
+     ╭─[ rust.baml:115:41 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                         ──────┬─────  
@@ -6064,7 +6064,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:115:53 ]
+     ╭─[ rust.baml:115:53 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                                     ─┬  
@@ -6074,7 +6074,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:115:55 ]
+     ╭─[ rust.baml:115:55 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                                       ──┬─  
@@ -6084,7 +6084,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:115:59 ]
+     ╭─[ rust.baml:115:59 ]
      │
  115 │         self.syntax.children().find_map(FunctionBody::cast)
      │                                                           ┬  
@@ -6094,7 +6094,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:116:5 ]
+     ╭─[ rust.baml:116:5 ]
      │
  116 │     }
      │     ┬  
@@ -6104,7 +6104,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:119:5 ]
+     ╭─[ rust.baml:119:5 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │     ─┬─  
@@ -6114,7 +6114,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:119:9 ]
+     ╭─[ rust.baml:119:9 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │         ─┬  
@@ -6124,7 +6124,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:119:12 ]
+     ╭─[ rust.baml:119:12 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │            ────┬───  
@@ -6134,7 +6134,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:119:20 ]
+     ╭─[ rust.baml:119:20 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                    ┬  
@@ -6144,7 +6144,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:119:21 ]
+     ╭─[ rust.baml:119:21 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                     ┬  
@@ -6154,7 +6154,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:119:22 ]
+     ╭─[ rust.baml:119:22 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                      ──┬─  
@@ -6164,7 +6164,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:119:26 ]
+     ╭─[ rust.baml:119:26 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                          ┬  
@@ -6174,7 +6174,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:119:28 ]
+     ╭─[ rust.baml:119:28 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                            ─┬  
@@ -6184,7 +6184,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:119:31 ]
+     ╭─[ rust.baml:119:31 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                               ───┬──  
@@ -6194,7 +6194,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:119:37 ]
+     ╭─[ rust.baml:119:37 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                                     ┬  
@@ -6204,7 +6204,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:119:38 ]
+     ╭─[ rust.baml:119:38 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                                      ───────┬───────  
@@ -6214,7 +6214,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:119:53 ]
+     ╭─[ rust.baml:119:53 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                                                     ┬  
@@ -6224,7 +6224,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:119:55 ]
+     ╭─[ rust.baml:119:55 ]
      │
  119 │     pub fn llm_body(&self) -> Option<LlmFunctionBody> {
      │                                                       ┬  
@@ -6234,7 +6234,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:120:9 ]
+     ╭─[ rust.baml:120:9 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │         ──┬─  
@@ -6244,7 +6244,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:120:13 ]
+     ╭─[ rust.baml:120:13 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │             ┬  
@@ -6254,7 +6254,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:120:14 ]
+     ╭─[ rust.baml:120:14 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │              ───┬──  
@@ -6264,7 +6264,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:120:20 ]
+     ╭─[ rust.baml:120:20 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                    ┬  
@@ -6274,7 +6274,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:120:21 ]
+     ╭─[ rust.baml:120:21 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                     ────┬───  
@@ -6284,7 +6284,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:120:29 ]
+     ╭─[ rust.baml:120:29 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                             ┬  
@@ -6294,7 +6294,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:120:30 ]
+     ╭─[ rust.baml:120:30 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                              ┬  
@@ -6304,7 +6304,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:120:31 ]
+     ╭─[ rust.baml:120:31 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                               ┬  
@@ -6314,7 +6314,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:120:32 ]
+     ╭─[ rust.baml:120:32 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                ────┬───  
@@ -6324,7 +6324,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:120:40 ]
+     ╭─[ rust.baml:120:40 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                        ┬  
@@ -6334,7 +6334,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:120:41 ]
+     ╭─[ rust.baml:120:41 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                         ───────┬───────  
@@ -6344,7 +6344,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:120:56 ]
+     ╭─[ rust.baml:120:56 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                                        ─┬  
@@ -6354,7 +6354,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:120:58 ]
+     ╭─[ rust.baml:120:58 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                                          ──┬─  
@@ -6364,7 +6364,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:120:62 ]
+     ╭─[ rust.baml:120:62 ]
      │
  120 │         self.syntax.children().find_map(LlmFunctionBody::cast)
      │                                                              ┬  
@@ -6374,7 +6374,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:121:5 ]
+     ╭─[ rust.baml:121:5 ]
      │
  121 │     }
      │     ┬  
@@ -6384,7 +6384,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:124:5 ]
+     ╭─[ rust.baml:124:5 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │     ─┬─  
@@ -6394,7 +6394,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:124:9 ]
+     ╭─[ rust.baml:124:9 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │         ─┬  
@@ -6404,7 +6404,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:124:12 ]
+     ╭─[ rust.baml:124:12 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │            ────┬────  
@@ -6414,7 +6414,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:124:21 ]
+     ╭─[ rust.baml:124:21 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                     ┬  
@@ -6424,7 +6424,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:124:22 ]
+     ╭─[ rust.baml:124:22 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                      ┬  
@@ -6434,7 +6434,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:124:23 ]
+     ╭─[ rust.baml:124:23 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                       ──┬─  
@@ -6444,7 +6444,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:124:27 ]
+     ╭─[ rust.baml:124:27 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                           ┬  
@@ -6454,7 +6454,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:124:29 ]
+     ╭─[ rust.baml:124:29 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                             ─┬  
@@ -6464,7 +6464,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:124:32 ]
+     ╭─[ rust.baml:124:32 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                ───┬──  
@@ -6474,7 +6474,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:124:38 ]
+     ╭─[ rust.baml:124:38 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                      ┬  
@@ -6484,7 +6484,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:124:39 ]
+     ╭─[ rust.baml:124:39 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                       ────────┬───────  
@@ -6494,7 +6494,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:124:55 ]
+     ╭─[ rust.baml:124:55 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                                       ┬  
@@ -6504,7 +6504,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:124:57 ]
+     ╭─[ rust.baml:124:57 ]
      │
  124 │     pub fn expr_body(&self) -> Option<ExprFunctionBody> {
      │                                                         ┬  
@@ -6514,7 +6514,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:125:9 ]
+     ╭─[ rust.baml:125:9 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │         ──┬─  
@@ -6524,7 +6524,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:125:13 ]
+     ╭─[ rust.baml:125:13 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │             ┬  
@@ -6534,7 +6534,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:125:14 ]
+     ╭─[ rust.baml:125:14 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │              ───┬──  
@@ -6544,7 +6544,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:125:20 ]
+     ╭─[ rust.baml:125:20 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                    ┬  
@@ -6554,7 +6554,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:125:21 ]
+     ╭─[ rust.baml:125:21 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                     ────┬───  
@@ -6564,7 +6564,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:125:29 ]
+     ╭─[ rust.baml:125:29 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                             ┬  
@@ -6574,7 +6574,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:125:30 ]
+     ╭─[ rust.baml:125:30 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                              ┬  
@@ -6584,7 +6584,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:125:31 ]
+     ╭─[ rust.baml:125:31 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                               ┬  
@@ -6594,7 +6594,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:125:32 ]
+     ╭─[ rust.baml:125:32 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                ────┬───  
@@ -6604,7 +6604,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:125:40 ]
+     ╭─[ rust.baml:125:40 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                        ┬  
@@ -6614,7 +6614,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:125:41 ]
+     ╭─[ rust.baml:125:41 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                         ────────┬───────  
@@ -6624,7 +6624,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:125:57 ]
+     ╭─[ rust.baml:125:57 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                                         ─┬  
@@ -6634,7 +6634,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:125:59 ]
+     ╭─[ rust.baml:125:59 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                                           ──┬─  
@@ -6644,7 +6644,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:125:63 ]
+     ╭─[ rust.baml:125:63 ]
      │
  125 │         self.syntax.children().find_map(ExprFunctionBody::cast)
      │                                                               ┬  
@@ -6654,7 +6654,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:126:5 ]
+     ╭─[ rust.baml:126:5 ]
      │
  126 │     }
      │     ┬  
@@ -6664,7 +6664,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:129:5 ]
+     ╭─[ rust.baml:129:5 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │     ─┬─  
@@ -6674,7 +6674,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:129:9 ]
+     ╭─[ rust.baml:129:9 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │         ─┬  
@@ -6684,7 +6684,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:129:12 ]
+     ╭─[ rust.baml:129:12 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │            ───────┬───────  
@@ -6694,7 +6694,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:129:27 ]
+     ╭─[ rust.baml:129:27 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                           ┬  
@@ -6704,7 +6704,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:129:28 ]
+     ╭─[ rust.baml:129:28 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                            ┬  
@@ -6714,7 +6714,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:129:29 ]
+     ╭─[ rust.baml:129:29 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                             ──┬─  
@@ -6724,7 +6724,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:129:33 ]
+     ╭─[ rust.baml:129:33 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                                 ┬  
@@ -6734,7 +6734,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:129:35 ]
+     ╭─[ rust.baml:129:35 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                                   ─┬  
@@ -6744,7 +6744,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:129:38 ]
+     ╭─[ rust.baml:129:38 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                                      ──┬─  
@@ -6754,7 +6754,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:129:43 ]
+     ╭─[ rust.baml:129:43 ]
      │
  129 │     pub fn is_llm_function(&self) -> bool {
      │                                           ┬  
@@ -6764,7 +6764,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:130:9 ]
+     ╭─[ rust.baml:130:9 ]
      │
  130 │         self.llm_body().is_some()
      │         ──┬─  
@@ -6774,7 +6774,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:130:13 ]
+     ╭─[ rust.baml:130:13 ]
      │
  130 │         self.llm_body().is_some()
      │             ┬  
@@ -6784,7 +6784,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:130:14 ]
+     ╭─[ rust.baml:130:14 ]
      │
  130 │         self.llm_body().is_some()
      │              ────┬───  
@@ -6794,7 +6794,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:130:22 ]
+     ╭─[ rust.baml:130:22 ]
      │
  130 │         self.llm_body().is_some()
      │                      ┬  
@@ -6804,7 +6804,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:130:23 ]
+     ╭─[ rust.baml:130:23 ]
      │
  130 │         self.llm_body().is_some()
      │                       ┬  
@@ -6814,7 +6814,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:130:24 ]
+     ╭─[ rust.baml:130:24 ]
      │
  130 │         self.llm_body().is_some()
      │                        ┬  
@@ -6824,7 +6824,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:130:25 ]
+     ╭─[ rust.baml:130:25 ]
      │
  130 │         self.llm_body().is_some()
      │                         ───┬───  
@@ -6834,7 +6834,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:130:32 ]
+     ╭─[ rust.baml:130:32 ]
      │
  130 │         self.llm_body().is_some()
      │                                ┬  
@@ -6844,7 +6844,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:130:33 ]
+     ╭─[ rust.baml:130:33 ]
      │
  130 │         self.llm_body().is_some()
      │                                 ┬  
@@ -6854,7 +6854,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:131:5 ]
+     ╭─[ rust.baml:131:5 ]
      │
  131 │     }
      │     ┬  
@@ -6864,7 +6864,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:134:5 ]
+     ╭─[ rust.baml:134:5 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │     ─┬─  
@@ -6874,7 +6874,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:134:9 ]
+     ╭─[ rust.baml:134:9 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │         ─┬  
@@ -6884,7 +6884,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:134:12 ]
+     ╭─[ rust.baml:134:12 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │            ────────┬───────  
@@ -6894,7 +6894,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:134:28 ]
+     ╭─[ rust.baml:134:28 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                            ┬  
@@ -6904,7 +6904,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:134:29 ]
+     ╭─[ rust.baml:134:29 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                             ┬  
@@ -6914,7 +6914,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:134:30 ]
+     ╭─[ rust.baml:134:30 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                              ──┬─  
@@ -6924,7 +6924,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:134:34 ]
+     ╭─[ rust.baml:134:34 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                                  ┬  
@@ -6934,7 +6934,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:134:36 ]
+     ╭─[ rust.baml:134:36 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                                    ─┬  
@@ -6944,7 +6944,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:134:39 ]
+     ╭─[ rust.baml:134:39 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                                       ──┬─  
@@ -6954,7 +6954,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:134:44 ]
+     ╭─[ rust.baml:134:44 ]
      │
  134 │     pub fn is_expr_function(&self) -> bool {
      │                                            ┬  
@@ -6964,7 +6964,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:135:9 ]
+     ╭─[ rust.baml:135:9 ]
      │
  135 │         self.expr_body().is_some()
      │         ──┬─  
@@ -6974,7 +6974,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:135:13 ]
+     ╭─[ rust.baml:135:13 ]
      │
  135 │         self.expr_body().is_some()
      │             ┬  
@@ -6984,7 +6984,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:135:14 ]
+     ╭─[ rust.baml:135:14 ]
      │
  135 │         self.expr_body().is_some()
      │              ────┬────  
@@ -6994,7 +6994,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:135:23 ]
+     ╭─[ rust.baml:135:23 ]
      │
  135 │         self.expr_body().is_some()
      │                       ┬  
@@ -7004,7 +7004,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:135:24 ]
+     ╭─[ rust.baml:135:24 ]
      │
  135 │         self.expr_body().is_some()
      │                        ┬  
@@ -7014,7 +7014,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:135:25 ]
+     ╭─[ rust.baml:135:25 ]
      │
  135 │         self.expr_body().is_some()
      │                         ┬  
@@ -7024,7 +7024,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:135:26 ]
+     ╭─[ rust.baml:135:26 ]
      │
  135 │         self.expr_body().is_some()
      │                          ───┬───  
@@ -7034,7 +7034,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:135:33 ]
+     ╭─[ rust.baml:135:33 ]
      │
  135 │         self.expr_body().is_some()
      │                                 ┬  
@@ -7044,7 +7044,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:135:34 ]
+     ╭─[ rust.baml:135:34 ]
      │
  135 │         self.expr_body().is_some()
      │                                  ┬  
@@ -7054,7 +7054,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:136:5 ]
+     ╭─[ rust.baml:136:5 ]
      │
  136 │     }
      │     ┬  
@@ -7064,7 +7064,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:137:1 ]
+     ╭─[ rust.baml:137:1 ]
      │
  137 │ }
      │ ┬  
@@ -7074,7 +7074,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:139:1 ]
+     ╭─[ rust.baml:139:1 ]
      │
  139 │ impl ParameterList {
      │ ──┬─  
@@ -7084,7 +7084,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:139:6 ]
+     ╭─[ rust.baml:139:6 ]
      │
  139 │ impl ParameterList {
      │      ──────┬──────  
@@ -7094,7 +7094,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:139:20 ]
+     ╭─[ rust.baml:139:20 ]
      │
  139 │ impl ParameterList {
      │                    ┬  
@@ -7104,7 +7104,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:141:5 ]
+     ╭─[ rust.baml:141:5 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │     ─┬─  
@@ -7114,7 +7114,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:141:9 ]
+     ╭─[ rust.baml:141:9 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │         ─┬  
@@ -7124,7 +7124,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:141:12 ]
+     ╭─[ rust.baml:141:12 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │            ───┬──  
@@ -7134,7 +7134,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:141:18 ]
+     ╭─[ rust.baml:141:18 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                  ┬  
@@ -7144,7 +7144,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:141:19 ]
+     ╭─[ rust.baml:141:19 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                   ┬  
@@ -7154,7 +7154,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:141:20 ]
+     ╭─[ rust.baml:141:20 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                    ──┬─  
@@ -7164,7 +7164,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:141:24 ]
+     ╭─[ rust.baml:141:24 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                        ┬  
@@ -7174,7 +7174,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:141:26 ]
+     ╭─[ rust.baml:141:26 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                          ─┬  
@@ -7184,7 +7184,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:141:29 ]
+     ╭─[ rust.baml:141:29 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                             ──┬─  
@@ -7194,7 +7194,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:141:34 ]
+     ╭─[ rust.baml:141:34 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                  ────┬───  
@@ -7204,7 +7204,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:141:42 ]
+     ╭─[ rust.baml:141:42 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                          ┬  
@@ -7214,7 +7214,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:141:43 ]
+     ╭─[ rust.baml:141:43 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                           ──┬─  
@@ -7224,7 +7224,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '='
-     ╭─[ 3:141:48 ]
+     ╭─[ rust.baml:141:48 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                                ┬  
@@ -7234,7 +7234,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:141:50 ]
+     ╭─[ rust.baml:141:50 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                                  ────┬────  
@@ -7244,7 +7244,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:141:59 ]
+     ╭─[ rust.baml:141:59 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                                           ┬  
@@ -7254,7 +7254,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:141:61 ]
+     ╭─[ rust.baml:141:61 ]
      │
  141 │     pub fn params(&self) -> impl Iterator<Item = Parameter> {
      │                                                             ┬  
@@ -7264,7 +7264,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:142:9 ]
+     ╭─[ rust.baml:142:9 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │         ──┬─  
@@ -7274,7 +7274,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:142:13 ]
+     ╭─[ rust.baml:142:13 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │             ┬  
@@ -7284,7 +7284,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:142:14 ]
+     ╭─[ rust.baml:142:14 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │              ───┬──  
@@ -7294,7 +7294,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:142:20 ]
+     ╭─[ rust.baml:142:20 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                    ┬  
@@ -7304,7 +7304,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:142:21 ]
+     ╭─[ rust.baml:142:21 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                     ────┬───  
@@ -7314,7 +7314,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:142:29 ]
+     ╭─[ rust.baml:142:29 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                             ┬  
@@ -7324,7 +7324,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:142:30 ]
+     ╭─[ rust.baml:142:30 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                              ┬  
@@ -7334,7 +7334,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:142:31 ]
+     ╭─[ rust.baml:142:31 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                               ┬  
@@ -7344,7 +7344,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:142:32 ]
+     ╭─[ rust.baml:142:32 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                ─────┬────  
@@ -7354,7 +7354,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:142:42 ]
+     ╭─[ rust.baml:142:42 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                          ┬  
@@ -7364,7 +7364,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:142:43 ]
+     ╭─[ rust.baml:142:43 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                           ────┬────  
@@ -7374,7 +7374,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:142:52 ]
+     ╭─[ rust.baml:142:52 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                                    ─┬  
@@ -7384,7 +7384,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:142:54 ]
+     ╭─[ rust.baml:142:54 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                                      ──┬─  
@@ -7394,7 +7394,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:142:58 ]
+     ╭─[ rust.baml:142:58 ]
      │
  142 │         self.syntax.children().filter_map(Parameter::cast)
      │                                                          ┬  
@@ -7404,7 +7404,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:143:5 ]
+     ╭─[ rust.baml:143:5 ]
      │
  143 │     }
      │     ┬  
@@ -7414,7 +7414,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:144:1 ]
+     ╭─[ rust.baml:144:1 ]
      │
  144 │ }
      │ ┬  
@@ -7424,7 +7424,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:146:1 ]
+     ╭─[ rust.baml:146:1 ]
      │
  146 │ impl ClassDef {
      │ ──┬─  
@@ -7434,7 +7434,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:146:6 ]
+     ╭─[ rust.baml:146:6 ]
      │
  146 │ impl ClassDef {
      │      ────┬───  
@@ -7444,7 +7444,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:146:15 ]
+     ╭─[ rust.baml:146:15 ]
      │
  146 │ impl ClassDef {
      │               ┬  
@@ -7454,7 +7454,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:148:5 ]
+     ╭─[ rust.baml:148:5 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │     ─┬─  
@@ -7464,7 +7464,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:148:9 ]
+     ╭─[ rust.baml:148:9 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │         ─┬  
@@ -7474,7 +7474,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:148:12 ]
+     ╭─[ rust.baml:148:12 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │            ──┬─  
@@ -7484,7 +7484,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:148:16 ]
+     ╭─[ rust.baml:148:16 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                ┬  
@@ -7494,7 +7494,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:148:17 ]
+     ╭─[ rust.baml:148:17 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                 ┬  
@@ -7504,7 +7504,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:148:18 ]
+     ╭─[ rust.baml:148:18 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                  ──┬─  
@@ -7514,7 +7514,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:148:22 ]
+     ╭─[ rust.baml:148:22 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                      ┬  
@@ -7524,7 +7524,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:148:24 ]
+     ╭─[ rust.baml:148:24 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                        ─┬  
@@ -7534,7 +7534,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:148:27 ]
+     ╭─[ rust.baml:148:27 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                           ───┬──  
@@ -7544,7 +7544,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:148:33 ]
+     ╭─[ rust.baml:148:33 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                 ┬  
@@ -7554,7 +7554,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:148:34 ]
+     ╭─[ rust.baml:148:34 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                  ─────┬─────  
@@ -7564,7 +7564,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:148:45 ]
+     ╭─[ rust.baml:148:45 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                             ┬  
@@ -7574,7 +7574,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:148:47 ]
+     ╭─[ rust.baml:148:47 ]
      │
  148 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                               ┬  
@@ -7584,7 +7584,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:149:9 ]
+     ╭─[ rust.baml:149:9 ]
      │
  149 │         self.syntax
      │         ──┬─  
@@ -7594,7 +7594,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:149:13 ]
+     ╭─[ rust.baml:149:13 ]
      │
  149 │         self.syntax
      │             ┬  
@@ -7604,7 +7604,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:149:14 ]
+     ╭─[ rust.baml:149:14 ]
      │
  149 │         self.syntax
      │              ───┬──  
@@ -7614,7 +7614,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:150:13 ]
+     ╭─[ rust.baml:150:13 ]
      │
  150 │             .children_with_tokens()
      │             ┬  
@@ -7624,7 +7624,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:150:14 ]
+     ╭─[ rust.baml:150:14 ]
      │
  150 │             .children_with_tokens()
      │              ──────────┬─────────  
@@ -7634,7 +7634,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:150:34 ]
+     ╭─[ rust.baml:150:34 ]
      │
  150 │             .children_with_tokens()
      │                                  ┬  
@@ -7644,7 +7644,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:150:35 ]
+     ╭─[ rust.baml:150:35 ]
      │
  150 │             .children_with_tokens()
      │                                   ┬  
@@ -7654,7 +7654,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:151:13 ]
+     ╭─[ rust.baml:151:13 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │             ┬  
@@ -7664,7 +7664,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:151:14 ]
+     ╭─[ rust.baml:151:14 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │              ─────┬────  
@@ -7674,7 +7674,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:151:24 ]
+     ╭─[ rust.baml:151:24 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                        ┬  
@@ -7684,7 +7684,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:151:25 ]
+     ╭─[ rust.baml:151:25 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                         ──┬──  
@@ -7694,7 +7694,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:151:30 ]
+     ╭─[ rust.baml:151:30 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                              ─┬  
@@ -7704,7 +7704,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:151:32 ]
+     ╭─[ rust.baml:151:32 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                ─────┬─────  
@@ -7714,7 +7714,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:151:43 ]
+     ╭─[ rust.baml:151:43 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                           ─┬  
@@ -7724,7 +7724,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:151:45 ]
+     ╭─[ rust.baml:151:45 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                             ─────┬────  
@@ -7734,7 +7734,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:151:55 ]
+     ╭─[ rust.baml:151:55 ]
      │
  151 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                                       ┬  
@@ -7744,7 +7744,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:152:13 ]
+     ╭─[ rust.baml:152:13 ]
      │
  152 │             .filter(|token| {
      │             ┬  
@@ -7754,7 +7754,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:152:14 ]
+     ╭─[ rust.baml:152:14 ]
      │
  152 │             .filter(|token| {
      │              ───┬──  
@@ -7764,7 +7764,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:152:20 ]
+     ╭─[ rust.baml:152:20 ]
      │
  152 │             .filter(|token| {
      │                    ┬  
@@ -7774,7 +7774,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:152:21 ]
+     ╭─[ rust.baml:152:21 ]
      │
  152 │             .filter(|token| {
      │                     ┬  
@@ -7784,7 +7784,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:152:22 ]
+     ╭─[ rust.baml:152:22 ]
      │
  152 │             .filter(|token| {
      │                      ──┬──  
@@ -7794,7 +7794,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:152:27 ]
+     ╭─[ rust.baml:152:27 ]
      │
  152 │             .filter(|token| {
      │                           ┬  
@@ -7804,7 +7804,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:152:29 ]
+     ╭─[ rust.baml:152:29 ]
      │
  152 │             .filter(|token| {
      │                             ┬  
@@ -7814,7 +7814,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:17 ]
+     ╭─[ rust.baml:153:17 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                 ──┬──  
@@ -7824,7 +7824,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:153:22 ]
+     ╭─[ rust.baml:153:22 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                      ┬  
@@ -7834,7 +7834,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:23 ]
+     ╭─[ rust.baml:153:23 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                       ──┬─  
@@ -7844,7 +7844,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:153:27 ]
+     ╭─[ rust.baml:153:27 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                           ┬  
@@ -7854,7 +7854,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:153:28 ]
+     ╭─[ rust.baml:153:28 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                            ┬  
@@ -7864,7 +7864,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=='
-     ╭─[ 3:153:30 ]
+     ╭─[ rust.baml:153:30 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                              ─┬  
@@ -7874,7 +7874,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:33 ]
+     ╭─[ rust.baml:153:33 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                 ─────┬────  
@@ -7884,7 +7884,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:153:43 ]
+     ╭─[ rust.baml:153:43 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                           ─┬  
@@ -7894,7 +7894,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:45 ]
+     ╭─[ rust.baml:153:45 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                             ──┬─  
@@ -7904,7 +7904,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&&'
-     ╭─[ 3:153:50 ]
+     ╭─[ rust.baml:153:50 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                  ─┬  
@@ -7914,7 +7914,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:53 ]
+     ╭─[ rust.baml:153:53 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                     ──┬──  
@@ -7924,7 +7924,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:153:58 ]
+     ╭─[ rust.baml:153:58 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                          ┬  
@@ -7934,7 +7934,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:59 ]
+     ╭─[ rust.baml:153:59 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                           ───┬──  
@@ -7944,7 +7944,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:153:65 ]
+     ╭─[ rust.baml:153:65 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                 ┬  
@@ -7954,7 +7954,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:153:66 ]
+     ╭─[ rust.baml:153:66 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                  ┬  
@@ -7964,7 +7964,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=='
-     ╭─[ 3:153:68 ]
+     ╭─[ rust.baml:153:68 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                    ─┬  
@@ -7974,7 +7974,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:71 ]
+     ╭─[ rust.baml:153:71 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                       ──┬─  
@@ -7984,7 +7984,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:153:75 ]
+     ╭─[ rust.baml:153:75 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                           ┬  
@@ -7994,7 +7994,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:76 ]
+     ╭─[ rust.baml:153:76 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                            ──┬─  
@@ -8004,7 +8004,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:153:80 ]
+     ╭─[ rust.baml:153:80 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                ┬  
@@ -8014,7 +8014,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:81 ]
+     ╭─[ rust.baml:153:81 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                 ───┬──  
@@ -8024,7 +8024,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:153:87 ]
+     ╭─[ rust.baml:153:87 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                       ┬  
@@ -8034,7 +8034,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:153:88 ]
+     ╭─[ rust.baml:153:88 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                        ──┬──  
@@ -8044,7 +8044,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:153:93 ]
+     ╭─[ rust.baml:153:93 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                             ┬  
@@ -8054,7 +8054,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:153:94 ]
+     ╭─[ rust.baml:153:94 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                              ┬  
@@ -8064,7 +8064,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:153:95 ]
+     ╭─[ rust.baml:153:95 ]
      │
  153 │                 token.kind() == SyntaxKind::WORD && token.parent() == Some(self.syntax.clone())
      │                                                                                               ┬  
@@ -8074,7 +8074,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:154:13 ]
+     ╭─[ rust.baml:154:13 ]
      │
  154 │             })
      │             ┬  
@@ -8084,7 +8084,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:154:14 ]
+     ╭─[ rust.baml:154:14 ]
      │
  154 │             })
      │              ┬  
@@ -8094,7 +8094,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:155:13 ]
+     ╭─[ rust.baml:155:13 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │             ┬  
@@ -8104,7 +8104,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:155:14 ]
+     ╭─[ rust.baml:155:14 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │              ─┬─  
@@ -8114,7 +8114,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:155:17 ]
+     ╭─[ rust.baml:155:17 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │                 ┬  
@@ -8124,7 +8124,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found integer
-     ╭─[ 3:155:18 ]
+     ╭─[ rust.baml:155:18 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │                  ┬  
@@ -8134,7 +8134,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:155:19 ]
+     ╭─[ rust.baml:155:19 ]
      │
  155 │             .nth(1) // Skip the "class" keyword, get the second WORD
      │                   ┬  
@@ -8144,7 +8144,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:156:5 ]
+     ╭─[ rust.baml:156:5 ]
      │
  156 │     }
      │     ┬  
@@ -8154,7 +8154,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:159:5 ]
+     ╭─[ rust.baml:159:5 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │     ─┬─  
@@ -8164,7 +8164,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:159:9 ]
+     ╭─[ rust.baml:159:9 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │         ─┬  
@@ -8174,7 +8174,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:159:12 ]
+     ╭─[ rust.baml:159:12 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │            ───┬──  
@@ -8184,7 +8184,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:159:18 ]
+     ╭─[ rust.baml:159:18 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                  ┬  
@@ -8194,7 +8194,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:159:19 ]
+     ╭─[ rust.baml:159:19 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                   ┬  
@@ -8204,7 +8204,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:159:20 ]
+     ╭─[ rust.baml:159:20 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                    ──┬─  
@@ -8214,7 +8214,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:159:24 ]
+     ╭─[ rust.baml:159:24 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                        ┬  
@@ -8224,7 +8224,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:159:26 ]
+     ╭─[ rust.baml:159:26 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                          ─┬  
@@ -8234,7 +8234,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:159:29 ]
+     ╭─[ rust.baml:159:29 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                             ──┬─  
@@ -8244,7 +8244,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:159:34 ]
+     ╭─[ rust.baml:159:34 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                  ────┬───  
@@ -8254,7 +8254,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:159:42 ]
+     ╭─[ rust.baml:159:42 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                          ┬  
@@ -8264,7 +8264,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:159:43 ]
+     ╭─[ rust.baml:159:43 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                           ──┬─  
@@ -8274,7 +8274,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '='
-     ╭─[ 3:159:48 ]
+     ╭─[ rust.baml:159:48 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                                ┬  
@@ -8284,7 +8284,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:159:50 ]
+     ╭─[ rust.baml:159:50 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                                  ──┬──  
@@ -8294,7 +8294,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:159:55 ]
+     ╭─[ rust.baml:159:55 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                                       ┬  
@@ -8304,7 +8304,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:159:57 ]
+     ╭─[ rust.baml:159:57 ]
      │
  159 │     pub fn fields(&self) -> impl Iterator<Item = Field> {
      │                                                         ┬  
@@ -8314,7 +8314,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:160:9 ]
+     ╭─[ rust.baml:160:9 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │         ──┬─  
@@ -8324,7 +8324,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:160:13 ]
+     ╭─[ rust.baml:160:13 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │             ┬  
@@ -8334,7 +8334,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:160:14 ]
+     ╭─[ rust.baml:160:14 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │              ───┬──  
@@ -8344,7 +8344,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:160:20 ]
+     ╭─[ rust.baml:160:20 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                    ┬  
@@ -8354,7 +8354,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:160:21 ]
+     ╭─[ rust.baml:160:21 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                     ────┬───  
@@ -8364,7 +8364,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:160:29 ]
+     ╭─[ rust.baml:160:29 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                             ┬  
@@ -8374,7 +8374,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:160:30 ]
+     ╭─[ rust.baml:160:30 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                              ┬  
@@ -8384,7 +8384,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:160:31 ]
+     ╭─[ rust.baml:160:31 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                               ┬  
@@ -8394,7 +8394,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:160:32 ]
+     ╭─[ rust.baml:160:32 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                ─────┬────  
@@ -8404,7 +8404,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:160:42 ]
+     ╭─[ rust.baml:160:42 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                          ┬  
@@ -8414,7 +8414,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:160:43 ]
+     ╭─[ rust.baml:160:43 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                           ──┬──  
@@ -8424,7 +8424,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:160:48 ]
+     ╭─[ rust.baml:160:48 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                                ─┬  
@@ -8434,7 +8434,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:160:50 ]
+     ╭─[ rust.baml:160:50 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                                  ──┬─  
@@ -8444,7 +8444,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:160:54 ]
+     ╭─[ rust.baml:160:54 ]
      │
  160 │         self.syntax.children().filter_map(Field::cast)
      │                                                      ┬  
@@ -8454,7 +8454,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:161:5 ]
+     ╭─[ rust.baml:161:5 ]
      │
  161 │     }
      │     ┬  
@@ -8464,7 +8464,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:164:5 ]
+     ╭─[ rust.baml:164:5 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │     ─┬─  
@@ -8474,7 +8474,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:164:9 ]
+     ╭─[ rust.baml:164:9 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │         ─┬  
@@ -8484,7 +8484,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:164:12 ]
+     ╭─[ rust.baml:164:12 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │            ────────┬───────  
@@ -8494,7 +8494,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:164:28 ]
+     ╭─[ rust.baml:164:28 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                            ┬  
@@ -8504,7 +8504,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:164:29 ]
+     ╭─[ rust.baml:164:29 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                             ┬  
@@ -8514,7 +8514,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:164:30 ]
+     ╭─[ rust.baml:164:30 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                              ──┬─  
@@ -8524,7 +8524,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:164:34 ]
+     ╭─[ rust.baml:164:34 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                  ┬  
@@ -8534,7 +8534,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:164:36 ]
+     ╭─[ rust.baml:164:36 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                    ─┬  
@@ -8544,7 +8544,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:164:39 ]
+     ╭─[ rust.baml:164:39 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                       ──┬─  
@@ -8554,7 +8554,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:164:44 ]
+     ╭─[ rust.baml:164:44 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                            ────┬───  
@@ -8564,7 +8564,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:164:52 ]
+     ╭─[ rust.baml:164:52 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                    ┬  
@@ -8574,7 +8574,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:164:53 ]
+     ╭─[ rust.baml:164:53 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                     ──┬─  
@@ -8584,7 +8584,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '='
-     ╭─[ 3:164:58 ]
+     ╭─[ rust.baml:164:58 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                          ┬  
@@ -8594,7 +8594,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:164:60 ]
+     ╭─[ rust.baml:164:60 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                            ───────┬──────  
@@ -8604,7 +8604,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:164:74 ]
+     ╭─[ rust.baml:164:74 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                                          ┬  
@@ -8614,7 +8614,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:164:76 ]
+     ╭─[ rust.baml:164:76 ]
      │
  164 │     pub fn block_attributes(&self) -> impl Iterator<Item = BlockAttribute> {
      │                                                                            ┬  
@@ -8624,7 +8624,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:165:9 ]
+     ╭─[ rust.baml:165:9 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │         ──┬─  
@@ -8634,7 +8634,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:165:13 ]
+     ╭─[ rust.baml:165:13 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │             ┬  
@@ -8644,7 +8644,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:165:14 ]
+     ╭─[ rust.baml:165:14 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │              ───┬──  
@@ -8654,7 +8654,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:165:20 ]
+     ╭─[ rust.baml:165:20 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                    ┬  
@@ -8664,7 +8664,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:165:21 ]
+     ╭─[ rust.baml:165:21 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                     ────┬───  
@@ -8674,7 +8674,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:165:29 ]
+     ╭─[ rust.baml:165:29 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                             ┬  
@@ -8684,7 +8684,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:165:30 ]
+     ╭─[ rust.baml:165:30 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                              ┬  
@@ -8694,7 +8694,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:165:31 ]
+     ╭─[ rust.baml:165:31 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                               ┬  
@@ -8704,7 +8704,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:165:32 ]
+     ╭─[ rust.baml:165:32 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                ─────┬────  
@@ -8714,7 +8714,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:165:42 ]
+     ╭─[ rust.baml:165:42 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                          ┬  
@@ -8724,7 +8724,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:165:43 ]
+     ╭─[ rust.baml:165:43 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                           ───────┬──────  
@@ -8734,7 +8734,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:165:57 ]
+     ╭─[ rust.baml:165:57 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                                         ─┬  
@@ -8744,7 +8744,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:165:59 ]
+     ╭─[ rust.baml:165:59 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                                           ──┬─  
@@ -8754,7 +8754,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:165:63 ]
+     ╭─[ rust.baml:165:63 ]
      │
  165 │         self.syntax.children().filter_map(BlockAttribute::cast)
      │                                                               ┬  
@@ -8764,7 +8764,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:166:5 ]
+     ╭─[ rust.baml:166:5 ]
      │
  166 │     }
      │     ┬  
@@ -8774,7 +8774,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:167:1 ]
+     ╭─[ rust.baml:167:1 ]
      │
  167 │ }
      │ ┬  
@@ -8784,7 +8784,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:169:1 ]
+     ╭─[ rust.baml:169:1 ]
      │
  169 │ impl Field {
      │ ──┬─  
@@ -8794,7 +8794,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:169:6 ]
+     ╭─[ rust.baml:169:6 ]
      │
  169 │ impl Field {
      │      ──┬──  
@@ -8804,7 +8804,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:169:12 ]
+     ╭─[ rust.baml:169:12 ]
      │
  169 │ impl Field {
      │            ┬  
@@ -8814,7 +8814,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:171:5 ]
+     ╭─[ rust.baml:171:5 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │     ─┬─  
@@ -8824,7 +8824,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:171:9 ]
+     ╭─[ rust.baml:171:9 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │         ─┬  
@@ -8834,7 +8834,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:171:12 ]
+     ╭─[ rust.baml:171:12 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │            ──┬─  
@@ -8844,7 +8844,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:171:16 ]
+     ╭─[ rust.baml:171:16 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                ┬  
@@ -8854,7 +8854,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:171:17 ]
+     ╭─[ rust.baml:171:17 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                 ┬  
@@ -8864,7 +8864,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:171:18 ]
+     ╭─[ rust.baml:171:18 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                  ──┬─  
@@ -8874,7 +8874,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:171:22 ]
+     ╭─[ rust.baml:171:22 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                      ┬  
@@ -8884,7 +8884,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:171:24 ]
+     ╭─[ rust.baml:171:24 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                        ─┬  
@@ -8894,7 +8894,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:171:27 ]
+     ╭─[ rust.baml:171:27 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                           ───┬──  
@@ -8904,7 +8904,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:171:33 ]
+     ╭─[ rust.baml:171:33 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                 ┬  
@@ -8914,7 +8914,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:171:34 ]
+     ╭─[ rust.baml:171:34 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                  ─────┬─────  
@@ -8924,7 +8924,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:171:45 ]
+     ╭─[ rust.baml:171:45 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                             ┬  
@@ -8934,7 +8934,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:171:47 ]
+     ╭─[ rust.baml:171:47 ]
      │
  171 │     pub fn name(&self) -> Option<SyntaxToken> {
      │                                               ┬  
@@ -8944,7 +8944,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:172:9 ]
+     ╭─[ rust.baml:172:9 ]
      │
  172 │         self.syntax
      │         ──┬─  
@@ -8954,7 +8954,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:172:13 ]
+     ╭─[ rust.baml:172:13 ]
      │
  172 │         self.syntax
      │             ┬  
@@ -8964,7 +8964,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:172:14 ]
+     ╭─[ rust.baml:172:14 ]
      │
  172 │         self.syntax
      │              ───┬──  
@@ -8974,7 +8974,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:173:13 ]
+     ╭─[ rust.baml:173:13 ]
      │
  173 │             .children_with_tokens()
      │             ┬  
@@ -8984,7 +8984,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:173:14 ]
+     ╭─[ rust.baml:173:14 ]
      │
  173 │             .children_with_tokens()
      │              ──────────┬─────────  
@@ -8994,7 +8994,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:173:34 ]
+     ╭─[ rust.baml:173:34 ]
      │
  173 │             .children_with_tokens()
      │                                  ┬  
@@ -9004,7 +9004,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:173:35 ]
+     ╭─[ rust.baml:173:35 ]
      │
  173 │             .children_with_tokens()
      │                                   ┬  
@@ -9014,7 +9014,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:174:13 ]
+     ╭─[ rust.baml:174:13 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │             ┬  
@@ -9024,7 +9024,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:174:14 ]
+     ╭─[ rust.baml:174:14 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │              ─────┬────  
@@ -9034,7 +9034,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:174:24 ]
+     ╭─[ rust.baml:174:24 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                        ┬  
@@ -9044,7 +9044,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:174:25 ]
+     ╭─[ rust.baml:174:25 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                         ──┬──  
@@ -9054,7 +9054,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:174:30 ]
+     ╭─[ rust.baml:174:30 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                              ─┬  
@@ -9064,7 +9064,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:174:32 ]
+     ╭─[ rust.baml:174:32 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                ─────┬─────  
@@ -9074,7 +9074,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:174:43 ]
+     ╭─[ rust.baml:174:43 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                           ─┬  
@@ -9084,7 +9084,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:174:45 ]
+     ╭─[ rust.baml:174:45 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                             ─────┬────  
@@ -9094,7 +9094,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:174:55 ]
+     ╭─[ rust.baml:174:55 ]
      │
  174 │             .filter_map(rowan::NodeOrToken::into_token)
      │                                                       ┬  
@@ -9104,7 +9104,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:175:13 ]
+     ╭─[ rust.baml:175:13 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │             ┬  
@@ -9114,7 +9114,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:175:14 ]
+     ╭─[ rust.baml:175:14 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │              ──┬─  
@@ -9124,7 +9124,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:175:18 ]
+     ╭─[ rust.baml:175:18 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                  ┬  
@@ -9134,7 +9134,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:175:19 ]
+     ╭─[ rust.baml:175:19 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                   ┬  
@@ -9144,7 +9144,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:175:20 ]
+     ╭─[ rust.baml:175:20 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                    ──┬──  
@@ -9154,7 +9154,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:175:25 ]
+     ╭─[ rust.baml:175:25 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                         ┬  
@@ -9164,7 +9164,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:175:27 ]
+     ╭─[ rust.baml:175:27 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                           ──┬──  
@@ -9174,7 +9174,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:175:32 ]
+     ╭─[ rust.baml:175:32 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                ┬  
@@ -9184,7 +9184,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:175:33 ]
+     ╭─[ rust.baml:175:33 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                 ──┬─  
@@ -9194,7 +9194,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:175:37 ]
+     ╭─[ rust.baml:175:37 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                     ┬  
@@ -9204,7 +9204,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:175:38 ]
+     ╭─[ rust.baml:175:38 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                      ┬  
@@ -9214,7 +9214,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=='
-     ╭─[ 3:175:40 ]
+     ╭─[ rust.baml:175:40 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                        ─┬  
@@ -9224,7 +9224,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:175:43 ]
+     ╭─[ rust.baml:175:43 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                           ─────┬────  
@@ -9234,7 +9234,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:175:53 ]
+     ╭─[ rust.baml:175:53 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                                     ─┬  
@@ -9244,7 +9244,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:175:55 ]
+     ╭─[ rust.baml:175:55 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                                       ──┬─  
@@ -9254,7 +9254,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:175:59 ]
+     ╭─[ rust.baml:175:59 ]
      │
  175 │             .find(|token| token.kind() == SyntaxKind::WORD)
      │                                                           ┬  
@@ -9264,7 +9264,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:176:5 ]
+     ╭─[ rust.baml:176:5 ]
      │
  176 │     }
      │     ┬  
@@ -9274,7 +9274,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:179:5 ]
+     ╭─[ rust.baml:179:5 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │     ─┬─  
@@ -9284,7 +9284,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:179:9 ]
+     ╭─[ rust.baml:179:9 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │         ─┬  
@@ -9294,7 +9294,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:179:12 ]
+     ╭─[ rust.baml:179:12 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │            ─┬  
@@ -9304,7 +9304,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:179:14 ]
+     ╭─[ rust.baml:179:14 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │              ┬  
@@ -9314,7 +9314,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:179:15 ]
+     ╭─[ rust.baml:179:15 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │               ┬  
@@ -9324,7 +9324,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:179:16 ]
+     ╭─[ rust.baml:179:16 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                ──┬─  
@@ -9334,7 +9334,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:179:20 ]
+     ╭─[ rust.baml:179:20 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                    ┬  
@@ -9344,7 +9344,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:179:22 ]
+     ╭─[ rust.baml:179:22 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                      ─┬  
@@ -9354,7 +9354,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:179:25 ]
+     ╭─[ rust.baml:179:25 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                         ───┬──  
@@ -9364,7 +9364,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:179:31 ]
+     ╭─[ rust.baml:179:31 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                               ┬  
@@ -9374,7 +9374,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:179:32 ]
+     ╭─[ rust.baml:179:32 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                                ────┬───  
@@ -9384,7 +9384,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:179:40 ]
+     ╭─[ rust.baml:179:40 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                                        ┬  
@@ -9394,7 +9394,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:179:42 ]
+     ╭─[ rust.baml:179:42 ]
      │
  179 │     pub fn ty(&self) -> Option<TypeExpr> {
      │                                          ┬  
@@ -9404,7 +9404,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:180:9 ]
+     ╭─[ rust.baml:180:9 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │         ──┬─  
@@ -9414,7 +9414,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:180:13 ]
+     ╭─[ rust.baml:180:13 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │             ┬  
@@ -9424,7 +9424,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:180:14 ]
+     ╭─[ rust.baml:180:14 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │              ───┬──  
@@ -9434,7 +9434,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:180:20 ]
+     ╭─[ rust.baml:180:20 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                    ┬  
@@ -9444,7 +9444,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:180:21 ]
+     ╭─[ rust.baml:180:21 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                     ────┬───  
@@ -9454,7 +9454,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:180:29 ]
+     ╭─[ rust.baml:180:29 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                             ┬  
@@ -9464,7 +9464,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:180:30 ]
+     ╭─[ rust.baml:180:30 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                              ┬  
@@ -9474,7 +9474,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:180:31 ]
+     ╭─[ rust.baml:180:31 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                               ┬  
@@ -9484,7 +9484,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:180:32 ]
+     ╭─[ rust.baml:180:32 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                ────┬───  
@@ -9494,7 +9494,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:180:40 ]
+     ╭─[ rust.baml:180:40 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                        ┬  
@@ -9504,7 +9504,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:180:41 ]
+     ╭─[ rust.baml:180:41 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                         ────┬───  
@@ -9514,7 +9514,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:180:49 ]
+     ╭─[ rust.baml:180:49 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                 ─┬  
@@ -9524,7 +9524,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:180:51 ]
+     ╭─[ rust.baml:180:51 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                   ──┬─  
@@ -9534,7 +9534,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:180:55 ]
+     ╭─[ rust.baml:180:55 ]
      │
  180 │         self.syntax.children().find_map(TypeExpr::cast)
      │                                                       ┬  
@@ -9544,7 +9544,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:181:5 ]
+     ╭─[ rust.baml:181:5 ]
      │
  181 │     }
      │     ┬  
@@ -9554,7 +9554,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:184:5 ]
+     ╭─[ rust.baml:184:5 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │     ─┬─  
@@ -9564,7 +9564,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:184:9 ]
+     ╭─[ rust.baml:184:9 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │         ─┬  
@@ -9574,7 +9574,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:184:12 ]
+     ╭─[ rust.baml:184:12 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │            ─────┬────  
@@ -9584,7 +9584,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:184:22 ]
+     ╭─[ rust.baml:184:22 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                      ┬  
@@ -9594,7 +9594,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:184:23 ]
+     ╭─[ rust.baml:184:23 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                       ┬  
@@ -9604,7 +9604,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:184:24 ]
+     ╭─[ rust.baml:184:24 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                        ──┬─  
@@ -9614,7 +9614,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:184:28 ]
+     ╭─[ rust.baml:184:28 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                            ┬  
@@ -9624,7 +9624,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:184:30 ]
+     ╭─[ rust.baml:184:30 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                              ─┬  
@@ -9634,7 +9634,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:184:33 ]
+     ╭─[ rust.baml:184:33 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                 ──┬─  
@@ -9644,7 +9644,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:184:38 ]
+     ╭─[ rust.baml:184:38 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                      ────┬───  
@@ -9654,7 +9654,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:184:46 ]
+     ╭─[ rust.baml:184:46 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                              ┬  
@@ -9664,7 +9664,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:184:47 ]
+     ╭─[ rust.baml:184:47 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                               ──┬─  
@@ -9674,7 +9674,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '='
-     ╭─[ 3:184:52 ]
+     ╭─[ rust.baml:184:52 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                                    ┬  
@@ -9684,7 +9684,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:184:54 ]
+     ╭─[ rust.baml:184:54 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                                      ────┬────  
@@ -9694,7 +9694,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:184:63 ]
+     ╭─[ rust.baml:184:63 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                                               ┬  
@@ -9704,7 +9704,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:184:65 ]
+     ╭─[ rust.baml:184:65 ]
      │
  184 │     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
      │                                                                 ┬  
@@ -9714,7 +9714,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:185:9 ]
+     ╭─[ rust.baml:185:9 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │         ──┬─  
@@ -9724,7 +9724,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:185:13 ]
+     ╭─[ rust.baml:185:13 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │             ┬  
@@ -9734,7 +9734,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:185:14 ]
+     ╭─[ rust.baml:185:14 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │              ───┬──  
@@ -9744,7 +9744,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:185:20 ]
+     ╭─[ rust.baml:185:20 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                    ┬  
@@ -9754,7 +9754,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:185:21 ]
+     ╭─[ rust.baml:185:21 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                     ────┬───  
@@ -9764,7 +9764,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:185:29 ]
+     ╭─[ rust.baml:185:29 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                             ┬  
@@ -9774,7 +9774,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:185:30 ]
+     ╭─[ rust.baml:185:30 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                              ┬  
@@ -9784,7 +9784,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:185:31 ]
+     ╭─[ rust.baml:185:31 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                               ┬  
@@ -9794,7 +9794,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:185:32 ]
+     ╭─[ rust.baml:185:32 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                ─────┬────  
@@ -9804,7 +9804,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:185:42 ]
+     ╭─[ rust.baml:185:42 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                          ┬  
@@ -9814,7 +9814,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:185:43 ]
+     ╭─[ rust.baml:185:43 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                           ────┬────  
@@ -9824,7 +9824,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:185:52 ]
+     ╭─[ rust.baml:185:52 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                                    ─┬  
@@ -9834,7 +9834,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:185:54 ]
+     ╭─[ rust.baml:185:54 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                                      ──┬─  
@@ -9844,7 +9844,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:185:58 ]
+     ╭─[ rust.baml:185:58 ]
      │
  185 │         self.syntax.children().filter_map(Attribute::cast)
      │                                                          ┬  
@@ -9854,7 +9854,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:186:5 ]
+     ╭─[ rust.baml:186:5 ]
      │
  186 │     }
      │     ┬  
@@ -9864,7 +9864,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:187:1 ]
+     ╭─[ rust.baml:187:1 ]
      │
  187 │ }
      │ ┬  
@@ -9874,7 +9874,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '#'
-     ╭─[ 3:190:1 ]
+     ╭─[ rust.baml:190:1 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │ ┬  
@@ -9884,7 +9884,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '['
-     ╭─[ 3:190:2 ]
+     ╭─[ rust.baml:190:2 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │  ┬  
@@ -9894,7 +9894,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:190:3 ]
+     ╭─[ rust.baml:190:3 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │   ───┬──  
@@ -9904,7 +9904,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:190:9 ]
+     ╭─[ rust.baml:190:9 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │         ┬  
@@ -9914,7 +9914,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:190:10 ]
+     ╭─[ rust.baml:190:10 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │          ──┬──  
@@ -9924,7 +9924,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:190:15 ]
+     ╭─[ rust.baml:190:15 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │               ┬  
@@ -9934,7 +9934,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:190:17 ]
+     ╭─[ rust.baml:190:17 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                 ──┬──  
@@ -9944,7 +9944,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:190:22 ]
+     ╭─[ rust.baml:190:22 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                      ┬  
@@ -9954,7 +9954,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:190:24 ]
+     ╭─[ rust.baml:190:24 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                        ────┬────  
@@ -9964,7 +9964,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:190:33 ]
+     ╭─[ rust.baml:190:33 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                 ┬  
@@ -9974,7 +9974,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:190:35 ]
+     ╭─[ rust.baml:190:35 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                   ─┬  
@@ -9984,7 +9984,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:190:37 ]
+     ╭─[ rust.baml:190:37 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                     ┬  
@@ -9994,7 +9994,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:190:39 ]
+     ╭─[ rust.baml:190:39 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                       ──┬─  
@@ -10004,7 +10004,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:190:43 ]
+     ╭─[ rust.baml:190:43 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                           ┬  
@@ -10014,7 +10014,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ']'
-     ╭─[ 3:190:44 ]
+     ╭─[ rust.baml:190:44 ]
      │
  190 │ #[derive(Debug, Clone, PartialEq, Eq, Hash)]
      │                                            ┬  
@@ -10024,7 +10024,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:191:1 ]
+     ╭─[ rust.baml:191:1 ]
      │
  191 │ pub enum Item {
      │ ─┬─  
@@ -10034,7 +10034,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 3:192:13 ]
+     ╭─[ rust.baml:192:13 ]
      │
  192 │     Function(FunctionDef),
      │             ┬  
@@ -10044,7 +10044,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 3:192:25 ]
+     ╭─[ rust.baml:192:25 ]
      │
  192 │     Function(FunctionDef),
      │                         ┬  
@@ -10054,7 +10054,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 3:192:26 ]
+     ╭─[ rust.baml:192:26 ]
      │
  192 │     Function(FunctionDef),
      │                          ┬  
@@ -10064,7 +10064,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 3:193:10 ]
+     ╭─[ rust.baml:193:10 ]
      │
  193 │     Class(ClassDef),
      │          ┬  
@@ -10074,7 +10074,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 3:193:19 ]
+     ╭─[ rust.baml:193:19 ]
      │
  193 │     Class(ClassDef),
      │                   ┬  
@@ -10084,7 +10084,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 3:193:20 ]
+     ╭─[ rust.baml:193:20 ]
      │
  193 │     Class(ClassDef),
      │                    ┬  
@@ -10094,7 +10094,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 3:194:9 ]
+     ╭─[ rust.baml:194:9 ]
      │
  194 │     Enum(EnumDef),
      │         ┬  
@@ -10104,7 +10104,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 3:194:17 ]
+     ╭─[ rust.baml:194:17 ]
      │
  194 │     Enum(EnumDef),
      │                 ┬  
@@ -10114,7 +10114,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 3:194:18 ]
+     ╭─[ rust.baml:194:18 ]
      │
  194 │     Enum(EnumDef),
      │                  ┬  
@@ -10124,7 +10124,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 3:195:11 ]
+     ╭─[ rust.baml:195:11 ]
      │
  195 │     Client(ClientDef),
      │           ┬  
@@ -10134,7 +10134,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 3:195:21 ]
+     ╭─[ rust.baml:195:21 ]
      │
  195 │     Client(ClientDef),
      │                     ┬  
@@ -10144,7 +10144,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 3:195:22 ]
+     ╭─[ rust.baml:195:22 ]
      │
  195 │     Client(ClientDef),
      │                      ┬  
@@ -10154,7 +10154,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 3:196:9 ]
+     ╭─[ rust.baml:196:9 ]
      │
  196 │     Test(TestDef),
      │         ┬  
@@ -10164,7 +10164,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 3:196:17 ]
+     ╭─[ rust.baml:196:17 ]
      │
  196 │     Test(TestDef),
      │                 ┬  
@@ -10174,7 +10174,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 3:196:18 ]
+     ╭─[ rust.baml:196:18 ]
      │
  196 │     Test(TestDef),
      │                  ┬  
@@ -10184,7 +10184,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 3:197:16 ]
+     ╭─[ rust.baml:197:16 ]
      │
  197 │     RetryPolicy(RetryPolicyDef),
      │                ┬  
@@ -10194,7 +10194,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 3:197:31 ]
+     ╭─[ rust.baml:197:31 ]
      │
  197 │     RetryPolicy(RetryPolicyDef),
      │                               ┬  
@@ -10204,7 +10204,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 3:197:32 ]
+     ╭─[ rust.baml:197:32 ]
      │
  197 │     RetryPolicy(RetryPolicyDef),
      │                                ┬  
@@ -10214,7 +10214,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 3:198:19 ]
+     ╭─[ rust.baml:198:19 ]
      │
  198 │     TemplateString(TemplateStringDef),
      │                   ┬  
@@ -10224,7 +10224,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 3:198:37 ]
+     ╭─[ rust.baml:198:37 ]
      │
  198 │     TemplateString(TemplateStringDef),
      │                                     ┬  
@@ -10234,7 +10234,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 3:198:38 ]
+     ╭─[ rust.baml:198:38 ]
      │
  198 │     TemplateString(TemplateStringDef),
      │                                      ┬  
@@ -10244,7 +10244,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found '('
-     ╭─[ 3:199:14 ]
+     ╭─[ rust.baml:199:14 ]
      │
  199 │     TypeAlias(TypeAliasDef),
      │              ┬  
@@ -10254,7 +10254,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ 3:199:27 ]
+     ╭─[ rust.baml:199:27 ]
      │
  199 │     TypeAlias(TypeAliasDef),
      │                           ┬  
@@ -10264,7 +10264,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ 3:199:28 ]
+     ╭─[ rust.baml:199:28 ]
      │
  199 │     TypeAlias(TypeAliasDef),
      │                            ┬  
@@ -10274,7 +10274,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:202:1 ]
+     ╭─[ rust.baml:202:1 ]
      │
  202 │ impl AstNode for Item {
      │ ──┬─  
@@ -10284,7 +10284,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:202:6 ]
+     ╭─[ rust.baml:202:6 ]
      │
  202 │ impl AstNode for Item {
      │      ───┬───  
@@ -10294,7 +10294,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found for
-     ╭─[ 3:202:14 ]
+     ╭─[ rust.baml:202:14 ]
      │
  202 │ impl AstNode for Item {
      │              ─┬─  
@@ -10304,7 +10304,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:202:18 ]
+     ╭─[ rust.baml:202:18 ]
      │
  202 │ impl AstNode for Item {
      │                  ──┬─  
@@ -10314,7 +10314,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:202:23 ]
+     ╭─[ rust.baml:202:23 ]
      │
  202 │ impl AstNode for Item {
      │                       ┬  
@@ -10324,7 +10324,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:203:26 ]
+     ╭─[ rust.baml:203:26 ]
      │
  203 │     type Language = crate::BamlLanguage;
      │                          ─┬  
@@ -10334,7 +10334,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:203:28 ]
+     ╭─[ rust.baml:203:28 ]
      │
  203 │     type Language = crate::BamlLanguage;
      │                            ──────┬─────  
@@ -10344,7 +10344,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ';'
-     ╭─[ 3:203:40 ]
+     ╭─[ rust.baml:203:40 ]
      │
  203 │     type Language = crate::BamlLanguage;
      │                                        ┬  
@@ -10354,7 +10354,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:5 ]
+     ╭─[ rust.baml:205:5 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │     ─┬  
@@ -10364,7 +10364,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:8 ]
+     ╭─[ rust.baml:205:8 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │        ────┬───  
@@ -10374,7 +10374,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:205:16 ]
+     ╭─[ rust.baml:205:16 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                ┬  
@@ -10384,7 +10384,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:17 ]
+     ╭─[ rust.baml:205:17 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                 ──┬─  
@@ -10394,7 +10394,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ':'
-     ╭─[ 3:205:21 ]
+     ╭─[ rust.baml:205:21 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                     ┬  
@@ -10404,7 +10404,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:205:23 ]
+     ╭─[ rust.baml:205:23 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                       ┬  
@@ -10414,7 +10414,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:24 ]
+     ╭─[ rust.baml:205:24 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                        ──┬─  
@@ -10424,7 +10424,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:205:28 ]
+     ╭─[ rust.baml:205:28 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                            ─┬  
@@ -10434,7 +10434,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:30 ]
+     ╭─[ rust.baml:205:30 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                              ────┬───  
@@ -10444,7 +10444,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:39 ]
+     ╭─[ rust.baml:205:39 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                       ─┬  
@@ -10454,7 +10454,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:42 ]
+     ╭─[ rust.baml:205:42 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                          ──┬──  
@@ -10464,7 +10464,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:205:47 ]
+     ╭─[ rust.baml:205:47 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                               ─┬  
@@ -10474,7 +10474,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:49 ]
+     ╭─[ rust.baml:205:49 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                 ────┬───  
@@ -10484,7 +10484,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:205:57 ]
+     ╭─[ rust.baml:205:57 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                         ┬  
@@ -10494,7 +10494,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:205:58 ]
+     ╭─[ rust.baml:205:58 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                          ─┬  
@@ -10504,7 +10504,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:60 ]
+     ╭─[ rust.baml:205:60 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                            ──┬─  
@@ -10514,7 +10514,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:205:64 ]
+     ╭─[ rust.baml:205:64 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                                ┬  
@@ -10524,7 +10524,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:205:66 ]
+     ╭─[ rust.baml:205:66 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                                  ─┬  
@@ -10534,7 +10534,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:205:69 ]
+     ╭─[ rust.baml:205:69 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                                     ──┬─  
@@ -10544,7 +10544,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:205:74 ]
+     ╭─[ rust.baml:205:74 ]
      │
  205 │     fn can_cast(kind: <Self::Language as rowan::Language>::Kind) -> bool {
      │                                                                          ┬  
@@ -10554,7 +10554,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:206:9 ]
+     ╭─[ rust.baml:206:9 ]
      │
  206 │         matches!(
      │         ───┬───  
@@ -10564,7 +10564,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '!'
-     ╭─[ 3:206:16 ]
+     ╭─[ rust.baml:206:16 ]
      │
  206 │         matches!(
      │                ┬  
@@ -10574,7 +10574,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:206:17 ]
+     ╭─[ rust.baml:206:17 ]
      │
  206 │         matches!(
      │                 ┬  
@@ -10584,7 +10584,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:207:13 ]
+     ╭─[ rust.baml:207:13 ]
      │
  207 │             kind,
      │             ──┬─  
@@ -10594,7 +10594,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:207:17 ]
+     ╭─[ rust.baml:207:17 ]
      │
  207 │             kind,
      │                 ┬  
@@ -10604,7 +10604,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:208:13 ]
+     ╭─[ rust.baml:208:13 ]
      │
  208 │             SyntaxKind::FUNCTION_DEF
      │             ─────┬────  
@@ -10614,7 +10614,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:208:23 ]
+     ╭─[ rust.baml:208:23 ]
      │
  208 │             SyntaxKind::FUNCTION_DEF
      │                       ─┬  
@@ -10624,7 +10624,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:208:25 ]
+     ╭─[ rust.baml:208:25 ]
      │
  208 │             SyntaxKind::FUNCTION_DEF
      │                         ──────┬─────  
@@ -10634,7 +10634,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:209:17 ]
+     ╭─[ rust.baml:209:17 ]
      │
  209 │                 | SyntaxKind::CLASS_DEF
      │                 ┬  
@@ -10644,7 +10644,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:209:19 ]
+     ╭─[ rust.baml:209:19 ]
      │
  209 │                 | SyntaxKind::CLASS_DEF
      │                   ─────┬────  
@@ -10654,7 +10654,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:209:29 ]
+     ╭─[ rust.baml:209:29 ]
      │
  209 │                 | SyntaxKind::CLASS_DEF
      │                             ─┬  
@@ -10664,7 +10664,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:209:31 ]
+     ╭─[ rust.baml:209:31 ]
      │
  209 │                 | SyntaxKind::CLASS_DEF
      │                               ────┬────  
@@ -10674,7 +10674,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:210:17 ]
+     ╭─[ rust.baml:210:17 ]
      │
  210 │                 | SyntaxKind::ENUM_DEF
      │                 ┬  
@@ -10684,7 +10684,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:210:19 ]
+     ╭─[ rust.baml:210:19 ]
      │
  210 │                 | SyntaxKind::ENUM_DEF
      │                   ─────┬────  
@@ -10694,7 +10694,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:210:29 ]
+     ╭─[ rust.baml:210:29 ]
      │
  210 │                 | SyntaxKind::ENUM_DEF
      │                             ─┬  
@@ -10704,7 +10704,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:210:31 ]
+     ╭─[ rust.baml:210:31 ]
      │
  210 │                 | SyntaxKind::ENUM_DEF
      │                               ────┬───  
@@ -10714,7 +10714,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:211:17 ]
+     ╭─[ rust.baml:211:17 ]
      │
  211 │                 | SyntaxKind::CLIENT_DEF
      │                 ┬  
@@ -10724,7 +10724,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:211:19 ]
+     ╭─[ rust.baml:211:19 ]
      │
  211 │                 | SyntaxKind::CLIENT_DEF
      │                   ─────┬────  
@@ -10734,7 +10734,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:211:29 ]
+     ╭─[ rust.baml:211:29 ]
      │
  211 │                 | SyntaxKind::CLIENT_DEF
      │                             ─┬  
@@ -10744,7 +10744,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:211:31 ]
+     ╭─[ rust.baml:211:31 ]
      │
  211 │                 | SyntaxKind::CLIENT_DEF
      │                               ─────┬────  
@@ -10754,7 +10754,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:212:17 ]
+     ╭─[ rust.baml:212:17 ]
      │
  212 │                 | SyntaxKind::TEST_DEF
      │                 ┬  
@@ -10764,7 +10764,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:212:19 ]
+     ╭─[ rust.baml:212:19 ]
      │
  212 │                 | SyntaxKind::TEST_DEF
      │                   ─────┬────  
@@ -10774,7 +10774,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:212:29 ]
+     ╭─[ rust.baml:212:29 ]
      │
  212 │                 | SyntaxKind::TEST_DEF
      │                             ─┬  
@@ -10784,7 +10784,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:212:31 ]
+     ╭─[ rust.baml:212:31 ]
      │
  212 │                 | SyntaxKind::TEST_DEF
      │                               ────┬───  
@@ -10794,7 +10794,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:213:17 ]
+     ╭─[ rust.baml:213:17 ]
      │
  213 │                 | SyntaxKind::RETRY_POLICY_DEF
      │                 ┬  
@@ -10804,7 +10804,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:213:19 ]
+     ╭─[ rust.baml:213:19 ]
      │
  213 │                 | SyntaxKind::RETRY_POLICY_DEF
      │                   ─────┬────  
@@ -10814,7 +10814,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:213:29 ]
+     ╭─[ rust.baml:213:29 ]
      │
  213 │                 | SyntaxKind::RETRY_POLICY_DEF
      │                             ─┬  
@@ -10824,7 +10824,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:213:31 ]
+     ╭─[ rust.baml:213:31 ]
      │
  213 │                 | SyntaxKind::RETRY_POLICY_DEF
      │                               ────────┬───────  
@@ -10834,7 +10834,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:214:17 ]
+     ╭─[ rust.baml:214:17 ]
      │
  214 │                 | SyntaxKind::TEMPLATE_STRING_DEF
      │                 ┬  
@@ -10844,7 +10844,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:214:19 ]
+     ╭─[ rust.baml:214:19 ]
      │
  214 │                 | SyntaxKind::TEMPLATE_STRING_DEF
      │                   ─────┬────  
@@ -10854,7 +10854,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:214:29 ]
+     ╭─[ rust.baml:214:29 ]
      │
  214 │                 | SyntaxKind::TEMPLATE_STRING_DEF
      │                             ─┬  
@@ -10864,7 +10864,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:214:31 ]
+     ╭─[ rust.baml:214:31 ]
      │
  214 │                 | SyntaxKind::TEMPLATE_STRING_DEF
      │                               ─────────┬─────────  
@@ -10874,7 +10874,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '|'
-     ╭─[ 3:215:17 ]
+     ╭─[ rust.baml:215:17 ]
      │
  215 │                 | SyntaxKind::TYPE_ALIAS_DEF
      │                 ┬  
@@ -10884,7 +10884,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:215:19 ]
+     ╭─[ rust.baml:215:19 ]
      │
  215 │                 | SyntaxKind::TYPE_ALIAS_DEF
      │                   ─────┬────  
@@ -10894,7 +10894,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:215:29 ]
+     ╭─[ rust.baml:215:29 ]
      │
  215 │                 | SyntaxKind::TYPE_ALIAS_DEF
      │                             ─┬  
@@ -10904,7 +10904,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:215:31 ]
+     ╭─[ rust.baml:215:31 ]
      │
  215 │                 | SyntaxKind::TYPE_ALIAS_DEF
      │                               ───────┬──────  
@@ -10914,7 +10914,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:216:9 ]
+     ╭─[ rust.baml:216:9 ]
      │
  216 │         )
      │         ┬  
@@ -10924,7 +10924,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:217:5 ]
+     ╭─[ rust.baml:217:5 ]
      │
  217 │     }
      │     ┬  
@@ -10934,7 +10934,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:219:5 ]
+     ╭─[ rust.baml:219:5 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │     ─┬  
@@ -10944,7 +10944,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:219:8 ]
+     ╭─[ rust.baml:219:8 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │        ──┬─  
@@ -10954,7 +10954,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:219:12 ]
+     ╭─[ rust.baml:219:12 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │            ┬  
@@ -10964,7 +10964,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:219:13 ]
+     ╭─[ rust.baml:219:13 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │             ───┬──  
@@ -10974,7 +10974,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ':'
-     ╭─[ 3:219:19 ]
+     ╭─[ rust.baml:219:19 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                   ┬  
@@ -10984,7 +10984,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:219:21 ]
+     ╭─[ rust.baml:219:21 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                     ─────┬────  
@@ -10994,7 +10994,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:219:31 ]
+     ╭─[ rust.baml:219:31 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                               ┬  
@@ -11004,7 +11004,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:219:33 ]
+     ╭─[ rust.baml:219:33 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                 ─┬  
@@ -11014,7 +11014,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:219:36 ]
+     ╭─[ rust.baml:219:36 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                    ───┬──  
@@ -11024,7 +11024,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '<'
-     ╭─[ 3:219:42 ]
+     ╭─[ rust.baml:219:42 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                          ┬  
@@ -11034,7 +11034,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:219:43 ]
+     ╭─[ rust.baml:219:43 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                           ──┬─  
@@ -11044,7 +11044,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '>'
-     ╭─[ 3:219:47 ]
+     ╭─[ rust.baml:219:47 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                               ┬  
@@ -11054,7 +11054,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:219:49 ]
+     ╭─[ rust.baml:219:49 ]
      │
  219 │     fn cast(syntax: SyntaxNode) -> Option<Self> {
      │                                                 ┬  
@@ -11064,7 +11064,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found match
-     ╭─[ 3:220:9 ]
+     ╭─[ rust.baml:220:9 ]
      │
  220 │         match syntax.kind() {
      │         ──┬──  
@@ -11074,7 +11074,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:220:15 ]
+     ╭─[ rust.baml:220:15 ]
      │
  220 │         match syntax.kind() {
      │               ───┬──  
@@ -11084,7 +11084,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:220:21 ]
+     ╭─[ rust.baml:220:21 ]
      │
  220 │         match syntax.kind() {
      │                     ┬  
@@ -11094,7 +11094,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:220:22 ]
+     ╭─[ rust.baml:220:22 ]
      │
  220 │         match syntax.kind() {
      │                      ──┬─  
@@ -11104,7 +11104,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:220:26 ]
+     ╭─[ rust.baml:220:26 ]
      │
  220 │         match syntax.kind() {
      │                          ┬  
@@ -11114,7 +11114,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:220:27 ]
+     ╭─[ rust.baml:220:27 ]
      │
  220 │         match syntax.kind() {
      │                           ┬  
@@ -11124,7 +11124,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:220:29 ]
+     ╭─[ rust.baml:220:29 ]
      │
  220 │         match syntax.kind() {
      │                             ┬  
@@ -11134,7 +11134,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:221:13 ]
+     ╭─[ rust.baml:221:13 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │             ─────┬────  
@@ -11144,7 +11144,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:221:23 ]
+     ╭─[ rust.baml:221:23 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                       ─┬  
@@ -11154,7 +11154,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:221:25 ]
+     ╭─[ rust.baml:221:25 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                         ──────┬─────  
@@ -11164,7 +11164,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:221:38 ]
+     ╭─[ rust.baml:221:38 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                      ─┬  
@@ -11174,7 +11174,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:221:41 ]
+     ╭─[ rust.baml:221:41 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                         ──┬─  
@@ -11184,7 +11184,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:221:45 ]
+     ╭─[ rust.baml:221:45 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                             ┬  
@@ -11194,7 +11194,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:221:46 ]
+     ╭─[ rust.baml:221:46 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                              ──┬─  
@@ -11204,7 +11204,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:221:50 ]
+     ╭─[ rust.baml:221:50 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                  ─┬  
@@ -11214,7 +11214,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:221:52 ]
+     ╭─[ rust.baml:221:52 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                    ────┬───  
@@ -11224,7 +11224,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:221:60 ]
+     ╭─[ rust.baml:221:60 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                            ┬  
@@ -11234,7 +11234,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:221:61 ]
+     ╭─[ rust.baml:221:61 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                             ─────┬─────  
@@ -11244,7 +11244,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:221:73 ]
+     ╭─[ rust.baml:221:73 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                         ┬  
@@ -11254,7 +11254,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:221:75 ]
+     ╭─[ rust.baml:221:75 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                           ───┬──  
@@ -11264,7 +11264,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:221:82 ]
+     ╭─[ rust.baml:221:82 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                                  ┬  
@@ -11274,7 +11274,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:221:83 ]
+     ╭─[ rust.baml:221:83 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                                   ┬  
@@ -11284,7 +11284,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:221:84 ]
+     ╭─[ rust.baml:221:84 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                                    ┬  
@@ -11294,7 +11294,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:221:85 ]
+     ╭─[ rust.baml:221:85 ]
      │
  221 │             SyntaxKind::FUNCTION_DEF => Some(Item::Function(FunctionDef { syntax })),
      │                                                                                     ┬  
@@ -11304,7 +11304,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:222:13 ]
+     ╭─[ rust.baml:222:13 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │             ─────┬────  
@@ -11314,7 +11314,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:222:23 ]
+     ╭─[ rust.baml:222:23 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                       ─┬  
@@ -11324,7 +11324,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:222:25 ]
+     ╭─[ rust.baml:222:25 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                         ────┬────  
@@ -11334,7 +11334,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:222:35 ]
+     ╭─[ rust.baml:222:35 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                   ─┬  
@@ -11344,7 +11344,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:222:38 ]
+     ╭─[ rust.baml:222:38 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                      ──┬─  
@@ -11354,7 +11354,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:222:42 ]
+     ╭─[ rust.baml:222:42 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                          ┬  
@@ -11364,7 +11364,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:222:43 ]
+     ╭─[ rust.baml:222:43 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                           ──┬─  
@@ -11374,7 +11374,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:222:47 ]
+     ╭─[ rust.baml:222:47 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                               ─┬  
@@ -11384,7 +11384,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:222:49 ]
+     ╭─[ rust.baml:222:49 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                 ──┬──  
@@ -11394,7 +11394,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:222:54 ]
+     ╭─[ rust.baml:222:54 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                      ┬  
@@ -11404,7 +11404,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:222:55 ]
+     ╭─[ rust.baml:222:55 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                       ────┬───  
@@ -11414,7 +11414,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:222:64 ]
+     ╭─[ rust.baml:222:64 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                ┬  
@@ -11424,7 +11424,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:222:66 ]
+     ╭─[ rust.baml:222:66 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                  ───┬──  
@@ -11434,7 +11434,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:222:73 ]
+     ╭─[ rust.baml:222:73 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                         ┬  
@@ -11444,7 +11444,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:222:74 ]
+     ╭─[ rust.baml:222:74 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                          ┬  
@@ -11454,7 +11454,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:222:75 ]
+     ╭─[ rust.baml:222:75 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                           ┬  
@@ -11464,7 +11464,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:222:76 ]
+     ╭─[ rust.baml:222:76 ]
      │
  222 │             SyntaxKind::CLASS_DEF => Some(Item::Class(ClassDef { syntax })),
      │                                                                            ┬  
@@ -11474,7 +11474,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:223:13 ]
+     ╭─[ rust.baml:223:13 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │             ─────┬────  
@@ -11484,7 +11484,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:223:23 ]
+     ╭─[ rust.baml:223:23 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                       ─┬  
@@ -11494,7 +11494,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:223:25 ]
+     ╭─[ rust.baml:223:25 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                         ────┬───  
@@ -11504,7 +11504,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:223:34 ]
+     ╭─[ rust.baml:223:34 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                  ─┬  
@@ -11514,7 +11514,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:223:37 ]
+     ╭─[ rust.baml:223:37 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                     ──┬─  
@@ -11524,7 +11524,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:223:41 ]
+     ╭─[ rust.baml:223:41 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                         ┬  
@@ -11534,7 +11534,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:223:42 ]
+     ╭─[ rust.baml:223:42 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                          ──┬─  
@@ -11544,7 +11544,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:223:46 ]
+     ╭─[ rust.baml:223:46 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                              ─┬  
@@ -11554,7 +11554,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:223:48 ]
+     ╭─[ rust.baml:223:48 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                ──┬─  
@@ -11564,7 +11564,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:223:52 ]
+     ╭─[ rust.baml:223:52 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                    ┬  
@@ -11574,7 +11574,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:223:53 ]
+     ╭─[ rust.baml:223:53 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                     ───┬───  
@@ -11584,7 +11584,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:223:61 ]
+     ╭─[ rust.baml:223:61 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                             ┬  
@@ -11594,7 +11594,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:223:63 ]
+     ╭─[ rust.baml:223:63 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                               ───┬──  
@@ -11604,7 +11604,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:223:70 ]
+     ╭─[ rust.baml:223:70 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                                      ┬  
@@ -11614,7 +11614,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:223:71 ]
+     ╭─[ rust.baml:223:71 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                                       ┬  
@@ -11624,7 +11624,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:223:72 ]
+     ╭─[ rust.baml:223:72 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                                        ┬  
@@ -11634,7 +11634,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:223:73 ]
+     ╭─[ rust.baml:223:73 ]
      │
  223 │             SyntaxKind::ENUM_DEF => Some(Item::Enum(EnumDef { syntax })),
      │                                                                         ┬  
@@ -11644,7 +11644,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:224:13 ]
+     ╭─[ rust.baml:224:13 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │             ─────┬────  
@@ -11654,7 +11654,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:224:23 ]
+     ╭─[ rust.baml:224:23 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                       ─┬  
@@ -11664,7 +11664,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:224:25 ]
+     ╭─[ rust.baml:224:25 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                         ─────┬────  
@@ -11674,7 +11674,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:224:36 ]
+     ╭─[ rust.baml:224:36 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                    ─┬  
@@ -11684,7 +11684,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:224:39 ]
+     ╭─[ rust.baml:224:39 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                       ──┬─  
@@ -11694,7 +11694,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:224:43 ]
+     ╭─[ rust.baml:224:43 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                           ┬  
@@ -11704,7 +11704,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:224:44 ]
+     ╭─[ rust.baml:224:44 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                            ──┬─  
@@ -11714,7 +11714,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:224:48 ]
+     ╭─[ rust.baml:224:48 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                ─┬  
@@ -11724,7 +11724,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:224:50 ]
+     ╭─[ rust.baml:224:50 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                  ───┬──  
@@ -11734,7 +11734,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:224:56 ]
+     ╭─[ rust.baml:224:56 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                        ┬  
@@ -11744,7 +11744,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:224:57 ]
+     ╭─[ rust.baml:224:57 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                         ────┬────  
@@ -11754,7 +11754,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:224:67 ]
+     ╭─[ rust.baml:224:67 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                   ┬  
@@ -11764,7 +11764,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:224:69 ]
+     ╭─[ rust.baml:224:69 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                     ───┬──  
@@ -11774,7 +11774,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:224:76 ]
+     ╭─[ rust.baml:224:76 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                            ┬  
@@ -11784,7 +11784,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:224:77 ]
+     ╭─[ rust.baml:224:77 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                             ┬  
@@ -11794,7 +11794,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:224:78 ]
+     ╭─[ rust.baml:224:78 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                              ┬  
@@ -11804,7 +11804,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:224:79 ]
+     ╭─[ rust.baml:224:79 ]
      │
  224 │             SyntaxKind::CLIENT_DEF => Some(Item::Client(ClientDef { syntax })),
      │                                                                               ┬  
@@ -11814,7 +11814,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:225:13 ]
+     ╭─[ rust.baml:225:13 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │             ─────┬────  
@@ -11824,7 +11824,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:225:23 ]
+     ╭─[ rust.baml:225:23 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                       ─┬  
@@ -11834,7 +11834,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:225:25 ]
+     ╭─[ rust.baml:225:25 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                         ────┬───  
@@ -11844,7 +11844,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:225:34 ]
+     ╭─[ rust.baml:225:34 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                  ─┬  
@@ -11854,7 +11854,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:225:37 ]
+     ╭─[ rust.baml:225:37 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                     ──┬─  
@@ -11864,7 +11864,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:225:41 ]
+     ╭─[ rust.baml:225:41 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                         ┬  
@@ -11874,7 +11874,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:225:42 ]
+     ╭─[ rust.baml:225:42 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                          ──┬─  
@@ -11884,7 +11884,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:225:46 ]
+     ╭─[ rust.baml:225:46 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                              ─┬  
@@ -11894,7 +11894,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:225:48 ]
+     ╭─[ rust.baml:225:48 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                ──┬─  
@@ -11904,7 +11904,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:225:52 ]
+     ╭─[ rust.baml:225:52 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                    ┬  
@@ -11914,7 +11914,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:225:53 ]
+     ╭─[ rust.baml:225:53 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                     ───┬───  
@@ -11924,7 +11924,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:225:61 ]
+     ╭─[ rust.baml:225:61 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                             ┬  
@@ -11934,7 +11934,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:225:63 ]
+     ╭─[ rust.baml:225:63 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                               ───┬──  
@@ -11944,7 +11944,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:225:70 ]
+     ╭─[ rust.baml:225:70 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                                      ┬  
@@ -11954,7 +11954,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:225:71 ]
+     ╭─[ rust.baml:225:71 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                                       ┬  
@@ -11964,7 +11964,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:225:72 ]
+     ╭─[ rust.baml:225:72 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                                        ┬  
@@ -11974,7 +11974,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:225:73 ]
+     ╭─[ rust.baml:225:73 ]
      │
  225 │             SyntaxKind::TEST_DEF => Some(Item::Test(TestDef { syntax })),
      │                                                                         ┬  
@@ -11984,7 +11984,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:226:13 ]
+     ╭─[ rust.baml:226:13 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │             ─────┬────  
@@ -11994,7 +11994,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:226:23 ]
+     ╭─[ rust.baml:226:23 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                       ─┬  
@@ -12004,7 +12004,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:226:25 ]
+     ╭─[ rust.baml:226:25 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                         ────────┬───────  
@@ -12014,7 +12014,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:226:42 ]
+     ╭─[ rust.baml:226:42 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                          ─┬  
@@ -12024,7 +12024,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:226:45 ]
+     ╭─[ rust.baml:226:45 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                             ──┬─  
@@ -12034,7 +12034,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:226:49 ]
+     ╭─[ rust.baml:226:49 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                 ┬  
@@ -12044,7 +12044,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:226:50 ]
+     ╭─[ rust.baml:226:50 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                  ──┬─  
@@ -12054,7 +12054,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:226:54 ]
+     ╭─[ rust.baml:226:54 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                      ─┬  
@@ -12064,7 +12064,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:226:56 ]
+     ╭─[ rust.baml:226:56 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                        ─────┬─────  
@@ -12074,7 +12074,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:226:67 ]
+     ╭─[ rust.baml:226:67 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                   ┬  
@@ -12084,7 +12084,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:226:68 ]
+     ╭─[ rust.baml:226:68 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                    ───────┬──────  
@@ -12094,7 +12094,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:226:83 ]
+     ╭─[ rust.baml:226:83 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                   ┬  
@@ -12104,7 +12104,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:226:85 ]
+     ╭─[ rust.baml:226:85 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                     ───┬──  
@@ -12114,7 +12114,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:226:92 ]
+     ╭─[ rust.baml:226:92 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                            ┬  
@@ -12124,7 +12124,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:226:93 ]
+     ╭─[ rust.baml:226:93 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                             ┬  
@@ -12134,7 +12134,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:226:94 ]
+     ╭─[ rust.baml:226:94 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                              ┬  
@@ -12144,7 +12144,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:226:95 ]
+     ╭─[ rust.baml:226:95 ]
      │
  226 │             SyntaxKind::RETRY_POLICY_DEF => Some(Item::RetryPolicy(RetryPolicyDef { syntax })),
      │                                                                                               ┬  
@@ -12154,7 +12154,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:227:13 ]
+     ╭─[ rust.baml:227:13 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │             ─────┬────  
@@ -12164,7 +12164,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:227:23 ]
+     ╭─[ rust.baml:227:23 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │                       ─┬  
@@ -12174,7 +12174,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:227:25 ]
+     ╭─[ rust.baml:227:25 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │                         ─────────┬─────────  
@@ -12184,7 +12184,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:227:45 ]
+     ╭─[ rust.baml:227:45 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │                                             ─┬  
@@ -12194,7 +12194,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:227:48 ]
+     ╭─[ rust.baml:227:48 ]
      │
  227 │             SyntaxKind::TEMPLATE_STRING_DEF => {
      │                                                ┬  
@@ -12204,7 +12204,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:228:17 ]
+     ╭─[ rust.baml:228:17 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                 ──┬─  
@@ -12214,7 +12214,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:228:21 ]
+     ╭─[ rust.baml:228:21 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                     ┬  
@@ -12224,7 +12224,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:228:22 ]
+     ╭─[ rust.baml:228:22 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                      ──┬─  
@@ -12234,7 +12234,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:228:26 ]
+     ╭─[ rust.baml:228:26 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                          ─┬  
@@ -12244,7 +12244,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:228:28 ]
+     ╭─[ rust.baml:228:28 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                            ───────┬──────  
@@ -12254,7 +12254,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:228:42 ]
+     ╭─[ rust.baml:228:42 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                          ┬  
@@ -12264,7 +12264,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:228:43 ]
+     ╭─[ rust.baml:228:43 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                           ────────┬────────  
@@ -12274,7 +12274,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:228:61 ]
+     ╭─[ rust.baml:228:61 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                             ┬  
@@ -12284,7 +12284,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:228:63 ]
+     ╭─[ rust.baml:228:63 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                               ───┬──  
@@ -12294,7 +12294,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:228:70 ]
+     ╭─[ rust.baml:228:70 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                                      ┬  
@@ -12304,7 +12304,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:228:71 ]
+     ╭─[ rust.baml:228:71 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                                       ┬  
@@ -12314,7 +12314,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:228:72 ]
+     ╭─[ rust.baml:228:72 ]
      │
  228 │                 Some(Item::TemplateString(TemplateStringDef { syntax }))
      │                                                                        ┬  
@@ -12324,7 +12324,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:229:13 ]
+     ╭─[ rust.baml:229:13 ]
      │
  229 │             }
      │             ┬  
@@ -12334,7 +12334,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:230:13 ]
+     ╭─[ rust.baml:230:13 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │             ─────┬────  
@@ -12344,7 +12344,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:230:23 ]
+     ╭─[ rust.baml:230:23 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                       ─┬  
@@ -12354,7 +12354,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:230:25 ]
+     ╭─[ rust.baml:230:25 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                         ───────┬──────  
@@ -12364,7 +12364,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:230:40 ]
+     ╭─[ rust.baml:230:40 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                        ─┬  
@@ -12374,7 +12374,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:230:43 ]
+     ╭─[ rust.baml:230:43 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                           ──┬─  
@@ -12384,7 +12384,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:230:47 ]
+     ╭─[ rust.baml:230:47 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                               ┬  
@@ -12394,7 +12394,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:230:48 ]
+     ╭─[ rust.baml:230:48 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                ──┬─  
@@ -12404,7 +12404,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:230:52 ]
+     ╭─[ rust.baml:230:52 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                    ─┬  
@@ -12414,7 +12414,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:230:54 ]
+     ╭─[ rust.baml:230:54 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                      ────┬────  
@@ -12424,7 +12424,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:230:63 ]
+     ╭─[ rust.baml:230:63 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                               ┬  
@@ -12434,7 +12434,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:230:64 ]
+     ╭─[ rust.baml:230:64 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                ──────┬─────  
@@ -12444,7 +12444,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:230:77 ]
+     ╭─[ rust.baml:230:77 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                             ┬  
@@ -12454,7 +12454,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:230:79 ]
+     ╭─[ rust.baml:230:79 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                               ───┬──  
@@ -12464,7 +12464,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:230:86 ]
+     ╭─[ rust.baml:230:86 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                                      ┬  
@@ -12474,7 +12474,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:230:87 ]
+     ╭─[ rust.baml:230:87 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                                       ┬  
@@ -12484,7 +12484,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:230:88 ]
+     ╭─[ rust.baml:230:88 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                                        ┬  
@@ -12494,7 +12494,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:230:89 ]
+     ╭─[ rust.baml:230:89 ]
      │
  230 │             SyntaxKind::TYPE_ALIAS_DEF => Some(Item::TypeAlias(TypeAliasDef { syntax })),
      │                                                                                         ┬  
@@ -12504,7 +12504,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:231:13 ]
+     ╭─[ rust.baml:231:13 ]
      │
  231 │             _ => None,
      │             ┬  
@@ -12514,7 +12514,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:231:15 ]
+     ╭─[ rust.baml:231:15 ]
      │
  231 │             _ => None,
      │               ─┬  
@@ -12524,7 +12524,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:231:18 ]
+     ╭─[ rust.baml:231:18 ]
      │
  231 │             _ => None,
      │                  ──┬─  
@@ -12534,7 +12534,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:231:22 ]
+     ╭─[ rust.baml:231:22 ]
      │
  231 │             _ => None,
      │                      ┬  
@@ -12544,7 +12544,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:232:9 ]
+     ╭─[ rust.baml:232:9 ]
      │
  232 │         }
      │         ┬  
@@ -12554,7 +12554,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:233:5 ]
+     ╭─[ rust.baml:233:5 ]
      │
  233 │     }
      │     ┬  
@@ -12564,7 +12564,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:235:5 ]
+     ╭─[ rust.baml:235:5 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │     ─┬  
@@ -12574,7 +12574,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:235:8 ]
+     ╭─[ rust.baml:235:8 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │        ───┬──  
@@ -12584,7 +12584,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:235:14 ]
+     ╭─[ rust.baml:235:14 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │              ┬  
@@ -12594,7 +12594,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:235:15 ]
+     ╭─[ rust.baml:235:15 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │               ┬  
@@ -12604,7 +12604,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:235:16 ]
+     ╭─[ rust.baml:235:16 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                ──┬─  
@@ -12614,7 +12614,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:235:20 ]
+     ╭─[ rust.baml:235:20 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                    ┬  
@@ -12624,7 +12624,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-     ╭─[ 3:235:22 ]
+     ╭─[ rust.baml:235:22 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                      ─┬  
@@ -12634,7 +12634,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '&'
-     ╭─[ 3:235:25 ]
+     ╭─[ rust.baml:235:25 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                         ┬  
@@ -12644,7 +12644,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:235:26 ]
+     ╭─[ rust.baml:235:26 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                          ─────┬────  
@@ -12654,7 +12654,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:235:37 ]
+     ╭─[ rust.baml:235:37 ]
      │
  235 │     fn syntax(&self) -> &SyntaxNode {
      │                                     ┬  
@@ -12664,7 +12664,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found match
-     ╭─[ 3:236:9 ]
+     ╭─[ rust.baml:236:9 ]
      │
  236 │         match self {
      │         ──┬──  
@@ -12674,7 +12674,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:236:15 ]
+     ╭─[ rust.baml:236:15 ]
      │
  236 │         match self {
      │               ──┬─  
@@ -12684,7 +12684,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-     ╭─[ 3:236:20 ]
+     ╭─[ rust.baml:236:20 ]
      │
  236 │         match self {
      │                    ┬  
@@ -12694,7 +12694,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:237:13 ]
+     ╭─[ rust.baml:237:13 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │             ──┬─  
@@ -12704,7 +12704,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:237:17 ]
+     ╭─[ rust.baml:237:17 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                 ─┬  
@@ -12714,7 +12714,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:237:19 ]
+     ╭─[ rust.baml:237:19 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                   ────┬───  
@@ -12724,7 +12724,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:237:27 ]
+     ╭─[ rust.baml:237:27 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                           ┬  
@@ -12734,7 +12734,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:237:28 ]
+     ╭─[ rust.baml:237:28 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                            ─┬  
@@ -12744,7 +12744,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:237:30 ]
+     ╭─[ rust.baml:237:30 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                              ┬  
@@ -12754,7 +12754,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:237:32 ]
+     ╭─[ rust.baml:237:32 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                ─┬  
@@ -12764,7 +12764,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:237:35 ]
+     ╭─[ rust.baml:237:35 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                   ─┬  
@@ -12774,7 +12774,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:237:37 ]
+     ╭─[ rust.baml:237:37 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                     ┬  
@@ -12784,7 +12784,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:237:38 ]
+     ╭─[ rust.baml:237:38 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                      ───┬──  
@@ -12794,7 +12794,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:237:44 ]
+     ╭─[ rust.baml:237:44 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                            ┬  
@@ -12804,7 +12804,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:237:45 ]
+     ╭─[ rust.baml:237:45 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                             ┬  
@@ -12814,7 +12814,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:237:46 ]
+     ╭─[ rust.baml:237:46 ]
      │
  237 │             Item::Function(it) => it.syntax(),
      │                                              ┬  
@@ -12824,7 +12824,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:238:13 ]
+     ╭─[ rust.baml:238:13 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │             ──┬─  
@@ -12834,7 +12834,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:238:17 ]
+     ╭─[ rust.baml:238:17 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                 ─┬  
@@ -12844,7 +12844,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:238:19 ]
+     ╭─[ rust.baml:238:19 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                   ──┬──  
@@ -12854,7 +12854,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:238:24 ]
+     ╭─[ rust.baml:238:24 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                        ┬  
@@ -12864,7 +12864,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:238:25 ]
+     ╭─[ rust.baml:238:25 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                         ─┬  
@@ -12874,7 +12874,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:238:27 ]
+     ╭─[ rust.baml:238:27 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                           ┬  
@@ -12884,7 +12884,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:238:29 ]
+     ╭─[ rust.baml:238:29 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                             ─┬  
@@ -12894,7 +12894,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:238:32 ]
+     ╭─[ rust.baml:238:32 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                ─┬  
@@ -12904,7 +12904,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:238:34 ]
+     ╭─[ rust.baml:238:34 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                  ┬  
@@ -12914,7 +12914,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:238:35 ]
+     ╭─[ rust.baml:238:35 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                   ───┬──  
@@ -12924,7 +12924,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:238:41 ]
+     ╭─[ rust.baml:238:41 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                         ┬  
@@ -12934,7 +12934,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:238:42 ]
+     ╭─[ rust.baml:238:42 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                          ┬  
@@ -12944,7 +12944,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:238:43 ]
+     ╭─[ rust.baml:238:43 ]
      │
  238 │             Item::Class(it) => it.syntax(),
      │                                           ┬  
@@ -12954,7 +12954,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:239:13 ]
+     ╭─[ rust.baml:239:13 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │             ──┬─  
@@ -12964,7 +12964,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:239:17 ]
+     ╭─[ rust.baml:239:17 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                 ─┬  
@@ -12974,7 +12974,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:239:19 ]
+     ╭─[ rust.baml:239:19 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                   ──┬─  
@@ -12984,7 +12984,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:239:23 ]
+     ╭─[ rust.baml:239:23 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                       ┬  
@@ -12994,7 +12994,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:239:24 ]
+     ╭─[ rust.baml:239:24 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                        ─┬  
@@ -13004,7 +13004,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:239:26 ]
+     ╭─[ rust.baml:239:26 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                          ┬  
@@ -13014,7 +13014,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:239:28 ]
+     ╭─[ rust.baml:239:28 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                            ─┬  
@@ -13024,7 +13024,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:239:31 ]
+     ╭─[ rust.baml:239:31 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                               ─┬  
@@ -13034,7 +13034,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:239:33 ]
+     ╭─[ rust.baml:239:33 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                 ┬  
@@ -13044,7 +13044,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:239:34 ]
+     ╭─[ rust.baml:239:34 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                  ───┬──  
@@ -13054,7 +13054,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:239:40 ]
+     ╭─[ rust.baml:239:40 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                        ┬  
@@ -13064,7 +13064,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:239:41 ]
+     ╭─[ rust.baml:239:41 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                         ┬  
@@ -13074,7 +13074,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:239:42 ]
+     ╭─[ rust.baml:239:42 ]
      │
  239 │             Item::Enum(it) => it.syntax(),
      │                                          ┬  
@@ -13084,7 +13084,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:240:13 ]
+     ╭─[ rust.baml:240:13 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │             ──┬─  
@@ -13094,7 +13094,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:240:17 ]
+     ╭─[ rust.baml:240:17 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                 ─┬  
@@ -13104,7 +13104,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:240:19 ]
+     ╭─[ rust.baml:240:19 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                   ───┬──  
@@ -13114,7 +13114,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:240:25 ]
+     ╭─[ rust.baml:240:25 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                         ┬  
@@ -13124,7 +13124,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:240:26 ]
+     ╭─[ rust.baml:240:26 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                          ─┬  
@@ -13134,7 +13134,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:240:28 ]
+     ╭─[ rust.baml:240:28 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                            ┬  
@@ -13144,7 +13144,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:240:30 ]
+     ╭─[ rust.baml:240:30 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                              ─┬  
@@ -13154,7 +13154,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:240:33 ]
+     ╭─[ rust.baml:240:33 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                 ─┬  
@@ -13164,7 +13164,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:240:35 ]
+     ╭─[ rust.baml:240:35 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                   ┬  
@@ -13174,7 +13174,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:240:36 ]
+     ╭─[ rust.baml:240:36 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                    ───┬──  
@@ -13184,7 +13184,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:240:42 ]
+     ╭─[ rust.baml:240:42 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                          ┬  
@@ -13194,7 +13194,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:240:43 ]
+     ╭─[ rust.baml:240:43 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                           ┬  
@@ -13204,7 +13204,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:240:44 ]
+     ╭─[ rust.baml:240:44 ]
      │
  240 │             Item::Client(it) => it.syntax(),
      │                                            ┬  
@@ -13214,7 +13214,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:241:13 ]
+     ╭─[ rust.baml:241:13 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │             ──┬─  
@@ -13224,7 +13224,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:241:17 ]
+     ╭─[ rust.baml:241:17 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                 ─┬  
@@ -13234,7 +13234,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:241:19 ]
+     ╭─[ rust.baml:241:19 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                   ──┬─  
@@ -13244,7 +13244,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:241:23 ]
+     ╭─[ rust.baml:241:23 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                       ┬  
@@ -13254,7 +13254,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:241:24 ]
+     ╭─[ rust.baml:241:24 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                        ─┬  
@@ -13264,7 +13264,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:241:26 ]
+     ╭─[ rust.baml:241:26 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                          ┬  
@@ -13274,7 +13274,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:241:28 ]
+     ╭─[ rust.baml:241:28 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                            ─┬  
@@ -13284,7 +13284,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:241:31 ]
+     ╭─[ rust.baml:241:31 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                               ─┬  
@@ -13294,7 +13294,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:241:33 ]
+     ╭─[ rust.baml:241:33 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                 ┬  
@@ -13304,7 +13304,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:241:34 ]
+     ╭─[ rust.baml:241:34 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                  ───┬──  
@@ -13314,7 +13314,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:241:40 ]
+     ╭─[ rust.baml:241:40 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                        ┬  
@@ -13324,7 +13324,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:241:41 ]
+     ╭─[ rust.baml:241:41 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                         ┬  
@@ -13334,7 +13334,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:241:42 ]
+     ╭─[ rust.baml:241:42 ]
      │
  241 │             Item::Test(it) => it.syntax(),
      │                                          ┬  
@@ -13344,7 +13344,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:242:13 ]
+     ╭─[ rust.baml:242:13 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │             ──┬─  
@@ -13354,7 +13354,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:242:17 ]
+     ╭─[ rust.baml:242:17 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                 ─┬  
@@ -13364,7 +13364,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:242:19 ]
+     ╭─[ rust.baml:242:19 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                   ─────┬─────  
@@ -13374,7 +13374,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:242:30 ]
+     ╭─[ rust.baml:242:30 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                              ┬  
@@ -13384,7 +13384,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:242:31 ]
+     ╭─[ rust.baml:242:31 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                               ─┬  
@@ -13394,7 +13394,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:242:33 ]
+     ╭─[ rust.baml:242:33 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                 ┬  
@@ -13404,7 +13404,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:242:35 ]
+     ╭─[ rust.baml:242:35 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                   ─┬  
@@ -13414,7 +13414,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:242:38 ]
+     ╭─[ rust.baml:242:38 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                      ─┬  
@@ -13424,7 +13424,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:242:40 ]
+     ╭─[ rust.baml:242:40 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                        ┬  
@@ -13434,7 +13434,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:242:41 ]
+     ╭─[ rust.baml:242:41 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                         ───┬──  
@@ -13444,7 +13444,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:242:47 ]
+     ╭─[ rust.baml:242:47 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                               ┬  
@@ -13454,7 +13454,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:242:48 ]
+     ╭─[ rust.baml:242:48 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                                ┬  
@@ -13464,7 +13464,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:242:49 ]
+     ╭─[ rust.baml:242:49 ]
      │
  242 │             Item::RetryPolicy(it) => it.syntax(),
      │                                                 ┬  
@@ -13474,7 +13474,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:243:13 ]
+     ╭─[ rust.baml:243:13 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │             ──┬─  
@@ -13484,7 +13484,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:243:17 ]
+     ╭─[ rust.baml:243:17 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                 ─┬  
@@ -13494,7 +13494,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:243:19 ]
+     ╭─[ rust.baml:243:19 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                   ───────┬──────  
@@ -13504,7 +13504,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:243:33 ]
+     ╭─[ rust.baml:243:33 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                 ┬  
@@ -13514,7 +13514,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:243:34 ]
+     ╭─[ rust.baml:243:34 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                  ─┬  
@@ -13524,7 +13524,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:243:36 ]
+     ╭─[ rust.baml:243:36 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                    ┬  
@@ -13534,7 +13534,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:243:38 ]
+     ╭─[ rust.baml:243:38 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                      ─┬  
@@ -13544,7 +13544,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:243:41 ]
+     ╭─[ rust.baml:243:41 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                         ─┬  
@@ -13554,7 +13554,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:243:43 ]
+     ╭─[ rust.baml:243:43 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                           ┬  
@@ -13564,7 +13564,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:243:44 ]
+     ╭─[ rust.baml:243:44 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                            ───┬──  
@@ -13574,7 +13574,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:243:50 ]
+     ╭─[ rust.baml:243:50 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                                  ┬  
@@ -13584,7 +13584,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:243:51 ]
+     ╭─[ rust.baml:243:51 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                                   ┬  
@@ -13594,7 +13594,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:243:52 ]
+     ╭─[ rust.baml:243:52 ]
      │
  243 │             Item::TemplateString(it) => it.syntax(),
      │                                                    ┬  
@@ -13604,7 +13604,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:244:13 ]
+     ╭─[ rust.baml:244:13 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │             ──┬─  
@@ -13614,7 +13614,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '::'
-     ╭─[ 3:244:17 ]
+     ╭─[ rust.baml:244:17 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                 ─┬  
@@ -13624,7 +13624,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:244:19 ]
+     ╭─[ rust.baml:244:19 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                   ────┬────  
@@ -13634,7 +13634,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:244:28 ]
+     ╭─[ rust.baml:244:28 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                            ┬  
@@ -13644,7 +13644,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:244:29 ]
+     ╭─[ rust.baml:244:29 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                             ─┬  
@@ -13654,7 +13654,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:244:31 ]
+     ╭─[ rust.baml:244:31 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                               ┬  
@@ -13664,7 +13664,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '=>'
-     ╭─[ 3:244:33 ]
+     ╭─[ rust.baml:244:33 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                 ─┬  
@@ -13674,7 +13674,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:244:36 ]
+     ╭─[ rust.baml:244:36 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                    ─┬  
@@ -13684,7 +13684,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '.'
-     ╭─[ 3:244:38 ]
+     ╭─[ rust.baml:244:38 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                      ┬  
@@ -13694,7 +13694,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-     ╭─[ 3:244:39 ]
+     ╭─[ rust.baml:244:39 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                       ───┬──  
@@ -13704,7 +13704,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '('
-     ╭─[ 3:244:45 ]
+     ╭─[ rust.baml:244:45 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                             ┬  
@@ -13714,7 +13714,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-     ╭─[ 3:244:46 ]
+     ╭─[ rust.baml:244:46 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                              ┬  
@@ -13724,7 +13724,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found ','
-     ╭─[ 3:244:47 ]
+     ╭─[ rust.baml:244:47 ]
      │
  244 │             Item::TypeAlias(it) => it.syntax(),
      │                                               ┬  
@@ -13734,7 +13734,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:245:9 ]
+     ╭─[ rust.baml:245:9 ]
      │
  245 │         }
      │         ┬  
@@ -13744,7 +13744,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:246:5 ]
+     ╭─[ rust.baml:246:5 ]
      │
  246 │     }
      │     ┬  
@@ -13754,7 +13754,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected top-level declaration, found '}'
-     ╭─[ 3:247:1 ]
+     ╭─[ rust.baml:247:1 ]
      │
  247 │ }
      │ ┬  
@@ -13764,7 +13764,7 @@ expression: output
 ─────╯
 
   [parse] Error: Expected expression, found error
-   ╭─[ 4:6:11 ]
+   ╭─[ very_invalid.baml:6:11 ]
    │
  6 │   let x = ¿;
    │           ─┬  
@@ -13774,7 +13774,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected expression, found error
-   ╭─[ 4:8:10 ]
+   ╭─[ very_invalid.baml:8:10 ]
    │
  8 │   while \ {
    │          ┬  
@@ -13784,7 +13784,7 @@ expression: output
 ───╯
 
   [name] Error: Duplicate type alias 'Language'
-   ╭─[ 3:1:1 ]
+   ╭─[ rust.baml:1:1 ]
    │
  1 │ // Try parsing rust source with baml.
    │ │ 
@@ -13796,7 +13796,7 @@ expression: output
 ───╯
 
   [type] Error: Expected bool, found void
-    ╭─[ 4:8:11 ]
+    ╭─[ very_invalid.baml:8:11 ]
     │
   8 │ ╭─▶   while \ {
     ┆ ┆   
@@ -13808,7 +13808,7 @@ expression: output
 ────╯
 
   [type] Error: Expected int, found void
-   ╭─[ 0:1:1 ]
+   ╭─[ complex_strings.baml:1:1 ]
    │
  1 │ class StringTorture {
    │ │ 

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__02_parser__nested_quotes.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__02_parser__nested_quotes.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -183,7 +183,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected attribute argument, found error
-   ╭─[ 0:4:34 ]
+   ╭─[ nested_quotes.baml:4:34 ]
    │
  4 │   double_in_single string @alias('She said "hello"')
    │                                  ┬  
@@ -193,7 +193,7 @@ Error: Expected attribute argument, found error
 ───╯
 
 Error: Expected ')', found error
-   ╭─[ 0:4:34 ]
+   ╭─[ nested_quotes.baml:4:34 ]
    │
  4 │   double_in_single string @alias('She said "hello"')
    │                                  ┬  
@@ -203,7 +203,7 @@ Error: Expected ')', found error
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:4:34 ]
+   ╭─[ nested_quotes.baml:4:34 ]
    │
  4 │   double_in_single string @alias('She said "hello"')
    │                                  ┬  
@@ -213,7 +213,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:4:44 ]
+   ╭─[ nested_quotes.baml:4:44 ]
    │
  4 │   double_in_single string @alias('She said "hello"')
    │                                            ┬  
@@ -223,7 +223,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: field 'The' is missing a type annotation
-   ╭─[ 0:5:37 ]
+   ╭─[ nested_quotes.baml:5:37 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                     ─┬─  
@@ -233,7 +233,7 @@ Error: field 'The' is missing a type annotation
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:5:41 ]
+   ╭─[ nested_quotes.baml:5:41 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                         ┬  
@@ -243,7 +243,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:5:42 ]
+   ╭─[ nested_quotes.baml:5:42 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                          ┬  
@@ -253,7 +253,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: field 'quote' is missing a type annotation
-   ╭─[ 0:5:43 ]
+   ╭─[ nested_quotes.baml:5:43 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                           ──┬──  
@@ -263,7 +263,7 @@ Error: field 'quote' is missing a type annotation
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:5:48 ]
+   ╭─[ nested_quotes.baml:5:48 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                                ┬  
@@ -273,7 +273,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:5:49 ]
+   ╭─[ nested_quotes.baml:5:49 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                                 ┬  
@@ -283,7 +283,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:5:58 ]
+   ╭─[ nested_quotes.baml:5:58 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                                          ┬  
@@ -293,7 +293,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: Expected Unexpected token in class body, found ')'
-   ╭─[ 0:5:59 ]
+   ╭─[ nested_quotes.baml:5:59 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                                           ┬  
@@ -303,7 +303,7 @@ Error: Expected Unexpected token in class body, found ')'
 ───╯
 
 Error: Expected ')', found identifier
-   ╭─[ 0:6:47 ]
+   ╭─[ nested_quotes.baml:6:47 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                               ───┬──  
@@ -313,7 +313,7 @@ Error: Expected ')', found identifier
 ───╯
 
 Error: field 'really' is missing a type annotation
-   ╭─[ 0:6:47 ]
+   ╭─[ nested_quotes.baml:6:47 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                               ───┬──  
@@ -323,7 +323,7 @@ Error: field 'really' is missing a type annotation
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:6:53 ]
+   ╭─[ nested_quotes.baml:6:53 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                     ┬  
@@ -333,7 +333,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:6:54 ]
+   ╭─[ nested_quotes.baml:6:54 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                      ┬  
@@ -343,7 +343,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:6:56 ]
+   ╭─[ nested_quotes.baml:6:56 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                        ┬  
@@ -353,7 +353,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: field 'complex' is missing a type annotation
-   ╭─[ 0:6:57 ]
+   ╭─[ nested_quotes.baml:6:57 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                         ───┬───  
@@ -363,7 +363,7 @@ Error: field 'complex' is missing a type annotation
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:6:64 ]
+   ╭─[ nested_quotes.baml:6:64 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                                ┬  
@@ -373,7 +373,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:6:65 ]
+   ╭─[ nested_quotes.baml:6:65 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                                 ┬  
@@ -383,7 +383,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: Expected Unexpected token in class body, found ')'
-   ╭─[ 0:6:66 ]
+   ╭─[ nested_quotes.baml:6:66 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                                  ┬  
@@ -393,7 +393,7 @@ Error: Expected Unexpected token in class body, found ')'
 ───╯
 
 Error: Expected ')', found identifier
-   ╭─[ 0:7:31 ]
+   ╭─[ nested_quotes.baml:7:31 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                               ─┬─  
@@ -403,7 +403,7 @@ Error: Expected ')', found identifier
 ───╯
 
 Error: field 'key' is missing a type annotation
-   ╭─[ 0:7:31 ]
+   ╭─[ nested_quotes.baml:7:31 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                               ─┬─  
@@ -413,7 +413,7 @@ Error: field 'key' is missing a type annotation
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:7:34 ]
+   ╭─[ nested_quotes.baml:7:34 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                  ┬  
@@ -423,7 +423,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:7:35 ]
+   ╭─[ nested_quotes.baml:7:35 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                   ┬  
@@ -433,7 +433,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: Expected Unexpected token in class body, found ':'
-   ╭─[ 0:7:36 ]
+   ╭─[ nested_quotes.baml:7:36 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                    ┬  
@@ -443,7 +443,7 @@ Error: Expected Unexpected token in class body, found ':'
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:7:38 ]
+   ╭─[ nested_quotes.baml:7:38 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                      ┬  
@@ -453,7 +453,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:7:39 ]
+   ╭─[ nested_quotes.baml:7:39 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                       ┬  
@@ -463,7 +463,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: field 'value' is missing a type annotation
-   ╭─[ 0:7:40 ]
+   ╭─[ nested_quotes.baml:7:40 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                        ──┬──  
@@ -473,7 +473,7 @@ Error: field 'value' is missing a type annotation
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:7:45 ]
+   ╭─[ nested_quotes.baml:7:45 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                             ┬  
@@ -483,7 +483,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:7:46 ]
+   ╭─[ nested_quotes.baml:7:46 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                              ┬  
@@ -493,7 +493,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: Expected top-level declaration, found '"'
-   ╭─[ 0:7:48 ]
+   ╭─[ nested_quotes.baml:7:48 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                                ┬  
@@ -503,7 +503,7 @@ Error: Expected top-level declaration, found '"'
 ───╯
 
 Error: Expected top-level declaration, found ')'
-   ╭─[ 0:7:49 ]
+   ╭─[ nested_quotes.baml:7:49 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                                 ┬  
@@ -513,7 +513,7 @@ Error: Expected top-level declaration, found ')'
 ───╯
 
 Error: Expected top-level declaration, found '}'
-   ╭─[ 0:8:1 ]
+   ╭─[ nested_quotes.baml:8:1 ]
    │
  8 │ }
    │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__02_parser__simple_strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__02_parser__simple_strings.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -126,7 +126,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected ')', found identifier
-   ╭─[ 0:7:41 ]
+   ╭─[ simple_strings.baml:7:41 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                         ──┬──  
@@ -136,7 +136,7 @@ Error: Expected ')', found identifier
 ───╯
 
 Error: field 'hello' is missing a type annotation
-   ╭─[ 0:7:41 ]
+   ╭─[ simple_strings.baml:7:41 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                         ──┬──  
@@ -146,7 +146,7 @@ Error: field 'hello' is missing a type annotation
 ───╯
 
 Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:7:46 ]
+   ╭─[ simple_strings.baml:7:46 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                              ┬  
@@ -156,7 +156,7 @@ Error: Expected Unexpected token in class body, found error
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:7:47 ]
+   ╭─[ simple_strings.baml:7:47 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                               ┬  
@@ -166,7 +166,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:7:48 ]
+   ╭─[ simple_strings.baml:7:48 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                                ┬  
@@ -176,7 +176,7 @@ Error: Expected Unexpected token in class body, found '"'
 ───╯
 
 Error: Expected Unexpected token in class body, found ')'
-   ╭─[ 0:7:49 ]
+   ╭─[ simple_strings.baml:7:49 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                                 ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__02_parser__unicode_strings.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__02_parser__unicode_strings.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -279,7 +279,7 @@ SOURCE_FILE
 
 === ERRORS ===
 Error: Expected function name, found error
-    ╭─[ 0:29:1 ]
+    ╭─[ unicode_strings.baml:29:1 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │ ─┬─  
@@ -289,7 +289,7 @@ Error: Expected function name, found error
 ────╯
 
 Error: Expected parameter name, found error
-    ╭─[ 0:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -299,7 +299,7 @@ Error: Expected parameter name, found error
 ────╯
 
 Error: Expected type annotation, found error
-    ╭─[ 0:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -309,7 +309,7 @@ Error: Expected type annotation, found error
 ────╯
 
 Error: Expected ')', found error
-    ╭─[ 0:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -319,7 +319,7 @@ Error: Expected ')', found error
 ────╯
 
 Error: Expected return type (->), found error
-    ╭─[ 0:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -329,7 +329,7 @@ Error: Expected return type (->), found error
 ────╯
 
 Error: Expected function body, found error
-    ╭─[ 0:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -339,7 +339,7 @@ Error: Expected function body, found error
 ────╯
 
 Error: Expected top-level declaration, found error
-    ╭─[ 0:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -349,7 +349,7 @@ Error: Expected top-level declaration, found error
 ────╯
 
 Error: Expected top-level declaration, found error
-    ╭─[ 0:29:17 ]
+    ╭─[ unicode_strings.baml:29:17 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                 ─┬─  
@@ -359,7 +359,7 @@ Error: Expected top-level declaration, found error
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:29:21 ]
+    ╭─[ unicode_strings.baml:29:21 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                     ───┬──  
@@ -369,7 +369,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found ')'
-    ╭─[ 0:29:27 ]
+    ╭─[ unicode_strings.baml:29:27 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                           ┬  
@@ -379,7 +379,7 @@ Error: Expected top-level declaration, found ')'
 ────╯
 
 Error: Expected top-level declaration, found '->'
-    ╭─[ 0:29:29 ]
+    ╭─[ unicode_strings.baml:29:29 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                             ─┬   
@@ -389,7 +389,7 @@ Error: Expected top-level declaration, found '->'
 ────╯
 
 Error: Expected top-level declaration, found identifier
-    ╭─[ 0:29:32 ]
+    ╭─[ unicode_strings.baml:29:32 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                                ────┬───  
@@ -399,7 +399,7 @@ Error: Expected top-level declaration, found identifier
 ────╯
 
 Error: Expected top-level declaration, found '{'
-    ╭─[ 0:30:1 ]
+    ╭─[ unicode_strings.baml:30:1 ]
     │
  30 │   "#
     │ ┬  

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [parse] Error: Expected attribute argument, found error
-   ╭─[ 0:4:34 ]
+   ╭─[ nested_quotes.baml:4:34 ]
    │
  4 │   double_in_single string @alias('She said "hello"')
    │                                  ┬  
@@ -14,7 +14,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected ')', found error
-   ╭─[ 0:4:34 ]
+   ╭─[ nested_quotes.baml:4:34 ]
    │
  4 │   double_in_single string @alias('She said "hello"')
    │                                  ┬  
@@ -24,7 +24,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:4:34 ]
+   ╭─[ nested_quotes.baml:4:34 ]
    │
  4 │   double_in_single string @alias('She said "hello"')
    │                                  ┬  
@@ -34,7 +34,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:4:44 ]
+   ╭─[ nested_quotes.baml:4:44 ]
    │
  4 │   double_in_single string @alias('She said "hello"')
    │                                            ┬  
@@ -44,7 +44,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'The' is missing a type annotation
-   ╭─[ 0:5:37 ]
+   ╭─[ nested_quotes.baml:5:37 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                     ─┬─  
@@ -54,7 +54,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:5:41 ]
+   ╭─[ nested_quotes.baml:5:41 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                         ┬  
@@ -64,7 +64,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:5:42 ]
+   ╭─[ nested_quotes.baml:5:42 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                          ┬  
@@ -74,7 +74,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'quote' is missing a type annotation
-   ╭─[ 0:5:43 ]
+   ╭─[ nested_quotes.baml:5:43 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                           ──┬──  
@@ -84,7 +84,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:5:48 ]
+   ╭─[ nested_quotes.baml:5:48 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                                ┬  
@@ -94,7 +94,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:5:49 ]
+   ╭─[ nested_quotes.baml:5:49 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                                 ┬  
@@ -104,7 +104,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:5:58 ]
+   ╭─[ nested_quotes.baml:5:58 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                                          ┬  
@@ -114,7 +114,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found ')'
-   ╭─[ 0:5:59 ]
+   ╭─[ nested_quotes.baml:5:59 ]
    │
  5 │   escaped_in_escaped string @alias("The \"quote\" is here")
    │                                                           ┬  
@@ -124,7 +124,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected ')', found identifier
-   ╭─[ 0:6:47 ]
+   ╭─[ nested_quotes.baml:6:47 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                               ───┬──  
@@ -134,7 +134,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'really' is missing a type annotation
-   ╭─[ 0:6:47 ]
+   ╭─[ nested_quotes.baml:6:47 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                               ───┬──  
@@ -144,7 +144,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:6:53 ]
+   ╭─[ nested_quotes.baml:6:53 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                     ┬  
@@ -154,7 +154,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:6:54 ]
+   ╭─[ nested_quotes.baml:6:54 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                      ┬  
@@ -164,7 +164,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:6:56 ]
+   ╭─[ nested_quotes.baml:6:56 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                        ┬  
@@ -174,7 +174,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'complex' is missing a type annotation
-   ╭─[ 0:6:57 ]
+   ╭─[ nested_quotes.baml:6:57 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                         ───┬───  
@@ -184,7 +184,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:6:64 ]
+   ╭─[ nested_quotes.baml:6:64 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                                ┬  
@@ -194,7 +194,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:6:65 ]
+   ╭─[ nested_quotes.baml:6:65 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                                 ┬  
@@ -204,7 +204,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found ')'
-   ╭─[ 0:6:66 ]
+   ╭─[ nested_quotes.baml:6:66 ]
    │
  6 │   complex_nesting string @description("It's \"really\" 'complex'")
    │                                                                  ┬  
@@ -214,7 +214,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected ')', found identifier
-   ╭─[ 0:7:31 ]
+   ╭─[ nested_quotes.baml:7:31 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                               ─┬─  
@@ -224,7 +224,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'key' is missing a type annotation
-   ╭─[ 0:7:31 ]
+   ╭─[ nested_quotes.baml:7:31 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                               ─┬─  
@@ -234,7 +234,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:7:34 ]
+   ╭─[ nested_quotes.baml:7:34 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                  ┬  
@@ -244,7 +244,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:7:35 ]
+   ╭─[ nested_quotes.baml:7:35 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                   ┬  
@@ -254,7 +254,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found ':'
-   ╭─[ 0:7:36 ]
+   ╭─[ nested_quotes.baml:7:36 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                    ┬  
@@ -264,7 +264,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:7:38 ]
+   ╭─[ nested_quotes.baml:7:38 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                      ┬  
@@ -274,7 +274,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:7:39 ]
+   ╭─[ nested_quotes.baml:7:39 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                       ┬  
@@ -284,7 +284,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'value' is missing a type annotation
-   ╭─[ 0:7:40 ]
+   ╭─[ nested_quotes.baml:7:40 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                        ──┬──  
@@ -294,7 +294,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 0:7:45 ]
+   ╭─[ nested_quotes.baml:7:45 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                             ┬  
@@ -304,7 +304,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 0:7:46 ]
+   ╭─[ nested_quotes.baml:7:46 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                              ┬  
@@ -314,7 +314,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found '"'
-   ╭─[ 0:7:48 ]
+   ╭─[ nested_quotes.baml:7:48 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                                ┬  
@@ -324,7 +324,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found ')'
-   ╭─[ 0:7:49 ]
+   ╭─[ nested_quotes.baml:7:49 ]
    │
  7 │   json_like string @alias("{\"key\": \"value\"}")
    │                                                 ┬  
@@ -334,7 +334,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected top-level declaration, found '}'
-   ╭─[ 0:8:1 ]
+   ╭─[ nested_quotes.baml:8:1 ]
    │
  8 │ }
    │ ┬  
@@ -344,7 +344,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected ')', found identifier
-   ╭─[ 2:7:41 ]
+   ╭─[ simple_strings.baml:7:41 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                         ──┬──  
@@ -354,7 +354,7 @@ expression: output
 ───╯
 
   [parse] Error: field 'hello' is missing a type annotation
-   ╭─[ 2:7:41 ]
+   ╭─[ simple_strings.baml:7:41 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                         ──┬──  
@@ -364,7 +364,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found error
-   ╭─[ 2:7:46 ]
+   ╭─[ simple_strings.baml:7:46 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                              ┬  
@@ -374,7 +374,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 2:7:47 ]
+   ╭─[ simple_strings.baml:7:47 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                               ┬  
@@ -384,7 +384,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found '"'
-   ╭─[ 2:7:48 ]
+   ╭─[ simple_strings.baml:7:48 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                                ┬  
@@ -394,7 +394,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected Unexpected token in class body, found ')'
-   ╭─[ 2:7:49 ]
+   ╭─[ simple_strings.baml:7:49 ]
    │
  7 │   with_quotes string @alias("She said \"hello\"")
    │                                                 ┬  
@@ -404,7 +404,7 @@ expression: output
 ───╯
 
   [parse] Error: Expected function name, found error
-    ╭─[ 3:29:1 ]
+    ╭─[ unicode_strings.baml:29:1 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │ ─┬─  
@@ -414,7 +414,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected parameter name, found error
-    ╭─[ 3:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -424,7 +424,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected type annotation, found error
-    ╭─[ 3:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -434,7 +434,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected ')', found error
-    ╭─[ 3:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -444,7 +444,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected return type (->), found error
-    ╭─[ 3:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -454,7 +454,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected function body, found error
-    ╭─[ 3:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -464,7 +464,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found error
-    ╭─[ 3:29:14 ]
+    ╭─[ unicode_strings.baml:29:14 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │              ─┬─  
@@ -474,7 +474,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found error
-    ╭─[ 3:29:17 ]
+    ╭─[ unicode_strings.baml:29:17 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                 ─┬─  
@@ -484,7 +484,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:29:21 ]
+    ╭─[ unicode_strings.baml:29:21 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                     ───┬──  
@@ -494,7 +494,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found ')'
-    ╭─[ 3:29:27 ]
+    ╭─[ unicode_strings.baml:29:27 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                           ┬  
@@ -504,7 +504,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '->'
-    ╭─[ 3:29:29 ]
+    ╭─[ unicode_strings.baml:29:29 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                             ─┬   
@@ -514,7 +514,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found identifier
-    ╭─[ 3:29:32 ]
+    ╭─[ unicode_strings.baml:29:32 ]
     │
  29 │     Return result with emojis: ✅ or ❌
     │                                ────┬───  
@@ -524,7 +524,7 @@ expression: output
 ────╯
 
   [parse] Error: Expected top-level declaration, found '{'
-    ╭─[ 3:30:1 ]
+    ╭─[ unicode_strings.baml:30:1 ]
     │
  30 │   "#
     │ ┬  
@@ -586,7 +586,7 @@ expression: output
   [hir] Error: Missing `provider` field in client. e.g. `provider openai`
 
   [type] Error: Expected "admin" | "user" | "guest", found string
-   ╭─[ 0:1:1 ]
+   ╭─[ nested_quotes.baml:1:1 ]
    │
  1 │ // Test nested quote handling in strings
    │ │ 

--- a/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [type] Error: Cannot apply operator 'Add' to types int and string
-   ╭─[ 0:2:3 ]
+   ╭─[ simple_type_error.baml:2:3 ]
    │
  2 │   1 + "foo"
    │   ────┬────  

--- a/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-a56cff903b8232b2/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [type] Error: Expected foo, found bool
-   ╭─[ 0:1:1 ]
+   ╭─[ type_aliases.baml:1:1 ]
    │
  1 │ type foo = bar
    │ │ 
@@ -14,7 +14,7 @@ expression: output
 ───╯
 
   [type] Error: Expected JSON, found NotJSON
-   ╭─[ 0:1:1 ]
+   ╭─[ type_aliases.baml:1:1 ]
    │
  1 │ type foo = bar
    │ │ 

--- a/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__05_diagnostics.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
   [type] Error: Unknown type unknown_param_type
-   ╭─[ 0:1:1 ]
+   ╭─[ unknown_type_error.baml:1:1 ]
    │
  1 │ // Test case: unknown type in return position should report error
    │ │ 
@@ -14,7 +14,7 @@ expression: output
 ───╯
 
   [type] Error: Unknown type blah
-   ╭─[ 0:1:1 ]
+   ╭─[ unknown_type_error.baml:1:1 ]
    │
  1 │ // Test case: unknown type in return position should report error
    │ │ 
@@ -24,7 +24,7 @@ expression: output
 ───╯
 
   [type] Error: Unknown type unknown_optional
-   ╭─[ 0:1:1 ]
+   ╭─[ unknown_type_error.baml:1:1 ]
    │
  1 │ // Test case: unknown type in return position should report error
    │ │ 


### PR DESCRIPTION
Changes ariadne diagnostics rendering to use file names in place of file indices:

```

Error: Expected '=>' after pattern, found ':'
-   ╭─[ 0:18:19 ]
+   ╭─[ syntax_errors.baml:18:19 ]
    │
 18 │         a: int | b: bool => "bad"
    │                   ┬  
```

This is implemented in terms of `ariadne`'s `Cache` trait, which is responsible for rendering span locations.

The ariadne cache is a mutable store of file contents indexed by their filenames. It's a bit unfortunate that we have to pull in the whole cache just to twiddle how spans are rendered. However maybe this speeds up the way snippets of source are found when rendering the pretty diagnostics? A consequence is that any driver of the compiler must first initialize a mutable `DbSourceCache`, and pass it as a mutable ref to the diagnostics rendering functions.