### PR TITLE
aaron/fix windows cli build

### DIFF
--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -72,6 +72,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # This sets up protoc-gen-go for non-Windows builds
+      # and on windows this seems to hang forever since 0.217.0
       - name: Setup Tools
         if: matrix._.os != 'windows-2022'
         uses: ./.github/actions/setup-tools

--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -16,6 +16,7 @@ on:
     branches:
       - sam/mise-protoc-gen-go
       - aaron/fix-windows
+      - aaron/fix-windows-cli-build
 env:
   MACOSX_DEPLOYMENT_TARGET: "10.13"
   # Turbo remote caching
@@ -72,6 +73,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Tools
+        if: matrix._.os != 'windows-2022'
         uses: ./.github/actions/setup-tools
 
       - name: Setup Rust


### PR DESCRIPTION
- **fix windows build**
- **fix build**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines CLI release workflow for Windows stability.
> 
> - Skips `Setup Tools` on `windows-2022` to avoid hangs with `protoc-gen-go`
> - Adds `aaron/fix-windows-cli-build` to `push` branch triggers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 700410810566254a8a3b7a386bc22c27c4911f20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->