### PR TITLE
fix(cffi): wrap result and error callbacks in block_in_place

### DIFF
--- a/engine/language_client_cffi/src/ffi/callbacks.rs
+++ b/engine/language_client_cffi/src/ffi/callbacks.rs
@@ -77,7 +77,12 @@ pub fn send_result_to_callback(
     match buf_result {
         Ok(buf) => {
             let is_done_int = if is_done { 1 } else { 0 };
-            callback_fn(id, is_done_int, buf.as_ptr() as *const i8, buf.len());
+            // Use block_in_place to tell Tokio this is a blocking operation.
+            // This allows Tokio to move other async tasks to different worker threads,
+            // preventing deadlock when the callback performs blocking FFI calls.
+            tokio::task::block_in_place(|| {
+                callback_fn(id, is_done_int, buf.as_ptr() as *const i8, buf.len());
+            });
         }
         Err(panic_info) => {
             let error_msg = if let Some(s) = panic_info.downcast_ref::<&str>() {
@@ -90,7 +95,10 @@ pub fn send_result_to_callback(
 
             if is_done {
                 // For final results, send error via callback
-                error_callback_fn(id, 1, error_msg.as_ptr() as *const i8, error_msg.len());
+                // Use block_in_place to tell Tokio this is a blocking operation.
+                tokio::task::block_in_place(|| {
+                    error_callback_fn(id, 1, error_msg.as_ptr() as *const i8, error_msg.len());
+                });
             } else {
                 // For streaming events, just log and drop the event
                 baml_log::error!("Encoding error: {}", error_msg);
@@ -104,7 +112,12 @@ pub fn send_error_to_callback(id: u32, error: &anyhow::Error) {
         .get()
         .expect("expected error callback function to be set. Did you call register_callbacks?");
     let message = error.to_string();
-    error_callback_fn(id, 1, message.as_ptr() as *const i8, message.len());
+    // Use block_in_place to tell Tokio this is a blocking operation.
+    // This allows Tokio to move other async tasks to different worker threads,
+    // preventing deadlock when the callback performs blocking FFI calls.
+    tokio::task::block_in_place(|| {
+        error_callback_fn(id, 1, message.as_ptr() as *const i8, message.len());
+    });
 }
 
 pub fn safe_trigger_callback(


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [x] This PR follows up on #2949 which added `block_in_place` to the `on_tick` callback

## Changes
Please describe the changes proposed in this pull request

This PR extends the `block_in_place` treatment from PR #2949 to the result and error callbacks in the CFFI layer.

In Go, all three callbacks (`trigger_callback`, `error_callback`, `on_tick_callback`) acquire the `callbackMutex` lock, and the result/error callbacks also send to Go channels. Using `block_in_place` allows Tokio to make better scheduling decisions.

**Changes:**
- Wrap `callback_fn` invocation in `send_result_to_callback` with `block_in_place`
- Wrap `error_callback_fn` invocation in panic handler with `block_in_place`  
- Wrap `error_callback_fn` invocation in `send_error_to_callback` with `block_in_place`

## Testing
Please describe how you tested these changes

- [x] Manual testing performed
- [x] Ran Go integration tests (`TestOnTick`, `TestJson`, streaming tests) - all pass
- [x] Verified library compiles without errors

**Note:** Some integration tests failed when running the full suite, but these failures appear to be pre-existing (tests also failed prior to these changes being applied).

## Screenshots
If applicable, add screenshots to help explain your changes

N/A - no UI changes

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

This is a consistency fix - the `on_tick` callback was already wrapped in `block_in_place` by PR #2949, and the result/error callbacks have the same characteristics (blocking FFI calls to Go that acquire mutexes and send to channels). Wrapping them ensures Tokio is aware of all blocking FFI operations and can optimize scheduling accordingly.