### PR TITLE
Add map arity validations

### DIFF
--- a/baml_language/TEST_INSTRUCTIONS.md
+++ b/baml_language/TEST_INSTRUCTIONS.md
@@ -71,7 +71,8 @@ UPDATE_EXPECT=1 cargo test --package baml_ide_tests
 ### 7. Verify all tests pass
 
 ```bash
-cargo test --package baml_tests
+# Run all tests (can skip slow parser_stress with --skip parser_stress)
+cargo test --package baml_tests -- --skip parser_stress
 cargo test --package baml_ide_tests
 ```
 
@@ -83,6 +84,9 @@ cargo test --package baml_tests my_project_name
 
 # Run all snapshot tests
 cargo test --package baml_tests
+
+# Run all snapshot tests (skip slow parser_stress tests)
+cargo test --package baml_tests -- --skip parser_stress
 
 # Run LSP tests and auto-update expectations
 UPDATE_EXPECT=1 cargo test --package baml_ide_tests

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -103,6 +103,9 @@ pub enum DiagnosticId {
     // Type literal errors (E0033)
     UnsupportedFloatLiteral,
 
+    // Map type errors (E0039)
+    InvalidMapArity,
+
     // Test diagnostics (E0034-E0036)
     UnknownTestProperty,
     MissingTestProperty,
@@ -173,6 +176,9 @@ impl DiagnosticId {
 
             // Type literal errors
             DiagnosticId::UnsupportedFloatLiteral => "E0033",
+
+            // Map type errors
+            DiagnosticId::InvalidMapArity => "E0039",
 
             // Test diagnostics
             DiagnosticId::UnknownTestProperty => "E0034",

--- a/baml_language/crates/baml_compiler_diagnostics/src/errors/hir_diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/errors/hir_diagnostic.rs
@@ -194,7 +194,7 @@ pub enum HirDiagnostic {
     UnsupportedFloatLiteral { value: String, span: Span },
 
     /// Invalid map type arity (wrong number of type parameters).
-    /// Maps require exactly 2 type parameters: map<KeyType, ValueType>
+    /// Maps require exactly 2 type parameters: `map<KeyType, ValueType>`
     InvalidMapArity {
         expected: usize,
         found: usize,

--- a/baml_language/crates/baml_compiler_diagnostics/src/errors/hir_diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/errors/hir_diagnostic.rs
@@ -193,6 +193,14 @@ pub enum HirDiagnostic {
     /// Float literal used as a type, which is not supported.
     UnsupportedFloatLiteral { value: String, span: Span },
 
+    /// Invalid map type arity (wrong number of type parameters).
+    /// Maps require exactly 2 type parameters: map<KeyType, ValueType>
+    InvalidMapArity {
+        expected: usize,
+        found: usize,
+        span: Span,
+    },
+
     // ============ Test Diagnostics ============
     /// Unknown property in test block.
     UnknownTestProperty {

--- a/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
@@ -580,6 +580,18 @@ impl ToDiagnostic for HirDiagnostic {
                 ),
             )
             .with_primary_span(*span),
+
+            HirDiagnostic::InvalidMapArity {
+                expected,
+                found,
+                span,
+            } => Diagnostic::error(
+                DiagnosticId::InvalidMapArity,
+                format!(
+                    "map<K, V> requires exactly {expected} type parameters, found {found}"
+                ),
+            )
+            .with_primary_span(*span),
         };
         diag.with_phase(DiagnosticPhase::Hir)
     }

--- a/baml_language/crates/baml_compiler_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_hir/src/lib.rs
@@ -827,6 +827,11 @@ pub(crate) fn lower_class(node: &SyntaxNode, ctx: &mut LoweringContext) -> Optio
                 }
             }
 
+            // Validate map type arity before converting to TypeRef
+            if let Some(type_expr) = field_node.ty() {
+                validate_map_type_arity(&type_expr, ctx);
+            }
+
             let type_ref = field_node
                 .ty()
                 .map(|t| TypeRef::from_ast(&t))
@@ -1508,6 +1513,95 @@ fn describe_block_attribute_args(attr: &baml_compiler_syntax::ast::BlockAttribut
         }
         n => format!("{n} arguments"),
     }
