### PR TITLE
feat(bex): complete garbage collector implementation

### DIFF
--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -20,17 +20,37 @@
 //! Resources (file handles, connections, etc.) are stored in a `ResourceRegistry`.
 //! External ops can store resources and return their ID to the VM. Later ops
 //! can retrieve resources by ID. The VM only sees integer IDs.
+//!
+//! # Garbage Collection Coordination
+//!
+//! The engine coordinates GC using an epoch-based system:
+//!
+//! 1. **Epoch tracking**: Each `call_function` registers with the current epoch
+//! 2. **GC trigger**: `collect_garbage()` increments epoch, causing old-epoch VMs to park
+//! 3. **Safe collection**: Once all VMs park, GC collects roots from:
+//!    - Handle table (objects returned to external code)
+//!    - Parked VM stacks (via VM pointer registry)
+//! 4. **Stack update**: GC updates parked VM stacks with forwarding pointers
+//! 5. **TLAB invalidation**: Parked VMs get TLABs invalidated before resuming
+//! 6. **Resume**: `gc_complete.notify_waiters()` releases parked VMs
+//!
+//! ## Safety Invariants
+//!
+//! - VMs register pointers before parking, unregister after waking
+//! - GC only accesses VM stacks while holding `parked_vms` lock
+//! - Handles always resolve through table (no cached indices)
+//! - New calls wait for in-progress GC before processing handle args
 
 use std::{
     collections::HashMap,
     sync::{
-        Arc,
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
     },
 };
 
 use baml_snapshot::BamlSnapshot;
-pub use bex_external_types::{ExternalValue, Snapshot};
+pub use bex_external_types::{EpochGuard, ExternalValue, Snapshot};
 use bex_heap::BexHeap;
 // Re-export GcStats for users of the engine
 pub use bex_heap::GcStats;
@@ -54,6 +74,20 @@ struct FutureResult {
     result: Result<ResolvedValue, EngineError>,
 }
 
+/// Wrapper for VM pointer that implements Send.
+///
+/// # Safety
+///
+/// This is safe because:
+/// - The pointer is only used while holding the `parked_vms` lock
+/// - We only dereference when all VMs are parked at safepoints
+/// - The VM lives on the async task's stack and won't move/drop while parked
+struct VmPtr(*const BexVm);
+
+// SAFETY: We control all access through the mutex and only use while VMs are parked
+#[allow(unsafe_code)]
+unsafe impl Send for VmPtr {}
+
 /// State for a single epoch slot.
 /// Used to track VMs that started in a particular epoch.
 struct EpochState {
@@ -61,6 +95,16 @@ struct EpochState {
     active: AtomicUsize,
     /// Number of VMs parked waiting for GC.
     parked: AtomicUsize,
+    /// Pointers to parked VMs for root collection during GC.
+    ///
+    /// # Safety
+    ///
+    /// These raw pointers are valid because:
+    /// - VM is borrowed from `call_function`'s stack frame
+    /// - `.await` on `gc_complete` suspends but doesn't drop the VM
+    /// - GC only reads/writes while all VMs are parked
+    /// - VM unregisters before resuming execution
+    parked_vms: Mutex<Vec<VmPtr>>,
 }
 
 impl EpochState {
@@ -68,6 +112,7 @@ impl EpochState {
         Self {
             active: AtomicUsize::new(0),
             parked: AtomicUsize::new(0),
+            parked_vms: Mutex::new(Vec::new()),
         }
     }
 }
@@ -184,6 +229,9 @@ pub struct BexEngine {
     epoch_drained: Notify,
     /// Notified when GC completes and parked VMs can resume.
     gc_complete: Notify,
+    /// Flag indicating GC is currently in progress.
+    /// Used to prevent handle resolution races.
+    gc_in_progress: AtomicBool,
 }
 
 impl BexEngine {
@@ -217,6 +265,7 @@ impl BexEngine {
             epoch_states: [EpochState::new(), EpochState::new()],
             epoch_drained: Notify::new(),
             gc_complete: Notify::new(),
+            gc_in_progress: AtomicBool::new(false),
         })
     }
 
@@ -279,15 +328,26 @@ impl BexEngine {
     }
 
     /// Convert a handle to a snapshot.
+    ///
+    /// This is safe for external code to call (no `EpochGuard` needed) because
+    /// we hold the handle table read lock for the entire operation, preventing
+    /// GC from moving objects while we're snapshotting.
     fn snapshot_handle(
         &self,
         handle: &bex_external_types::Handle,
     ) -> Result<Snapshot, EngineError> {
-        let idx = self
-            .heap()
-            .resolve_handle(handle)
-            .expect("Handle is a GC root - object should never be collected");
-        self.snapshot_object(idx)
+        // Hold the handles read lock for the entire snapshot operation.
+        // This prevents GC from running update_handles (which needs write lock),
+        // ensuring all ObjectIndex values remain valid during recursive snapshotting.
+        //
+        // The GcProtectedHeap guard ensures resolve_handle can only be called
+        // while the lock is held - you can't accidentally use it unsafely.
+        self.heap.with_gc_protection(|protected| {
+            let idx = protected
+                .resolve_handle(handle.slab_key())
+                .expect("Handle is a GC root - object should never be collected");
+            self.snapshot_object(idx)
+        })
     }
 
     /// Convert an object at the given index to a snapshot.
