### PR TITLE
Strip debug symbols from release binaries to reduce size

### DIFF
--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -268,6 +268,21 @@ jobs:
           path: engine/target/${{ matrix._.target }}/release/${{ steps.cffi_info.outputs.new_lib_name }}
           if-no-files-found: error # Fail if the library file doesn't exist
 
+      # Upload CFFI debug symbols for crash analysis (internal use)
+      # Linux: .dwp files, macOS: .dSYM directories, Windows: .pdb files
+      - name: Upload CFFI debug symbols
+        uses: actions/upload-artifact@v4
+        with:
+          name: libbaml-cffi-debuginfo-${{ matrix._.target }}
+          path: |
+            engine/target/${{ matrix._.target }}/release/libbaml_cffi.so.dwp
+            engine/target/${{ matrix._.target }}/release/deps/libbaml_cffi*.dwp
+            engine/target/${{ matrix._.target }}/release/libbaml_cffi.dylib.dSYM
+            engine/target/${{ matrix._.target }}/release/deps/libbaml_cffi*.dSYM
+            engine/target/${{ matrix._.target }}/release/baml_cffi.pdb
+            engine/target/${{ matrix._.target }}/release/deps/baml_cffi*.pdb
+          if-no-files-found: ignore
+
       # Determine binary path and archive name
       - name: Set binary and archive paths
         id: paths
@@ -418,3 +433,18 @@ jobs:
           name: baml-cli-${{ matrix._.target }}
           path: |
             ${{ matrix._.os == 'windows-2022' && format('engine/target/{0}/release/baml-cli.exe', matrix._.target) || format('engine/target/{0}/release/baml-cli', matrix._.target) }}
+
+      # Upload debug symbols for crash analysis (internal use)
+      # Linux: .dwp files, macOS: .dSYM directories, Windows: .pdb files
+      - name: Upload CLI debug symbols
+        uses: actions/upload-artifact@v4
+        with:
+          name: baml-cli-debuginfo-${{ matrix._.target }}
+          path: |
+            engine/target/${{ matrix._.target }}/release/baml-cli.dwp
+            engine/target/${{ matrix._.target }}/release/deps/baml_cli*.dwp
+            engine/target/${{ matrix._.target }}/release/baml-cli.dSYM
+            engine/target/${{ matrix._.target }}/release/deps/baml_cli*.dSYM
+            engine/target/${{ matrix._.target }}/release/baml-cli.pdb
+            engine/target/${{ matrix._.target }}/release/deps/baml_cli*.pdb
+          if-no-files-found: ignore

--- a/.github/workflows/build-python-release.reusable.yaml
+++ b/.github/workflows/build-python-release.reusable.yaml
@@ -176,3 +176,18 @@ jobs:
           name: wheels-${{ matrix._.target }}
           path: engine/language_client_python/dist
           if-no-files-found: error
+
+      # Upload debug symbols for crash analysis (internal use)
+      # Linux: .dwp files, macOS: .dSYM directories, Windows: .pdb files
+      - name: Upload Python FFI debug symbols
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-debuginfo-${{ matrix._.target }}
+          path: |
+            engine/target/${{ matrix._.target }}/release/libbaml_py.so.dwp
+            engine/target/${{ matrix._.target }}/release/deps/libbaml_py.so.dwp
+            engine/target/${{ matrix._.target }}/release/libbaml_py.dylib.dSYM
+            engine/target/${{ matrix._.target }}/release/deps/libbaml_py.dylib.dSYM
+            engine/target/${{ matrix._.target }}/release/baml_py.pdb
+            engine/target/${{ matrix._.target }}/release/deps/baml_py.pdb
+          if-no-files-found: ignore

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -142,3 +142,18 @@ jobs:
           name: bindings-${{ matrix._.target }}
           path: engine/language_client_typescript/*.node
           if-no-files-found: error
+
+      # Upload debug symbols for crash analysis (internal use)
+      # Linux: .dwp files, macOS: .dSYM directories, Windows: .pdb files
+      - name: Upload TypeScript FFI debug symbols
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings-debuginfo-${{ matrix._.target }}
+          path: |
+            engine/target/${{ matrix._.target }}/release/libbaml.so.dwp
+            engine/target/${{ matrix._.target }}/release/deps/libbaml.so.dwp
+            engine/target/${{ matrix._.target }}/release/libbaml.dylib.dSYM
+            engine/target/${{ matrix._.target }}/release/deps/libbaml.dylib.dSYM
+            engine/target/${{ matrix._.target }}/release/baml.pdb
+            engine/target/${{ matrix._.target }}/release/deps/baml.pdb
+          if-no-files-found: ignore

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -143,7 +143,7 @@ impl ProjectDatabase {
         // Build all maps
         for source_file in &source_files {
             let file_id = source_file.file_id(self);
-            let text = source_file.text(self).to_string();
+            let text = source_file.text(self).clone();
             let path = source_file.path(self);
 
             sources.insert(file_id, text);

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -205,3 +205,6 @@ inherits = "dev"
 
 [profile.release]
 lto = true
+strip = true
+split-debuginfo = "packed"  # Creates .dwp file for Linux, .dSYM for macOS
+debug = "full"              # Required for split-debuginfo to generate .dwp files


### PR DESCRIPTION
## Summary

- Add `strip=true` to release profile to remove debug symbols from binaries
- Add `split-debuginfo=packed` to generate separate debug symbol files
- Update CI workflows to upload debug symbols as separate artifacts for crash analysis

## Binary Size Reductions

| Binary | Before | After | Savings |
|--------|--------|-------|---------|
| TypeScript FFI | 62 MB | 52 MB | 16% |
| Python FFI | 60 MB | 52 MB | 13% |
| CLI | 60 MB | 48 MB | 20% |
| CFFI | 57 MB | 51 MB | 11% |

## Debug Symbols

Debug symbols are now stored separately and uploaded as CI artifacts:
- Linux: `.dwp` files
- macOS: `.dSYM` directories  
- Windows: `.pdb` files

These can be downloaded from GitHub Actions to symbolicate crash reports if needed.

## Test Plan

- [x] Local release build produces stripped binaries
- [x] `file` command confirms binaries are "stripped"
- [x] `.dwp` files are generated alongside binaries
- [ ] CI builds successfully with new settings
- [ ] Debug symbol artifacts are uploaded correctly