+}
+
+/// Count the number of top-level generic parameters in a map type.
+///
+/// For `string, int` returns 2 (correct for map).
+/// For `string, string, string` returns 3 (error: too many params).
+/// For `string` returns 1 (error: too few params).
+fn count_generic_params(s: &str) -> usize {
+    if s.trim().is_empty() {
+        return 0;
+    }
+    let mut depth = 0;
+    let mut count = 1; // Start at 1 because we count separators + 1
+    for c in s.chars() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth -= 1,
+            ',' if depth == 0 => count += 1,
+            _ => {}
+        }
+    }
+    count
+}
+
+/// Validate map type arity in a type expression.
+///
+/// Maps require exactly 2 type parameters: `map<K, V>`.
+/// This function checks for cases like `map<string, string, string>` (3 params).
+fn validate_map_type_arity(
+    type_expr: &baml_compiler_syntax::ast::TypeExpr,
+    ctx: &mut LoweringContext,
+) {
+    // Get all parts (handles union types like `string | map<...>`)
+    for part in type_expr.parts() {
+        validate_map_type_in_text(&part, type_expr, ctx);
+    }
+}
+
+/// Recursively validate map types in a type text string.
+fn validate_map_type_in_text(
+    text: &str,
+    type_expr: &baml_compiler_syntax::ast::TypeExpr,
+    ctx: &mut LoweringContext,
+) {
+    // Check if this is a map type
+    if let Some(rest) = text.strip_prefix("map<") {
+        if let Some(inner) = rest.strip_suffix('>') {
+            let param_count = count_generic_params(inner);
+            if param_count != 2 {
+                ctx.push_diagnostic(HirDiagnostic::InvalidMapArity {
+                    expected: 2,
+                    found: param_count,
+                    span: ctx.span(type_expr.syntax().text_range()),
+                });
+            } else {
+                // Recursively check nested types in both key and value
+                if let Some(comma_idx) = find_top_level_comma(inner) {
+                    let key_text = inner[..comma_idx].trim();
+                    let value_text = inner[comma_idx + 1..].trim();
+                    validate_map_type_in_text(key_text, type_expr, ctx);
+                    validate_map_type_in_text(value_text, type_expr, ctx);
+                }
+            }
+        }
+    }
+
+    // Also check for nested maps in array types (e.g., `map<string, string, string>[]`)
+    if let Some(inner_text) = text.strip_suffix("[]") {
+        validate_map_type_in_text(inner_text, type_expr, ctx);
+    }
+
+    // Check for nested maps in optional types (e.g., `map<string, string, string>?`)
+    if let Some(inner_text) = text.strip_suffix('?') {
+        validate_map_type_in_text(inner_text, type_expr, ctx);
+    }
+}
+
+/// Find the index of the first top-level comma in a string.
+fn find_top_level_comma(s: &str) -> Option<usize> {
+    let mut depth = 0;
+    for (i, c) in s.char_indices() {
+        match c {
+            '<' => depth += 1,
+            '>' => depth -= 1,
+            ',' if depth == 0 => return Some(i),
+            _ => {}
+        }
+    }
+    None
 }
 
 /// Helper to check for duplicate names and record errors.

--- a/baml_language/crates/baml_ide_tests/test_files/syntax/class/map_types2.baml
+++ b/baml_language/crates/baml_ide_tests/test_files/syntax/class/map_types2.baml
@@ -68,3 +68,30 @@ function InputAndOutput(i1: map<string, string>, i2: map<MapDummy, string>) -> m
 //     │ 
 //     │ Note: Error code: E0010
 // ────╯
+// Error: map<K, V> requires exactly 2 type parameters, found 0
+//     ╭─[ class_map_types2.baml:26:5 ]
+//     │
+//  26 │   d1 map<>
+//     │     ───┬──  
+//     │        ╰──── map<K, V> requires exactly 2 type parameters, found 0
+//     │ 
+//     │ Note: Error code: E0039
+// ────╯
+// Error: map<K, V> requires exactly 2 type parameters, found 1
+//     ╭─[ class_map_types2.baml:27:5 ]
+//     │
+//  27 │   d2 map<string>
+//     │     ──────┬─────  
+//     │           ╰─────── map<K, V> requires exactly 2 type parameters, found 1
+//     │ 
+//     │ Note: Error code: E0039
+// ────╯
+// Error: map<K, V> requires exactly 2 type parameters, found 3
+//     ╭─[ class_map_types2.baml:28:5 ]
+//     │
+//  28 │   d3 map<string, string, string>
+//     │     ──────────────┬─────────────  
+//     │                   ╰─────────────── map<K, V> requires exactly 2 type parameters, found 3
+//     │ 
+//     │ Note: Error code: E0039
+// ────╯


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds HIR validation to enforce `map<K, V>` arity and wires a new diagnostic through the pipeline.
> 
> - Introduces `InvalidMapArity` (E0039) and validates map generics during HIR lowering, including nested, union, array (`[]`), and optional (`?`) cases
> - Plumbs new diagnostic through `HirDiagnostic` → `to_diagnostic` and `DiagnosticId` → error code mapping
> - Updates `map_types2.baml` IDE test expectations to include E0039 errors
> - Test guide: document how to skip slow `parser_stress` tests when running all snapshots
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7aa936a7416b0c5efa88bf36f321df869de743f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->