### PR TITLE
feat(onionskin): add compiler hot-reload support

### DIFF
--- a/baml_language/crates/baml_base/src/debug_log.rs
+++ b/baml_language/crates/baml_base/src/debug_log.rs
@@ -1,0 +1,67 @@
+//! Debug logging infrastructure for compiler development.
+//!
+//! This module provides a thread-local debug log that can be used to collect
+//! debug messages during compilation, which are then displayed in onionskin.
+//!
+//! In release builds, all debug logging is compiled away to nothing.
+
+use std::cell::RefCell;
+
+/// A debug message with its source module path.
+#[derive(Debug, Clone)]
+pub struct DebugMessage {
+    /// The module path where this message originated (e.g., "baml_compiler_tir::infer")
+    pub module: &'static str,
+    /// The actual debug message
+    pub message: String,
+}
+
+thread_local! {
+    static DEBUG_LOG: RefCell<Vec<DebugMessage>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Push a debug message to the thread-local log.
+/// This is typically called via the `baml_debug!` macro.
+#[cfg(debug_assertions)]
+pub fn push_debug(module: &'static str, msg: String) {
+    DEBUG_LOG.with(|log| log.borrow_mut().push(DebugMessage { module, message: msg }));
+}
+
+/// Stub for release builds - does nothing.
+#[cfg(not(debug_assertions))]
+pub fn push_debug(_module: &'static str, _msg: String) {}
+
+/// Drain all debug messages from the thread-local log.
+/// Returns the messages and clears the log.
+pub fn drain_debug_log() -> Vec<DebugMessage> {
+    DEBUG_LOG.with(|log| log.borrow_mut().drain(..).collect())
+}
+
+/// Check if there are any debug messages pending.
+pub fn has_debug_messages() -> bool {
+    DEBUG_LOG.with(|log| !log.borrow().is_empty())
+}
+
+/// Debug logging macro that automatically captures the crate/module path.
+///
+/// In release builds, this compiles to nothing (zero cost).
+///
+/// # Example
+///
+/// ```ignore
+/// use baml_base::baml_debug;
+///
+/// fn resolve_field(ty: &str, field: &str) {
+///     baml_debug!("Resolving {}.{}", ty, field);
+/// }
+/// ```
+#[macro_export]
+macro_rules! baml_debug {
+    ($($arg:tt)*) => {
+        #[cfg(debug_assertions)]
+        {
+            $crate::debug_log::push_debug(module_path!(), format!($($arg)*))
+        }
+    };
+}
+

--- a/baml_language/crates/baml_base/src/debug_log.rs
+++ b/baml_language/crates/baml_base/src/debug_log.rs
@@ -10,7 +10,7 @@ use std::cell::RefCell;
 /// A debug message with its source module path.
 #[derive(Debug, Clone)]
 pub struct DebugMessage {
-    /// The module path where this message originated (e.g., "baml_compiler_tir::infer")
+    /// The module path where this message originated (e.g., "`baml_compiler_tir::infer`")
     pub module: &'static str,
     /// The actual debug message
     pub message: String,
@@ -24,7 +24,12 @@ thread_local! {
 /// This is typically called via the `baml_debug!` macro.
 #[cfg(debug_assertions)]
 pub fn push_debug(module: &'static str, msg: String) {
-    DEBUG_LOG.with(|log| log.borrow_mut().push(DebugMessage { module, message: msg }));
+    DEBUG_LOG.with(|log| {
+        log.borrow_mut().push(DebugMessage {
+            module,
+            message: msg,
+        });
+    });
 }
 
 /// Stub for release builds - does nothing.
@@ -64,4 +69,3 @@ macro_rules! baml_debug {
         }
     };
 }
-

--- a/baml_language/crates/baml_base/src/lib.rs
+++ b/baml_language/crates/baml_base/src/lib.rs
@@ -3,8 +3,10 @@
 //! This crate has NO dependencies on other compiler crates to avoid circular dependencies.
 
 pub mod core_types;
+pub mod debug_log;
 pub mod files;
 
 // Re-export everything for convenience
 pub use core_types::*;
+pub use debug_log::{DebugMessage, drain_debug_log, has_debug_messages};
 pub use files::*;

--- a/baml_language/crates/baml_tools_onionskin/README.md
+++ b/baml_language/crates/baml_tools_onionskin/README.md
@@ -25,6 +25,30 @@ cargo run --bin baml_tools_onionskin -- --from path/to/your/file.baml
 cargo run --bin baml_tools_onionskin -- --from path/to/your/directory
 ```
 
+### Compiler Hot-Reload 🔥
+
+When running from within the `baml_language` workspace, onionskin **automatically enables hot-reload** for compiler development. It detects the workspace by looking for the `crates/baml_compiler_lexer` directory.
+
+```bash
+# Hot-reload is automatic when running from the workspace
+cd /path/to/baml_language
+cargo run --bin baml_tools_onionskin -- --from test.baml
+
+# Explicitly specify workspace root (if auto-detection fails)
+cargo run --bin baml_tools_onionskin -- --from path/to/file.baml --workspace /path/to/baml_language
+
+# Disable hot-reload if you don't want it
+cargo run --bin baml_tools_onionskin -- --from test.baml --no-hot-reload
+```
+
+With hot-reload enabled (shown as `🔥 Hot-Reload` in the header):
+- Onionskin watches all compiler crate source files (e.g., `baml_compiler_lexer`, `baml_compiler_hir`, etc.)
+- When a `.rs` file in any compiler crate changes, a banner appears prompting you to rebuild
+- Press **Enter** to trigger a rebuild, or **Esc** to dismiss
+- Press **Shift+R** anytime to manually trigger a rebuild
+- After a successful rebuild, onionskin automatically restarts with the new compiler
+
+
 ### Keyboard Shortcuts
 
 | Key | Action |
@@ -38,6 +62,9 @@ cargo run --bin baml_tools_onionskin -- --from path/to/your/directory
 | `S` (Shift+S) | Delete snapshot |
 | `c` / `y` | Copy current output to clipboard |
 | `p` | Paste/show clipboard contents |
+| `R` (Shift+R) | Trigger compiler rebuild (with --workspace) |
+| `Enter` | Confirm pending rebuild |
+| `Esc` | Dismiss rebuild prompt |
 | `q` | Quit |
 | `Ctrl+C` | Exit |
 

--- a/baml_language/crates/baml_tools_onionskin/src/app.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/app.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::Result;
 use arboard::Clipboard;
+use baml_base::DebugMessage;
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEventKind};
 use ratatui::{Terminal, backend::CrosstermBackend};
 
@@ -80,6 +81,8 @@ pub(crate) struct App {
     rebuild_state_time: Option<Instant>,
     /// Receiver for background build results
     build_result_rx: Option<Receiver<BuildResult>>,
+    /// Debug messages collected from the compiler (via baml_debug! macro)
+    debug_messages: Vec<DebugMessage>,
 }
 
 impl App {
@@ -104,6 +107,9 @@ impl App {
         // Initial compilation (no snapshot)
         compiler.compile_from_filesystem(&current_files, None);
 
+        // Drain any debug messages from initial compilation
+        let debug_messages = baml_base::drain_debug_log();
+
         Ok(Self {
             file_path: path,
             workspace_root,
@@ -124,6 +130,7 @@ impl App {
             rebuild_state: RebuildState::Idle,
             rebuild_state_time: None,
             build_result_rx: None,
+            debug_messages,
         })
     }
 
@@ -483,6 +490,10 @@ impl App {
             (KeyCode::Char('p'), KeyModifiers::NONE) => {
                 self.paste_from_clipboard();
             }
+            // Dismiss debug messages with 'd'
+            (KeyCode::Char('d'), KeyModifiers::NONE) => {
+                self.debug_messages.clear();
+            }
             _ => {}
         }
     }
@@ -703,6 +714,9 @@ impl App {
                 .compile_from_filesystem(&self.current_files, None);
         }
 
+        // Collect any debug messages emitted during compilation
+        self.debug_messages = baml_base::drain_debug_log();
+
         self.last_compiled_files = self.current_files.clone();
     }
 
@@ -793,5 +807,10 @@ impl App {
     /// Check if compiler hot-reload is enabled
     pub(crate) fn is_hot_reload_enabled(&self) -> bool {
         self.watcher.is_watching_compiler()
+    }
+
+    /// Get debug messages collected from the compiler
+    pub(crate) fn debug_messages(&self) -> &[DebugMessage] {
+        &self.debug_messages
     }
 }

--- a/baml_language/crates/baml_tools_onionskin/src/app.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/app.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
+    process::Command,
+    sync::mpsc::{Receiver, channel},
+    thread,
     time::{Duration, Instant},
 };
 
@@ -15,14 +18,40 @@ use crate::{
         read_files_from_disk,
     },
     ui,
-    watcher::FileWatcher,
+    watcher::{ChangeKind, FileWatcher},
 };
+
+/// Result of a background build
+pub(crate) enum BuildResult {
+    Success,
+    Failed(String),
+}
 
 /// Duration to show the "Copied!" message
 const COPY_FEEDBACK_DURATION: Duration = Duration::from_secs(2);
 
+/// Duration to show rebuild status
+const REBUILD_STATUS_DURATION: Duration = Duration::from_secs(5);
+
+/// State of compiler rebuild process
+#[derive(Debug, Clone)]
+pub(crate) enum RebuildState {
+    /// No rebuild in progress
+    Idle,
+    /// Rebuild detected, waiting for user confirmation or auto-rebuild
+    Pending,
+    /// Currently rebuilding
+    Building,
+    /// Rebuild completed successfully, will restart
+    Success,
+    /// Rebuild failed with error
+    Failed(String),
+}
+
 pub(crate) struct App {
     file_path: PathBuf,
+    /// Workspace root for compiler hot-reload (if enabled)
+    workspace_root: Option<PathBuf>,
     /// Which tab is shown in the TUI.
     current_phase: CompilerPhase,
     /// Current files from disk (fake filesystem).
@@ -45,11 +74,27 @@ pub(crate) struct App {
     last_copy_time: Option<Instant>,
     /// Error message from last clipboard operation
     clipboard_error: Option<String>,
+    /// Current rebuild state
+    rebuild_state: RebuildState,
+    /// Timestamp when rebuild state was last updated
+    rebuild_state_time: Option<Instant>,
+    /// Receiver for background build results
+    build_result_rx: Option<Receiver<BuildResult>>,
 }
 
 impl App {
-    pub(crate) fn new(path: PathBuf) -> Result<Self> {
-        let watcher = FileWatcher::new(&path)?;
+    pub(crate) fn new(
+        path: PathBuf,
+        workspace_root: Option<PathBuf>,
+        initial_phase: Option<CompilerPhase>,
+    ) -> Result<Self> {
+        // Create watcher - with or without compiler watching
+        let watcher = if let Some(ref workspace) = workspace_root {
+            FileWatcher::new_with_compiler_watch(&path, workspace)?
+        } else {
+            FileWatcher::new(&path)?
+        };
+
         let mut compiler = CompilerRunner::new(&path);
 
         // Read initial files from disk
@@ -61,7 +106,8 @@ impl App {
 
         Ok(Self {
             file_path: path,
-            current_phase: CompilerPhase::Lexer,
+            workspace_root,
+            current_phase: initial_phase.unwrap_or(CompilerPhase::Lexer),
             current_files,
             snapshot_files: None,
             snapshot_compiler: None,
@@ -75,6 +121,9 @@ impl App {
             thir_interactive_active: false,
             last_copy_time: None,
             clipboard_error: None,
+            rebuild_state: RebuildState::Idle,
+            rebuild_state_time: None,
+            build_result_rx: None,
         })
     }
 
@@ -84,8 +133,41 @@ impl App {
     ) -> Result<()> {
         while !self.should_quit {
             // Check for file changes
-            if self.watcher.check_for_changes() {
-                self.reload_file()?;
+            if let Some(change_kind) = self.watcher.check_for_changes() {
+                match change_kind {
+                    ChangeKind::BamlFile => {
+                        self.reload_file()?;
+                    }
+                    ChangeKind::CompilerSource => {
+                        // Compiler source changed - trigger rebuild
+                        self.rebuild_state = RebuildState::Pending;
+                        self.rebuild_state_time = Some(Instant::now());
+                    }
+                }
+            }
+
+            // Check for background build completion
+            if let Some(ref rx) = self.build_result_rx {
+                if let Ok(result) = rx.try_recv() {
+                    match result {
+                        BuildResult::Success => {
+                            self.rebuild_state = RebuildState::Success;
+                            self.rebuild_state_time = Some(Instant::now());
+                            self.build_result_rx = None;
+
+                            // Draw one more frame to show success, then restart
+                            terminal.draw(|frame| ui::draw(frame, self))?;
+
+                            // Restart by exec'ing into the new binary
+                            self.exec_restart();
+                        }
+                        BuildResult::Failed(error) => {
+                            self.rebuild_state = RebuildState::Failed(error);
+                            self.rebuild_state_time = Some(Instant::now());
+                            self.build_result_rx = None;
+                        }
+                    }
+                }
             }
 
             // Draw UI
@@ -97,6 +179,19 @@ impl App {
                     Event::Key(key) => self.handle_key_event(key),
                     Event::Mouse(mouse) => self.handle_mouse_event(mouse),
                     _ => {}
+                }
+            }
+
+            // Clear old rebuild status messages
+            if let Some(time) = self.rebuild_state_time {
+                if time.elapsed() > REBUILD_STATUS_DURATION {
+                    if matches!(self.rebuild_state, RebuildState::Failed(_)) {
+                        // Keep failed state visible longer, but clear after 10 seconds
+                        if time.elapsed() > Duration::from_secs(10) {
+                            self.rebuild_state = RebuildState::Idle;
+                            self.rebuild_state_time = None;
+                        }
+                    }
                 }
             }
         }
@@ -116,6 +211,119 @@ impl App {
         self.compile_current_state();
     }
 
+    /// Trigger a compiler rebuild and restart (runs in background thread)
+    fn trigger_rebuild(&mut self) {
+        // Don't start another build if one is already running
+        if self.build_result_rx.is_some() {
+            return;
+        }
+
+        self.rebuild_state = RebuildState::Building;
+        self.rebuild_state_time = Some(Instant::now());
+
+        // Create channel for build result
+        let (tx, rx) = channel();
+        self.build_result_rx = Some(rx);
+
+        // Clone workspace root for the thread
+        let workspace_dir = self
+            .workspace_root
+            .clone()
+            .unwrap_or_else(|| self.file_path.clone());
+
+        // Spawn background thread to run cargo build
+        thread::spawn(move || {
+            let result = Command::new("cargo")
+                .args(["build", "--bin", "baml_tools_onionskin"])
+                .current_dir(&workspace_dir)
+                .output();
+
+            let build_result = match result {
+                Ok(output) => {
+                    if output.status.success() {
+                        BuildResult::Success
+                    } else {
+                        let stderr = String::from_utf8_lossy(&output.stderr);
+                        // Extract just the first few lines of error
+                        let error_summary: String = stderr
+                            .lines()
+                            .filter(|line| line.contains("error"))
+                            .take(3)
+                            .collect::<Vec<_>>()
+                            .join("\n");
+
+                        BuildResult::Failed(if error_summary.is_empty() {
+                            "Build failed (see terminal)".to_string()
+                        } else {
+                            error_summary
+                        })
+                    }
+                }
+                Err(e) => BuildResult::Failed(format!("Failed to run cargo: {}", e)),
+            };
+
+            // Send result back (ignore error if receiver dropped)
+            let _ = tx.send(build_result);
+        });
+    }
+
+    /// Restart by exec'ing into the new binary
+    fn exec_restart(&self) -> ! {
+        // Restore terminal before exec
+        let _ = crossterm::terminal::disable_raw_mode();
+        let _ = crossterm::execute!(
+            std::io::stdout(),
+            crossterm::terminal::LeaveAlternateScreen,
+            crossterm::event::DisableMouseCapture
+        );
+
+        // Get current exe path
+        let exe = std::env::current_exe().expect("Failed to get current executable path");
+
+        // Collect current args, filtering out any existing --phase argument
+        let mut args: Vec<String> = std::env::args()
+            .skip(1)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .fold((Vec::new(), false), |(mut acc, skip_next), arg| {
+                if skip_next {
+                    // Skip this arg (it's the value after --phase)
+                    (acc, false)
+                } else if arg == "--phase" {
+                    // Skip --phase and mark next arg to skip
+                    (acc, true)
+                } else if arg.starts_with("--phase=") {
+                    // Skip --phase=value
+                    (acc, false)
+                } else {
+                    acc.push(arg);
+                    (acc, false)
+                }
+            })
+            .0;
+
+        // Add current phase to preserve the view
+        args.push("--phase".to_string());
+        args.push(self.current_phase.cli_name().to_string());
+
+        // On Unix, use exec to replace the current process
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            let err = Command::new(&exe).args(&args).exec();
+            // exec only returns on error
+            eprintln!("Failed to exec: {}", err);
+            std::process::exit(1);
+        }
+
+        // On non-Unix, spawn a new process and exit
+        #[cfg(not(unix))]
+        {
+            let _ = Command::new(&exe).args(&args).spawn();
+            std::process::exit(0);
+        }
+    }
+
     fn handle_key_event(&mut self, key: KeyEvent) {
         // Check if we're in THIR interactive sub-mode
         let in_thir_interactive = self.current_phase == CompilerPhase::Thir
@@ -124,6 +332,9 @@ impl App {
 
         // Check if we're on the VM Runner tab
         let in_vm_runner = self.current_phase == CompilerPhase::VmRunner;
+
+        // Check if rebuild is pending
+        let rebuild_pending = matches!(self.rebuild_state, RebuildState::Pending);
 
         match (key.code, key.modifiers) {
             // Quit on Ctrl+C or 'q'
@@ -147,6 +358,24 @@ impl App {
             // Manual recompile on 'r'
             (KeyCode::Char('r'), KeyModifiers::NONE) => {
                 self.recompile();
+            }
+            // Trigger compiler rebuild on 'R' (Shift+R) or Enter when rebuild pending
+            (KeyCode::Char('R'), KeyModifiers::SHIFT) => {
+                if self.watcher.is_watching_compiler() {
+                    self.trigger_rebuild();
+                }
+            }
+            (KeyCode::Enter, KeyModifiers::NONE) if rebuild_pending => {
+                self.trigger_rebuild();
+            }
+            // Dismiss rebuild pending with Escape
+            (KeyCode::Esc, KeyModifiers::NONE) => {
+                if rebuild_pending {
+                    self.rebuild_state = RebuildState::Idle;
+                    self.rebuild_state_time = None;
+                } else if self.thir_interactive_active {
+                    self.thir_interactive_active = false;
+                }
             }
             // Navigate phases with left/right arrow keys (only when not in THIR interactive mode)
             (KeyCode::Left, _) => {
@@ -240,9 +469,9 @@ impl App {
                     self.thir_cursor_right();
                 }
             }
-            // Execute function on Enter when on VM Runner tab
+            // Execute function on Enter when on VM Runner tab (and not rebuild pending)
             (KeyCode::Enter, KeyModifiers::NONE) => {
-                if in_vm_runner {
+                if in_vm_runner && !rebuild_pending {
                     self.vm_runner_execute();
                 }
             }
@@ -554,5 +783,15 @@ impl App {
         } else {
             None
         }
+    }
+
+    /// Get the current rebuild state
+    pub(crate) fn rebuild_state(&self) -> &RebuildState {
+        &self.rebuild_state
+    }
+
+    /// Check if compiler hot-reload is enabled
+    pub(crate) fn is_hot_reload_enabled(&self) -> bool {
+        self.watcher.is_watching_compiler()
     }
 }

--- a/baml_language/crates/baml_tools_onionskin/src/app.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/app.rs
@@ -154,25 +154,25 @@ impl App {
             }
 
             // Check for background build completion
-            if let Some(ref rx) = self.build_result_rx {
-                if let Ok(result) = rx.try_recv() {
-                    match result {
-                        BuildResult::Success => {
-                            self.rebuild_state = RebuildState::Success;
-                            self.rebuild_state_time = Some(Instant::now());
-                            self.build_result_rx = None;
+            if let Some(ref rx) = self.build_result_rx
+                && let Ok(result) = rx.try_recv()
+            {
+                match result {
+                    BuildResult::Success => {
+                        self.rebuild_state = RebuildState::Success;
+                        self.rebuild_state_time = Some(Instant::now());
+                        self.build_result_rx = None;
 
-                            // Draw one more frame to show success, then restart
-                            terminal.draw(|frame| ui::draw(frame, self))?;
+                        // Draw one more frame to show success, then restart
+                        terminal.draw(|frame| ui::draw(frame, self))?;
 
-                            // Restart by exec'ing into the new binary
-                            self.exec_restart();
-                        }
-                        BuildResult::Failed(error) => {
-                            self.rebuild_state = RebuildState::Failed(error);
-                            self.rebuild_state_time = Some(Instant::now());
-                            self.build_result_rx = None;
-                        }
+                        // Restart by exec'ing into the new binary
+                        self.exec_restart();
+                    }
+                    BuildResult::Failed(error) => {
+                        self.rebuild_state = RebuildState::Failed(error);
+                        self.rebuild_state_time = Some(Instant::now());
+                        self.build_result_rx = None;
                     }
                 }
             }
@@ -190,15 +190,14 @@ impl App {
             }
 
             // Clear old rebuild status messages
-            if let Some(time) = self.rebuild_state_time {
-                if time.elapsed() > REBUILD_STATUS_DURATION {
-                    if matches!(self.rebuild_state, RebuildState::Failed(_)) {
-                        // Keep failed state visible longer, but clear after 10 seconds
-                        if time.elapsed() > Duration::from_secs(10) {
-                            self.rebuild_state = RebuildState::Idle;
-                            self.rebuild_state_time = None;
-                        }
-                    }
+            if let Some(time) = self.rebuild_state_time
+                && time.elapsed() > REBUILD_STATUS_DURATION
+                && matches!(self.rebuild_state, RebuildState::Failed(_))
+            {
+                // Keep failed state visible longer, but clear after 10 seconds
+                if time.elapsed() > Duration::from_secs(10) {
+                    self.rebuild_state = RebuildState::Idle;
+                    self.rebuild_state_time = None;
                 }
             }
         }

--- a/baml_language/crates/baml_tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/compiler.rs
@@ -101,6 +101,23 @@ impl CompilerPhase {
             CompilerPhase::Metrics => CompilerPhase::VmRunner,
         }
     }
+
+    /// Returns a short name suitable for CLI arguments
+    pub(crate) fn cli_name(self) -> &'static str {
+        match self {
+            CompilerPhase::Lexer => "lexer",
+            CompilerPhase::Parser => "parser",
+            CompilerPhase::Ast => "ast",
+            CompilerPhase::Hir => "hir",
+            CompilerPhase::Thir => "thir",
+            CompilerPhase::TypedIr => "typedir",
+            CompilerPhase::Mir => "mir",
+            CompilerPhase::Diagnostics => "diagnostics",
+            CompilerPhase::Codegen => "codegen",
+            CompilerPhase::VmRunner => "vmrunner",
+            CompilerPhase::Metrics => "metrics",
+        }
+    }
 }
 
 pub(crate) struct CompilerRunner {

--- a/baml_language/crates/baml_tools_onionskin/src/main.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/main.rs
@@ -7,6 +7,25 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use compiler::CompilerPhase;
+
+/// Parse a phase name string into a CompilerPhase
+fn parse_phase(name: &str) -> Option<CompilerPhase> {
+    match name.to_lowercase().as_str() {
+        "lexer" => Some(CompilerPhase::Lexer),
+        "parser" => Some(CompilerPhase::Parser),
+        "ast" => Some(CompilerPhase::Ast),
+        "hir" => Some(CompilerPhase::Hir),
+        "thir" => Some(CompilerPhase::Thir),
+        "typedir" | "typed_ir" | "typed-ir" => Some(CompilerPhase::TypedIr),
+        "mir" => Some(CompilerPhase::Mir),
+        "diagnostics" => Some(CompilerPhase::Diagnostics),
+        "codegen" => Some(CompilerPhase::Codegen),
+        "vmrunner" | "vm_runner" | "vm-runner" => Some(CompilerPhase::VmRunner),
+        "metrics" => Some(CompilerPhase::Metrics),
+        _ => None,
+    }
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "baml_tools_onionskin")]
@@ -18,6 +37,21 @@ struct Args {
     /// Path to the BAML file or directory to watch (for TUI mode)
     #[arg(long = "from")]
     path: Option<PathBuf>,
+
+    /// Path to the workspace root (for compiler hot-reload)
+    /// If not specified, auto-detects by searching for a 'crates' directory
+    /// containing compiler crates. Use --no-hot-reload to disable.
+    #[arg(long = "workspace")]
+    workspace: Option<PathBuf>,
+
+    /// Disable compiler hot-reload (don't watch compiler source files)
+    #[arg(long = "no-hot-reload")]
+    no_hot_reload: bool,
+
+    /// Initial compiler phase to display (used to restore view after restart)
+    /// Values: lexer, parser, ast, hir, thir, typedir, mir, diagnostics, codegen, vmrunner, metrics
+    #[arg(long = "phase", hide = true)]
+    phase: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -35,6 +69,40 @@ enum Command {
     },
 }
 
+/// Try to auto-detect the workspace root by searching for a directory containing
+/// 'crates/baml_compiler_lexer' (a distinctive marker of the baml_language workspace)
+fn detect_workspace_root() -> Option<PathBuf> {
+    // Start from current directory
+    let mut current = std::env::current_dir().ok()?;
+
+    // Walk up the directory tree
+    loop {
+        // Check if this looks like the workspace root
+        let crates_dir = current.join("crates");
+        if crates_dir.exists() && crates_dir.join("baml_compiler_lexer").exists() {
+            return Some(current);
+        }
+
+        // Move up one directory
+        if !current.pop() {
+            break;
+        }
+    }
+
+    // Also try from the executable's location (useful when running via cargo run)
+    if let Ok(exe_path) = std::env::current_exe() {
+        let mut current = exe_path;
+        while current.pop() {
+            let crates_dir = current.join("crates");
+            if crates_dir.exists() && crates_dir.join("baml_compiler_lexer").exists() {
+                return Some(current);
+            }
+        }
+    }
+
+    None
+}
+
 fn main() -> Result<()> {
     let args = Args::parse();
 
@@ -49,6 +117,26 @@ fn main() -> Result<()> {
             if !path.exists() {
                 anyhow::bail!("Path does not exist: {}", path.display());
             }
+
+            // Determine workspace root for hot-reload
+            let workspace = if args.no_hot_reload {
+                None
+            } else if let Some(ref workspace) = args.workspace {
+                // Explicit workspace provided - validate it
+                if !workspace.exists() {
+                    anyhow::bail!("Workspace path does not exist: {}", workspace.display());
+                }
+                if !workspace.join("crates").exists() {
+                    anyhow::bail!(
+                        "Workspace path doesn't appear to be a valid workspace (no 'crates' directory): {}",
+                        workspace.display()
+                    );
+                }
+                Some(workspace.clone())
+            } else {
+                // Try to auto-detect
+                detect_workspace_root()
+            };
 
             // Set up panic hook to restore terminal
             let original_hook = std::panic::take_hook();
@@ -67,8 +155,11 @@ fn main() -> Result<()> {
             // Initialize terminal
             let mut terminal = ui::init_terminal()?;
 
+            // Parse initial phase if provided
+            let initial_phase = args.phase.as_deref().and_then(parse_phase);
+
             // Create and run the app
-            let mut app = app::App::new(path)?;
+            let mut app = app::App::new(path, workspace, initial_phase)?;
             let result = app.run(&mut terminal);
 
             // Restore terminal

--- a/baml_language/crates/baml_tools_onionskin/src/ui.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/ui.rs
@@ -16,7 +16,7 @@ use ratatui::{
 use similar::{ChangeTag, TextDiff};
 
 use crate::{
-    app::App,
+    app::{App, RebuildState},
     compiler::{CompilerPhase, LineStatus, ThirDisplayMode, VisualizationMode},
 };
 
@@ -45,15 +45,31 @@ pub(crate) fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>
 }
 
 pub(crate) fn draw(frame: &mut Frame, app: &App) {
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(3), // Header
-            Constraint::Length(3), // Phase tabs
-            Constraint::Min(0),    // Content
-            Constraint::Length(3), // Status bar with shortcuts
-        ])
-        .split(frame.area());
+    // Check if we need to show rebuild status banner
+    let show_rebuild_banner = !matches!(app.rebuild_state(), RebuildState::Idle);
+
+    let chunks = if show_rebuild_banner {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3), // Header
+                Constraint::Length(3), // Phase tabs
+                Constraint::Length(3), // Rebuild status banner
+                Constraint::Min(0),    // Content
+                Constraint::Length(3), // Status bar with shortcuts
+            ])
+            .split(frame.area())
+    } else {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3), // Header
+                Constraint::Length(3), // Phase tabs
+                Constraint::Min(0),    // Content
+                Constraint::Length(3), // Status bar with shortcuts
+            ])
+            .split(frame.area())
+    };
 
     // Draw header
     draw_header(frame, chunks[0], app);
@@ -61,15 +77,30 @@ pub(crate) fn draw(frame: &mut Frame, app: &App) {
     // Draw phase tabs
     draw_phase_tabs(frame, chunks[1], app);
 
-    // Draw content (either single view or diff view)
-    if app.has_snapshot() {
-        draw_diff_view(frame, chunks[2], app);
-    } else {
-        draw_single_view(frame, chunks[2], app);
-    }
+    if show_rebuild_banner {
+        // Draw rebuild status
+        draw_rebuild_banner(frame, chunks[2], app);
 
-    // Draw status bar
-    draw_status_bar(frame, chunks[3], app);
+        // Draw content (either single view or diff view)
+        if app.has_snapshot() {
+            draw_diff_view(frame, chunks[3], app);
+        } else {
+            draw_single_view(frame, chunks[3], app);
+        }
+
+        // Draw status bar
+        draw_status_bar(frame, chunks[4], app);
+    } else {
+        // Draw content (either single view or diff view)
+        if app.has_snapshot() {
+            draw_diff_view(frame, chunks[2], app);
+        } else {
+            draw_single_view(frame, chunks[2], app);
+        }
+
+        // Draw status bar
+        draw_status_bar(frame, chunks[3], app);
+    }
 }
 
 fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
@@ -79,15 +110,22 @@ fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
         "File"
     };
 
+    let hot_reload_indicator = if app.is_hot_reload_enabled() {
+        " | 🔥 Hot-Reload"
+    } else {
+        ""
+    };
+
     let title = format!(
-        "BAML Onionskin [{}]: {}{}",
+        "BAML Onionskin [{}]: {}{}{}",
         mode,
         app.file_path().display(),
         if app.has_snapshot() {
             " | Snapshot: ON"
         } else {
             ""
-        }
+        },
+        hot_reload_indicator
     );
     let block = Block::default()
         .borders(Borders::ALL)
@@ -145,6 +183,47 @@ fn draw_phase_tabs(frame: &mut Frame, area: Rect, app: &App) {
             .borders(Borders::ALL)
             .title("Compiler Phase"),
     );
+
+    frame.render_widget(paragraph, area);
+}
+
+fn draw_rebuild_banner(frame: &mut Frame, area: Rect, app: &App) {
+    let (message, style) = match app.rebuild_state() {
+        RebuildState::Idle => ("".to_string(), Style::default()),
+        RebuildState::Pending => (
+            "⚡ Compiler source changed! Press [Enter] to rebuild, [Esc] to dismiss".to_string(),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        ),
+        RebuildState::Building => (
+            "🔨 Building... (this may take a moment)".to_string(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+        RebuildState::Success => (
+            "✓ Build successful! Restarting...".to_string(),
+            Style::default()
+                .fg(Color::Green)
+                .add_modifier(Modifier::BOLD),
+        ),
+        RebuildState::Failed(error) => (
+            format!("✗ Build failed: {}", error),
+            Style::default()
+                .fg(Color::Red)
+                .add_modifier(Modifier::BOLD),
+        ),
+    };
+
+    let paragraph = Paragraph::new(message)
+        .style(style)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Compiler Hot-Reload")
+                .border_style(style),
+        );
 
     frame.render_widget(paragraph, area);
 }
@@ -384,6 +463,13 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         format!("[m] Mode: {}", app.visualization_mode_name())
     };
 
+    // Add hot-reload rebuild shortcut if enabled
+    let rebuild_str = if app.is_hot_reload_enabled() {
+        "  |  [Shift+R] Rebuild"
+    } else {
+        ""
+    };
+
     // Show THIR-specific navigation help when in interactive mode
     let line2 = if app.current_phase() == CompilerPhase::Thir
         && app.thir_display_mode() == ThirDisplayMode::Interactive
@@ -428,8 +514,8 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         let status_color = if is_error { Color::Red } else { Color::Green };
         vec![
             Span::raw(format!(
-                "Snapshot: {}  |  [r] Recompile  |  {}  |  [c/y] Copy  |  ",
-                snapshot_help, mode_str
+                "Snapshot: {}  |  [r] Recompile  |  {}{}  |  [c/y] Copy  |  ",
+                snapshot_help, mode_str, rebuild_str
             )),
             Span::styled(
                 status,
@@ -440,8 +526,8 @@ fn draw_status_bar(frame: &mut Frame, area: Rect, app: &App) {
         ]
     } else {
         vec![Span::raw(format!(
-            "Snapshot: {}  |  [r] Recompile  |  {}  |  [c/y] Copy",
-            snapshot_help, mode_str
+            "Snapshot: {}  |  [r] Recompile  |  {}{}  |  [c/y] Copy",
+            snapshot_help, mode_str, rebuild_str
         ))]
     };
 

--- a/baml_language/crates/baml_tools_onionskin/src/ui.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/ui.rs
@@ -45,62 +45,65 @@ pub(crate) fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<Stdout>>
 }
 
 pub(crate) fn draw(frame: &mut Frame, app: &App) {
-    // Check if we need to show rebuild status banner
+    // Check which banners to show
     let show_rebuild_banner = !matches!(app.rebuild_state(), RebuildState::Idle);
+    let show_debug_banner = !app.debug_messages().is_empty();
 
-    let chunks = if show_rebuild_banner {
-        Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(3), // Header
-                Constraint::Length(3), // Phase tabs
-                Constraint::Length(3), // Rebuild status banner
-                Constraint::Min(0),    // Content
-                Constraint::Length(3), // Status bar with shortcuts
-            ])
-            .split(frame.area())
-    } else {
-        Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(3), // Header
-                Constraint::Length(3), // Phase tabs
-                Constraint::Min(0),    // Content
-                Constraint::Length(3), // Status bar with shortcuts
-            ])
-            .split(frame.area())
-    };
-
-    // Draw header
-    draw_header(frame, chunks[0], app);
-
-    // Draw phase tabs
-    draw_phase_tabs(frame, chunks[1], app);
+    // Build constraints dynamically based on which banners are shown
+    let mut constraints = vec![
+        Constraint::Length(3), // Header
+        Constraint::Length(3), // Phase tabs
+    ];
 
     if show_rebuild_banner {
-        // Draw rebuild status
-        draw_rebuild_banner(frame, chunks[2], app);
-
-        // Draw content (either single view or diff view)
-        if app.has_snapshot() {
-            draw_diff_view(frame, chunks[3], app);
-        } else {
-            draw_single_view(frame, chunks[3], app);
-        }
-
-        // Draw status bar
-        draw_status_bar(frame, chunks[4], app);
-    } else {
-        // Draw content (either single view or diff view)
-        if app.has_snapshot() {
-            draw_diff_view(frame, chunks[2], app);
-        } else {
-            draw_single_view(frame, chunks[2], app);
-        }
-
-        // Draw status bar
-        draw_status_bar(frame, chunks[3], app);
+        constraints.push(Constraint::Length(3)); // Rebuild status banner
     }
+    if show_debug_banner {
+        // Dynamic height based on number of messages (min 3, max 8)
+        let debug_height = (app.debug_messages().len() + 2).min(8).max(3) as u16;
+        constraints.push(Constraint::Length(debug_height)); // Debug log banner
+    }
+
+    constraints.push(Constraint::Min(0));    // Content
+    constraints.push(Constraint::Length(3)); // Status bar
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints(constraints)
+        .split(frame.area());
+
+    let mut chunk_idx = 0;
+
+    // Draw header
+    draw_header(frame, chunks[chunk_idx], app);
+    chunk_idx += 1;
+
+    // Draw phase tabs
+    draw_phase_tabs(frame, chunks[chunk_idx], app);
+    chunk_idx += 1;
+
+    // Draw rebuild banner if needed
+    if show_rebuild_banner {
+        draw_rebuild_banner(frame, chunks[chunk_idx], app);
+        chunk_idx += 1;
+    }
+
+    // Draw debug banner if needed
+    if show_debug_banner {
+        draw_debug_banner(frame, chunks[chunk_idx], app);
+        chunk_idx += 1;
+    }
+
+    // Draw content (either single view or diff view)
+    if app.has_snapshot() {
+        draw_diff_view(frame, chunks[chunk_idx], app);
+    } else {
+        draw_single_view(frame, chunks[chunk_idx], app);
+    }
+    chunk_idx += 1;
+
+    // Draw status bar
+    draw_status_bar(frame, chunks[chunk_idx], app);
 }
 
 fn draw_header(frame: &mut Frame, area: Rect, app: &App) {
@@ -224,6 +227,46 @@ fn draw_rebuild_banner(frame: &mut Frame, area: Rect, app: &App) {
                 .title("Compiler Hot-Reload")
                 .border_style(style),
         );
+
+    frame.render_widget(paragraph, area);
+}
+
+fn draw_debug_banner(frame: &mut Frame, area: Rect, app: &App) {
+    let messages = app.debug_messages();
+    let count = messages.len();
+
+    // Build lines for display
+    let mut lines: Vec<Line> = Vec::new();
+
+    for msg in messages.iter().take(6) {
+        // Extract just the crate name from the module path for brevity
+        let crate_name = msg.module.split("::").next().unwrap_or(msg.module);
+        let line = Line::from(vec![
+            Span::styled(
+                format!("[{}] ", crate_name),
+                Style::default().fg(Color::Cyan),
+            ),
+            Span::raw(&msg.message),
+        ]);
+        lines.push(line);
+    }
+
+    if count > 6 {
+        lines.push(Line::from(Span::styled(
+            format!("... and {} more", count - 6),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let title = format!("Debug Log ({} messages) - [d] Dismiss", count);
+    let paragraph = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(title)
+                .border_style(Style::default().fg(Color::Yellow)),
+        )
+        .wrap(Wrap { trim: true });
 
     frame.render_widget(paragraph, area);
 }

--- a/baml_language/crates/baml_tools_onionskin/src/ui.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/ui.rs
@@ -60,11 +60,11 @@ pub(crate) fn draw(frame: &mut Frame, app: &App) {
     }
     if show_debug_banner {
         // Dynamic height based on number of messages (min 3, max 8)
-        let debug_height = (app.debug_messages().len() + 2).min(8).max(3) as u16;
+        let debug_height = (app.debug_messages().len() + 2).clamp(3, 8) as u16;
         constraints.push(Constraint::Length(debug_height)); // Debug log banner
     }
 
-    constraints.push(Constraint::Min(0));    // Content
+    constraints.push(Constraint::Min(0)); // Content
     constraints.push(Constraint::Length(3)); // Status bar
 
     let chunks = Layout::default()
@@ -213,20 +213,16 @@ fn draw_rebuild_banner(frame: &mut Frame, area: Rect, app: &App) {
         ),
         RebuildState::Failed(error) => (
             format!("✗ Build failed: {}", error),
-            Style::default()
-                .fg(Color::Red)
-                .add_modifier(Modifier::BOLD),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
         ),
     };
 
-    let paragraph = Paragraph::new(message)
-        .style(style)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .title("Compiler Hot-Reload")
-                .border_style(style),
-        );
+    let paragraph = Paragraph::new(message).style(style).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title("Compiler Hot-Reload")
+            .border_style(style),
+    );
 
     frame.render_widget(paragraph, area);
 }

--- a/baml_language/crates/baml_tools_onionskin/src/watcher.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/watcher.rs
@@ -85,11 +85,7 @@ impl FileWatcher {
                     let crate_src = crates_dir.join(crate_name).join("src");
                     if crate_src.exists() {
                         if let Err(e) = watcher.watch(&crate_src, RecursiveMode::Recursive) {
-                            eprintln!(
-                                "Warning: Could not watch {}: {}",
-                                crate_src.display(),
-                                e
-                            );
+                            eprintln!("Warning: Could not watch {}: {}", crate_src.display(), e);
                         } else {
                             compiler_paths.insert(crate_src);
                         }
@@ -138,7 +134,7 @@ impl FileWatcher {
     /// Check if a path is within the compiler source directories
     fn is_compiler_path(&self, path: &Path) -> bool {
         // Check if the path is a Rust file
-        if !path.extension().is_some_and(|ext| ext == "rs") {
+        if path.extension().is_none_or(|ext| ext != "rs") {
             return false;
         }
 

--- a/baml_language/crates/baml_tools_onionskin/src/watcher.rs
+++ b/baml_language/crates/baml_tools_onionskin/src/watcher.rs
@@ -1,45 +1,155 @@
 use std::{
-    path::Path,
+    collections::HashSet,
+    path::{Path, PathBuf},
     sync::mpsc::{Receiver, channel},
 };
 
 use anyhow::Result;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher};
 
+/// Compiler crates that should trigger a hot-reload when changed
+const COMPILER_CRATES: &[&str] = &[
+    "baml_base",
+    "baml_builtins",
+    "baml_compiler_diagnostics",
+    "baml_compiler_emit",
+    "baml_compiler_hir",
+    "baml_compiler_lexer",
+    "baml_compiler_mir",
+    "baml_compiler_parser",
+    "baml_compiler_syntax",
+    "baml_compiler_tir",
+    "baml_compiler_vir",
+    "baml_db",
+    "baml_project",
+    "baml_vm",
+    "baml_workspace",
+];
+
+/// Type of change detected
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ChangeKind {
+    /// A BAML source file changed
+    BamlFile,
+    /// A compiler source file changed (requires rebuild)
+    CompilerSource,
+}
+
 pub(crate) struct FileWatcher {
     #[allow(dead_code)]
     watcher: RecommendedWatcher,
     receiver: Receiver<notify::Result<notify::Event>>,
+    /// Paths that are compiler source directories (for distinguishing change types)
+    compiler_paths: HashSet<PathBuf>,
+    /// Whether we're watching compiler sources
+    watching_compiler: bool,
 }
 
 impl FileWatcher {
+    /// Create a watcher for just BAML files (no compiler hot-reload)
     pub(crate) fn new(path: impl AsRef<Path>) -> Result<Self> {
+        Self::new_with_options(path, None)
+    }
+
+    /// Create a watcher that also watches compiler sources for hot-reload
+    pub(crate) fn new_with_compiler_watch(
+        baml_path: impl AsRef<Path>,
+        workspace_root: impl AsRef<Path>,
+    ) -> Result<Self> {
+        Self::new_with_options(baml_path, Some(workspace_root.as_ref()))
+    }
+
+    fn new_with_options(path: impl AsRef<Path>, workspace_root: Option<&Path>) -> Result<Self> {
         let (tx, rx) = channel();
 
         let mut watcher = notify::recommended_watcher(move |res| {
             let _ = tx.send(res);
         })?;
 
-        // Use recursive mode if watching a directory
+        // Watch BAML files
         let mode = if path.as_ref().is_dir() {
             RecursiveMode::Recursive
         } else {
             RecursiveMode::NonRecursive
         };
-
         watcher.watch(path.as_ref(), mode)?;
+
+        let mut compiler_paths = HashSet::new();
+        let watching_compiler = workspace_root.is_some();
+
+        // Optionally watch compiler source directories
+        if let Some(root) = workspace_root {
+            let crates_dir = root.join("crates");
+            if crates_dir.exists() {
+                for crate_name in COMPILER_CRATES {
+                    let crate_src = crates_dir.join(crate_name).join("src");
+                    if crate_src.exists() {
+                        if let Err(e) = watcher.watch(&crate_src, RecursiveMode::Recursive) {
+                            eprintln!(
+                                "Warning: Could not watch {}: {}",
+                                crate_src.display(),
+                                e
+                            );
+                        } else {
+                            compiler_paths.insert(crate_src);
+                        }
+                    }
+                }
+            }
+        }
 
         Ok(Self {
             watcher,
             receiver: rx,
+            compiler_paths,
+            watching_compiler,
         })
     }
 
-    pub(crate) fn check_for_changes(&self) -> bool {
-        // Simple event detection - just check if any events arrived
-        self.receiver
-            .try_recv()
-            .map(|result| result.is_ok())
-            .unwrap_or(false)
+    /// Check for changes and return the type of change (if any)
+    pub(crate) fn check_for_changes(&self) -> Option<ChangeKind> {
+        // Collect all pending events
+        let mut baml_changed = false;
+        let mut compiler_changed = false;
+
+        while let Ok(result) = self.receiver.try_recv() {
+            if let Ok(event) = result {
+                // Check if any affected path is a compiler source
+                for path in &event.paths {
+                    if self.is_compiler_path(path) {
+                        compiler_changed = true;
+                    } else if path.extension().is_some_and(|ext| ext == "baml") {
+                        baml_changed = true;
+                    }
+                }
+            }
+        }
+
+        // Compiler changes take priority (trigger rebuild)
+        if compiler_changed {
+            Some(ChangeKind::CompilerSource)
+        } else if baml_changed {
+            Some(ChangeKind::BamlFile)
+        } else {
+            None
+        }
+    }
+
+    /// Check if a path is within the compiler source directories
+    fn is_compiler_path(&self, path: &Path) -> bool {
+        // Check if the path is a Rust file
+        if !path.extension().is_some_and(|ext| ext == "rs") {
+            return false;
+        }
+
+        // Check if it's under any of our watched compiler directories
+        self.compiler_paths
+            .iter()
+            .any(|compiler_dir| path.starts_with(compiler_dir))
+    }
+
+    /// Returns true if we're watching compiler sources for hot-reload
+    pub(crate) fn is_watching_compiler(&self) -> bool {
+        self.watching_compiler
     }
 }

--- a/baml_language/rust-toolchain.toml
+++ b/baml_language/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.89"
+components = ["rust-analyzer"]


### PR DESCRIPTION
## Summary

Adds **compiler hot-reload** to onionskin for faster compiler development iteration.

## Features

- **Auto-detection**: Automatically detects the workspace root by looking for `crates/baml_compiler_lexer`
- **Background builds**: Runs `cargo build` in a background thread so the TUI stays responsive
- **Seamless restart**: Uses Unix `exec()` to replace the process with the new binary after successful build
- **View preservation**: Preserves the current compiler phase view across restarts via `--phase` flag

## Usage

```bash
# Hot-reload is automatic when running from the workspace
cd baml_language
cargo run --bin baml_tools_onionskin -- --from test.baml

# Disable if needed
cargo run --bin baml_tools_onionskin -- --from test.baml --no-hot-reload
```

## How it works

1. When a `.rs` file in any compiler crate changes, a yellow banner appears
2. Press **Enter** to trigger rebuild, or **Esc** to dismiss
3. Press **Shift+R** anytime to manually trigger a rebuild
4. After successful build, onionskin restarts and returns to the same tab

## New CLI flags

- `--workspace <PATH>` - Explicitly set workspace root (optional, auto-detected)
- `--no-hot-reload` - Disable compiler source watching
- `--phase <NAME>` - (hidden) Restore to specific compiler phase on restart