### PR TITLE
Fix API key dialog not showing for new users

### DIFF
--- a/typescript/packages/playground-common/src/baml_wasm_web/EventListener.tsx
+++ b/typescript/packages/playground-common/src/baml_wasm_web/EventListener.tsx
@@ -14,11 +14,6 @@ import { useBAMLSDK } from "../sdk";
 // ============================================================================
 // EventListener-specific atoms (not managed by SDK)
 // ============================================================================
-export const hasClosedEnvVarsDialogAtom = atomWithStorage<boolean>(
-  "has-closed-env-vars-dialog",
-  false,
-  vscodeLocalStorageStore,
-);
 
 export const bamlCliVersionAtom = atom<string | null>(null);
 

--- a/typescript/packages/playground-common/src/components/api-keys-dialog/atoms.ts
+++ b/typescript/packages/playground-common/src/components/api-keys-dialog/atoms.ts
@@ -3,6 +3,7 @@ import { atomWithStorage } from 'jotai/utils';
 import { vscodeLocalStorageStore } from '../../shared/baml-project-panel/Jotai';
 import { vscode } from '../../shared/baml-project-panel/vscode';
 import { proxyUrlAtom, runtimeAtom } from '../../shared/baml-project-panel/atoms';
+import { isPlaceholderApiKey } from './utils';
 
 export const apiKeyVisibilityAtom = atom<Record<string, boolean>>({});
 
@@ -13,39 +14,56 @@ export interface ApiKeyEntry {
   hidden: boolean;
 }
 
-const hasShownApiKeyDialogAtom = atomWithStorage(
-  'has-closed-env-vars-dialog',
+// Track if user has explicitly dismissed the dialog (persisted)
+const hasUserDismissedDialogAtom = atomWithStorage(
+  'has-dismissed-api-key-dialog',
   false,
   vscodeLocalStorageStore,
+  { getOnInit: true }  // Sync read from storage on init
 );
 
+// Track if dialog is currently open (not persisted)
 const apiKeyDialogOpenAtom = atom(false);
+
+// Track if we've already auto-shown the dialog this session (not persisted)
+const hasAutoShownThisSessionAtom = atom(false);
 
 export const showApiKeyDialogAtom = atom(
   (get) => {
     const apiKeyDialogOpen = get(apiKeyDialogOpenAtom)
     if (apiKeyDialogOpen) return true
 
-    const requiredVars = get(requiredApiKeysAtom)
-    const envVars = get(apiKeysAtom)
+    // Check if user has ever dismissed the dialog
+    const hasUserDismissed = get(hasUserDismissedDialogAtom)
+    if (hasUserDismissed) return false
 
-    // Check if ALL required vars are missing
-    const hasMissingVars =
-      requiredVars.length > 0 && requiredVars.every((key: string) => !envVars[key])
+    // Check if we already auto-showed this session
+    const hasAutoShownThisSession = get(hasAutoShownThisSessionAtom)
+    if (hasAutoShownThisSession) return false
 
-    const hasShownDialog = get(hasShownApiKeyDialogAtom)
-    if (hasShownDialog) return apiKeyDialogOpen
-
-    // if we are in vscode, we don't want to show the dialog
+    // Only auto-show in VSCode
     if (!vscode.isVscode()) {
       return false
     }
 
+    const requiredVars = get(requiredApiKeysAtom)
+    const envVars = get(apiKeysAtom)
+
+    // Check if ALL required vars are missing or have placeholder values
+    const hasMissingVars =
+      requiredVars.length > 0 && requiredVars.every((key: string) => {
+        return !envVars[key] || isPlaceholderApiKey(envVars[key])
+      })
+
     return hasMissingVars
   },
   (get, set, value: boolean) => {
-    if (!value) {
-      set(hasShownApiKeyDialogAtom, true)
+    if (value) {
+      // Opening the dialog - mark that we've auto-shown this session
+      set(hasAutoShownThisSessionAtom, true)
+    } else {
+      // User is closing the dialog - mark as permanently dismissed
+      set(hasUserDismissedDialogAtom, true)
     }
     set(apiKeyDialogOpenAtom, value)
   },


### PR DESCRIPTION
### Summary

  - Fixed bug where the API key configuration dialog wouldn't automatically appear for
  new VSCode users
  - New users with placeholder API keys were silently making failed LLM requests without
   realizing they needed to configure their keys

### Changes:

  1. atoms.ts:
    - Treat placeholder API keys (PLACEHOLDER_OPENAI_KEY, etc.) as missing values when deciding to show the dialog
    - Separated state into 3 atoms to fix race condition with Jotai's async storage hydration:
      - hasUserDismissedDialogAtom (persisted) - remembers if user dismissed
      - hasAutoShownThisSessionAtom (session) - prevents re-showing within session
      - apiKeyDialogOpenAtom (transient) - tracks open/closed state
    - Added { getOnInit: true } for synchronous storage reads
  3. EventListener.tsx: Removed duplicate atom using the same storage key