### PR TITLE
fix: make hmr tests pass in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,8 +272,6 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.webview == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/webview-tests.reusable.yaml
-    with:
-      webview_changed: ${{ needs.determine_changes.outputs.webview }}
     secrets: inherit
 
   benchmarks-instrumented:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -272,6 +272,8 @@ jobs:
     needs: determine_changes
     if: needs.determine_changes.outputs.webview == 'true' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/webview-tests.reusable.yaml
+    with:
+      webview_changed: ${{ needs.determine_changes.outputs.webview }}
     secrets: inherit
 
   benchmarks-instrumented:

--- a/.github/workflows/webview-tests.reusable.yaml
+++ b/.github/workflows/webview-tests.reusable.yaml
@@ -1,9 +1,7 @@
 name: Webview Tests (Reusable)
 
 on:
-  workflow_call: {}
-  g s
-  ;qa
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/webview-tests.reusable.yaml
+++ b/.github/workflows/webview-tests.reusable.yaml
@@ -2,6 +2,8 @@ name: Webview Tests (Reusable)
 
 on:
   workflow_call: {}
+  g s
+  ;qa
 
 permissions:
   contents: read
@@ -92,8 +94,6 @@ jobs:
   hmr-tests:
     name: "HMR Tests (Hot Reload)"
     runs-on: ubuntu-latest
-    # Only run on main/canary
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/canary'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/typescript2/app-vscode-webview/src/hot-reload.hmr.test.ts
+++ b/typescript2/app-vscode-webview/src/hot-reload.hmr.test.ts
@@ -76,6 +76,7 @@ async function startDevServer(): Promise<DevServer> {
     cwd: projectRoot,
     stdio: ['pipe', 'pipe', 'pipe'],
     shell: true,
+    env: { ...process.env, NO_COLOR: '1' },
   })
 
   // Collect output and parse port

--- a/typescript2/app-vscode-webview/src/hot-reload.hmr.test.ts
+++ b/typescript2/app-vscode-webview/src/hot-reload.hmr.test.ts
@@ -64,13 +64,14 @@ function waitForOutput(
 
 /**
  * Start the Vite dev server and wait for it to be ready.
- * Uses a random available port.
+ * Uses a random port between 4900 and 4999.
  */
 async function startDevServer(): Promise<DevServer> {
   // Use --force to re-optimize deps and avoid 504 "Outdated Optimize Dep" errors
-  // Use --port 0 to let Vite pick a random available port
-  console.log(`[vite] Starting dev server in ${projectRoot}`)
-  const proc = spawn('pnpm', ['dev', '--force', '--port', '0'], {
+  // Use a random port between 4900 and 4999 to avoid conflicts
+  const randomPort = Math.floor(Math.random() * 100) + 4900
+  console.log(`[vite] Starting dev server in ${projectRoot} on port ${randomPort}`)
+  const proc = spawn('pnpm', ['dev', '--force', '--port', String(randomPort)], {
     cwd: projectRoot,
     stdio: ['pipe', 'pipe', 'pipe'],
     shell: true,

--- a/typescript2/app-vscode-webview/src/hot-reload.hmr.test.ts
+++ b/typescript2/app-vscode-webview/src/hot-reload.hmr.test.ts
@@ -69,9 +69,10 @@ function waitForOutput(
 async function startDevServer(): Promise<DevServer> {
   // Use --force to re-optimize deps and avoid 504 "Outdated Optimize Dep" errors
   // Use a random port between 4900 and 4999 to avoid conflicts
+  // Disable strictPort so Vite will try next available port if chosen port is in use
   const randomPort = Math.floor(Math.random() * 100) + 4900
   console.log(`[vite] Starting dev server in ${projectRoot} on port ${randomPort}`)
-  const proc = spawn('pnpm', ['dev', '--force', '--port', String(randomPort)], {
+  const proc = spawn('pnpm', ['dev', '--force', '--port', String(randomPort), '--strictPort', 'false'], {
     cwd: projectRoot,
     stdio: ['pipe', 'pipe', 'pipe'],
     shell: true,
@@ -94,12 +95,15 @@ async function startDevServer(): Promise<DevServer> {
       }
 
       // Parse port from Vite output: "Local: http://localhost:XXXX/"
-      const match = text.match(/Local:\s*http:\/\/localhost:(\d+)/)
-      if (match) {
-        port = parseInt(match[1], 10)
-        console.log(`[vite] Dev server running on port ${port}`)
-        clearTimeout(timeout)
-        resolve(port)
+      // Match against accumulated output in case the line arrives in multiple chunks
+      if (!port) {
+        const match = output.match(/Local:\s*http:\/\/localhost:(\d+)/)
+        if (match) {
+          port = parseInt(match[1], 10)
+          console.log(`[vite] Dev server running on port ${port}`)
+          clearTimeout(timeout)
+          resolve(port)
+        }
       }
     }
 


### PR DESCRIPTION
Assorted fixes to make them pass in CI:

- opus decided to copy the existing pattern of passing inputs to the tests.reusable.yaml workflow file from ci.yaml, which serves no purpose
- NO_COLOR to prevent ascii color codes from messing up regex extraction of the 'vite dev' port
- make 'vite dev' startup in the HMR test more reliable (manually randomize port, and allow vite to try multiple ports on retry)