### PR TITLE
Fix backwards type checking in Jinja filter validation

### DIFF
--- a/engine/baml-lib/jinja/src/evaluate_type/expr.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/expr.rs
@@ -453,7 +453,7 @@ fn tracker_visit_expr(
             ];
             match expr.name {
                 "abs" => {
-                    if Type::Number.is_subtype_of(&inner) {
+                    if !inner.is_subtype_of(&Type::Number) {
                         ensure_type("number");
                     }
                     Type::Number
@@ -462,7 +462,7 @@ fn tracker_visit_expr(
                 "batch" => Type::Unknown,
                 "bool" => Type::Bool,
                 "capitalize" | "escape" => {
-                    if Type::String.is_subtype_of(&inner) {
+                    if !inner.is_subtype_of(&Type::String) {
                         ensure_type("string");
                     }
                     Type::String
@@ -500,7 +500,7 @@ fn tracker_visit_expr(
                 },
                 "list" => Type::List(Box::new(Type::Unknown)),
                 "lower" | "upper" => {
-                    if Type::String.is_subtype_of(&inner) {
+                    if !inner.is_subtype_of(&Type::String) {
                         ensure_type("string");
                     }
                     Type::String

--- a/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
+++ b/engine/baml-lib/jinja/src/evaluate_type/test_expr.rs
@@ -384,3 +384,54 @@ fn test_function_reference_without_call_expr() {
         ]
     );
 }
+
+#[test]
+fn test_filter_chain_type_propagation() {
+    let mut types = PredefinedTypes::default(JinjaContext::Prompt);
+    types.add_class(
+        "Location",
+        vec![("country".into(), Type::String)].into_iter().collect(),
+    );
+    types.add_variable("this", Type::ClassRef("Location".into()));
+
+    // format() returns String, so chaining lower (expects String) should work
+    assert_eq!(
+        assert_evaluates_to!(r#"this|format(type="json")|lower"#, &types),
+        Type::String
+    );
+
+    // format() returns String, so chaining lower then regex_match should work
+    assert_eq!(
+        assert_evaluates_to!(
+            r#"this|format(type="json")|lower|regex_match("usa")"#,
+            &types
+        ),
+        Type::Bool
+    );
+
+    // String literal should work with lower filter
+    assert_eq!(
+        assert_evaluates_to!(r#""hello"|lower"#, &types),
+        Type::String
+    );
+
+    // String variable should work with lower filter
+    types.add_variable("string_var", Type::String);
+    assert_eq!(
+        assert_evaluates_to!(r#"string_var|lower"#, &types),
+        Type::String
+    );
+
+    // Chaining string filters: capitalize -> lower -> upper
+    assert_eq!(
+        assert_evaluates_to!(r#""hello"|capitalize|lower|upper"#, &types),
+        Type::String
+    );
+
+    // Int should NOT work with lower filter (should produce error)
+    types.add_variable("int_var", Type::Int);
+    assert_eq!(
+        assert_fails_to!(r#"int_var|lower"#, &types),
+        vec!["'int_var' is a int, expected string"]
+    );
+}


### PR DESCRIPTION
## Summary
- Fix inverted type checking condition for filters `lower`, `upper`, `capitalize`, `escape`, and `abs`
- Previously checked `Type::Expected.is_subtype_of(&inner)` instead of `!inner.is_subtype_of(&Type::Expected)`
- This caused false positive errors like `'this|format(type="json")' is a string, expected string` when chaining filters after `format()`

## Test plan
- [x] Added `test_filter_chain_type_propagation` test covering:
  - Filter chains: `format() | lower | regex_match()`
  - String literals with filters: `"hello" | lower`
  - String variables with filters
  - Chained string filters: `capitalize | lower | upper`
  - Negative case: `int_var | lower` correctly errors
- [x] All 36 tests in `internal-baml-jinja-types` pass
- [x] `cargo fmt` applied

## Related
- Fixes #2940
- Linear: BAML-569

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes incorrect subtype validation for Jinja filters, preventing false errors when chaining string-producing filters.
> 
> - Corrects filter type checks in `expr.rs` for `abs`, `capitalize`, `escape`, `lower`, and `upper` to use `!inner.is_subtype_of(&Type::Expected)`
> - Adds `test_filter_chain_type_propagation` covering `this|format(type="json")|lower`, chaining with `regex_match`, string literals/vars, chained string filters, and an int error case
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc65570b7d83de6ec331b088bdad67cad90e9a0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->