### PR TITLE
fix(go): handle optional image encoding (*types.Image)

### DIFF
--- a/engine/baml-lib/baml-types/src/ir_type/converters/streaming.rs
+++ b/engine/baml-lib/baml-types/src/ir_type/converters/streaming.rs
@@ -1,7 +1,7 @@
 use crate::{
     baml_value::TypeLookups,
     ir_type::{ArrowGeneric, TypeStreaming, UnionTypeGeneric},
-    type_meta, BamlMediaType, StreamingMode, TypeIR, TypeValue,
+    type_meta, StreamingMode, TypeIR, TypeValue,
 };
 
 pub fn from_type_ir(r#type: &TypeIR, lookup: &impl TypeLookups) -> TypeStreaming {
@@ -33,8 +33,8 @@ pub fn from_type_ir(r#type: &TypeIR, lookup: &impl TypeLookups) -> TypeStreaming
                 TypeValue::Float => TypeStreaming::Primitive(TypeValue::Float, meta),
                 TypeValue::Bool => TypeStreaming::Primitive(TypeValue::Bool, meta),
                 TypeValue::String => TypeStreaming::Primitive(TypeValue::String, meta),
-                TypeValue::Media(_) => {
-                    TypeStreaming::Primitive(TypeValue::Media(BamlMediaType::Image), meta)
+                TypeValue::Media(media_type) => {
+                    TypeStreaming::Primitive(TypeValue::Media(*media_type), meta)
                 }
             },
             TypeIR::Enum { name, dynamic, .. } => TypeStreaming::Enum {

--- a/engine/generators/type_serialization_tests.md
+++ b/engine/generators/type_serialization_tests.md
@@ -149,6 +149,128 @@ class T { f bool }
 
 ---
 
+# Media Types
+
+## image_field
+
+```baml
+class T { f image }
+```
+
+### target: `T.f`
+
+### Python
+
+- Non-streaming: `baml_py.Image`
+- Streaming: `typing.Optional[baml_py.Image]`
+
+### TypeScript
+
+- Non-streaming: `Image`
+- Streaming: `Image | null`
+
+### Go
+
+- Non-streaming: `Image`
+- Streaming: `*types.Image`
+
+### Rust
+
+- Non-streaming: `Image`
+- Streaming: `Option<types::Image>`
+
+---
+
+## optional_image
+
+```baml
+class T { f image? }
+```
+
+### target: `T.f`
+
+### Python
+
+- Non-streaming: `typing.Optional[baml_py.Image]`
+- Streaming: `typing.Optional[baml_py.Image]`
+
+### TypeScript
+
+- Non-streaming: `Image | null`
+- Streaming: `Image | null`
+
+### Go
+
+- Non-streaming: `*Image`
+- Streaming: `*types.Image`
+
+### Rust
+
+- Non-streaming: `Option<Image>`
+- Streaming: `Option<types::Image>`
+
+---
+
+## audio_field
+
+```baml
+class T { f audio }
+```
+
+### target: `T.f`
+
+### Python
+
+- Non-streaming: `baml_py.Audio`
+- Streaming: `typing.Optional[baml_py.Audio]`
+
+### TypeScript
+
+- Non-streaming: `Audio`
+- Streaming: `Audio | null`
+
+### Go
+
+- Non-streaming: `Audio`
+- Streaming: `*types.Audio`
+
+### Rust
+
+- Non-streaming: `Audio`
+- Streaming: `Option<types::Audio>`
+
+---
+
+## optional_audio
+
+```baml
+class T { f audio? }
+```
+
+### target: `T.f`
+
+### Python
+
+- Non-streaming: `typing.Optional[baml_py.Audio]`
+- Streaming: `typing.Optional[baml_py.Audio]`
+
+### TypeScript
+
+- Non-streaming: `Audio | null`
+- Streaming: `Audio | null`
+
+### Go
+
+- Non-streaming: `*Audio`
+- Streaming: `*types.Audio`
+
+### Rust
+
+- Non-streaming: `Option<Audio>`
+- Streaming: `Option<types::Audio>`
+
+---
+
 # Optional Types
 
 ## optional_string

--- a/engine/language_client_go/baml_go/serde/encode.go
+++ b/engine/language_client_go/baml_go/serde/encode.go
@@ -85,7 +85,23 @@ func encodeValue(value any) (*cffi.HostValue, error) {
 	// Use the potentially dereferenced value 'rv.Interface()' here if concrete types are structs
 	concreteValue := rv.Interface() // Get the concrete value (dereferenced if original was pointer)
 
+	// Check originalValue first (for non-pointer cases)
 	if internalObject, ok := originalValue.(InternalBamlSerializer); ok {
+		handle, err := internalObject.Encode()
+		if err != nil {
+			return nil, fmt.Errorf("encoding internal object: %w", err)
+		}
+		return &cffi.HostValue{
+			Value: &cffi.HostValue_Handle{
+				Handle: handle,
+			},
+		}, nil
+	}
+
+	// Also check the dereferenced value for pointer-to-interface cases (e.g., *types.Image)
+	// In Go, a pointer to an interface doesn't implement the interface, but the dereferenced
+	// value (the interface itself) does.
+	if internalObject, ok := concreteValue.(InternalBamlSerializer); ok {
 		handle, err := internalObject.Encode()
 		if err != nil {
 			return nil, fmt.Errorf("encoding internal object: %w", err)

--- a/integ-tests/go/test_functions_media_test.go
+++ b/integ-tests/go/test_functions_media_test.go
@@ -180,3 +180,36 @@ func TestPDFInputVertex(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, result, "Expected non-empty Vertex PDF result")
 }
+
+// TestOptionalImageInputNil tests that optional image parameters work with nil
+// This tests the fix for encoding *types.Image (pointer to interface)
+func TestOptionalImageInputNil(t *testing.T) {
+	ctx := context.Background()
+
+	// Call ExtractResume with nil image - this tests the encoder handles *types.Image correctly
+	result, err := b.ExtractResume(ctx, "John Doe\nSoftware Engineer\n5 years experience", nil)
+	require.NoError(t, err, "ExtractResume with nil image should not fail")
+
+	// Should have extracted some name
+	assert.NotEmpty(t, result.Name, "Expected name to be extracted")
+}
+
+// TestOptionalImageInputWithValue tests that optional image parameters work with an actual image
+// This tests the fix for encoding *types.Image (pointer to interface) with a non-nil value
+func TestOptionalImageInputWithValue(t *testing.T) {
+	ctx := context.Background()
+
+	// Create an image - b.NewImageFromUrl returns baml_client.Image (which is baml.Image)
+	img, err := b.NewImageFromUrl("https://i.imgur.com/93fWs5R.png", nil)
+	require.NoError(t, err)
+
+	// Convert to types.Image (which is a distinct type from baml_client.Image)
+	typesImg := types.Image(img)
+
+	// Call ExtractResume with the image - this tests encoding a non-nil *types.Image
+	result, err := b.ExtractResume(ctx, "John Doe\nSoftware Engineer\n5 years experience", &typesImg)
+	require.NoError(t, err, "ExtractResume with image should not fail")
+
+	// Should have extracted some name
+	assert.NotEmpty(t, result.Name, "Expected name to be extracted")
+}


### PR DESCRIPTION
## Summary
- Fix Go encoder to handle pointer-to-interface types like `*types.Image` 
- In Go, `*types.Image` (pointer to interface) doesn't implement `InternalBamlSerializer`, but the dereferenced value does
- Also fixes a bug where all media types were converted to `Image` in streaming type conversion

## Test plan
- [x] All 115 type_gen tests pass across Go, Python, TypeScript, Rust
- [x] Manual verification of optional image encoding
- [x] Added Go integration tests `TestOptionalImageInputNil` and `TestOptionalImageInputWithValue`

🤖 Generated with [Claude Code](https://claude.com/claude-code)