@@ -421,6 +481,9 @@ impl BexEngine {
     ///
     /// Statistics about the collection (live count, collected count, etc.)
     pub async fn collect_garbage(&self) -> bex_heap::GcStats {
+        // Signal GC starting - new calls will wait
+        self.gc_in_progress.store(true, Ordering::Release);
+
         // Increment epoch - new calls get the new epoch
         let gc_epoch = self.current_epoch.fetch_add(1, Ordering::SeqCst);
         let slot = (gc_epoch % 2) as usize;
@@ -444,22 +507,61 @@ impl BexEngine {
         }
 
         // Collect roots from handles (objects returned to external code)
-        // These must be preserved during GC.
-        let handle_roots = self.heap.collect_handle_roots();
+        let mut all_roots = self.heap.collect_handle_roots();
 
-        tracing::debug!("GC: {} handle roots collected", handle_roots.len());
+        // Acquire parked_vms lock - hold it through GC to update stacks
+        let parked_vms = self.epoch_states[slot].parked_vms.lock().unwrap();
 
-        // Note: For a complete implementation, we would also collect roots from parked VMs.
-        // For now, we only use handle roots. Parked VMs would need their stacks updated
-        // with remapped indices after GC.
-
-        // Run GC with handle roots
+        // SAFETY: All VMs are parked (verified above), so we have exclusive read access
+        // to their stacks. The parked_vms vec contains valid pointers because VMs
+        // register before parking and unregister only after gc_complete is notified.
         #[allow(unsafe_code)]
-        let (stats, _remapped_roots) = unsafe { self.heap.collect_garbage(&handle_roots) };
+        for vm_ptr in parked_vms.iter() {
+            let vm = unsafe { &*vm_ptr.0 };
+            all_roots.extend(Self::collect_vm_roots(vm));
+        }
+
+        tracing::debug!(
+            "GC: {} total roots from {} handles and {} parked VMs",
+            all_roots.len(),
+            self.heap.stats().active_handles,
+            parked_vms.len()
+        );
+
+        // Run GC with forwarding map
+        #[allow(unsafe_code)]
+        let (stats, _remapped_roots, forwarding) =
+            unsafe { self.heap.collect_garbage_with_forwarding(&all_roots) };
+
+        // Update all parked VM stacks with forwarding pointers and invalidate TLABs
+        // SAFETY: VMs are still parked (gc_complete not yet notified), we have
+        // exclusive access via the parked_vms lock we're still holding
+        #[allow(unsafe_code)]
+        for vm_ptr in parked_vms.iter() {
+            let vm = unsafe { &mut *vm_ptr.0.cast_mut() };
+
+            // Update stack values
+            for value in &mut vm.stack.0 {
+                if let Value::Object(idx) = value {
+                    if let Some(&new_idx) = forwarding.get(idx) {
+                        *idx = new_idx;
+                    }
+                }
+            }
+
+            // Invalidate TLAB so next allocation gets chunk from new space
+            vm.tlab.invalidate();
+        }
+
+        // Release lock before notifying waiters
+        drop(parked_vms);
 
         // Reset epoch state for reuse
         self.epoch_states[slot].active.store(0, Ordering::Release);
         self.epoch_states[slot].parked.store(0, Ordering::Release);
+
+        // Signal GC complete before releasing parked VMs
+        self.gc_in_progress.store(false, Ordering::Release);
 
         // Release parked VMs
         self.gc_complete.notify_waiters();
@@ -509,6 +611,12 @@ impl BexEngine {
         function_name: &str,
         args: &[ExternalValue],
     ) -> Result<ExternalValue, EngineError> {
+        // Wait for any in-progress GC to complete.
+        // This ensures Handles in args have stable indices.
+        while self.gc_in_progress.load(Ordering::Acquire) {
+            self.gc_complete.notified().await;
+        }
+
         // Look up the function to verify it exists
         let function_index = self.lookup_function(function_name)?;
 
@@ -518,6 +626,10 @@ impl BexEngine {
         self.epoch_states[slot]
             .active
             .fetch_add(1, Ordering::AcqRel);
+
+        // SAFETY: We just registered with the epoch above
+        #[allow(unsafe_code)]
+        let guard = unsafe { EpochGuard::new() };
 
         // Create VM with shared heap (each VM gets its own TLAB)
         let mut vm = BexVm::new(
@@ -529,7 +641,7 @@ impl BexEngine {
         // Convert ExternalValue args to Value, allocating Snapshots on the heap
         let vm_args: Vec<Value> = args
             .iter()
-            .map(|arg| Self::externalize_to_value(&mut vm, arg))
+            .map(|arg| Self::externalize_to_value(&mut vm, arg, &guard))
             .collect();
 
         // Set entry point with converted args
@@ -556,11 +668,24 @@ impl BexEngine {
 
     /// Convert an `ExternalValue` to a VM `Value`.
     ///
+    /// Requires `EpochGuard` because resolving handles returns an `ObjectIndex`
+    /// that must remain valid while we use it.
+    ///
     /// - `Object(Handle)` extracts the `ObjectIndex`
     /// - `Snapshot(...)` recursively allocates on the heap
-    fn externalize_to_value(vm: &mut BexVm, external: &ExternalValue) -> Value {
+    fn externalize_to_value(
+        vm: &mut BexVm,
+        external: &ExternalValue,
+        guard: &EpochGuard<'_>,
+    ) -> Value {
         match external {
-            ExternalValue::Object(handle) => Value::Object(handle.object_index()),
+            ExternalValue::Object(handle) => {
+                // Resolve through table to get current index after any GC
+                let idx = handle
+                    .object_index(guard)
+                    .expect("Handle should be valid - object was returned to external code");
+                Value::Object(idx)
+            }
             ExternalValue::Snapshot(snapshot) => Self::allocate_snapshot(vm, snapshot),
         }
     }
@@ -628,20 +753,32 @@ impl BexEngine {
     }
 
     /// Run GC if conditions are met (called at safepoints).
-    fn maybe_run_gc(&self, vm: &BexVm) {
+    fn maybe_run_gc(&self, vm: &mut BexVm) {
         if self.heap.should_gc() {
             let roots = Self::collect_vm_roots(vm);
             #[allow(unsafe_code)]
             unsafe {
-                let (stats, _remapped_roots) = self.heap.collect_garbage(&roots);
+                let (stats, _remapped_roots, forwarding) =
+                    self.heap.collect_garbage_with_forwarding(&roots);
+
+                // Update VM stack with forwarding pointers
+                for value in &mut vm.stack.0 {
+                    if let Value::Object(idx) = value {
+                        if let Some(&new_idx) = forwarding.get(idx) {
+                            *idx = new_idx;
+                        }
+                    }
+                }
+
+                // Invalidate TLAB so next allocation gets chunk from new space
+                vm.tlab.invalidate();
+
                 self.heap.reset_gc_counter();
                 tracing::debug!(
-                    "GC completed: {} live, {} collected, {} handles invalidated",
+                    "GC completed: {} live, {} collected",
                     stats.live_count,
-                    stats.collected_count,
-                    stats.handles_invalidated
+                    stats.collected_count
                 );
-                // TODO: Phase 5/6 - Update VM stack with remapped roots
             }
         }
     }
@@ -724,6 +861,14 @@ impl BexEngine {
                         // GC has been requested - we need to park
                         let slot = (my_epoch % 2) as usize;
 
+                        // Register VM pointer before parking
+                        // SAFETY: VM lives on our async task's stack and won't be dropped
+                        // until after we unregister (after gc_complete.notified().await returns)
+                        {
+                            let mut parked_vms = self.epoch_states[slot].parked_vms.lock().unwrap();
+                            parked_vms.push(VmPtr(std::ptr::from_ref(vm)));
+                        }
+
                         // Increment parked count and notify GC
                         self.epoch_states[slot]
                             .parked
@@ -733,6 +878,13 @@ impl BexEngine {
                         // Wait for GC to complete
                         // Note: GC will update our VM's stack with new object indices
                         self.gc_complete.notified().await;
+
+                        // Unregister VM pointer after waking
+                        {
+                            let mut parked_vms = self.epoch_states[slot].parked_vms.lock().unwrap();
+                            let vm_ptr = std::ptr::from_ref(vm);
+                            parked_vms.retain(|p| p.0 != vm_ptr);
+                        }
 
                         // Decrement parked count
                         self.epoch_states[slot]

--- a/baml_language/crates/bex_engine/tests/gc.rs
+++ b/baml_language/crates/bex_engine/tests/gc.rs
@@ -72,6 +72,94 @@ async fn test_array_preserved_through_gc() {
     }
 }
 
+/// Test that GC updates forwarding pointers correctly.
+///
+/// This test verifies Gap #2 (root remapping) is fixed by:
+/// 1. Creating multiple objects that will be moved during GC
+/// 2. Triggering GC
+/// 3. Verifying all objects are still accessible at their new locations
+#[tokio::test]
+async fn test_gc_updates_forwarding_pointers() {
+    let source = r#"
+        function create_objects() -> string[] {
+            let a = "first"
+            let b = "second"
+            let c = "third"
+            let arr = [a, b, c]
+            arr
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = BexEngine::new(snapshot, HashMap::new()).unwrap();
+
+    // Create objects
+    let result = engine.call_function("create_objects", &[]).await.unwrap();
+
+    // Trigger multiple GC cycles to ensure forwarding works
+    for _ in 0..3 {
+        let _stats = engine.collect_garbage().await;
+    }
+
+    // Objects should still be accessible with correct values
+    let snapshot = engine.to_snapshot(result).unwrap();
+    match snapshot {
+        Snapshot::Array(arr) => {
+            assert_eq!(arr.len(), 3);
+            assert_eq!(arr[0], Snapshot::String("first".to_string()));
+            assert_eq!(arr[1], Snapshot::String("second".to_string()));
+            assert_eq!(arr[2], Snapshot::String("third".to_string()));
+        }
+        other => panic!("Expected array, got: {other:?}"),
+    }
+}
+
+/// Test that multiple handles survive GC.
+///
+/// This verifies the handle table is properly updated during GC.
+#[tokio::test]
+async fn test_multiple_handles_survive_gc() {
+    let source = r#"
+        function make_string(s: string) -> string {
+            s
+        }
+    "#;
+
+    let snapshot = compile_for_engine(source);
+    let engine = BexEngine::new(snapshot, HashMap::new()).unwrap();
+
+    // Create multiple handles
+    let h1 = engine
+        .call_function("make_string", &["hello".into()])
+        .await
+        .unwrap();
+    let h2 = engine
+        .call_function("make_string", &["world".into()])
+        .await
+        .unwrap();
+    let h3 = engine
+        .call_function("make_string", &["test".into()])
+        .await
+        .unwrap();
+
+    // Trigger GC
+    let _stats = engine.collect_garbage().await;
+
+    // All handles should still be valid
+    assert_eq!(
+        engine.to_snapshot(h1).unwrap(),
+        Snapshot::String("hello".to_string())
+    );
+    assert_eq!(
+        engine.to_snapshot(h2).unwrap(),
+        Snapshot::String("world".to_string())
+    );
+    assert_eq!(
+        engine.to_snapshot(h3).unwrap(),
+        Snapshot::String("test".to_string())
+    );
+}
+
 /// Test primitive return values (should be Snapshot, not Handle).
 #[tokio::test]
 async fn test_primitive_returns_are_snapshots() {

--- a/baml_language/crates/bex_external_types/src/epoch_guard.rs
+++ b/baml_language/crates/bex_external_types/src/epoch_guard.rs
@@ -1,0 +1,49 @@
+//! Epoch protection token for safe ObjectIndex access.
+//!
+//! This module provides the `EpochGuard` type, which proves that code is
+//! running in an epoch-protected context where GC cannot invalidate
+//! ObjectIndex values.
+
+use std::marker::PhantomData;
+
+/// Token proving caller is in an active epoch.
+///
+/// Cannot be constructed outside of epoch-protected code paths.
+/// Zero-sized - no runtime overhead.
+///
+/// # Safety Guarantee
+///
+/// Code holding an `EpochGuard` is guaranteed that:
+/// - The current async task is registered as "active" in an epoch
+/// - GC will wait for this task to park or complete before running
+/// - ObjectIndex values resolved while holding the guard remain valid
+///   until the guard is dropped (and the task parks or completes)
+///
+/// # Usage
+///
+/// ```ignore
+/// // Only engine can create guards (inside call_function)
+/// let guard = unsafe { EpochGuard::new() };
+///
+/// // Pass guard to methods that need epoch protection
+/// let idx = handle.object_index(&guard)?;
+/// ```
+pub struct EpochGuard<'a> {
+    _marker: PhantomData<&'a ()>,
+}
+
+impl<'a> EpochGuard<'a> {
+    /// Create a new epoch guard.
+    ///
+    /// # Safety
+    ///
+    /// This must only be called after registering with an epoch
+    /// (incrementing `epoch_states[slot].active`).
+    /// Only `BexEngine` should call this.
+    #[doc(hidden)]
+    pub unsafe fn new() -> Self {
+        Self {
+            _marker: PhantomData,
+        }
+    }
+}

--- a/baml_language/crates/bex_external_types/src/external_value.rs
+++ b/baml_language/crates/bex_external_types/src/external_value.rs
@@ -161,8 +161,6 @@ impl PartialEq for ExternalValue {
 
 #[cfg(test)]
 mod tests {
-    use bex_vm_types::ObjectIndex;
-
     use super::*;
 
     #[test]
@@ -190,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_external_value_object() {
-        let handle = Handle::new_detached(42, ObjectIndex::from_raw(100));
+        let handle = Handle::new_detached(42);
         let v = ExternalValue::Object(handle);
 
         assert!(v.as_object().is_some());
@@ -204,7 +202,7 @@ mod tests {
         assert_eq!(ExternalValue::from(0.0f64).type_name(), "float");
         assert_eq!(ExternalValue::from(false).type_name(), "bool");
 
-        let handle = Handle::new_detached(0, ObjectIndex::from_raw(0));
+        let handle = Handle::new_detached(0);
         assert_eq!(ExternalValue::Object(handle).type_name(), "object");
     }
 

--- a/baml_language/crates/bex_external_types/src/handle.rs
+++ b/baml_language/crates/bex_external_types/src/handle.rs
@@ -8,6 +8,8 @@ use std::sync::Arc;
 
 use bex_vm_types::ObjectIndex;
 
+use crate::EpochGuard;
+
 /// Trait for releasing handles back to the heap.
 ///
 /// This is implemented by `BexHeap` to allow handles to clean up
@@ -15,6 +17,10 @@ use bex_vm_types::ObjectIndex;
 pub trait WeakHeapRef: Send + Sync {
     /// Release a handle slot by its slab key.
     fn release_handle(&self, slab_key: usize);
+
+    /// Resolve a handle to its current ObjectIndex.
+    /// Returns None if handle is invalid.
+    fn resolve_handle(&self, slab_key: usize) -> Option<ObjectIndex>;
 }
 
 /// Opaque handle to a heap object.
@@ -52,8 +58,6 @@ pub struct Handle {
 pub struct HandleInner {
     /// Key in the sharded_slab handle table.
     pub slab_key: usize,
-    /// Cached ObjectIndex for fast access.
-    pub idx: ObjectIndex,
     /// Weak reference to heap for cleanup on drop.
     /// Using trait object to avoid circular dependency with bex_heap.
     pub heap: Option<Arc<dyn WeakHeapRef>>,
@@ -63,11 +67,10 @@ impl Handle {
     /// Create a new handle.
     ///
     /// This is intended for use by `bex_heap` only.
-    pub fn new(slab_key: usize, idx: ObjectIndex, heap: Arc<dyn WeakHeapRef>) -> Self {
+    pub fn new(slab_key: usize, heap: Arc<dyn WeakHeapRef>) -> Self {
         Self {
             inner: Arc::new(HandleInner {
                 slab_key,
-                idx,
                 heap: Some(heap),
             }),
         }
@@ -75,11 +78,10 @@ impl Handle {
 
     /// Create a handle without a heap reference (for testing).
     #[cfg(test)]
-    pub fn new_detached(slab_key: usize, idx: ObjectIndex) -> Self {
+    pub fn new_detached(slab_key: usize) -> Self {
         Self {
             inner: Arc::new(HandleInner {
                 slab_key,
-                idx,
                 heap: None,
             }),
         }
@@ -87,9 +89,28 @@ impl Handle {
 
     /// Get the ObjectIndex this handle points to.
     ///
-    /// This is primarily for internal use by `bex_heap` and `bex_vm`.
-    pub fn object_index(&self) -> ObjectIndex {
-        self.inner.idx
+    /// Requires an `EpochGuard` to prove the caller is in epoch-protected code.
+    /// This ensures GC cannot run and invalidate the returned index before
+    /// the caller uses it.
+    ///
+    /// # When to use
+    ///
+    /// Use this method when you need the raw `ObjectIndex` for VM operations
+    /// (e.g., pushing to stack, storing in objects). Only callable from
+    /// epoch-protected code paths.
+    ///
+    /// # For external code
+    ///
+    /// External code (`baml_sys`) should use the heap accessor API instead:
+    /// - `heap.read_string(handle)`
+    /// - `heap.with_object(handle, |obj| ...)`
+    ///
+    /// Returns None if the handle has been invalidated.
+    pub fn object_index(&self, _guard: &EpochGuard<'_>) -> Option<ObjectIndex> {
+        self.inner
+            .heap
+            .as_ref()?
+            .resolve_handle(self.inner.slab_key)
     }
 
     /// Get the slab key for this handle.
@@ -113,7 +134,6 @@ impl std::fmt::Debug for Handle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Handle")
             .field("slab_key", &self.inner.slab_key)
-            .field("idx", &self.inner.idx)
             .finish()
     }
 }
@@ -124,18 +144,17 @@ mod tests {
 
     #[test]
     fn test_handle_clone() {
-        let handle1 = Handle::new_detached(42, ObjectIndex::from_raw(100));
+        let handle1 = Handle::new_detached(42);
         let handle2 = handle1.clone();
 
         assert_eq!(handle1.slab_key(), 42);
         assert_eq!(handle2.slab_key(), 42);
-        assert_eq!(handle1.object_index(), ObjectIndex::from_raw(100));
-        assert_eq!(handle2.object_index(), ObjectIndex::from_raw(100));
+        // Note: object_index() requires EpochGuard and returns None for detached handles
     }
 
     #[test]
     fn test_handle_debug() {
-        let handle = Handle::new_detached(42, ObjectIndex::from_raw(100));
+        let handle = Handle::new_detached(42);
         let debug_str = format!("{:?}", handle);
         assert!(debug_str.contains("42"));
     }

--- a/baml_language/crates/bex_external_types/src/lib.rs
+++ b/baml_language/crates/bex_external_types/src/lib.rs
@@ -21,10 +21,12 @@
 //! (internal)       (external)              (memory)     (exec)     (async)
 //! ```
 
+mod epoch_guard;
 mod external_value;
 mod handle;
 mod snapshot;
 
+pub use epoch_guard::EpochGuard;
 pub use external_value::ExternalValue;
 pub use handle::{Handle, HandleInner, WeakHeapRef};
 pub use snapshot::Snapshot;

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -1,0 +1,159 @@
+//! Safe accessor API for external code to read heap objects.
+//!
+//! External code (`baml_sys`) runs outside the epoch system and cannot
+//! safely hold bare `ObjectIndex` values. This module provides an API
+//! that holds the handle table lock during access, preventing GC races.
+//!
+//! # Example
+//!
+//! ```ignore
+//! // In baml_sys code (no EpochGuard available)
+//! let content = heap.read_string(&handle)?;
+//!
+//! // Or for complex access with GC protection:
+//! let result = heap.with_gc_protection(|protected| {
+//!     let idx = protected.resolve_handle(handle.slab_key())?;
+//!     // idx is safe to use - GC cannot run while we hold the guard
+//!     Some(recursive_snapshot(protected, idx))
+//! });
+//! ```
+
+use std::sync::RwLockReadGuard;
+
+use bex_external_types::Handle;
+use bex_vm_types::{Object, ObjectIndex, Value};
+
+use crate::BexHeap;
+
+/// Guard type proving the handles read lock is held.
+///
+/// This type can only be obtained from `BexHeap::with_gc_protection`.
+/// Methods that return `ObjectIndex` require this guard to ensure
+/// the index remains valid (GC cannot run while the lock is held).
+pub struct GcProtectedHeap<'a, F> {
+    heap: &'a BexHeap<F>,
+    // Hold the read lock - prevents GC from updating handles
+    _guard: RwLockReadGuard<'a, std::collections::HashMap<usize, ObjectIndex>>,
+}
+
+impl<'a, F> GcProtectedHeap<'a, F> {
+    /// Resolve a handle's slab key to an ObjectIndex.
+    ///
+    /// Safe because we hold the handles read lock, preventing GC from
+    /// moving objects and invalidating indices.
+    pub fn resolve_handle(&self, slab_key: usize) -> Option<ObjectIndex> {
+        self._guard.get(&slab_key).copied()
+    }
+
+    /// Get the underlying heap reference.
+    ///
+    /// Use this for operations that don't return ObjectIndex
+    /// (e.g., reading object contents).
+    pub fn heap(&self) -> &'a BexHeap<F> {
+        self.heap
+    }
+}
+
+/// Safe object access API for external code.
+///
+/// All methods hold the handle table read lock during access,
+/// ensuring GC cannot run and invalidate indices mid-operation.
+impl<F> BexHeap<F>
+where
+    F: Send + Sync,
+{
+    /// Read a string object through a handle.
+    ///
+    /// Returns `None` if the handle is invalid or doesn't point to a string.
+    pub fn read_string(&self, handle: &Handle) -> Option<String> {
+        // Hold read lock on handles during entire operation
+        let handles = self.handles.read().ok()?;
+        let idx = *handles.get(&handle.slab_key())?;
+
+        // SAFETY: We hold the handles read lock, so GC cannot run
+        // (GC needs write lock). The index is valid.
+        let obj = unsafe { self.get_object(idx) };
+        match obj {
+            Object::String(s) => Some(s.clone()),
+            _ => None,
+        }
+    }
+
+    /// Read an array object through a handle.
+    ///
+    /// Returns a clone of the array values.
+    /// Returns `None` if the handle is invalid or doesn't point to an array.
+    pub fn read_array(&self, handle: &Handle) -> Option<Vec<Value>> {
+        let handles = self.handles.read().ok()?;
+        let idx = *handles.get(&handle.slab_key())?;
+
+        let obj = unsafe { self.get_object(idx) };
+        match obj {
+            Object::Array(arr) => Some(arr.clone()),
+            _ => None,
+        }
+    }
+
+    /// Read a map object through a handle.
+    ///
+    /// Returns a clone of the map.
+    /// Returns `None` if the handle is invalid or doesn't point to a map.
+    pub fn read_map(&self, handle: &Handle) -> Option<indexmap::IndexMap<String, Value>> {
+        let handles = self.handles.read().ok()?;
+        let idx = *handles.get(&handle.slab_key())?;
+
+        let obj = unsafe { self.get_object(idx) };
+        match obj {
+            Object::Map(map) => Some(map.clone()),
+            _ => None,
+        }
+    }
+
+    /// Access an object through a handle with a closure.
+    ///
+    /// The closure receives a reference to the object. GC cannot run
+    /// while the closure executes.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let len = heap.with_object(&handle, |obj| {
+    ///     match obj {
+    ///         Object::Array(arr) => arr.len(),
+    ///         Object::String(s) => s.len(),
+    ///         _ => 0,
+    ///     }
+    /// })?;
+    /// ```
+    pub fn with_object<R>(&self, handle: &Handle, f: impl FnOnce(&Object<F>) -> R) -> Option<R> {
+        let handles = self.handles.read().ok()?;
+        let idx = *handles.get(&handle.slab_key())?;
+
+        // SAFETY: Handle table read lock held, GC cannot run
+        let obj = unsafe { self.get_object(idx) };
+        Some(f(obj))
+    }
+
+    /// Execute a closure while holding the handles read lock.
+    ///
+    /// This prevents GC from updating handle indices during the operation.
+    /// The closure receives a `GcProtectedHeap` which provides safe access
+    /// to `resolve_handle` - you can't accidentally call it without the lock.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Snapshot an entire object graph while protected from GC
+    /// let snapshot = heap.with_gc_protection(|protected| {
+    ///     let idx = protected.resolve_handle(handle.slab_key())?;
+    ///     recursive_snapshot(protected.heap(), idx)
+    /// });
+    /// ```
+    pub fn with_gc_protection<R>(&self, f: impl FnOnce(GcProtectedHeap<'_, F>) -> R) -> R {
+        let guard = self.handles.read().expect("handles lock poisoned");
+        f(GcProtectedHeap {
+            heap: self,
+            _guard: guard,
+        })
+    }
+}

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -136,12 +136,12 @@ impl<F: Clone> BexHeap<F> {
             .collect();
 
         // Update handle table entries to point to new object locations
-        self.update_handles(&forwarding);
+        let handles_invalidated = self.update_handles(&forwarding);
 
         let stats = GcStats {
             live_count,
             collected_count,
-            handles_invalidated: 0, // Handles are updated, not invalidated
+            handles_invalidated,
         };
 
         (stats, remapped_roots)
@@ -213,12 +213,12 @@ impl<F: Clone> BexHeap<F> {
             .collect();
 
         // Update handle table
-        self.update_handles(&forwarding);
+        let handles_invalidated = self.update_handles(&forwarding);
 
         let stats = GcStats {
             live_count,
             collected_count,
-            handles_invalidated: 0,
+            handles_invalidated,
         };
 
         (stats, remapped_roots, forwarding)
@@ -538,7 +538,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // TODO: Handle invalidation not implemented
     fn test_gc_invalidates_dead_handles() {
         use bex_external_types::WeakHeapRef;
 

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -44,6 +44,24 @@ impl<F: Clone> BexHeap<F> {
         self.copy_collection(roots)
     }
 
+    /// Run garbage collection with the given roots, returning the forwarding map.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure all VMs are at safepoints (not executing).
+    ///
+    /// # Returns
+    ///
+    /// A tuple of (GcStats, remapped_roots, forwarding_map) where:
+    /// - remapped_roots contains the new ObjectIndex for each root
+    /// - forwarding_map maps old ObjectIndex to new ObjectIndex for all moved objects
+    pub unsafe fn collect_garbage_with_forwarding(
+        &self,
+        roots: &[ObjectIndex],
+    ) -> (GcStats, Vec<ObjectIndex>, HashMap<ObjectIndex, ObjectIndex>) {
+        self.copy_collection_with_forwarding(roots)
+    }
+
     /// Semi-space copy collection.
     ///
     /// Copies all live objects reachable from roots to the inactive space,
@@ -127,6 +145,83 @@ impl<F: Clone> BexHeap<F> {
         };
 
         (stats, remapped_roots)
+    }
+
+    /// Semi-space copy collection, returning forwarding map for external use.
+    fn copy_collection_with_forwarding(
+        &self,
+        roots: &[ObjectIndex],
+    ) -> (GcStats, Vec<ObjectIndex>, HashMap<ObjectIndex, ObjectIndex>) {
+        // Track old -> new index mappings (forwarding pointers)
+        let mut forwarding: HashMap<ObjectIndex, ObjectIndex> = HashMap::new();
+
+        // Get current and next space indices
+        let from_space = self.active_space_index();
+        let to_space = 1 - from_space;
+
+        // Get the old space size for stats calculation
+        let old_space_size = unsafe { (*self.spaces[from_space].get()).len() };
+
+        // Clear the target space and prepare for copying
+        unsafe {
+            (*self.spaces[to_space].get()).clear();
+        }
+
+        // Worklist for BFS traversal
+        let mut worklist: Vec<ObjectIndex> = roots.to_vec();
+
+        // Process all reachable objects
+        while let Some(old_idx) = worklist.pop() {
+            if forwarding.contains_key(&old_idx) {
+                continue;
+            }
+
+            if self.is_compile_time(old_idx) {
+                forwarding.insert(old_idx, old_idx);
+                continue;
+            }
+
+            let new_idx = self.copy_object_to_new_space(old_idx, to_space, &mut forwarding);
+
+            let ct_len = self.compile_time_len();
+            let obj = unsafe { &(&(*self.spaces[to_space].get()))[new_idx.into_raw() - ct_len] };
+            self.add_references_to_worklist(obj, &mut worklist);
+        }
+
+        // Fix up all references in the copied objects
+        unsafe {
+            self.fixup_references(to_space, &forwarding);
+        }
+
+        // Calculate stats before swapping
+        let live_count = unsafe { (*self.spaces[to_space].get()).len() };
+        let collected_count = old_space_size.saturating_sub(live_count);
+
+        // Swap spaces
+        self.active_space.store(to_space, Ordering::Release);
+        self.reset_next_chunk(live_count);
+
+        // Clear the old space
+        unsafe {
+            (*self.spaces[from_space].get()).clear();
+        }
+
+        // Remap roots to their new locations
+        let remapped_roots: Vec<ObjectIndex> = roots
+            .iter()
+            .map(|old_idx| *forwarding.get(old_idx).unwrap_or(old_idx))
+            .collect();
+
+        // Update handle table
+        self.update_handles(&forwarding);
+
+        let stats = GcStats {
+            live_count,
+            collected_count,
+            handles_invalidated: 0,
+        };
+
+        (stats, remapped_roots, forwarding)
     }
 
     /// Copy a single object from old space to new space.
@@ -445,6 +540,8 @@ mod tests {
     #[test]
     #[ignore] // TODO: Handle invalidation not implemented
     fn test_gc_invalidates_dead_handles() {
+        use bex_external_types::WeakHeapRef;
+
         let heap = BexHeap::<()>::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
 
@@ -453,13 +550,13 @@ mod tests {
         let handle = heap.create_handle(obj);
 
         // Verify handle is valid
-        assert!(heap.resolve_handle(&handle).is_some());
+        assert!(heap.resolve_handle(handle.slab_key()).is_some());
 
         // Run GC with no roots - object should be collected, handle invalidated
         let (stats, _) = unsafe { heap.collect_garbage(&[]) };
 
         assert_eq!(stats.handles_invalidated, 1);
-        assert!(heap.resolve_handle(&handle).is_none());
+        assert!(heap.resolve_handle(handle.slab_key()).is_none());
     }
 
     #[test]

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -399,14 +399,31 @@ impl<F> BexHeap<F> {
     ///
     /// Called by GC after copying objects to update handle table entries
     /// to point to the new locations.
-    pub fn update_handles(&self, forwarding: &HashMap<ObjectIndex, ObjectIndex>) {
+    /// Update handle entries after GC.
+    ///
+    /// Updates handles to point to new object locations. Invalidates handles
+    /// pointing to dead objects (runtime objects not found in forwarding map).
+    /// Preserves handles to compile-time objects even if not traced.
+    ///
+    /// Returns the number of handles invalidated.
+    pub fn update_handles(&self, forwarding: &HashMap<ObjectIndex, ObjectIndex>) -> usize {
+        let mut invalidated_count = 0;
         if let Ok(mut handles) = self.handles.write() {
-            for idx in handles.values_mut() {
+            handles.retain(|_, idx| {
                 if let Some(&new_idx) = forwarding.get(idx) {
                     *idx = new_idx;
+                    true
+                } else if self.is_compile_time(*idx) {
+                    // Compile-time objects are always valid
+                    true
+                } else {
+                    // Object dead (not forwarded and not compile-time)
+                    invalidated_count += 1;
+                    false
                 }
-            }
+            });
         }
+        invalidated_count
     }
 }
 

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -148,6 +148,13 @@ where
             handles.remove(&handle_key);
         }
     }
+
+    fn resolve_handle(&self, slab_key: usize) -> Option<ObjectIndex> {
+        self.handles
+            .read()
+            .ok()
+            .and_then(|handles| handles.get(&slab_key).copied())
+    }
 }
 
 impl<F> BexHeap<F> {
@@ -421,18 +428,8 @@ where
             handles.insert(handle_key, idx);
         }
 
-        // Use Handle::new from bex_external_types, passing self as WeakHeapRef
-        Handle::new(handle_key, idx, Arc::clone(self) as Arc<dyn WeakHeapRef>)
-    }
-
-    /// Resolve a handle to its ObjectIndex.
-    ///
-    /// Returns None if the handle has been invalidated (e.g., by GC).
-    pub fn resolve_handle(&self, handle: &Handle) -> Option<ObjectIndex> {
-        self.handles
-            .read()
-            .ok()
-            .and_then(|handles| handles.get(&handle.slab_key()).copied())
+        // Handle no longer stores idx - always resolves through table
+        Handle::new(handle_key, Arc::clone(self) as Arc<dyn WeakHeapRef>)
     }
 
     /// Collect all handle roots for garbage collection.
@@ -528,16 +525,20 @@ mod tests {
 
     #[test]
     fn test_handle_create_resolve() {
+        use bex_external_types::WeakHeapRef;
+
         let objects: Vec<Object<()>> = vec![Object::String("test".to_string())];
         let heap = BexHeap::new(objects);
 
         let handle = heap.create_handle(ObjectIndex::from_raw(0));
-        let resolved = heap.resolve_handle(&handle);
+        let resolved = heap.resolve_handle(handle.slab_key());
         assert_eq!(resolved, Some(ObjectIndex::from_raw(0)));
     }
 
     #[test]
     fn test_handle_clone_and_drop() {
+        use bex_external_types::WeakHeapRef;
+
         let objects: Vec<Object<()>> = vec![Object::String("test".to_string())];
         let heap = BexHeap::new(objects);
 
@@ -545,14 +546,14 @@ mod tests {
         let handle2 = handle1.clone();
 
         // Both handles resolve
-        assert!(heap.resolve_handle(&handle1).is_some());
-        assert!(heap.resolve_handle(&handle2).is_some());
+        assert!(heap.resolve_handle(handle1.slab_key()).is_some());
+        assert!(heap.resolve_handle(handle2.slab_key()).is_some());
 
         // Drop first clone
         drop(handle1);
 
         // Second clone still resolves
-        assert!(heap.resolve_handle(&handle2).is_some());
+        assert!(heap.resolve_handle(handle2.slab_key()).is_some());
 
         // Drop second clone - this should release the slab entry
         drop(handle2);

--- a/baml_language/crates/bex_heap/src/lib.rs
+++ b/baml_language/crates/bex_heap/src/lib.rs
@@ -58,11 +58,13 @@
 //! (internal)       (FFI boundary)         (memory)     (exec)     (async)
 //! ```
 
+mod accessor;
 mod gc;
 mod heap;
 mod tlab;
 
 // Re-export types from bex_external_types for convenience
+pub use accessor::GcProtectedHeap;
 pub use bex_external_types::{ExternalValue, Handle, Snapshot};
 pub use gc::GcStats;
 pub use heap::{BexHeap, DEFAULT_TLAB_SIZE, HeapStats};


### PR DESCRIPTION
## Summary

Complete the BEX garbage collector implementation by closing 5 identified gaps in the engine-level integration:

- **Gap 1**: Parked VM roots now collected via VM pointer registry
- **Gap 2**: VM stacks updated with forwarding pointers after GC  
- **Gap 3**: TLABs invalidated after GC space swap
- **Gap 6**: Handle race condition fixed with EpochGuard

## Key Changes

### VM Pointer Registry (Phase 1-2)
- Add `parked_vms: Mutex<Vec<VmPtr>>` to `EpochState` for tracking VMs at safepoints
- VMs register pointers before parking, unregister after GC completes
- GC collects roots from all parked VM stacks

### Stack Updates & TLAB Invalidation (Phase 3)
- Add `collect_garbage_with_forwarding()` that returns the forwarding map
- Update parked VM stacks with new object indices after GC moves objects
- Invalidate TLABs so VMs allocate from the new space

### Handle Race Condition Fixes (Phase 4)
- Remove cached `ObjectIndex` from `Handle` - always resolve through table
- Add `gc_in_progress` flag to synchronize new calls with GC
- New `call_function` invocations wait for in-progress GC before resolving handles

### EpochGuard & Accessor API (Phase 6)
- Add `EpochGuard` token type for compile-time epoch protection enforcement
- `Handle::object_index()` now requires `&EpochGuard<'_>` parameter
- Add heap accessor API (`read_string`, `read_array`, `with_object`) for safe external access

### Documentation & Tests (Phase 5)
- Add GC coordination documentation to module docs
- Add e2e tests: `test_gc_updates_forwarding_pointers`, `test_multiple_handles_survive_gc`

## Test plan

- [x] `cargo build -p bex_engine -p bex_heap -p bex_external_types` compiles
- [x] `cargo test -p bex_engine` - all tests pass (including 5 GC tests)
- [x] `cargo test -p bex_heap` - 28 tests pass
- [x] `cargo test -p bex_external_types` - all tests pass
- [x] `cargo clippy` passes
- [x] Compile-time enforcement: `handle.object_index()` without guard fails to compile

🤖 Generated with [Claude Code](https://claude.ai/code)