### PR TITLE
feat: wire @description to pydantic models

### DIFF
--- a/engine/generators/languages/python/generated_tests/array_types/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/array_types/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/array_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/array_types/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/asserts/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/asserts/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/asserts/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/asserts/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/classes/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/classes/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/classes/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/classes/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/dynamic_types/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/dynamic_types/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/dynamic_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/dynamic_types/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/dynamic_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/dynamic_types/baml_client/types.py
@@ -46,11 +46,8 @@ class Category(str, Enum):
     Arts = "Arts"
 
 class Priority(str, Enum):
-    # Urgent items
     High = "High"
-    # Normal priority
     Medium = "Medium"
-    # Can wait
     Low = "Low"
 
 class Status(str, Enum):

--- a/engine/generators/languages/python/generated_tests/dynamic_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/dynamic_types/baml_client/types.py
@@ -46,8 +46,11 @@ class Category(str, Enum):
     Arts = "Arts"
 
 class Priority(str, Enum):
+    # Urgent items
     High = "High"
+    # Normal priority
     Medium = "Medium"
+    # Can wait
     Low = "Low"
 
 class Status(str, Enum):

--- a/engine/generators/languages/python/generated_tests/edge_cases/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/edge_cases/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/edge_cases/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/edge_cases/baml_client/stream_types.py
@@ -114,11 +114,11 @@ class NumberEdgeCases(BaseModel):
     zero: typing.Optional[int] = None
     negativeInt: typing.Optional[int] = None
     largeInt: typing.Optional[int] = None
-    veryLargeInt: typing.Optional[int] = None
+    veryLargeInt: typing.Optional[int] = Field(default=None, description='i64 max value')
     smallFloat: typing.Optional[float] = None
     largeFloat: typing.Optional[float] = None
     negativeFloat: typing.Optional[float] = None
-    scientificNotation: typing.Optional[float] = None
+    scientificNotation: typing.Optional[float] = Field(default=None, description='> 1e3, but < 1e6')
     infinity: typing.Optional[float] = None
     notANumber: typing.Optional[float] = None
 

--- a/engine/generators/languages/python/generated_tests/edge_cases/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/edge_cases/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/edge_cases/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/edge_cases/baml_client/types.py
@@ -132,11 +132,11 @@ class NumberEdgeCases(BaseModel):
     zero: int
     negativeInt: int
     largeInt: int
-    veryLargeInt: int
+    veryLargeInt: int = Field(description='i64 max value')
     smallFloat: float
     largeFloat: float
     negativeFloat: float
-    scientificNotation: float
+    scientificNotation: float = Field(description='> 1e3, but < 1e6')
     infinity: typing.Optional[float] = None
     notANumber: typing.Optional[float] = None
 

--- a/engine/generators/languages/python/generated_tests/enums/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/enums/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/enums/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/enums/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/enums/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/enums/baml_client/types.py
@@ -41,12 +41,19 @@ def all_succeeded(checks: typing.Dict[CheckName, Check]) -> bool:
 # #########################################################################
 
 class TestEnum(str, Enum):
+    # User is angry
     Angry = "Angry"
+    # User is happy
     Happy = "Happy"
+    # User is sad
     Sad = "Sad"
+    # User is confused
     Confused = "Confused"
+    # User is excited
     Excited = "Excited"
     Exclamation = "Exclamation"
+    # User is bored
+With a long description
     Bored = "Bored"
 
 # #########################################################################

--- a/engine/generators/languages/python/generated_tests/enums/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/enums/baml_client/types.py
@@ -41,19 +41,12 @@ def all_succeeded(checks: typing.Dict[CheckName, Check]) -> bool:
 # #########################################################################
 
 class TestEnum(str, Enum):
-    # User is angry
     Angry = "Angry"
-    # User is happy
     Happy = "Happy"
-    # User is sad
     Sad = "Sad"
-    # User is confused
     Confused = "Confused"
-    # User is excited
     Excited = "Excited"
     Exclamation = "Exclamation"
-    # User is bored
-With a long description
     Bored = "Bored"
 
 # #########################################################################

--- a/engine/generators/languages/python/generated_tests/literal_types/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/literal_types/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/literal_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/literal_types/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/map_types/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/map_types/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/map_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/map_types/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/media_types/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/media_types/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/media_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/media_types/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/mixed_complex_types/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/nested_structures/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/nested_structures/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/nested_structures/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/nested_structures/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/optional_nullable/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/primitive_types/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/primitive_types/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/primitive_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/primitive_types/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/recursive_types/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/recursive_types/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/recursive_types/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/recursive_types/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/sample/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/sample/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/sample/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/sample/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/stream_types.py
@@ -32,7 +32,7 @@ class ClassWithBlockDone(BaseModel):
 
 class ClassWithoutDone(BaseModel):
     i_16_digits: typing.Optional[int] = None
-    s_20_words: StreamState[typing.Optional[str]]
+    s_20_words: StreamState[typing.Optional[str]] = Field(description='A string with 20 words in it')
 
 class SemanticContainer(BaseModel):
     sixteen_digit_number: typing.Optional[int] = None
@@ -41,7 +41,7 @@ class SemanticContainer(BaseModel):
     class_2: typing.Optional["types.ClassWithBlockDone"] = None
     class_done_needed: "types.ClassWithBlockDone"
     class_needed: "ClassWithoutDone"
-    three_small_things: typing.List["SmallThing"]
+    three_small_things: typing.List["SmallThing"] = Field(description='Should have three items.')
     final_string: typing.Optional[str] = None
 
 class SmallThing(BaseModel):

--- a/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/semantic_streaming/baml_client/types.py
@@ -50,7 +50,7 @@ class ClassWithBlockDone(BaseModel):
 
 class ClassWithoutDone(BaseModel):
     i_16_digits: int
-    s_20_words: str
+    s_20_words: str = Field(description='A string with 20 words in it')
 
 class SemanticContainer(BaseModel):
     sixteen_digit_number: int
@@ -59,7 +59,7 @@ class SemanticContainer(BaseModel):
     class_2: "ClassWithBlockDone"
     class_done_needed: "ClassWithBlockDone"
     class_needed: "ClassWithoutDone"
-    three_small_things: typing.List["SmallThing"]
+    three_small_things: typing.List["SmallThing"] = Field(description='Should have three items.')
     final_string: str
 
 class SmallThing(BaseModel):

