### PR TITLE
Fern collector docs update

### DIFF
--- a/fern/01-guide/05-baml-advanced/collector.mdx
+++ b/fern/01-guide/05-baml-advanced/collector.mdx
@@ -704,6 +704,166 @@ end
 </Tab>
 </Tabs>
 
+### Cached Token Tracking
+
+When using providers that support prompt caching (like Anthropic, OpenAI, Google, or Vertex), you can track cached input tokens via the `cached_input_tokens` field:
+
+<Tabs>
+<Tab title="Python" language="python">
+```python
+from baml_client import b
+from baml_py import Collector
+
+async def run():
+    collector = Collector(name="cache-tracker")
+    
+    # First call - content will be cached by the provider
+    res = await b.TestCaching(large_content, "Question 1", baml_options={"collector": collector})
+    
+    # Second call with same content - should use cached tokens
+    res2 = await b.TestCaching(large_content, "Question 2", baml_options={"collector": collector})
+    
+    # Access cached token counts
+    first_log = collector.logs[0]
+    second_log = collector.logs[1]
+    
+    print(f"First call cached tokens: {first_log.usage.cached_input_tokens}")
+    print(f"Second call cached tokens: {second_log.usage.cached_input_tokens}")
+    
+    # Collector aggregates cached tokens across all calls
+    print(f"Total cached tokens: {collector.usage.cached_input_tokens}")
+    
+    # You can also access cached tokens per LLM call (including retries)
+    print(f"Per-call cached tokens: {first_log.calls[0].usage.cached_input_tokens}")
+```
+</Tab>
+
+<Tab title="TypeScript" language="typescript">
+```typescript
+import { b } from 'baml_client'
+import { Collector } from '@boundaryml/baml'
+
+async function run() {
+    const collector = new Collector("cache-tracker")
+    
+    // First call - content will be cached by the provider
+    const res = await b.TestCaching(largeContent, "Question 1", { collector })
+    
+    // Second call with same content - should use cached tokens
+    const res2 = await b.TestCaching(largeContent, "Question 2", { collector })
+    
+    // Access cached token counts
+    const firstLog = collector.logs[0]
+    const secondLog = collector.logs[1]
+    
+    console.log(`First call cached tokens: ${firstLog.usage.cachedInputTokens}`)
+    console.log(`Second call cached tokens: ${secondLog.usage.cachedInputTokens}`)
+    
+    // Collector aggregates cached tokens across all calls
+    console.log(`Total cached tokens: ${collector.usage.cachedInputTokens}`)
+    
+    // You can also access cached tokens per LLM call (including retries)
+    console.log(`Per-call cached tokens: ${firstLog.calls[0].usage?.cachedInputTokens}`)
+}
+```
+</Tab>
+
+<Tab title="Go" language="go">
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+    
+    b "example.com/myproject/baml_client"
+)
+
+func run() {
+    ctx := context.Background()
+    
+    collector, err := b.NewCollector("cache-tracker")
+    if err != nil {
+        log.Fatalf("Failed to create collector: %v", err)
+    }
+    
+    // First call - content will be cached by the provider
+    _, err = b.TestCaching(ctx, largeContent, "Question 1", b.WithCollector(collector))
+    if err != nil {
+        log.Fatalf("First call failed: %v", err)
+    }
+    
+    // Second call with same content - should use cached tokens
+    _, err = b.TestCaching(ctx, largeContent, "Question 2", b.WithCollector(collector))
+    if err != nil {
+        log.Fatalf("Second call failed: %v", err)
+    }
+    
+    // Access cached token counts
+    logs, _ := collector.Logs()
+    firstLog := logs[0]
+    secondLog := logs[1]
+    
+    firstUsage, _ := firstLog.Usage()
+    secondUsage, _ := secondLog.Usage()
+    
+    firstCached, _ := firstUsage.CachedInputTokens()
+    secondCached, _ := secondUsage.CachedInputTokens()
+    
+    fmt.Printf("First call cached tokens: %d\n", firstCached)
+    fmt.Printf("Second call cached tokens: %d\n", secondCached)
+    
+    // Collector aggregates cached tokens across all calls
+    totalUsage, _ := collector.Usage()
+    totalCached, _ := totalUsage.CachedInputTokens()
+    fmt.Printf("Total cached tokens: %d\n", totalCached)
+}
+```
+</Tab>
+
+<Tab title="Ruby" language="ruby">
+```ruby
+require_relative "baml_client/client"
+
+def run
+    collector = Baml::Collector.new(name: "cache-tracker")
+    
+    # First call - content will be cached by the provider
+    res = Baml.Client.TestCaching(
+        content: large_content,
+        question: "Question 1",
+        baml_options: { collector: collector }
+    )
+    
+    # Second call with same content - should use cached tokens
+    res2 = Baml.Client.TestCaching(
+        content: large_content,
+        question: "Question 2",
+        baml_options: { collector: collector }
+    )
+    
+    # Access cached token counts
+    first_log = collector.logs[0]
+    second_log = collector.logs[1]
+    
+    puts "First call cached tokens: #{first_log.usage.cached_input_tokens}"
+    puts "Second call cached tokens: #{second_log.usage.cached_input_tokens}"
+    
+    # Collector aggregates cached tokens across all calls
+    puts "Total cached tokens: #{collector.usage.cached_input_tokens}"
+    
+    # You can also access cached tokens per LLM call (including retries)
+    puts "Per-call cached tokens: #{first_log.calls[0].usage.cached_input_tokens}"
+end
+```
+</Tab>
+</Tabs>
+
+<Info>
+Cached token tracking is supported for Anthropic, OpenAI, Google AI, and Vertex AI providers. AWS Bedrock does not currently support cached token reporting and will return `null` for this field.
+</Info>
+
 ## API Reference
 
 ### Collector Class
@@ -763,9 +923,10 @@ The `Usage` class has the following properties:
 |----------|------|-------------|
 | `input_tokens` | `int \| null` | The cumulative number of tokens used in the inputs. |
 | `output_tokens` | `int \| null` | The cumulative number of tokens used in the outputs. |
+| `cached_input_tokens` | `int \| null` | The number of cached input tokens (e.g., Anthropic's `cache_read_input_tokens`). |
 
 <Info>
-Note: Usage may not include all things like "thinking_tokens" or "cached_tokens". For that you may need to look at the raw HTTP response and build your own adapters.
+Note: Usage may not include all provider-specific token types like "thinking_tokens" or "cache_creation_input_tokens". For those, you may need to look at the raw HTTP response and build your own adapters.
 </Info>
 
 ### LLMCall Class

--- a/fern/03-reference/baml_client/collector.mdx
+++ b/fern/03-reference/baml_client/collector.mdx
@@ -504,6 +504,75 @@ async function run() {
 SSE responses capture the raw streaming data from the provider. For HTTP-based providers (OpenAI, Anthropic, Google, etc.), this is the actual SSE event data. For AWS Bedrock, which uses a binary protocol, the responses contain a JSON wrapper with the Debug representation of the SDK types (see [AWS SDK serialization issue](https://github.com/awslabs/aws-sdk-rust/issues/645)).
 </Info>
 
+### Cached Token Tracking
+
+When using providers that support prompt caching (like Anthropic, OpenAI, Google, or Vertex), you can track cached input tokens via the `cached_input_tokens` field:
+
+<Tabs>
+<Tab title="Python" language="python">
+```python
+from baml_client import b
+from baml_py import Collector
+
+async def run():
+    collector = Collector(name="cache-tracker")
+    
+    # First call - content will be cached by the provider
+    res = await b.TestCaching(large_content, "Question 1", baml_options={"collector": collector})
+    
+    # Second call with same content - should use cached tokens
+    res2 = await b.TestCaching(large_content, "Question 2", baml_options={"collector": collector})
+    
+    # Access cached token counts
+    first_log = collector.logs[0]
+    second_log = collector.logs[1]
+    
+    print(f"First call cached tokens: {first_log.usage.cached_input_tokens}")
+    print(f"Second call cached tokens: {second_log.usage.cached_input_tokens}")
+    
+    # Collector aggregates cached tokens across all calls
+    print(f"Total cached tokens: {collector.usage.cached_input_tokens}")
+    
+    # You can also access cached tokens per LLM call (including retries)
+    print(f"Per-call cached tokens: {first_log.calls[0].usage.cached_input_tokens}")
+```
+</Tab>
+
+<Tab title="TypeScript" language="typescript">
+```typescript
+import { b } from 'baml_client'
+import { Collector } from '@boundaryml/baml'
+
+async function run() {
+    const collector = new Collector("cache-tracker")
+    
+    // First call - content will be cached by the provider
+    const res = await b.TestCaching(largeContent, "Question 1", { collector })
+    
+    // Second call with same content - should use cached tokens
+    const res2 = await b.TestCaching(largeContent, "Question 2", { collector })
+    
+    // Access cached token counts
+    const firstLog = collector.logs[0]
+    const secondLog = collector.logs[1]
+    
+    console.log(`First call cached tokens: ${firstLog.usage.cachedInputTokens}`)
+    console.log(`Second call cached tokens: ${secondLog.usage.cachedInputTokens}`)
+    
+    // Collector aggregates cached tokens across all calls
+    console.log(`Total cached tokens: ${collector.usage.cachedInputTokens}`)
+    
+    // You can also access cached tokens per LLM call (including retries)
+    console.log(`Per-call cached tokens: ${firstLog.calls[0].usage?.cachedInputTokens}`)
+}
+```
+</Tab>
+</Tabs>
+
+<Info>
+Cached token tracking is supported for Anthropic, OpenAI, Google AI, and Vertex AI providers. AWS Bedrock does not currently support cached token reporting and will return `null` for this field.
+</Info>
+
 ## API Reference
 
 ### Collector Class


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes #[issue number]

## Changes
Please describe the changes proposed in this pull request

This PR updates the BAML Collector documentation to include `cached_input_tokens`.

Specifically:
-   **`/workspace/fern/01-guide/05-baml-advanced/collector.mdx` (Guide)**:
    -   Added `cached_input_tokens` to the Usage Class table.
    -   Updated the Info note to clarify provider-specific token types.
    -   Added a new "Cached Token Tracking" section with code examples for Python, TypeScript, Go, and Ruby.
-   **`/workspace/fern/03-reference/baml_client/collector.mdx` (Reference)**:
    -   Added a new "Cached Token Tracking" section with Python and TypeScript examples.
    -   Added an Info note detailing provider support for cached token tracking.

These changes ensure that users are aware of and can properly utilize the `cached_input_tokens` field for tracking prompt caching.

## Testing
Please describe how you tested these changes

-   [ ] Unit tests added/updated
-   [x] Manual testing performed (Verified updated documentation files locally)
-   [ ] Tested in [environment]

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

-   [ ] I have read and followed the contributing guidelines
-   [ ] My code follows the style guidelines of this project
-   [ ] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [ ] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

The examples demonstrate how to access `cached_input_tokens` at different levels: per individual log (`collector.logs[N].usage.cached_input_tokens`), aggregated across all calls (`collector.usage.cached_input_tokens`), and per LLM call (including retries, `log.calls[0].usage.cached_input_tokens`). Cached token tracking is supported by Anthropic, OpenAI, Google AI, and Vertex AI.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1767811531203509?thread_ts=1767811531.203509&cid=C09F3QMJE9G)

<a href="https://cursor.com/background-agent?bcId=bc-72260d11-baf8-4957-a63c-a063c6117cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-72260d11-baf8-4957-a63c-a063c6117cd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Documents prompt cache token reporting and how to access it via the Collector.
> 
> - Adds a new **Cached Token Tracking** section to `01-guide/05-baml-advanced/collector.mdx` with Python, TypeScript, Go, and Ruby examples using `usage.cached_input_tokens` at log, per-call, and aggregate levels
> - Adds the same section to `03-reference/baml_client/collector.mdx` (Python/TypeScript examples)
> - Extends the `Usage` class with `cached_input_tokens` and updates Info notes to clarify provider-specific token types and provider support (Anthropic, OpenAI, Google/Vertex; Bedrock returns `null`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 542530e03a1b7e693ecf94601e06528902e69575. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->