### PR TITLE
fix(cffi): prevent deadlock when FFI callbacks trigger more BAML calls

### DIFF
--- a/engine/language_client_cffi/src/ffi/callbacks.rs
+++ b/engine/language_client_cffi/src/ffi/callbacks.rs
@@ -140,5 +140,11 @@ pub fn trigger_on_tick_callback(id: u32) {
     let on_tick_fn = ON_TICK_CALLBACK_FN
         .get()
         .expect("expected on tick callback function to be set. Did you call register_callbacks?");
-    on_tick_fn(id);
+
+    // Use block_in_place to tell Tokio this is a blocking operation.
+    // This allows Tokio to move other async tasks to different worker threads,
+    // preventing deadlock when the callback performs blocking FFI calls.
+    tokio::task::block_in_place(|| {
+        on_tick_fn(id);
+    });
 }


### PR DESCRIPTION
## Issue Reference

N/A

## Changes

When streaming with on_tick callbacks, if the callback (e.g., from Go) makes
another BAML call (like ParseStream), a deadlock could occur. The Tokio worker
thread handling the stream would block waiting for the FFI callback to return,
while the callback's spawned task would wait for a worker thread - causing
thread starvation.

This patch wraps the on_tick callback invocation in
`tokio::task::block_in_place()` to signal to Tokio that the current thread is
about to block. This allows Tokio to move pending async tasks to other worker
threads, preventing the deadlock.

## Testing

- [ ] Unit tests added/updated
- [x] Manual testing performed
- [ ] Tested in [environment]

I verified this fix by first setting up a scenario in Golang that results in
thread starvation/deadlock, specifically a call to `CallStream` that has an
`OnTick` callback registered, in which I proceed to call `ParseStream`.

The result I observed was that everything grinded to a halt the instant
`ParseStream` was called, which was further confirmed to be the case after I
instrumented the BAML engine with debug logs in the `ParseStream`
implementation.

I reached the conclusion that, with `OnTick` callbacks being synchronous, the
Go->Rust boundary being crossed twice results in the second FFI call also
getting scheduled on the same thread, resulting in everything grinding to a
halt.

I tested the same scenario once again after the fix, and everything appeared to
be working reliably.

## Screenshots

N/A

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes

Apologies for not taking the time to log an issue before opening a PR, but I
felt the fix is straightforward enough :)