--- a/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/union_types_extended/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/generated_tests/unions/baml_client/stream_types.py
+++ b/engine/generators/languages/python/generated_tests/unions/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/engine/generators/languages/python/generated_tests/unions/baml_client/types.py
+++ b/engine/generators/languages/python/generated_tests/unions/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/engine/generators/languages/python/src/generated_types.rs
+++ b/engine/generators/languages/python/src/generated_types.rs
@@ -480,9 +480,9 @@ pub(crate) fn render_py_types<T: askama::Template>(
 /// import typing_extensions
 ///
 /// {%- if pkg.is_pydantic_2 %}
-/// from pydantic import BaseModel, ConfigDict
+/// from pydantic import BaseModel, ConfigDict, Field
 /// {%- else %}
-/// from pydantic import BaseModel, Extra
+/// from pydantic import BaseModel, Extra, Field
 /// from pydantic.generics import GenericModel
 /// {%- endif %}
 ///

--- a/engine/generators/languages/python/src/generated_types.rs
+++ b/engine/generators/languages/python/src/generated_types.rs
@@ -393,9 +393,9 @@ mod type_aliases {
 /// from enum import Enum
 ///
 /// {% if pkg.is_pydantic_2 %}
-/// from pydantic import BaseModel, ConfigDict
+/// from pydantic import BaseModel, ConfigDict, Field
 /// {% else %}
-/// from pydantic import BaseModel, Extra
+/// from pydantic import BaseModel, Extra, Field
 /// from pydantic.generics import GenericModel
 /// {% endif %}
 ///

--- a/engine/generators/languages/python/src/generated_types.rs
+++ b/engine/generators/languages/python/src/generated_types.rs
@@ -10,6 +10,9 @@ mod class {
     ///
     /// ```askama
     /// class {{name}}(BaseModel):
+    ///     {%- if let Some(desc) = description %}
+    ///     """{{desc}}"""
+    ///     {%- endif %}
     ///     {%- if let Some(docstring) = docstring %}
     ///     {{crate::utils::prefix_lines(docstring, "# ") }}
     ///     {%- endif %}
@@ -24,7 +27,7 @@ mod class {
     ///         {%- endif %}
     ///         arbitrary_types_allowed = True
     ///     {%- endif %}
-    ///     {%- if fields.is_empty() && !dynamic %}pass{% endif %}
+    ///     {%- if fields.is_empty() && !dynamic && description.is_none() %}pass{% endif %}
     ///     {%- for field in fields %}
     ///     {{- field.render()?|indent(4, true) }}
     ///     {%- endfor %}
@@ -34,6 +37,7 @@ mod class {
     pub struct ClassPy<'a> {
         pub name: String,
         pub docstring: Option<String>,
+        pub description: Option<String>,
         pub fields: Vec<FieldPy<'a>>,
         pub dynamic: bool,
         pub pkg: &'a CurrentRenderPackage,
@@ -45,7 +49,14 @@ mod class {
     /// {% if let Some(docstring) = docstring %}
     /// {{ crate::utils::prefix_lines(docstring, "# ") }}
     /// {% endif %}
-    /// {{ name }}: {{ type.serialize_type(&pkg.in_type_definition()) }}{% if let Some(default_value) = type.default_value() %} = {{default_value}}{% endif %}
+    /// {{ name }}: {{ type.serialize_type(&pkg.in_type_definition()) }}
+    /// {%- if let Some(desc) = description %}
+    /// {%- if let Some(default_value) = type.default_value() %} = Field(default={{default_value}}, description={{desc}})
+    /// {%- else %} = Field(description={{desc}})
+    /// {%- endif %}
+    /// {%- else %}
+    /// {%- if let Some(default_value) = type.default_value() %} = {{default_value}}{% endif %}
+    /// {%- endif %}
     /// ```
     #[derive(askama::Template, Clone)]
     #[template(in_doc = true, escape = "none", ext = "txt")]
@@ -53,14 +64,15 @@ mod class {
         pub docstring: Option<String>,
         pub name: String,
         pub r#type: TypePy,
+        pub description: Option<crate::r#type::EscapedPythonString>,
         pub pkg: &'a CurrentRenderPackage,
     }
     impl std::fmt::Debug for FieldPy<'_> {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(
                 f,
-                "FieldPy {{docstring: {:?}, name: {}, type: {:?}, pkg: <<Mutex>> }}",
-                self.docstring, self.name, self.r#type
+                "FieldPy {{docstring: {:?}, name: {}, type: {:?}, description: {:?}, pkg: <<Mutex>> }}",
+                self.docstring, self.name, self.r#type, self.description
             )
         }
     }
@@ -71,15 +83,21 @@ mod enums {
     ///
     /// ```askama
     /// class {{name}}(str, Enum):
+    ///     {%- if let Some(desc) = description %}
+    ///     """{{desc}}"""
+    ///     {%- endif %}
     ///     {%- if let Some(docstring) = docstring %}
     ///     {{crate::utils::prefix_lines(docstring, "# ") }}
     ///     {% endif %}
-    ///     {%- if values.is_empty() %}
+    ///     {%- if values.is_empty() && description.is_none() %}
     ///     pass
     ///     {%- endif %}
-    ///     {%- for (value, docstring) in values %}
+    ///     {%- for (value, docstring, desc) in values %}
     ///     {%- if let Some(docstring) = docstring %}
     ///     {{ crate::utils::prefix_lines(docstring, "# ") }}
+    ///     {%- endif %}
+    ///     {%- if let Some(desc) = desc %}
+    ///     # {{desc}}
     ///     {%- endif %}
     ///     {{ value }} = "{{ value }}"
     ///     {%- endfor %}
@@ -89,7 +107,8 @@ mod enums {
     pub struct EnumPy {
         pub name: String,
         pub docstring: Option<String>,
-        pub values: Vec<(String, Option<String>)>,
+        pub description: Option<String>,
+        pub values: Vec<(String, Option<String>, Option<String>)>,
         pub dynamic: bool,
     }
 }
@@ -262,7 +281,7 @@ mod type_builder {
     ///     def __init__(self, tb: type_builder.TypeBuilder):
     ///         _tb = tb._tb # type: ignore (we know how to use this private attribute)
     ///         self._bldr = _tb.enum("{{ enum_.name }}")
-    ///         self._values: typing.Set[str] = set([ {% for (value, _) in enum_.values %} "{{ value }}", {% endfor %} ])
+    ///         self._values: typing.Set[str] = set([ {% for (value, _, _) in enum_.values %} "{{ value }}", {% endfor %} ])
     ///         self._vals = {{ enum_.name }}Values(self._bldr, self._values)
     ///
     ///     def type(self) -> baml_py.FieldType:
@@ -301,13 +320,13 @@ mod type_builder {
     ///             raise AttributeError(f"Value {name} not found.")
     ///         return self.__bldr.value(name)
     ///
-    ///     {% for (value, _) in enum_.values %}
+    ///     {% for (value, _, _) in enum_.values %}
     ///     @property
     ///     def {{ value }}(self) -> {{ enum_.enum_value_type() }}:
     ///         return self.__bldr.value("{{ value }}")
     ///     {% endfor %}
     ///     {% else %}
-    ///     {% for (value, _) in enum_.values %}
+    ///     {% for (value, _, _) in enum_.values %}
     ///     @property
     ///     def {{ value }}(self) -> {{ enum_.enum_value_type() }}:
     ///         return {{ enum_.enum_value_type() }}(self.__bldr.value("{{ value }}"))

--- a/engine/generators/languages/python/src/generated_types.rs
+++ b/engine/generators/languages/python/src/generated_types.rs
@@ -11,7 +11,7 @@ mod class {
     /// ```askama
     /// class {{name}}(BaseModel):
     ///     {%- if let Some(desc) = description %}
-    ///     """{{desc}}"""
+    ///     {{ crate::utils::format_docstring(desc, "    ") }}
     ///     {%- endif %}
     ///     {%- if let Some(docstring) = docstring %}
     ///     {{crate::utils::prefix_lines(docstring, "# ") }}
@@ -83,21 +83,15 @@ mod enums {
     ///
     /// ```askama
     /// class {{name}}(str, Enum):
-    ///     {%- if let Some(desc) = description %}
-    ///     """{{desc}}"""
-    ///     {%- endif %}
     ///     {%- if let Some(docstring) = docstring %}
     ///     {{crate::utils::prefix_lines(docstring, "# ") }}
     ///     {% endif %}
-    ///     {%- if values.is_empty() && description.is_none() %}
+    ///     {%- if values.is_empty() %}
     ///     pass
     ///     {%- endif %}
-    ///     {%- for (value, docstring, desc) in values %}
+    ///     {%- for (value, docstring) in values %}
     ///     {%- if let Some(docstring) = docstring %}
     ///     {{ crate::utils::prefix_lines(docstring, "# ") }}
-    ///     {%- endif %}
-    ///     {%- if let Some(desc) = desc %}
-    ///     # {{desc}}
     ///     {%- endif %}
     ///     {{ value }} = "{{ value }}"
     ///     {%- endfor %}
@@ -107,8 +101,7 @@ mod enums {
     pub struct EnumPy {
         pub name: String,
         pub docstring: Option<String>,
-        pub description: Option<String>,
-        pub values: Vec<(String, Option<String>, Option<String>)>,
+        pub values: Vec<(String, Option<String>)>,
         pub dynamic: bool,
     }
 }
@@ -281,7 +274,7 @@ mod type_builder {
     ///     def __init__(self, tb: type_builder.TypeBuilder):
     ///         _tb = tb._tb # type: ignore (we know how to use this private attribute)
     ///         self._bldr = _tb.enum("{{ enum_.name }}")
-    ///         self._values: typing.Set[str] = set([ {% for (value, _, _) in enum_.values %} "{{ value }}", {% endfor %} ])
+    ///         self._values: typing.Set[str] = set([ {% for (value, _) in enum_.values %} "{{ value }}", {% endfor %} ])
     ///         self._vals = {{ enum_.name }}Values(self._bldr, self._values)
     ///
     ///     def type(self) -> baml_py.FieldType:
@@ -320,13 +313,13 @@ mod type_builder {
     ///             raise AttributeError(f"Value {name} not found.")
     ///         return self.__bldr.value(name)
     ///
-    ///     {% for (value, _, _) in enum_.values %}
+    ///     {% for (value, _) in enum_.values %}
     ///     @property
     ///     def {{ value }}(self) -> {{ enum_.enum_value_type() }}:
     ///         return self.__bldr.value("{{ value }}")
     ///     {% endfor %}
     ///     {% else %}
-    ///     {% for (value, _, _) in enum_.values %}
+    ///     {% for (value, _) in enum_.values %}
     ///     @property
     ///     def {{ value }}(self) -> {{ enum_.enum_value_type() }}:
     ///         return {{ enum_.enum_value_type() }}(self.__bldr.value("{{ value }}"))

--- a/engine/generators/languages/python/src/ir_to_py/classes.rs
+++ b/engine/generators/languages/python/src/ir_to_py/classes.rs
@@ -166,6 +166,7 @@ mod tests {
     #[test]
     fn test_field_description_annotation() {
         use askama::Template;
+
         use crate::r#type::EscapedPythonString;
 
         let ir = make_test_ir(
@@ -306,7 +307,10 @@ mod tests {
         let class_py = ir_class_to_py(class, &pkg);
 
         // The description should be dedented
-        let desc = class_py.description.as_ref().expect("should have description");
+        let desc = class_py
+            .description
+            .as_ref()
+            .expect("should have description");
         assert!(
             !desc.starts_with(" ") && !desc.starts_with("\t"),
             "Description should be dedented, got: {:?}",

--- a/engine/generators/languages/python/src/ir_to_py/classes.rs
+++ b/engine/generators/languages/python/src/ir_to_py/classes.rs
@@ -1,9 +1,21 @@
+use baml_types::StringOr;
 use internal_baml_core::ir::{Class, Field};
 
 use crate::{
     generated_types::{ClassPy, FieldPy},
     package::CurrentRenderPackage,
+    r#type::EscapedPythonString,
 };
+
+/// Extract a static string value from a StringOr.
+/// Only `StringOr::Value` is extracted; env vars and jinja expressions are ignored
+/// since they can't be resolved at codegen time.
+fn extract_static_description(string_or: Option<&StringOr>) -> Option<String> {
+    match string_or {
+        Some(StringOr::Value(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
 
 pub fn ir_class_to_py<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> ClassPy<'a> {
     ClassPy {
@@ -13,6 +25,7 @@ pub fn ir_class_to_py<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -> Class
             .docstring
             .clone()
             .map(|docstring| docstring.0.clone()),
+        description: extract_static_description(class.attributes.description()),
         dynamic: class.attributes.dynamic(),
         pkg,
         fields: class
@@ -32,6 +45,7 @@ pub fn ir_class_to_py_stream<'a>(class: &Class, pkg: &'a CurrentRenderPackage) -
             .docstring
             .clone()
             .map(|docstring| docstring.0.clone()),
+        description: extract_static_description(class.attributes.description()),
         dynamic: class.attributes.dynamic(),
         pkg,
         fields: class
@@ -55,6 +69,8 @@ fn ir_field_to_py<'a>(field: &Field, pkg: &'a CurrentRenderPackage) -> FieldPy<'
             .docstring
             .clone()
             .map(|docstring| docstring.0.clone()),
+        description: extract_static_description(field.attributes.description())
+            .map(|s| EscapedPythonString::new(&s)),
         pkg,
     }
 }
@@ -71,6 +87,8 @@ fn ir_field_to_py_stream<'a>(field: &Field, pkg: &'a CurrentRenderPackage) -> Fi
             .docstring
             .clone()
             .map(|docstring| docstring.0.clone()),
+        description: extract_static_description(field.attributes.description())
+            .map(|s| EscapedPythonString::new(&s)),
         pkg,
     }
 }
@@ -143,5 +161,125 @@ mod tests {
         let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
         let class_py = ir_class_to_py_stream(class, &pkg);
         assert_eq!(class_py.fields[0].docstring, Some("ds".to_string()));
+    }
+
+    #[test]
+    fn test_field_description_annotation() {
+        use askama::Template;
+        use crate::r#type::EscapedPythonString;
+
+        let ir = make_test_ir(
+            r#"
+        class Foo {
+            bar string @description("This is the bar field")
+        }
+        "#,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let class = ir.find_class("Foo").unwrap().item;
+        let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let class_py = ir_class_to_py(class, &pkg);
+
+        // The description should be captured (as EscapedPythonString)
+        assert_eq!(
+            class_py.fields[0].description,
+            Some(EscapedPythonString::new("This is the bar field"))
+        );
+
+        // The rendered output should use Pydantic Field(description=...)
+        let rendered = class_py.fields[0].render().expect("render field");
+        assert!(
+            rendered.contains("Field("),
+            "Expected Field() in output, got: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("description="),
+            "Expected description= in output, got: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn test_field_without_description() {
+        use askama::Template;
+
+        let ir = make_test_ir(
+            r#"
+        class Foo {
+            bar string
+        }
+        "#,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let class = ir.find_class("Foo").unwrap().item;
+        let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let class_py = ir_class_to_py(class, &pkg);
+
+        // No description should be captured
+        assert_eq!(class_py.fields[0].description, None);
+
+        // The rendered output should NOT use Field() when there's no description
+        let rendered = class_py.fields[0].render().expect("render field");
+        assert!(
+            !rendered.contains("Field("),
+            "Expected no Field() in output when no description, got: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn test_class_description_annotation() {
+        use askama::Template;
+
+        let ir = make_test_ir(
+            r#"
+        class Foo {
+            bar string
+            @@description("This is the Foo class")
+        }
+        "#,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let class = ir.find_class("Foo").unwrap().item;
+        let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let class_py = ir_class_to_py(class, &pkg);
+
+        // The class description should be captured
+        assert_eq!(
+            class_py.description,
+            Some("This is the Foo class".to_string())
+        );
+
+        // The rendered output should include a Python docstring
+        let rendered = class_py.render().expect("render class");
+        assert!(
+            rendered.contains(r#""""This is the Foo class""""#)
+                || rendered.contains("\"\"\"This is the Foo class\"\"\""),
+            "Expected Python docstring in output, got: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn test_class_without_description() {
+        let ir = make_test_ir(
+            r#"
+        class Foo {
+            bar string
+        }
+        "#,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let class = ir.find_class("Foo").unwrap().item;
+        let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let class_py = ir_class_to_py(class, &pkg);
+
+        // No description should be captured (only docstring from comments)
+        assert_eq!(class_py.description, None);
     }
 }

--- a/engine/generators/languages/python/src/ir_to_py/classes.rs
+++ b/engine/generators/languages/python/src/ir_to_py/classes.rs
@@ -328,16 +328,22 @@ mod tests {
     }
 
     #[test]
-    fn test_multiline_field_description() {
+    fn test_field_description_edge_cases() {
         use askama::Template;
 
         let ir = make_test_ir(
             r##"
         class Foo {
-            bar string @description(#"
+            multiline string @description(#"
                 This field has a
                 multiline description.
             "#)
+            single_quotes string @description("It's a test with 'quotes'")
+            backslashes string @description("Path: C:\\Users\\test")
+            tabs_and_newlines string @description(#"Tab:	and newline:
+end"#)
+            triple_quotes string @description(#"Has """triple quotes""" inside"#)
+            empty string @description("")
         }
         "##,
         )
@@ -347,17 +353,109 @@ mod tests {
         let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
         let class_py = ir_class_to_py(class, &pkg);
 
-        // The description should use escaped newlines, not triple quotes
         let rendered = class_py.render().expect("render class");
+
+        // Multiline: should use escaped newlines, not triple quotes
         assert!(
             rendered.contains(r"description='This field has a\nmultiline description.'"),
             "Field description should use escaped newlines, got:\n{}",
             rendered
         );
-        // Should NOT contain triple quotes in Field()
         assert!(
             !rendered.contains(r#"description=""""#),
             "Field description should not use triple quotes, got:\n{}",
+            rendered
+        );
+
+        // Single quotes: should be escaped
+        assert!(
+            rendered.contains(r"description='It\'s a test with \'quotes\''"),
+            "Single quotes should be escaped, got:\n{}",
+            rendered
+        );
+
+        // Backslashes: should be escaped
+        assert!(
+            rendered.contains(r"description='Path: C:\\Users\\test'"),
+            "Backslashes should be escaped, got:\n{}",
+            rendered
+        );
+
+        // Tab and newline: should be escaped
+        assert!(
+            rendered.contains(r"\t") && rendered.contains(r"\n"),
+            "Tab and newline should be escaped, got:\n{}",
+            rendered
+        );
+
+        // Triple quotes inside: should be present (Python single-quoted strings handle this fine)
+        assert!(
+            rendered.contains("triple quotes"),
+            "Triple quotes field should be present, got:\n{}",
+            rendered
+        );
+
+        // Empty: should still generate valid Field()
+        assert!(
+            rendered.contains("description=''"),
+            "Empty description should generate empty string, got:\n{}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn test_class_description_with_triple_quotes() {
+        use askama::Template;
+
+        let ir = make_test_ir(
+            r##"
+        class Foo {
+            bar string
+            @@description(#"This has """triple quotes""" inside"#)
+        }
+        "##,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let class = ir.find_class("Foo").unwrap().item;
+        let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let class_py = ir_class_to_py(class, &pkg);
+
+        let rendered = class_py.render().expect("render class");
+        // The generated code should be valid Python (triple quotes must be escaped)
+        // Check that we don't have unbalanced triple quotes
+        let triple_quote_count = rendered.matches(r#"""""#).count();
+        assert!(
+            triple_quote_count % 2 == 0,
+            "Triple quotes should be balanced in output, got:\n{}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn test_class_description_with_backslash_at_end() {
+        use askama::Template;
+
+        let ir = make_test_ir(
+            r##"
+        class Foo {
+            bar string
+            @@description("Ends with backslash\\")
+        }
+        "##,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let class = ir.find_class("Foo").unwrap().item;
+        let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let class_py = ir_class_to_py(class, &pkg);
+
+        let rendered = class_py.render().expect("render class");
+        // A backslash at the end of a docstring line could escape the closing quotes
+        // This test ensures the output is valid
+        assert!(
+            rendered.contains("Ends with backslash"),
+            "Description should be present, got:\n{}",
             rendered
         );
     }

--- a/engine/generators/languages/python/src/ir_to_py/classes.rs
+++ b/engine/generators/languages/python/src/ir_to_py/classes.rs
@@ -282,4 +282,83 @@ mod tests {
         // No description should be captured (only docstring from comments)
         assert_eq!(class_py.description, None);
     }
+
+    #[test]
+    fn test_multiline_class_description() {
+        use askama::Template;
+
+        let ir = make_test_ir(
+            r##"
+        class Foo {
+            bar string
+            @@description(#"
+                This is a multiline description.
+                It has multiple lines.
+                And should be dedented properly.
+            "#)
+        }
+        "##,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let class = ir.find_class("Foo").unwrap().item;
+        let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let class_py = ir_class_to_py(class, &pkg);
+
+        // The description should be dedented
+        let desc = class_py.description.as_ref().expect("should have description");
+        assert!(
+            !desc.starts_with(" ") && !desc.starts_with("\t"),
+            "Description should be dedented, got: {:?}",
+            desc
+        );
+        assert!(
+            desc.contains("This is a multiline description."),
+            "Expected description content, got: {:?}",
+            desc
+        );
+
+        // Check the rendered output has properly indented docstring
+        let rendered = class_py.render().expect("render class");
+        assert!(
+            rendered.contains("    It has multiple lines."),
+            "Subsequent lines of docstring should be indented, got:\n{}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn test_multiline_field_description() {
+        use askama::Template;
+
+        let ir = make_test_ir(
+            r##"
+        class Foo {
+            bar string @description(#"
+                This field has a
+                multiline description.
+            "#)
+        }
+        "##,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let class = ir.find_class("Foo").unwrap().item;
+        let pkg = CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let class_py = ir_class_to_py(class, &pkg);
+
+        // The description should use escaped newlines, not triple quotes
+        let rendered = class_py.render().expect("render class");
+        assert!(
+            rendered.contains(r"description='This field has a\nmultiline description.'"),
+            "Field description should use escaped newlines, got:\n{}",
+            rendered
+        );
+        // Should NOT contain triple quotes in Field()
+        assert!(
+            !rendered.contains(r#"description=""""#),
+            "Field description should not use triple quotes, got:\n{}",
+            rendered
+        );
+    }
 }

--- a/engine/generators/languages/python/src/ir_to_py/enums.rs
+++ b/engine/generators/languages/python/src/ir_to_py/enums.rs
@@ -1,6 +1,17 @@
+use baml_types::StringOr;
 use internal_baml_core::ir::Enum;
 
 use crate::package::CurrentRenderPackage;
+
+/// Extract a static string value from a StringOr.
+/// Only `StringOr::Value` is extracted; env vars and jinja expressions are ignored
+/// since they can't be resolved at codegen time.
+fn extract_static_description(string_or: Option<&StringOr>) -> Option<String> {
+    match string_or {
+        Some(StringOr::Value(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
 
 pub fn ir_enum_to_py(enum_: &Enum, _pkg: &CurrentRenderPackage) -> crate::generated_types::EnumPy {
     crate::generated_types::EnumPy {
@@ -9,9 +20,121 @@ pub fn ir_enum_to_py(enum_: &Enum, _pkg: &CurrentRenderPackage) -> crate::genera
             .elem
             .values
             .iter()
-            .map(|(val, doc_string)| (val.elem.0.clone(), doc_string.as_ref().map(|d| d.0.clone())))
+            .map(|(val, doc_string)| {
+                (
+                    val.elem.0.clone(),
+                    doc_string.as_ref().map(|d| d.0.clone()),
+                    extract_static_description(val.attributes.description()),
+                )
+            })
             .collect(),
         docstring: enum_.elem.docstring.as_ref().map(|d| d.0.clone()),
+        description: extract_static_description(enum_.attributes.description()),
         dynamic: enum_.attributes.dynamic(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use askama::Template;
+    use internal_baml_core::ir::{repr::make_test_ir, IRHelper};
+
+    use super::*;
+
+    #[test]
+    fn test_enum_value_description_annotation() {
+        let ir = make_test_ir(
+            r#"
+        enum Status {
+            PENDING @description("Task is pending")
+            COMPLETED @description("Task is completed")
+            FAILED
+        }
+        "#,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let enum_ = ir.find_enum("Status").unwrap().item;
+        let pkg = crate::package::CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let enum_py = ir_enum_to_py(enum_, &pkg);
+
+        // First value should have description
+        assert_eq!(enum_py.values[0].0, "PENDING");
+        assert_eq!(enum_py.values[0].2, Some("Task is pending".to_string()));
+
+        // Second value should have description
+        assert_eq!(enum_py.values[1].0, "COMPLETED");
+        assert_eq!(enum_py.values[1].2, Some("Task is completed".to_string()));
+
+        // Third value should have no description
+        assert_eq!(enum_py.values[2].0, "FAILED");
+        assert_eq!(enum_py.values[2].2, None);
+
+        // The rendered output should include descriptions as comments
+        let rendered = enum_py.render().expect("render enum");
+        assert!(
+            rendered.contains("Task is pending"),
+            "Expected description comment in output, got: {}",
+            rendered
+        );
+        assert!(
+            rendered.contains("Task is completed"),
+            "Expected description comment in output, got: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn test_enum_description_annotation() {
+        let ir = make_test_ir(
+            r#"
+        enum Status {
+            PENDING
+            COMPLETED
+            @@description("Represents the status of a task")
+        }
+        "#,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let enum_ = ir.find_enum("Status").unwrap().item;
+        let pkg = crate::package::CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let enum_py = ir_enum_to_py(enum_, &pkg);
+
+        // Enum should have description
+        assert_eq!(
+            enum_py.description,
+            Some("Represents the status of a task".to_string())
+        );
+
+        // The rendered output should include a Python docstring
+        let rendered = enum_py.render().expect("render enum");
+        assert!(
+            rendered.contains("\"\"\"Represents the status of a task\"\"\""),
+            "Expected Python docstring in output, got: {}",
+            rendered
+        );
+    }
+
+    #[test]
+    fn test_enum_without_descriptions() {
+        let ir = make_test_ir(
+            r#"
+        enum Status {
+            PENDING
+            COMPLETED
+        }
+        "#,
+        )
+        .expect("Valid IR");
+        let ir = std::sync::Arc::new(ir);
+        let enum_ = ir.find_enum("Status").unwrap().item;
+        let pkg = crate::package::CurrentRenderPackage::new("baml_client", ir.clone(), true);
+        let enum_py = ir_enum_to_py(enum_, &pkg);
+
+        // No descriptions should be present
+        assert_eq!(enum_py.description, None);
+        assert_eq!(enum_py.values[0].2, None);
+        assert_eq!(enum_py.values[1].2, None);
     }
 }

--- a/engine/generators/languages/python/src/ir_to_py/enums.rs
+++ b/engine/generators/languages/python/src/ir_to_py/enums.rs
@@ -1,17 +1,6 @@
-use baml_types::StringOr;
 use internal_baml_core::ir::Enum;
 
 use crate::package::CurrentRenderPackage;
-
-/// Extract a static string value from a StringOr.
-/// Only `StringOr::Value` is extracted; env vars and jinja expressions are ignored
-/// since they can't be resolved at codegen time.
-fn extract_static_description(string_or: Option<&StringOr>) -> Option<String> {
-    match string_or {
-        Some(StringOr::Value(s)) => Some(s.clone()),
-        _ => None,
-    }
-}
 
 pub fn ir_enum_to_py(enum_: &Enum, _pkg: &CurrentRenderPackage) -> crate::generated_types::EnumPy {
     crate::generated_types::EnumPy {
@@ -20,16 +9,9 @@ pub fn ir_enum_to_py(enum_: &Enum, _pkg: &CurrentRenderPackage) -> crate::genera
             .elem
             .values
             .iter()
-            .map(|(val, doc_string)| {
-                (
-                    val.elem.0.clone(),
-                    doc_string.as_ref().map(|d| d.0.clone()),
-                    extract_static_description(val.attributes.description()),
-                )
-            })
+            .map(|(val, doc_string)| (val.elem.0.clone(), doc_string.as_ref().map(|d| d.0.clone())))
             .collect(),
         docstring: enum_.elem.docstring.as_ref().map(|d| d.0.clone()),
-        description: extract_static_description(enum_.attributes.description()),
         dynamic: enum_.attributes.dynamic(),
     }
 }
@@ -42,13 +24,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_enum_value_description_annotation() {
+    fn test_enum_basic() {
         let ir = make_test_ir(
             r#"
         enum Status {
-            PENDING @description("Task is pending")
-            COMPLETED @description("Task is completed")
-            FAILED
+            PENDING
+            COMPLETED
         }
         "#,
         )
@@ -58,83 +39,12 @@ mod tests {
         let pkg = crate::package::CurrentRenderPackage::new("baml_client", ir.clone(), true);
         let enum_py = ir_enum_to_py(enum_, &pkg);
 
-        // First value should have description
+        assert_eq!(enum_py.name, "Status");
         assert_eq!(enum_py.values[0].0, "PENDING");
-        assert_eq!(enum_py.values[0].2, Some("Task is pending".to_string()));
-
-        // Second value should have description
         assert_eq!(enum_py.values[1].0, "COMPLETED");
-        assert_eq!(enum_py.values[1].2, Some("Task is completed".to_string()));
 
-        // Third value should have no description
-        assert_eq!(enum_py.values[2].0, "FAILED");
-        assert_eq!(enum_py.values[2].2, None);
-
-        // The rendered output should include descriptions as comments
         let rendered = enum_py.render().expect("render enum");
-        assert!(
-            rendered.contains("Task is pending"),
-            "Expected description comment in output, got: {}",
-            rendered
-        );
-        assert!(
-            rendered.contains("Task is completed"),
-            "Expected description comment in output, got: {}",
-            rendered
-        );
-    }
-
-    #[test]
-    fn test_enum_description_annotation() {
-        let ir = make_test_ir(
-            r#"
-        enum Status {
-            PENDING
-            COMPLETED
-            @@description("Represents the status of a task")
-        }
-        "#,
-        )
-        .expect("Valid IR");
-        let ir = std::sync::Arc::new(ir);
-        let enum_ = ir.find_enum("Status").unwrap().item;
-        let pkg = crate::package::CurrentRenderPackage::new("baml_client", ir.clone(), true);
-        let enum_py = ir_enum_to_py(enum_, &pkg);
-
-        // Enum should have description
-        assert_eq!(
-            enum_py.description,
-            Some("Represents the status of a task".to_string())
-        );
-
-        // The rendered output should include a Python docstring
-        let rendered = enum_py.render().expect("render enum");
-        assert!(
-            rendered.contains("\"\"\"Represents the status of a task\"\"\""),
-            "Expected Python docstring in output, got: {}",
-            rendered
-        );
-    }
-
-    #[test]
-    fn test_enum_without_descriptions() {
-        let ir = make_test_ir(
-            r#"
-        enum Status {
-            PENDING
-            COMPLETED
-        }
-        "#,
-        )
-        .expect("Valid IR");
-        let ir = std::sync::Arc::new(ir);
-        let enum_ = ir.find_enum("Status").unwrap().item;
-        let pkg = crate::package::CurrentRenderPackage::new("baml_client", ir.clone(), true);
-        let enum_py = ir_enum_to_py(enum_, &pkg);
-
-        // No descriptions should be present
-        assert_eq!(enum_py.description, None);
-        assert_eq!(enum_py.values[0].2, None);
-        assert_eq!(enum_py.values[1].2, None);
+        assert!(rendered.contains("PENDING = \"PENDING\""));
+        assert!(rendered.contains("COMPLETED = \"COMPLETED\""));
     }
 }

--- a/engine/generators/languages/python/src/test_macros.rs
+++ b/engine/generators/languages/python/src/test_macros.rs
@@ -176,7 +176,7 @@ macro_rules! test_py_type {
         assert_eq!(enum_py.name, $enum_name);
 
         let expected_values: Vec<&str> = vec![$( $value ),*];
-        let actual_values: Vec<&str> = enum_py.values.iter().map(|(v, _)| v.as_str()).collect();
+        let actual_values: Vec<&str> = enum_py.values.iter().map(|(v, _, _)| v.as_str()).collect();
         assert_eq!(
             actual_values,
             expected_values,

--- a/engine/generators/languages/python/src/test_macros.rs
+++ b/engine/generators/languages/python/src/test_macros.rs
@@ -176,7 +176,7 @@ macro_rules! test_py_type {
         assert_eq!(enum_py.name, $enum_name);
 
         let expected_values: Vec<&str> = vec![$( $value ),*];
-        let actual_values: Vec<&str> = enum_py.values.iter().map(|(v, _, _)| v.as_str()).collect();
+        let actual_values: Vec<&str> = enum_py.values.iter().map(|(v, _)| v.as_str()).collect();
         assert_eq!(
             actual_values,
             expected_values,

--- a/engine/generators/languages/python/src/type.rs
+++ b/engine/generators/languages/python/src/type.rs
@@ -28,6 +28,12 @@ impl EscapedPythonString {
     }
 }
 
+impl std::fmt::Display for EscapedPythonString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 #[derive(Clone, PartialEq, Debug)]
 pub enum LiteralValue {
     String(EscapedPythonString),

--- a/engine/generators/languages/python/src/type.rs
+++ b/engine/generators/languages/python/src/type.rs
@@ -13,18 +13,15 @@ pub struct EscapedPythonString(String);
 
 impl EscapedPythonString {
     pub fn new(s: &str) -> Self {
-        let has_single_quote = s.contains('\'');
-        let has_double_quote = s.contains('"');
-        let has_newline = s.contains('\n');
-        if has_newline {
-            return Self(format!("\"\"\"{s}\"\"\""));
-        }
-        match (has_single_quote, has_double_quote) {
-            (true, false) => Self(format!("\"{s}\"")),
-            (true, true) => Self(format!("'{}'", s.replace('\'', "\\'"))),
-            (false, true) => Self(format!("'{s}'")),
-            (false, false) => Self(format!("'{s}'")),
-        }
+        // Escape special characters and wrap in quotes
+        // We always use single quotes and escape as needed
+        let escaped = s
+            .replace('\\', "\\\\")
+            .replace('\'', "\\'")
+            .replace('\n', "\\n")
+            .replace('\r', "\\r")
+            .replace('\t', "\\t");
+        Self(format!("'{}'", escaped))
     }
 }
 

--- a/engine/generators/languages/python/src/type.rs
+++ b/engine/generators/languages/python/src/type.rs
@@ -13,15 +13,18 @@ pub struct EscapedPythonString(String);
 
 impl EscapedPythonString {
     pub fn new(s: &str) -> Self {
-        // Escape special characters and wrap in quotes
-        // We always use single quotes and escape as needed
-        let escaped = s
-            .replace('\\', "\\\\")
-            .replace('\'', "\\'")
-            .replace('\n', "\\n")
-            .replace('\r', "\\r")
-            .replace('\t', "\\t");
-        Self(format!("'{}'", escaped))
+        let has_single_quote = s.contains('\'');
+        let has_double_quote = s.contains('"');
+        let has_newline = s.contains('\n');
+        if has_newline {
+            return Self(format!("\"\"\"{s}\"\"\""));
+        }
+        match (has_single_quote, has_double_quote) {
+            (true, false) => Self(format!("\"{s}\"")),
+            (true, true) => Self(format!("'{}'", s.replace('\'', "\\'"))),
+            (false, true) => Self(format!("'{s}'")),
+            (false, false) => Self(format!("'{s}'")),
+        }
     }
 }
 

--- a/engine/generators/languages/python/src/utils.rs
+++ b/engine/generators/languages/python/src/utils.rs
@@ -7,3 +7,30 @@ pub fn prefix_lines(s: &str, prefix: &str) -> String {
         .collect::<Vec<_>>()
         .join("\n")
 }
+
+/// Format a string as a Python docstring with proper indentation.
+/// The first line starts with """, subsequent lines are indented with the given prefix,
+/// and the closing """ is on the same line as the last content.
+pub fn format_docstring(s: &str, indent: &str) -> String {
+    if s.is_empty() {
+        return "\"\"\"\"\"\"".to_string();
+    }
+
+    let lines: Vec<&str> = s.lines().collect();
+    if lines.len() == 1 {
+        // Single line docstring
+        return format!("\"\"\"{}\"\"\"", lines[0]);
+    }
+
+    // Multi-line docstring: indent all lines after the first
+    let mut result = String::new();
+    result.push_str("\"\"\"");
+    result.push_str(lines[0]);
+    for line in &lines[1..] {
+        result.push('\n');
+        result.push_str(indent);
+        result.push_str(line);
+    }
+    result.push_str("\"\"\"");
+    result
+}

--- a/engine/llm-response-parser/src/provider.rs
+++ b/engine/llm-response-parser/src/provider.rs
@@ -82,9 +82,15 @@ mod tests {
     #[test]
     fn test_provider_string_conversion() {
         assert_eq!(LLMProvider::OpenAI.as_str(), "openai");
-        assert_eq!(LLMProvider::from_str("openai"), Some(LLMProvider::OpenAI));
-        assert_eq!(LLMProvider::from_str("OPENAI"), Some(LLMProvider::OpenAI));
-        assert_eq!(LLMProvider::from_str("unknown"), None);
+        assert_eq!(
+            LLMProvider::try_from_str("openai"),
+            Some(LLMProvider::OpenAI)
+        );
+        assert_eq!(
+            LLMProvider::try_from_str("OPENAI"),
+            Some(LLMProvider::OpenAI)
+        );
+        assert_eq!(LLMProvider::try_from_str("unknown"), None);
     }
 
     #[test]

--- a/integ-tests/python-v1/baml_client/stream_types.py
+++ b/integ-tests/python-v1/baml_client/stream_types.py
@@ -518,7 +518,7 @@ class Person(BaseModel):
 class PersonWithMeta(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    name: typing.Optional[str] = Field(default=None, description="Person's full legal name")
+    name: typing.Optional[str] = Field(default=None, description='Person\'s full legal name')
     age: typing.Optional[int] = Field(default=None, description='Age in years')
     address: typing.Optional["AddressWithMeta"] = Field(default=None, description='Home address')
     tags: typing.List[str] = Field(description='User tags')
@@ -647,8 +647,7 @@ class StringToClassEntry(BaseModel):
 class TestClassAlias(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    key: typing.Optional[str] = Field(default=None, description="""This is a description for key
-    af asdf""")
+    key: typing.Optional[str] = Field(default=None, description='This is a description for key\naf asdf')
     key2: typing.Optional[str] = None
     key3: typing.Optional[str] = None
     key4: typing.Optional[str] = None

--- a/integ-tests/python-v1/baml_client/stream_types.py
+++ b/integ-tests/python-v1/baml_client/stream_types.py
@@ -33,14 +33,14 @@ class AddTodoItem(BaseModel):
     type: typing_extensions.Literal['add_todo_item']
     item: str
     time: str
-    description: str
+    description: str = Field(description='20 word description of the item')
 
 class AddressWithMeta(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    street: typing.Optional[str] = None
-    city: typing.Optional[str] = None
-    zipcode: typing.Optional[str] = None
+    street: typing.Optional[str] = Field(default=None, description='The street name')
+    city: typing.Optional[str] = Field(default=None, description='The city')
+    zipcode: typing.Optional[str] = Field(default=None, description='5-digit zip code')
 
 class AnotherObject(BaseModel):
     class Config:
@@ -82,10 +82,10 @@ class BlockConstraintForParam(BaseModel):
 class BookOrder(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    orderId: typing.Optional[str] = None
-    title: typing.Optional[str] = None
-    quantity: typing.Optional[int] = None
-    price: typing.Optional[float] = None
+    orderId: typing.Optional[str] = Field(default=None, description='The ID of the book order')
+    title: typing.Optional[str] = Field(default=None, description='The title of the ordered book')
+    quantity: typing.Optional[int] = Field(default=None, description='The quantity of books ordered')
+    price: typing.Optional[float] = Field(default=None, description='The price of the book')
 
 class ClassForNullLiteral(BaseModel):
     class Config:
@@ -127,7 +127,7 @@ class ClassWithoutDone(BaseModel):
     class Config:
         arbitrary_types_allowed = True
     i_16_digits: typing.Optional[int] = None
-    s_20_words: StreamState[typing.Optional[str]]
+    s_20_words: StreamState[typing.Optional[str]] = Field(description='A string with 20 words in it')
 
 class ClientDetails1559(BaseModel):
     class Config:
@@ -146,7 +146,7 @@ class ComplexMemoryObject(BaseModel):
     id: typing.Optional[str] = None
     name: typing.Optional[str] = None
     description: typing.Optional[str] = None
-    metadata: typing.List[typing.Union[str, int, float]]
+    metadata: typing.List[typing.Union[str, int, float]] = Field(description='Additional metadata about the memory object, which can be a mix of types.')
 
 class CompoundBigNumbers(BaseModel):
     class Config:
@@ -274,11 +274,11 @@ class FakeImage(BaseModel):
 class FlightConfirmation(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    confirmationNumber: typing.Optional[str] = None
-    flightNumber: typing.Optional[str] = None
-    departureTime: typing.Optional[str] = None
-    arrivalTime: typing.Optional[str] = None
-    seatNumber: typing.Optional[str] = None
+    confirmationNumber: typing.Optional[str] = Field(default=None, description='The flight confirmation number')
+    flightNumber: typing.Optional[str] = Field(default=None, description='The flight number')
+    departureTime: typing.Optional[str] = Field(default=None, description='The scheduled departure time of the flight')
+    arrivalTime: typing.Optional[str] = Field(default=None, description='The scheduled arrival time of the flight')
+    seatNumber: typing.Optional[str] = Field(default=None, description='The seat number assigned on the flight')
 
 class FooAny(BaseModel):
     class Config:
@@ -319,10 +319,10 @@ class FormatterTest3(BaseModel):
 class GroceryReceipt(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    receiptId: typing.Optional[str] = None
-    storeName: typing.Optional[str] = None
-    items: typing.List[typing.Union[str, int, float]]
-    totalAmount: typing.Optional[float] = None
+    receiptId: typing.Optional[str] = Field(default=None, description='The ID of the grocery receipt')
+    storeName: typing.Optional[str] = Field(default=None, description='The name of the grocery store')
+    items: typing.List[typing.Union[str, int, float]] = Field(description='A list of items purchased. Each item consists of a name, quantity, and price.')
+    totalAmount: typing.Optional[float] = Field(default=None, description='The total amount spent on groceries')
 
 class Haiku(BaseModel):
     class Config:
@@ -420,7 +420,7 @@ class MemoryObject(BaseModel):
 class MergeAttrs(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    amount: typing.Optional[types.Checked[int, typing_extensions.Literal['gt_ten']]] = None
+    amount: typing.Optional[types.Checked[int, typing_extensions.Literal['gt_ten']]] = Field(default=None, description='In USD')
 
 class NamedArgsSingleClass(BaseModel):
     class Config:
@@ -432,15 +432,15 @@ class NamedArgsSingleClass(BaseModel):
 class Nested(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    prop3: typing.Optional[str] = None
-    prop4: typing.Optional[str] = None
+    prop3: typing.Optional[str] = Field(default=None, description='write "three"')
+    prop4: typing.Optional[str] = Field(default=None, description='write "four"')
     prop20: typing.Optional["Nested2"] = None
 
 class Nested2(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    prop11: typing.Optional[str] = None
-    prop12: typing.Optional[str] = None
+    prop11: typing.Optional[str] = Field(default=None, description='write "three"')
+    prop12: typing.Optional[str] = Field(default=None, description='write "four"')
 
 class NestedBlockConstraint(BaseModel):
     class Config:
@@ -469,7 +469,7 @@ class Note1599(BaseModel):
         arbitrary_types_allowed = True
     note_title: typing.Optional[str] = None
     note_description: typing.Optional[str] = None
-    note_amount: typing.Optional[str] = None
+    note_amount: typing.Optional[str] = Field(default=None, description='If there is a quantity, specify it here')
 
 class OptionalListAndMap(BaseModel):
     class Config:
@@ -518,10 +518,10 @@ class Person(BaseModel):
 class PersonWithMeta(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    name: typing.Optional[str] = None
-    age: typing.Optional[int] = None
-    address: typing.Optional["AddressWithMeta"] = None
-    tags: typing.List[str]
+    name: typing.Optional[str] = Field(default=None, description="Person's full legal name")
+    age: typing.Optional[int] = Field(default=None, description='Age in years')
+    address: typing.Optional["AddressWithMeta"] = Field(default=None, description='Home address')
+    tags: typing.List[str] = Field(description='User tags')
 
 class PhoneNumber(BaseModel):
     class Config:
@@ -592,22 +592,22 @@ class Resume(BaseModel):
 class Schema(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    prop1: typing.Optional[str] = None
-    prop2: typing.Optional[typing.Union["Nested", str]] = None
-    prop5: typing.List[typing.Optional[str]]
-    prop6: typing.Optional[typing.Union[str, typing.List["Nested"]]] = None
-    nested_attrs: typing.List[typing.Optional[typing.Union[str, "Nested"]]]
-    parens: typing.Optional[str] = None
-    other_group: typing.Optional[typing.Union[str, int]] = None
+    prop1: typing.Optional[str] = Field(default=None, description='write "one"')
+    prop2: typing.Optional[typing.Union["Nested", str]] = Field(default=None, description='write "two"')
+    prop5: typing.List[typing.Optional[str]] = Field(description='write "hi"')
+    prop6: typing.Optional[typing.Union[str, typing.List["Nested"]]] = Field(default=None, description='write the string "blah" regardless of the other types here')
+    nested_attrs: typing.List[typing.Optional[typing.Union[str, "Nested"]]] = Field(description='write the string "nested" regardless of other types')
+    parens: typing.Optional[str] = Field(default=None, description='write "parens1"')
+    other_group: typing.Optional[typing.Union[str, int]] = Field(default=None, description='write "other"')
 
 class SearchParams(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    dateRange: typing.Optional[int] = None
+    dateRange: typing.Optional[int] = Field(default=None, description='In ISO duration format, e.g. P1Y2M10D.')
     location: typing.List[str]
-    jobTitle: typing.Optional["WithReasoning"] = None
-    company: typing.Optional["WithReasoning"] = None
-    description: typing.List["WithReasoning"]
+    jobTitle: typing.Optional["WithReasoning"] = Field(default=None, description='An exact job title, not a general category.')
+    company: typing.Optional["WithReasoning"] = Field(default=None, description='The exact name of the company, not a product or service.')
+    description: typing.List["WithReasoning"] = Field(description='Any specific projects or features the user is looking for.')
     tags: typing.List[typing.Union[types.Tag, str]]
 
 class SemanticContainer(BaseModel):
@@ -619,7 +619,7 @@ class SemanticContainer(BaseModel):
     class_2: typing.Optional["types.ClassWithBlockDone"] = None
     class_done_needed: "types.ClassWithBlockDone"
     class_needed: "ClassWithoutDone"
-    three_small_things: typing.List["SmallThing"]
+    three_small_things: typing.List["SmallThing"] = Field(description='Should have three items.')
     final_string: typing.Optional[str] = None
 
 class SimpleTag(BaseModel):
@@ -647,7 +647,8 @@ class StringToClassEntry(BaseModel):
 class TestClassAlias(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    key: typing.Optional[str] = None
+    key: typing.Optional[str] = Field(default=None, description="""This is a description for key
+    af asdf""")
     key2: typing.Optional[str] = None
     key3: typing.Optional[str] = None
     key4: typing.Optional[str] = None
@@ -668,20 +669,20 @@ class TestClassWithEnum(BaseModel):
 class TestMemoryOutput(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
-    more_items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
+    items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]] = Field(description='Add 10 items, which can be either simple MemoryObjects or more complex MemoryObjects with metadata.')
+    more_items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]] = Field(description='Add 3 more items, which can be either simple MemoryObjects or more complex MemoryObjects with metadata.')
 
 class TestOutputClass(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    prop1: typing.Optional[str] = None
+    prop1: typing.Optional[str] = Field(default=None, description='A long string with about 200 words')
     prop2: typing.Optional[int] = None
 
 class TodoMessageToUser(BaseModel):
     class Config:
         arbitrary_types_allowed = True
     type: typing_extensions.Literal['todo_message_to_user']
-    message: typing.Optional[str] = None
+    message: typing.Optional[str] = Field(default=None, description='A message to the user, about 50 words long')
 
 class Tree(BaseModel):
     class Config:
@@ -726,7 +727,7 @@ class WithReasoning(BaseModel):
     class Config:
         arbitrary_types_allowed = True
     value: typing.Optional[str] = None
-    reasoning: typing.Optional[str] = None
+    reasoning: typing.Optional[str] = Field(default=None, description='Why the value is a good fit.')
 
 # #########################################################################
 # Generated type aliases (21)

--- a/integ-tests/python-v1/baml_client/stream_types.py
+++ b/integ-tests/python-v1/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, Extra, Field
 from pydantic.generics import GenericModel
 
 import baml_py

--- a/integ-tests/python-v1/baml_client/types.py
+++ b/integ-tests/python-v1/baml_client/types.py
@@ -60,15 +60,10 @@ class Category2(str, Enum):
     Question = "Question"
 
 class Category3(str, Enum):
-    # Customer wants to refund a product
     Refund = "Refund"
-    # Customer wants to cancel an order
     CancelOrder = "CancelOrder"
-    # Customer needs help with a technical issue unrelated to account creation or login
     TechnicalSupport = "TechnicalSupport"
-    # Specifically relates to account-login or account-creation
     AccountIssue = "AccountIssue"
-    # Customer has a question
     Question = "Question"
 
 class Color(str, Enum):
@@ -104,9 +99,7 @@ class EnumOutput(str, Enum):
     # The first enum.
     ONE = "ONE"
     # The second enum.
-    # two
     TWO = "TWO"
-    # three
     THREE = "THREE"
 
 class Hobby(str, Enum):
@@ -152,19 +145,12 @@ class Tag(str, Enum):
     Blockchain = "Blockchain"
 
 class TestEnum(str, Enum):
-    # User is angry
     A = "A"
-    # User is happy
     B = "B"
-    # User is sad
     C = "C"
-    # User is confused
     D = "D"
-    # User is excited
     E = "E"
     F = "F"
-    # User is bored
-With a long description
     G = "G"
 
 # #########################################################################
@@ -662,7 +648,7 @@ class Person(BaseModel):
 class PersonWithMeta(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    name: str = Field(description="Person's full legal name")
+    name: str = Field(description='Person\'s full legal name')
     age: int = Field(description='Age in years')
     address: "AddressWithMeta" = Field(description='Home address')
     tags: typing.List[str] = Field(description='User tags')
@@ -791,8 +777,7 @@ class StringToClassEntry(BaseModel):
 class TestClassAlias(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    key: str = Field(description="""This is a description for key
-    af asdf""")
+    key: str = Field(description='This is a description for key\naf asdf')
     key2: str
     key3: str
     key4: str

--- a/integ-tests/python-v1/baml_client/types.py
+++ b/integ-tests/python-v1/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, Extra
+from pydantic import BaseModel, Extra, Field
 from pydantic.generics import GenericModel
 
 

--- a/integ-tests/python-v1/baml_client/types.py
+++ b/integ-tests/python-v1/baml_client/types.py
@@ -60,10 +60,15 @@ class Category2(str, Enum):
     Question = "Question"
 
 class Category3(str, Enum):
+    # Customer wants to refund a product
     Refund = "Refund"
+    # Customer wants to cancel an order
     CancelOrder = "CancelOrder"
+    # Customer needs help with a technical issue unrelated to account creation or login
     TechnicalSupport = "TechnicalSupport"
+    # Specifically relates to account-login or account-creation
     AccountIssue = "AccountIssue"
+    # Customer has a question
     Question = "Question"
 
 class Color(str, Enum):
@@ -99,7 +104,9 @@ class EnumOutput(str, Enum):
     # The first enum.
     ONE = "ONE"
     # The second enum.
+    # two
     TWO = "TWO"
+    # three
     THREE = "THREE"
 
 class Hobby(str, Enum):
@@ -145,12 +152,19 @@ class Tag(str, Enum):
     Blockchain = "Blockchain"
 
 class TestEnum(str, Enum):
+    # User is angry
     A = "A"
+    # User is happy
     B = "B"
+    # User is sad
     C = "C"
+    # User is confused
     D = "D"
+    # User is excited
     E = "E"
     F = "F"
+    # User is bored
+With a long description
     G = "G"
 
 # #########################################################################
@@ -163,14 +177,14 @@ class AddTodoItem(BaseModel):
     type: typing_extensions.Literal['add_todo_item']
     item: str
     time: str
-    description: str
+    description: str = Field(description='20 word description of the item')
 
 class AddressWithMeta(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    street: str
-    city: str
-    zipcode: str
+    street: str = Field(description='The street name')
+    city: str = Field(description='The city')
+    zipcode: str = Field(description='5-digit zip code')
 
 class AnotherObject(BaseModel):
     class Config:
@@ -212,10 +226,10 @@ class BlockConstraintForParam(BaseModel):
 class BookOrder(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    orderId: str
-    title: str
-    quantity: int
-    price: float
+    orderId: str = Field(description='The ID of the book order')
+    title: str = Field(description='The title of the ordered book')
+    quantity: int = Field(description='The quantity of books ordered')
+    price: float = Field(description='The price of the book')
 
 class ClassForNullLiteral(BaseModel):
     class Config:
@@ -257,7 +271,7 @@ class ClassWithoutDone(BaseModel):
     class Config:
         arbitrary_types_allowed = True
     i_16_digits: int
-    s_20_words: str
+    s_20_words: str = Field(description='A string with 20 words in it')
 
 class ClientDetails1559(BaseModel):
     class Config:
@@ -276,7 +290,7 @@ class ComplexMemoryObject(BaseModel):
     id: str
     name: str
     description: str
-    metadata: typing.List[typing.Union[str, int, float]]
+    metadata: typing.List[typing.Union[str, int, float]] = Field(description='Additional metadata about the memory object, which can be a mix of types.')
 
 class CompoundBigNumbers(BaseModel):
     class Config:
@@ -404,11 +418,11 @@ class FakeImage(BaseModel):
 class FlightConfirmation(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    confirmationNumber: str
-    flightNumber: str
-    departureTime: str
-    arrivalTime: str
-    seatNumber: str
+    confirmationNumber: str = Field(description='The flight confirmation number')
+    flightNumber: str = Field(description='The flight number')
+    departureTime: str = Field(description='The scheduled departure time of the flight')
+    arrivalTime: str = Field(description='The scheduled arrival time of the flight')
+    seatNumber: str = Field(description='The seat number assigned on the flight')
 
 class FooAny(BaseModel):
     class Config:
@@ -449,10 +463,10 @@ class FormatterTest3(BaseModel):
 class GroceryReceipt(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    receiptId: str
-    storeName: str
-    items: typing.List[typing.Union[str, int, float]]
-    totalAmount: float
+    receiptId: str = Field(description='The ID of the grocery receipt')
+    storeName: str = Field(description='The name of the grocery store')
+    items: typing.List[typing.Union[str, int, float]] = Field(description='A list of items purchased. Each item consists of a name, quantity, and price.')
+    totalAmount: float = Field(description='The total amount spent on groceries')
 
 class Haiku(BaseModel):
     class Config:
@@ -550,7 +564,7 @@ class MemoryObject(BaseModel):
 class MergeAttrs(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    amount: Checked[int, typing_extensions.Literal['gt_ten']]
+    amount: Checked[int, typing_extensions.Literal['gt_ten']] = Field(description='In USD')
 
 class NamedArgsSingleClass(BaseModel):
     class Config:
@@ -562,15 +576,15 @@ class NamedArgsSingleClass(BaseModel):
 class Nested(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    prop3: typing.Optional[str] = None
-    prop4: typing.Optional[str] = None
+    prop3: typing.Optional[str] = Field(default=None, description='write "three"')
+    prop4: typing.Optional[str] = Field(default=None, description='write "four"')
     prop20: "Nested2"
 
 class Nested2(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    prop11: typing.Optional[str] = None
-    prop12: typing.Optional[str] = None
+    prop11: typing.Optional[str] = Field(default=None, description='write "three"')
+    prop12: typing.Optional[str] = Field(default=None, description='write "four"')
 
 class NestedBlockConstraint(BaseModel):
     class Config:
@@ -599,7 +613,7 @@ class Note1599(BaseModel):
         arbitrary_types_allowed = True
     note_title: str
     note_description: typing.Optional[str] = None
-    note_amount: typing.Optional[str] = None
+    note_amount: typing.Optional[str] = Field(default=None, description='If there is a quantity, specify it here')
 
 class OptionalListAndMap(BaseModel):
     class Config:
@@ -648,10 +662,10 @@ class Person(BaseModel):
 class PersonWithMeta(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    name: str
-    age: int
-    address: "AddressWithMeta"
-    tags: typing.List[str]
+    name: str = Field(description="Person's full legal name")
+    age: int = Field(description='Age in years')
+    address: "AddressWithMeta" = Field(description='Home address')
+    tags: typing.List[str] = Field(description='User tags')
 
 class PhoneNumber(BaseModel):
     class Config:
@@ -722,22 +736,22 @@ class Resume(BaseModel):
 class Schema(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    prop1: typing.Optional[str] = None
-    prop2: typing.Union["Nested", str]
-    prop5: typing.List[typing.Optional[str]]
-    prop6: typing.Union[str, typing.List["Nested"]]
-    nested_attrs: typing.List[typing.Optional[typing.Union[str, "Nested"]]]
-    parens: typing.Optional[str] = None
-    other_group: typing.Union[str, int]
+    prop1: typing.Optional[str] = Field(default=None, description='write "one"')
+    prop2: typing.Union["Nested", str] = Field(description='write "two"')
+    prop5: typing.List[typing.Optional[str]] = Field(description='write "hi"')
+    prop6: typing.Union[str, typing.List["Nested"]] = Field(description='write the string "blah" regardless of the other types here')
+    nested_attrs: typing.List[typing.Optional[typing.Union[str, "Nested"]]] = Field(description='write the string "nested" regardless of other types')
+    parens: typing.Optional[str] = Field(default=None, description='write "parens1"')
+    other_group: typing.Union[str, int] = Field(description='write "other"')
 
 class SearchParams(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    dateRange: typing.Optional[int] = None
+    dateRange: typing.Optional[int] = Field(default=None, description='In ISO duration format, e.g. P1Y2M10D.')
     location: typing.List[str]
-    jobTitle: typing.Optional["WithReasoning"] = None
-    company: typing.Optional["WithReasoning"] = None
-    description: typing.List["WithReasoning"]
+    jobTitle: typing.Optional["WithReasoning"] = Field(default=None, description='An exact job title, not a general category.')
+    company: typing.Optional["WithReasoning"] = Field(default=None, description='The exact name of the company, not a product or service.')
+    description: typing.List["WithReasoning"] = Field(description='Any specific projects or features the user is looking for.')
     tags: typing.List[typing.Union[Tag, str]]
 
 class SemanticContainer(BaseModel):
@@ -749,7 +763,7 @@ class SemanticContainer(BaseModel):
     class_2: "ClassWithBlockDone"
     class_done_needed: "ClassWithBlockDone"
     class_needed: "ClassWithoutDone"
-    three_small_things: typing.List["SmallThing"]
+    three_small_things: typing.List["SmallThing"] = Field(description='Should have three items.')
     final_string: str
 
 class SimpleTag(BaseModel):
@@ -777,7 +791,8 @@ class StringToClassEntry(BaseModel):
 class TestClassAlias(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    key: str
+    key: str = Field(description="""This is a description for key
+    af asdf""")
     key2: str
     key3: str
     key4: str
@@ -798,20 +813,20 @@ class TestClassWithEnum(BaseModel):
 class TestMemoryOutput(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
-    more_items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
+    items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]] = Field(description='Add 10 items, which can be either simple MemoryObjects or more complex MemoryObjects with metadata.')
+    more_items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]] = Field(description='Add 3 more items, which can be either simple MemoryObjects or more complex MemoryObjects with metadata.')
 
 class TestOutputClass(BaseModel):
     class Config:
         arbitrary_types_allowed = True
-    prop1: str
+    prop1: str = Field(description='A long string with about 200 words')
     prop2: int
 
 class TodoMessageToUser(BaseModel):
     class Config:
         arbitrary_types_allowed = True
     type: typing_extensions.Literal['todo_message_to_user']
-    message: str
+    message: str = Field(description='A message to the user, about 50 words long')
 
 class Tree(BaseModel):
     class Config:
@@ -856,7 +871,7 @@ class WithReasoning(BaseModel):
     class Config:
         arbitrary_types_allowed = True
     value: str
-    reasoning: str
+    reasoning: str = Field(description='Why the value is a good fit.')
 
 # #########################################################################
 # Generated type aliases (21)

--- a/integ-tests/python/baml_client/stream_types.py
+++ b/integ-tests/python/baml_client/stream_types.py
@@ -12,7 +12,7 @@
 
 import typing
 import typing_extensions
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 import baml_py
 

--- a/integ-tests/python/baml_client/stream_types.py
+++ b/integ-tests/python/baml_client/stream_types.py
@@ -363,7 +363,7 @@ class Person(BaseModel):
     hair_color: typing.Optional[typing.Union[types.Color, str]] = None
 
 class PersonWithMeta(BaseModel):
-    name: typing.Optional[str] = Field(default=None, description="Person's full legal name")
+    name: typing.Optional[str] = Field(default=None, description='Person\'s full legal name')
     age: typing.Optional[int] = Field(default=None, description='Age in years')
     address: typing.Optional["AddressWithMeta"] = Field(default=None, description='Home address')
     tags: typing.List[str] = Field(description='User tags')
@@ -456,8 +456,7 @@ class StringToClassEntry(BaseModel):
     word: typing.Optional[str] = None
 
 class TestClassAlias(BaseModel):
-    key: typing.Optional[str] = Field(default=None, description="""This is a description for key
-    af asdf""")
+    key: typing.Optional[str] = Field(default=None, description='This is a description for key\naf asdf')
     key2: typing.Optional[str] = None
     key3: typing.Optional[str] = None
     key4: typing.Optional[str] = None

--- a/integ-tests/python/baml_client/stream_types.py
+++ b/integ-tests/python/baml_client/stream_types.py
@@ -30,12 +30,12 @@ class AddTodoItem(BaseModel):
     type: typing_extensions.Literal['add_todo_item']
     item: str
     time: str
-    description: str
+    description: str = Field(description='20 word description of the item')
 
 class AddressWithMeta(BaseModel):
-    street: typing.Optional[str] = None
-    city: typing.Optional[str] = None
-    zipcode: typing.Optional[str] = None
+    street: typing.Optional[str] = Field(default=None, description='The street name')
+    city: typing.Optional[str] = Field(default=None, description='The city')
+    zipcode: typing.Optional[str] = Field(default=None, description='5-digit zip code')
 
 class AnotherObject(BaseModel):
     id: typing.Optional[str] = None
@@ -63,10 +63,10 @@ class BlockConstraintForParam(BaseModel):
     bcfp2: typing.Optional[str] = None
 
 class BookOrder(BaseModel):
-    orderId: typing.Optional[str] = None
-    title: typing.Optional[str] = None
-    quantity: typing.Optional[int] = None
-    price: typing.Optional[float] = None
+    orderId: typing.Optional[str] = Field(default=None, description='The ID of the book order')
+    title: typing.Optional[str] = Field(default=None, description='The title of the ordered book')
+    quantity: typing.Optional[int] = Field(default=None, description='The quantity of books ordered')
+    price: typing.Optional[float] = Field(default=None, description='The price of the book')
 
 class ClassForNullLiteral(BaseModel):
     a: typing.Optional[typing_extensions.Literal['hi']] = None
@@ -94,7 +94,7 @@ class ClassWithImage(BaseModel):
 
 class ClassWithoutDone(BaseModel):
     i_16_digits: typing.Optional[int] = None
-    s_20_words: StreamState[typing.Optional[str]]
+    s_20_words: StreamState[typing.Optional[str]] = Field(description='A string with 20 words in it')
 
 class ClientDetails1559(BaseModel):
     client_name: typing.Optional[str] = None
@@ -109,7 +109,7 @@ class ComplexMemoryObject(BaseModel):
     id: typing.Optional[str] = None
     name: typing.Optional[str] = None
     description: typing.Optional[str] = None
-    metadata: typing.List[typing.Union[str, int, float]]
+    metadata: typing.List[typing.Union[str, int, float]] = Field(description='Additional metadata about the memory object, which can be a mix of types.')
 
 class CompoundBigNumbers(BaseModel):
     big: typing.Optional["BigNumbers"] = None
@@ -197,11 +197,11 @@ class FakeImage(BaseModel):
     url: typing.Optional[str] = None
 
 class FlightConfirmation(BaseModel):
-    confirmationNumber: typing.Optional[str] = None
-    flightNumber: typing.Optional[str] = None
-    departureTime: typing.Optional[str] = None
-    arrivalTime: typing.Optional[str] = None
-    seatNumber: typing.Optional[str] = None
+    confirmationNumber: typing.Optional[str] = Field(default=None, description='The flight confirmation number')
+    flightNumber: typing.Optional[str] = Field(default=None, description='The flight number')
+    departureTime: typing.Optional[str] = Field(default=None, description='The scheduled departure time of the flight')
+    arrivalTime: typing.Optional[str] = Field(default=None, description='The scheduled arrival time of the flight')
+    seatNumber: typing.Optional[str] = Field(default=None, description='The seat number assigned on the flight')
 
 class FooAny(BaseModel):
     planetary_age: typing.Optional[typing.Union["Martian", "Earthling"]] = None
@@ -228,10 +228,10 @@ class FormatterTest3(BaseModel):
     ipsum: typing.Optional[str] = None
 
 class GroceryReceipt(BaseModel):
-    receiptId: typing.Optional[str] = None
-    storeName: typing.Optional[str] = None
-    items: typing.List[typing.Union[str, int, float]]
-    totalAmount: typing.Optional[float] = None
+    receiptId: typing.Optional[str] = Field(default=None, description='The ID of the grocery receipt')
+    storeName: typing.Optional[str] = Field(default=None, description='The name of the grocery store')
+    items: typing.List[typing.Union[str, int, float]] = Field(description='A list of items purchased. Each item consists of a name, quantity, and price.')
+    totalAmount: typing.Optional[float] = Field(default=None, description='The total amount spent on groceries')
 
 class Haiku(BaseModel):
     line1: typing.Optional[str] = None
@@ -297,7 +297,7 @@ class MemoryObject(BaseModel):
     description: typing.Optional[str] = None
 
 class MergeAttrs(BaseModel):
-    amount: typing.Optional[types.Checked[int, typing_extensions.Literal['gt_ten']]] = None
+    amount: typing.Optional[types.Checked[int, typing_extensions.Literal['gt_ten']]] = Field(default=None, description='In USD')
 
 class NamedArgsSingleClass(BaseModel):
     key: typing.Optional[str] = None
@@ -305,13 +305,13 @@ class NamedArgsSingleClass(BaseModel):
     key_three: typing.Optional[int] = None
 
 class Nested(BaseModel):
-    prop3: typing.Optional[str] = None
-    prop4: typing.Optional[str] = None
+    prop3: typing.Optional[str] = Field(default=None, description='write "three"')
+    prop4: typing.Optional[str] = Field(default=None, description='write "four"')
     prop20: typing.Optional["Nested2"] = None
 
 class Nested2(BaseModel):
-    prop11: typing.Optional[str] = None
-    prop12: typing.Optional[str] = None
+    prop11: typing.Optional[str] = Field(default=None, description='write "three"')
+    prop12: typing.Optional[str] = Field(default=None, description='write "four"')
 
 class NestedBlockConstraint(BaseModel):
     nbc: typing.Optional[types.Checked["BlockConstraint", typing_extensions.Literal['cross_field', 'cross_field']]] = None
@@ -330,7 +330,7 @@ class NodeWithAliasIndirection(BaseModel):
 class Note1599(BaseModel):
     note_title: typing.Optional[str] = None
     note_description: typing.Optional[str] = None
-    note_amount: typing.Optional[str] = None
+    note_amount: typing.Optional[str] = Field(default=None, description='If there is a quantity, specify it here')
 
 class OptionalListAndMap(BaseModel):
     p: typing.Optional[typing.List[str]] = None
@@ -363,10 +363,10 @@ class Person(BaseModel):
     hair_color: typing.Optional[typing.Union[types.Color, str]] = None
 
 class PersonWithMeta(BaseModel):
-    name: typing.Optional[str] = None
-    age: typing.Optional[int] = None
-    address: typing.Optional["AddressWithMeta"] = None
-    tags: typing.List[str]
+    name: typing.Optional[str] = Field(default=None, description="Person's full legal name")
+    age: typing.Optional[int] = Field(default=None, description='Age in years')
+    address: typing.Optional["AddressWithMeta"] = Field(default=None, description='Home address')
+    tags: typing.List[str] = Field(description='User tags')
 
 class PhoneNumber(BaseModel):
     value: typing.Optional[str] = None
@@ -415,20 +415,20 @@ class Resume(BaseModel):
     skills: typing.List[str]
 
 class Schema(BaseModel):
-    prop1: typing.Optional[str] = None
-    prop2: typing.Optional[typing.Union["Nested", str]] = None
-    prop5: typing.List[typing.Optional[str]]
-    prop6: typing.Optional[typing.Union[str, typing.List["Nested"]]] = None
-    nested_attrs: typing.List[typing.Optional[typing.Union[str, "Nested"]]]
-    parens: typing.Optional[str] = None
-    other_group: typing.Optional[typing.Union[str, int]] = None
+    prop1: typing.Optional[str] = Field(default=None, description='write "one"')
+    prop2: typing.Optional[typing.Union["Nested", str]] = Field(default=None, description='write "two"')
+    prop5: typing.List[typing.Optional[str]] = Field(description='write "hi"')
+    prop6: typing.Optional[typing.Union[str, typing.List["Nested"]]] = Field(default=None, description='write the string "blah" regardless of the other types here')
+    nested_attrs: typing.List[typing.Optional[typing.Union[str, "Nested"]]] = Field(description='write the string "nested" regardless of other types')
+    parens: typing.Optional[str] = Field(default=None, description='write "parens1"')
+    other_group: typing.Optional[typing.Union[str, int]] = Field(default=None, description='write "other"')
 
 class SearchParams(BaseModel):
-    dateRange: typing.Optional[int] = None
+    dateRange: typing.Optional[int] = Field(default=None, description='In ISO duration format, e.g. P1Y2M10D.')
     location: typing.List[str]
-    jobTitle: typing.Optional["WithReasoning"] = None
-    company: typing.Optional["WithReasoning"] = None
-    description: typing.List["WithReasoning"]
+    jobTitle: typing.Optional["WithReasoning"] = Field(default=None, description='An exact job title, not a general category.')
+    company: typing.Optional["WithReasoning"] = Field(default=None, description='The exact name of the company, not a product or service.')
+    description: typing.List["WithReasoning"] = Field(description='Any specific projects or features the user is looking for.')
     tags: typing.List[typing.Union[types.Tag, str]]
 
 class SemanticContainer(BaseModel):
@@ -438,7 +438,7 @@ class SemanticContainer(BaseModel):
     class_2: typing.Optional["types.ClassWithBlockDone"] = None
     class_done_needed: "types.ClassWithBlockDone"
     class_needed: "ClassWithoutDone"
-    three_small_things: typing.List["SmallThing"]
+    three_small_things: typing.List["SmallThing"] = Field(description='Should have three items.')
     final_string: typing.Optional[str] = None
 
 class SimpleTag(BaseModel):
@@ -456,7 +456,8 @@ class StringToClassEntry(BaseModel):
     word: typing.Optional[str] = None
 
 class TestClassAlias(BaseModel):
-    key: typing.Optional[str] = None
+    key: typing.Optional[str] = Field(default=None, description="""This is a description for key
+    af asdf""")
     key2: typing.Optional[str] = None
     key3: typing.Optional[str] = None
     key4: typing.Optional[str] = None
@@ -471,16 +472,16 @@ class TestClassWithEnum(BaseModel):
     prop2: typing.Optional[types.EnumInClass] = None
 
 class TestMemoryOutput(BaseModel):
-    items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
-    more_items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
+    items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]] = Field(description='Add 10 items, which can be either simple MemoryObjects or more complex MemoryObjects with metadata.')
+    more_items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]] = Field(description='Add 3 more items, which can be either simple MemoryObjects or more complex MemoryObjects with metadata.')
 
 class TestOutputClass(BaseModel):
-    prop1: typing.Optional[str] = None
+    prop1: typing.Optional[str] = Field(default=None, description='A long string with about 200 words')
     prop2: typing.Optional[int] = None
 
 class TodoMessageToUser(BaseModel):
     type: typing_extensions.Literal['todo_message_to_user']
-    message: typing.Optional[str] = None
+    message: typing.Optional[str] = Field(default=None, description='A message to the user, about 50 words long')
 
 class Tree(BaseModel):
     data: typing.Optional[int] = None
@@ -511,7 +512,7 @@ class UniverseQuestionInput(BaseModel):
 
 class WithReasoning(BaseModel):
     value: typing.Optional[str] = None
-    reasoning: typing.Optional[str] = None
+    reasoning: typing.Optional[str] = Field(default=None, description='Why the value is a good fit.')
 
 # #########################################################################
 # Generated type aliases (21)

--- a/integ-tests/python/baml_client/types.py
+++ b/integ-tests/python/baml_client/types.py
@@ -15,7 +15,7 @@ import typing_extensions
 from enum import Enum
 
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 import baml_py

--- a/integ-tests/python/baml_client/types.py
+++ b/integ-tests/python/baml_client/types.py
@@ -59,10 +59,15 @@ class Category2(str, Enum):
     Question = "Question"
 
 class Category3(str, Enum):
+    # Customer wants to refund a product
     Refund = "Refund"
+    # Customer wants to cancel an order
     CancelOrder = "CancelOrder"
+    # Customer needs help with a technical issue unrelated to account creation or login
     TechnicalSupport = "TechnicalSupport"
+    # Specifically relates to account-login or account-creation
     AccountIssue = "AccountIssue"
+    # Customer has a question
     Question = "Question"
 
 class Color(str, Enum):
@@ -98,7 +103,9 @@ class EnumOutput(str, Enum):
     # The first enum.
     ONE = "ONE"
     # The second enum.
+    # two
     TWO = "TWO"
+    # three
     THREE = "THREE"
 
 class Hobby(str, Enum):
@@ -144,12 +151,19 @@ class Tag(str, Enum):
     Blockchain = "Blockchain"
 
 class TestEnum(str, Enum):
+    # User is angry
     A = "A"
+    # User is happy
     B = "B"
+    # User is sad
     C = "C"
+    # User is confused
     D = "D"
+    # User is excited
     E = "E"
     F = "F"
+    # User is bored
+With a long description
     G = "G"
 
 # #########################################################################
@@ -160,12 +174,12 @@ class AddTodoItem(BaseModel):
     type: typing_extensions.Literal['add_todo_item']
     item: str
     time: str
-    description: str
+    description: str = Field(description='20 word description of the item')
 
 class AddressWithMeta(BaseModel):
-    street: str
-    city: str
-    zipcode: str
+    street: str = Field(description='The street name')
+    city: str = Field(description='The city')
+    zipcode: str = Field(description='5-digit zip code')
 
 class AnotherObject(BaseModel):
     id: str
@@ -193,10 +207,10 @@ class BlockConstraintForParam(BaseModel):
     bcfp2: str
 
 class BookOrder(BaseModel):
-    orderId: str
-    title: str
-    quantity: int
-    price: float
+    orderId: str = Field(description='The ID of the book order')
+    title: str = Field(description='The title of the ordered book')
+    quantity: int = Field(description='The quantity of books ordered')
+    price: float = Field(description='The price of the book')
 
 class ClassForNullLiteral(BaseModel):
     a: typing_extensions.Literal['hi']
@@ -224,7 +238,7 @@ class ClassWithImage(BaseModel):
 
 class ClassWithoutDone(BaseModel):
     i_16_digits: int
-    s_20_words: str
+    s_20_words: str = Field(description='A string with 20 words in it')
 
 class ClientDetails1559(BaseModel):
     client_name: typing.Optional[str] = None
@@ -239,7 +253,7 @@ class ComplexMemoryObject(BaseModel):
     id: str
     name: str
     description: str
-    metadata: typing.List[typing.Union[str, int, float]]
+    metadata: typing.List[typing.Union[str, int, float]] = Field(description='Additional metadata about the memory object, which can be a mix of types.')
 
 class CompoundBigNumbers(BaseModel):
     big: "BigNumbers"
@@ -327,11 +341,11 @@ class FakeImage(BaseModel):
     url: str
 
 class FlightConfirmation(BaseModel):
-    confirmationNumber: str
-    flightNumber: str
-    departureTime: str
-    arrivalTime: str
-    seatNumber: str
+    confirmationNumber: str = Field(description='The flight confirmation number')
+    flightNumber: str = Field(description='The flight number')
+    departureTime: str = Field(description='The scheduled departure time of the flight')
+    arrivalTime: str = Field(description='The scheduled arrival time of the flight')
+    seatNumber: str = Field(description='The seat number assigned on the flight')
 
 class FooAny(BaseModel):
     planetary_age: typing.Union["Martian", "Earthling"]
@@ -358,10 +372,10 @@ class FormatterTest3(BaseModel):
     ipsum: str
 
 class GroceryReceipt(BaseModel):
-    receiptId: str
-    storeName: str
-    items: typing.List[typing.Union[str, int, float]]
-    totalAmount: float
+    receiptId: str = Field(description='The ID of the grocery receipt')
+    storeName: str = Field(description='The name of the grocery store')
+    items: typing.List[typing.Union[str, int, float]] = Field(description='A list of items purchased. Each item consists of a name, quantity, and price.')
+    totalAmount: float = Field(description='The total amount spent on groceries')
 
 class Haiku(BaseModel):
     line1: str
@@ -427,7 +441,7 @@ class MemoryObject(BaseModel):
     description: str
 
 class MergeAttrs(BaseModel):
-    amount: Checked[int, typing_extensions.Literal['gt_ten']]
+    amount: Checked[int, typing_extensions.Literal['gt_ten']] = Field(description='In USD')
 
 class NamedArgsSingleClass(BaseModel):
     key: str
@@ -435,13 +449,13 @@ class NamedArgsSingleClass(BaseModel):
     key_three: int
 
 class Nested(BaseModel):
-    prop3: typing.Optional[str] = None
-    prop4: typing.Optional[str] = None
+    prop3: typing.Optional[str] = Field(default=None, description='write "three"')
+    prop4: typing.Optional[str] = Field(default=None, description='write "four"')
     prop20: "Nested2"
 
 class Nested2(BaseModel):
-    prop11: typing.Optional[str] = None
-    prop12: typing.Optional[str] = None
+    prop11: typing.Optional[str] = Field(default=None, description='write "three"')
+    prop12: typing.Optional[str] = Field(default=None, description='write "four"')
 
 class NestedBlockConstraint(BaseModel):
     nbc: Checked["BlockConstraint", typing_extensions.Literal['cross_field', 'cross_field']]
@@ -460,7 +474,7 @@ class NodeWithAliasIndirection(BaseModel):
 class Note1599(BaseModel):
     note_title: str
     note_description: typing.Optional[str] = None
-    note_amount: typing.Optional[str] = None
+    note_amount: typing.Optional[str] = Field(default=None, description='If there is a quantity, specify it here')
 
 class OptionalListAndMap(BaseModel):
     p: typing.Optional[typing.List[str]] = None
@@ -493,10 +507,10 @@ class Person(BaseModel):
     hair_color: typing.Optional[typing.Union[Color, str]] = None
 
 class PersonWithMeta(BaseModel):
-    name: str
-    age: int
-    address: "AddressWithMeta"
-    tags: typing.List[str]
+    name: str = Field(description="Person's full legal name")
+    age: int = Field(description='Age in years')
+    address: "AddressWithMeta" = Field(description='Home address')
+    tags: typing.List[str] = Field(description='User tags')
 
 class PhoneNumber(BaseModel):
     value: str
@@ -545,20 +559,20 @@ class Resume(BaseModel):
     skills: typing.List[str]
 
 class Schema(BaseModel):
-    prop1: typing.Optional[str] = None
-    prop2: typing.Union["Nested", str]
-    prop5: typing.List[typing.Optional[str]]
-    prop6: typing.Union[str, typing.List["Nested"]]
-    nested_attrs: typing.List[typing.Optional[typing.Union[str, "Nested"]]]
-    parens: typing.Optional[str] = None
-    other_group: typing.Union[str, int]
+    prop1: typing.Optional[str] = Field(default=None, description='write "one"')
+    prop2: typing.Union["Nested", str] = Field(description='write "two"')
+    prop5: typing.List[typing.Optional[str]] = Field(description='write "hi"')
+    prop6: typing.Union[str, typing.List["Nested"]] = Field(description='write the string "blah" regardless of the other types here')
+    nested_attrs: typing.List[typing.Optional[typing.Union[str, "Nested"]]] = Field(description='write the string "nested" regardless of other types')
+    parens: typing.Optional[str] = Field(default=None, description='write "parens1"')
+    other_group: typing.Union[str, int] = Field(description='write "other"')
 
 class SearchParams(BaseModel):
-    dateRange: typing.Optional[int] = None
+    dateRange: typing.Optional[int] = Field(default=None, description='In ISO duration format, e.g. P1Y2M10D.')
     location: typing.List[str]
-    jobTitle: typing.Optional["WithReasoning"] = None
-    company: typing.Optional["WithReasoning"] = None
-    description: typing.List["WithReasoning"]
+    jobTitle: typing.Optional["WithReasoning"] = Field(default=None, description='An exact job title, not a general category.')
+    company: typing.Optional["WithReasoning"] = Field(default=None, description='The exact name of the company, not a product or service.')
+    description: typing.List["WithReasoning"] = Field(description='Any specific projects or features the user is looking for.')
     tags: typing.List[typing.Union[Tag, str]]
 
 class SemanticContainer(BaseModel):
@@ -568,7 +582,7 @@ class SemanticContainer(BaseModel):
     class_2: "ClassWithBlockDone"
     class_done_needed: "ClassWithBlockDone"
     class_needed: "ClassWithoutDone"
-    three_small_things: typing.List["SmallThing"]
+    three_small_things: typing.List["SmallThing"] = Field(description='Should have three items.')
     final_string: str
 
 class SimpleTag(BaseModel):
@@ -586,7 +600,8 @@ class StringToClassEntry(BaseModel):
     word: str
 
 class TestClassAlias(BaseModel):
-    key: str
+    key: str = Field(description="""This is a description for key
+    af asdf""")
     key2: str
     key3: str
     key4: str
@@ -601,16 +616,16 @@ class TestClassWithEnum(BaseModel):
     prop2: EnumInClass
 
 class TestMemoryOutput(BaseModel):
-    items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
-    more_items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]]
+    items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]] = Field(description='Add 10 items, which can be either simple MemoryObjects or more complex MemoryObjects with metadata.')
+    more_items: typing.List[typing.Union["MemoryObject", "ComplexMemoryObject", "AnotherObject"]] = Field(description='Add 3 more items, which can be either simple MemoryObjects or more complex MemoryObjects with metadata.')
 
 class TestOutputClass(BaseModel):
-    prop1: str
+    prop1: str = Field(description='A long string with about 200 words')
     prop2: int
 
 class TodoMessageToUser(BaseModel):
     type: typing_extensions.Literal['todo_message_to_user']
-    message: str
+    message: str = Field(description='A message to the user, about 50 words long')
 
 class Tree(BaseModel):
     data: int
@@ -641,7 +656,7 @@ class UniverseQuestionInput(BaseModel):
 
 class WithReasoning(BaseModel):
     value: str
-    reasoning: str
+    reasoning: str = Field(description='Why the value is a good fit.')
 
 # #########################################################################
 # Generated type aliases (21)

--- a/integ-tests/python/baml_client/types.py
+++ b/integ-tests/python/baml_client/types.py
@@ -59,15 +59,10 @@ class Category2(str, Enum):
     Question = "Question"
 
 class Category3(str, Enum):
-    # Customer wants to refund a product
     Refund = "Refund"
-    # Customer wants to cancel an order
     CancelOrder = "CancelOrder"
-    # Customer needs help with a technical issue unrelated to account creation or login
     TechnicalSupport = "TechnicalSupport"
-    # Specifically relates to account-login or account-creation
     AccountIssue = "AccountIssue"
-    # Customer has a question
     Question = "Question"
 
 class Color(str, Enum):
@@ -103,9 +98,7 @@ class EnumOutput(str, Enum):
     # The first enum.
     ONE = "ONE"
     # The second enum.
-    # two
     TWO = "TWO"
-    # three
     THREE = "THREE"
 
 class Hobby(str, Enum):
@@ -151,19 +144,12 @@ class Tag(str, Enum):
     Blockchain = "Blockchain"
 
 class TestEnum(str, Enum):
-    # User is angry
     A = "A"
-    # User is happy
     B = "B"
-    # User is sad
     C = "C"
-    # User is confused
     D = "D"
-    # User is excited
     E = "E"
     F = "F"
-    # User is bored
-With a long description
     G = "G"
 
 # #########################################################################
@@ -507,7 +493,7 @@ class Person(BaseModel):
     hair_color: typing.Optional[typing.Union[Color, str]] = None
 
 class PersonWithMeta(BaseModel):
-    name: str = Field(description="Person's full legal name")
+    name: str = Field(description='Person\'s full legal name')
     age: int = Field(description='Age in years')
     address: "AddressWithMeta" = Field(description='Home address')
     tags: typing.List[str] = Field(description='User tags')
@@ -600,8 +586,7 @@ class StringToClassEntry(BaseModel):
     word: str
 
 class TestClassAlias(BaseModel):
-    key: str = Field(description="""This is a description for key
-    af asdf""")
+    key: str = Field(description='This is a description for key\naf asdf')
     key2: str
     key3: str
     key4: str


### PR DESCRIPTION
The original reason we didn't implement this was that when we allow attributes to be derived from expressions, we then lose the ability to codegen expr-derived attributes.

However, there's still significant value in giving users JSON schemas when they're just bare strings, so wire that through.

@description is not implemented on enum fields, because there's no clean way to model those in pydantic.

Fixes #2882