### PR TITLE
fix(zed): version strings are wrong

### DIFF
--- a/engine/zed/Cargo.toml
+++ b/engine/zed/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "zed_baml"
 edition = "2024"
-# This version does NOT get published into the Zed extension ecosystem
-# extension.toml version is used for that
-version.workspace = true
+# Both Cargo.toml and extension.toml's version strings
+# are consumed by the Zed extension publishing logic
+version = "0.216.0"
 description = "BAML language support for Zed"
 
 [lib]

--- a/engine/zed/extension.toml
+++ b/engine/zed/extension.toml
@@ -1,7 +1,8 @@
 id = "baml"
 name = "Baml"
 description = "Baml support."
-# This is the version that gets published into the Zed extension ecosystem
+# Both Cargo.toml and extension.toml's version strings
+# are consumed by the Zed extension publishing logic
 version = "0.216.0"
 schema_version = 1
 authors = ["Boundary <contact@boundaryml.com>"]

--- a/tools/versions/zed.cfg
+++ b/tools/versions/zed.cfg
@@ -9,3 +9,7 @@ serialize =
 [bumpversion:file:../engine/zed/extension.toml]
 search = version = "{current_version}"
 replace = version = "{new_version}"
+
+[bumpversion:file:../engine/zed/Cargo.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"


### PR DESCRIPTION
Using `version.workspace = true` is screwing with the Zed extension[ build process:](https://github.com/zed-industries/extensions/actions/runs/20629222262/job/59422767719?pr=4329)

<img width="1703" height="1152" alt="image" src="https://github.com/user-attachments/assets/65b446bd-9a2f-4dd6-a6b9-0c6e98d26a59" />
