### PR TITLE
fix ts arm64 build

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -42,6 +42,10 @@ inputs:
     description: "GitHub token for API access (e.g., protoc installation)"
     required: false
     default: ${{ github.token }}
+  skip-protoc:
+    description: "Skip protoc installation (useful for cross-compilation targets)"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -113,6 +117,7 @@ runs:
       shell: bash
 
     - name: Install Protoc
+      if: inputs.skip-protoc != 'true'
       uses: arduino/setup-protoc@v3
       with:
         repo-token: ${{ inputs.github-token }}

--- a/.github/workflows/build-typescript-release.reusable.yaml
+++ b/.github/workflows/build-typescript-release.reusable.yaml
@@ -35,6 +35,7 @@ jobs:
               echo "CFLAGS_aarch64_unknown_linux_gnu=-D__ARM_ARCH=8" >> "$GITHUB_ENV"
             node_build: pnpm build:napi-release --target aarch64-unknown-linux-gnu
             cargo_args: -p baml-typescript-ffi -p baml-python-ffi
+            skip_protoc: true
 
           - target: aarch64-apple-darwin
             host: macos-14
@@ -116,6 +117,7 @@ jobs:
           targets: ${{ matrix._.target }}
           prefix-key: v5-rust-${{ matrix._.target }}
           cache-on-failure: true
+          skip-protoc: ${{ matrix._.skip_protoc || 'false' }}
 
       # Setup Zig for targets that need it (e.g. musl cross-compilation)
       - name: Setup Zig

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
       - "*.*"
     branches:
       - tool-update
+      - aaron/fixbuild
 concurrency:
   # No suffix specified - in reusable workflows we need a statically-defined suffix
   # to prevent workflow_call workflows from triggering a concurrency deadlock


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces conditional `protoc` installation and wires it through the TS release workflow.
> 
> - Add `skip-protoc` input to `./.github/actions/setup-rust` and guard `Install Protoc` step with `if: inputs.skip-protoc != 'true'`
> - In `build-typescript-release.reusable.yaml`, set `skip_protoc: true` for `aarch64-unknown-linux-gnu` and pass `skip-protoc` to the Rust setup step
> - In `release.yml`, allow workflow to run on branch `aaron/fixbuild`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaa93039d55a22f3ef45e755043924e4ee008fe7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->