### PR TITLE
fix playground index on test history

### DIFF
--- a/typescript/apps/fiddle-web-app/app/[project_id]/_components/ProjectView.tsx
+++ b/typescript/apps/fiddle-web-app/app/[project_id]/_components/ProjectView.tsx
@@ -3,15 +3,15 @@
 import { CodeMirrorViewer } from '@baml/playground-common/codemirror-viewer';
 import { CustomErrorBoundary } from '@baml/playground-common/custom-error-boundary';
 import { EventListener } from '@baml/playground-common/event-listener';
-import { BAMLSDKProvider } from '@baml/playground-common/sdk';
+import { BAMLSDKProvider, useBAMLSDK } from '@baml/playground-common/sdk';
 import { PromptPreview } from '@baml/playground-common/prompt-preview';
 import {
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
 } from '@baml/ui/resizable';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
-import { Suspense, useEffect, useRef, useState } from 'react';
+import { useAtomValue, useSetAtom } from 'jotai';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { useKeybindingOverrides } from '../../../hooks/command-s';
 import type { BAMLProject } from '../../../lib/exampleProjects';
@@ -22,9 +22,7 @@ import {
   filesAtom,
   functionsAtom,
   unifiedSelectionStateAtom,
-  type SelectionState,
 } from '@baml/playground-common';
-import { useBAMLSDK } from '@baml/playground-common/sdk';
 import { useFeedbackWidget } from '@baml/playground-common/lib/feedback_widget';
 import { ScrollArea } from '@baml/ui/scroll-area';
 import Image from 'next/image';
@@ -39,36 +37,6 @@ const ErrorBoundaryWrapper = ({
   children: React.ReactNode;
 }) => <CustomErrorBoundary message={message}>{children}</CustomErrorBoundary>;
 
-// Hook for project file management
-const useProjectFiles = (project: BAMLProject) => {
-  const sdk = useBAMLSDK();
-  const files = useAtomValue(filesAtom);
-  const [unsavedChanges, setUnsavedChanges] = useAtom(unsavedChangesAtom);
-
-  useEffect(() => {
-    if (project) {
-      console.log('Updating files via SDK: project', project.id);
-      setUnsavedChanges(false);
-      const newFiles = project.files.reduce(
-        (acc, f) => {
-          acc[f.path] = f.content;
-          return acc;
-        },
-        {} as Record<string, string>,
-      );
-      // Use SDK to update files and recreate runtime
-      sdk.files.update(newFiles);
-    }
-  }, [project, sdk, setUnsavedChanges]);
-
-  // Wrapper to update files via SDK
-  const setFiles = (newFiles: Record<string, string>) => {
-    sdk.files.update(newFiles);
-  };
-
-  return { files, setFiles, unsavedChanges };
-};
-
 // Hook for editable text fields
 const useEditableField = (initialValue: string) => {
   const [value, setValue] = useState(initialValue);
@@ -82,7 +50,9 @@ const ProjectViewImpl = ({ project }: { project: BAMLProject }) => {
   useFeedbackWidget();
   useKeybindingOverrides();
 
-  const { files, setFiles, unsavedChanges } = useProjectFiles(project);
+  const sdk = useBAMLSDK();
+  const files = useAtomValue(filesAtom);
+  const unsavedChanges = useAtomValue(unsavedChangesAtom);
   const activeFileName = useAtomValue(activeFileNameAtom);
   const { value: projectName, setValue: setProjectName } = useEditableField(
     project.name,
@@ -95,12 +65,15 @@ const ProjectViewImpl = ({ project }: { project: BAMLProject }) => {
     textareaRef: descriptionTextareaRef,
   } = useEditableField(project.description);
 
+  // Note: Initial files are provided via BAMLSDKProvider's initialFiles prop
+  // No need for a useEffect here - the provider handles initialization
+
   const handleContentChange = (newContent: string) => {
     const newFiles: Record<string, string> = {};
     for (const [key, value] of Object.entries(files)) {
       newFiles[key] = key === activeFileName ? newContent : value;
     }
-    setFiles(newFiles);
+    sdk.files.update(newFiles);
   };
 
   return (
@@ -214,7 +187,7 @@ export const FunctionSelectorProvider = () => {
       // Only auto-select on initial load or when file changes
       // Check if we already have this function selected to avoid loops
       if (currentSelection.mode === 'function' &&
-          currentSelection.functionName === func.name) {
+        currentSelection.functionName === func.name) {
         // Already selected this function, only update test if empty
         if (!currentSelection.testName && firstTestName) {
           setSelectionState({
@@ -281,11 +254,24 @@ export const ProjectSidebar = () => (
   </div>
 );
 
-export const ProjectView = ({ project }: { project: BAMLProject }) => (
-  <BAMLSDKProvider mode="wasm">
-    <ProjectViewImpl project={project} />
-  </BAMLSDKProvider>
-);
+export const ProjectView = ({ project }: { project: BAMLProject }) => {
+  // Convert project files to the format expected by the SDK (memoized to prevent re-renders)
+  const initialFiles = useMemo(() => {
+    return project.files.reduce(
+      (acc, f) => {
+        acc[f.path] = f.content;
+        return acc;
+      },
+      {} as Record<string, string>,
+    );
+  }, [project.files]);
+
+  return (
+    <BAMLSDKProvider mode="wasm" initialFiles={initialFiles}>
+      <ProjectViewImpl project={project} />
+    </BAMLSDKProvider>
+  );
+};
 
 const PlaygroundView = () => (
   <ErrorBoundaryWrapper message="Error loading playground">

--- a/typescript/apps/fiddle-web-app/app/embed/clientwrapper.tsx
+++ b/typescript/apps/fiddle-web-app/app/embed/clientwrapper.tsx
@@ -1,12 +1,12 @@
 'use client';
-import { bamlFilesTrackedAtom, filesAtom } from '@baml/playground-common';
+import { filesAtom } from '@baml/playground-common';
 import { PromptPreview } from '@baml/playground-common/prompt-preview';
-import { BAMLSDKProvider } from '@baml/playground-common/sdk';
+import { BAMLSDKProvider, useBAMLSDK } from '@baml/playground-common/sdk';
 import { CodeMirrorViewer } from '@baml/playground-common/codemirror-viewer';
 import { EventListener } from '@baml/playground-common/event-listener';
 import { ResizableHandle, ResizablePanelGroup } from '@baml/ui/resizable';
 import { ResizablePanel } from '@baml/ui/resizable';
-import { useAtom, useAtomValue, useSetAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { isMobile } from 'react-device-detect';
 
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
@@ -14,7 +14,6 @@ import { activeFileNameAtom } from '../[project_id]/_atoms/atoms';
 import { ErrorBoundary } from 'react-error-boundary';
 import { Button } from '@baml/ui/button';
 import { RefreshCcw } from 'lucide-react';
-import { BrandedLoading } from '../_components/BrandedLoading';
 import FileViewer from '../[project_id]/_components/Tree/FileViewer';
 import { useSearchParams } from 'next/navigation';
 
@@ -73,17 +72,25 @@ interface EmbedComponentProps {
 }
 
 export default function EmbedComponent({ files }: EmbedComponentProps) {
+  // Convert files array to record format for SDK
+  const initialFiles = useMemo(() => {
+    const record: Record<string, string> = {};
+    for (const f of files) {
+      record[f.path] = f.content;
+    }
+    return record;
+  }, [files]);
+
   return (
-    <BAMLSDKProvider mode="wasm">
+    <BAMLSDKProvider mode="wasm" initialFiles={initialFiles}>
       <EmbedComponentInner files={files} />
     </BAMLSDKProvider>
   );
 }
 
 function EmbedComponentInner({ files }: EmbedComponentProps) {
+  const sdk = useBAMLSDK();
   const editorFiles = useAtomValue(filesAtom);
-  const setEditorFiles = useSetAtom(bamlFilesTrackedAtom);
-  const [isLoading, setIsLoading] = useState(true);
   const [previewReady, setPreviewReady] = useState(false);
   // SDK provider already ensures WASM is loaded before rendering children
   const activeFileName = useAtomValue(activeFileNameAtom);
@@ -102,20 +109,13 @@ function EmbedComponentInner({ files }: EmbedComponentProps) {
     };
   }, [searchParams]);
 
-  useEffect(() => {
-    // Populate files atom from provided project files
-    const record: Record<string, string> = {};
-    for (const f of files) {
-      record[f.path] = f.content;
-    }
-    setEditorFiles(record);
-    setIsLoading(false);
-  }, [files, setEditorFiles]);
+  // Note: Initial files are provided via BAMLSDKProvider's initialFiles prop
+  // No need for a useEffect here - the provider handles initialization
 
   // Apply default file if provided via URL (takes precedence once on mount when valid)
   const appliedDefaultRef = useRef(false);
   useEffect(() => {
-    if (isLoading || appliedDefaultRef.current) return;
+    if (appliedDefaultRef.current) return;
     const availablePaths = Object.keys(editorFiles);
     const isValidPath = (p: string | null | undefined) => !!p && availablePaths.includes(p);
     const defaultFile = searchParams.get('defaultFile') ?? undefined;
@@ -123,19 +123,15 @@ function EmbedComponentInner({ files }: EmbedComponentProps) {
       appliedDefaultRef.current = true;
       setActiveFileName(defaultFile as string);
     }
-  }, [isLoading, editorFiles, setActiveFileName, searchParams]);
+  }, [editorFiles, setActiveFileName, searchParams]);
 
   // Mark preview as ready after first paint to avoid flash between loader and preview
   useEffect(() => {
-    if (!isLoading && !previewReady) {
+    if (!previewReady) {
       const id = requestAnimationFrame(() => setPreviewReady(true));
       return () => cancelAnimationFrame(id);
     }
-  }, [isLoading, previewReady]);
-
-  if (isLoading) {
-    return <BrandedLoading />;
-  }
+  }, [previewReady]);
 
   return (
     <div className="flex justify-center items-center w-screen h-screen bg-background relative">
@@ -176,7 +172,7 @@ function EmbedComponentInner({ files }: EmbedComponentProps) {
                         Object.entries(editorFiles).forEach(([key, value]) => {
                           newFiles[key] = key === activeFileName ? v : value;
                         });
-                        setEditorFiles(newFiles);
+                        sdk.files.update(newFiles);
                       }}
                     />
                   )}

--- a/typescript/packages/playground-common/src/sdk/atoms/test.atoms.ts
+++ b/typescript/packages/playground-common/src/sdk/atoms/test.atoms.ts
@@ -44,6 +44,7 @@ export interface TestHistoryEntry {
  * A single test run containing multiple test executions
  */
 export interface TestHistoryRun {
+  runId: string;
   timestamp: number;
   tests: TestHistoryEntry[];
 }

--- a/typescript/packages/playground-common/src/sdk/factory.ts
+++ b/typescript/packages/playground-common/src/sdk/factory.ts
@@ -81,6 +81,7 @@ export function createRealBAMLSDK(store: ReturnType<typeof createStore>): BAMLSD
     envVars?: Record<string, string>,
     featureFlags?: string[]
   ) => {
+    console.log('[createRealBAMLSDK] Creating runtime with files', files);
     const { wasm, runtime } = await BamlRuntime.create(files, envVars || {}, featureFlags || []);
     storage.setWasm(wasm);
     return runtime;

--- a/typescript/packages/playground-common/src/sdk/provider.tsx
+++ b/typescript/packages/playground-common/src/sdk/provider.tsx
@@ -21,12 +21,14 @@ import { BAMLSDKContext } from './context';
 interface BAMLSDKProviderProps {
   children: ReactNode;
   mode?: RuntimeMode;
+  /** Initial files to load. If not provided, uses debug fixtures in debug mode, otherwise empty. */
+  initialFiles?: Record<string, string>;
 }
 
 /**
  * Provider component that wraps the app and provides SDK access
  */
-export function BAMLSDKProvider({ children, mode: initialMode = 'wasm' }: BAMLSDKProviderProps) {
+export function BAMLSDKProvider({ children, mode: initialMode = 'wasm', initialFiles: propInitialFiles }: BAMLSDKProviderProps) {
   // Check if debug mode is enabled (memoized to avoid SSR issues)
   const debugMode = useMemo(() => isDebugMode(), []);
 
@@ -72,20 +74,16 @@ export function BAMLSDKProvider({ children, mode: initialMode = 'wasm' }: BAMLSD
     async function init() {
       console.log('⏳ Initializing SDK with mode:', runtimeMode);
 
-      // Use debug fixtures when in debug mode, otherwise use empty files
-      const initialFiles = debugMode
-        ? DEBUG_BAML_FILES
-        : {
-          'workflows/simple.baml': '// Mock workflow file',
-          'workflows/conditional.baml': '// Mock conditional workflow',
-        };
+      // Use provided files, or debug fixtures in debug mode, or skip initialization
+      // If no files provided and not in debug mode, the consumer is responsible for calling sdk.files.update()
+      const initialFiles = propInitialFiles ?? (debugMode ? DEBUG_BAML_FILES : null);
 
-      await sdk.initialize(initialFiles);
+      if (initialFiles) {
+        await sdk.initialize(initialFiles);
+      }
 
       if (mounted) {
-        console.log('✅ SDK initialized successfully');
-        const workflows = sdk.workflows.getAll();
-        console.log('📦 Loaded workflows:', workflows.length, workflows.map((w) => w.id));
+        console.log(' ✅ SDK initialized successfully');
         setIsInitialized(true);
       }
     }
@@ -95,7 +93,7 @@ export function BAMLSDKProvider({ children, mode: initialMode = 'wasm' }: BAMLSD
     return () => {
       mounted = false;
     };
-  }, [sdk, runtimeMode, debugMode]);
+  }, [sdk, runtimeMode, debugMode, propInitialFiles]);
 
   return (
     <BAMLSDKContext.Provider value={sdk}>

--- a/typescript/packages/playground-common/src/sdk/sdk.ts
+++ b/typescript/packages/playground-common/src/sdk/sdk.ts
@@ -1077,7 +1077,10 @@ export class BAMLSDK {
       this.storage.clearAllNodeIterations();
 
       // Create test history run with all tests
+      // Generate unique runId to track this specific run in callbacks
+      const runId = `run-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
       const historyRun: testAtoms.TestHistoryRun = {
+        runId,
         timestamp: Date.now(),
         tests: tests.map((test) => {
           const testCases = this.runtime!.getTestCases(test.functionName);
@@ -1129,7 +1132,7 @@ export class BAMLSDK {
         const testKey = `${test.functionName}:${test.testName}`;
         watchNotificationsByTest[testKey] = [];
         // Mark as running - execution is about to begin
-        this.storage.updateTestInHistory(0, i, { status: 'running' });
+        this.storage.updateTestInHistoryByRunId(runId, i, { status: 'running' });
 
         // Emit node.enter to execution log
         const testCase = this.runtime!.getTestCases(test.functionName).find((tc) => tc.name === test.testName);
@@ -1166,7 +1169,7 @@ export class BAMLSDK {
             );
             if (testIndex !== -1) {
               const testKey = `${functionName}:${testName}`;
-              this.storage.updateTestInHistory(0, testIndex, {
+              this.storage.updateTestInHistoryByRunId(runId, testIndex, {
                 status: 'running',
                 response: partial,
                 watchNotifications: watchNotificationsByTest[testKey] || [],
@@ -1182,7 +1185,7 @@ export class BAMLSDK {
             );
             if (testIndex !== -1) {
               const testKey = `${functionName}:${testName}`;
-              this.storage.updateTestInHistory(0, testIndex, {
+              this.storage.updateTestInHistoryByRunId(runId, testIndex, {
                 status: 'done',
                 response,
                 response_status: status,
@@ -1276,7 +1279,7 @@ export class BAMLSDK {
 
         // Update all running/queued tests to error
         tests.forEach((_, i) => {
-          this.storage.updateTestInHistory(0, i, {
+          this.storage.updateTestInHistoryByRunId(runId, i, {
             status: 'error',
             message: err.message,
           });

--- a/typescript/packages/playground-common/src/sdk/sdk.ts
+++ b/typescript/packages/playground-common/src/sdk/sdk.ts
@@ -50,8 +50,8 @@ export class BAMLSDK {
   private storage: SDKStorage;
   private activeExecutions = new Map<string, AbortController>();
   private runtimeFactory: BamlRuntimeFactory;
-  private currentFiles: Record<string, string> = {};
   private coordinator: NavigationCoordinator | null = null;
+  private initialized = false;
 
   /**
    * Expose all atoms directly via sdk.atoms
@@ -66,6 +66,7 @@ export class BAMLSDK {
   constructor(runtimeFactory: BamlRuntimeFactory, storage: SDKStorage) {
     this.runtimeFactory = runtimeFactory;
     this.storage = storage;
+    this.initialized = false;
   }
 
   /**
@@ -79,6 +80,11 @@ export class BAMLSDK {
       featureFlags?: string[];
     }
   ) {
+    if (this.initialized) {
+      console.log('aaron: SDK: Already initialized, skipping initialization');
+      return;
+    }
+    this.initialized = true;
     if (Object.keys(initialFiles).length === 0) {
       throw new Error('Cannot initialize SDK with empty files');
     }
@@ -87,7 +93,6 @@ export class BAMLSDK {
     await this.loadVSCodeSettings();
 
     // Store initial state in atoms
-    this.currentFiles = initialFiles;
     this.storage.setBAMLFiles(initialFiles);
 
     if (options?.envVars) {
@@ -96,6 +101,9 @@ export class BAMLSDK {
     if (options?.featureFlags) {
       this.storage.setFeatureFlags(options.featureFlags);
     }
+
+    // Create the runtime with the initial files
+    await this.recreateRuntime();
   }
 
   /**
@@ -139,13 +147,14 @@ export class BAMLSDK {
    * WasmProject and WasmRuntime instances (not the entire WASM module)
    */
   private async recreateRuntime() {
-    console.log('SDK: Recreating runtime instance');
 
+    const files = this.storage.getBAMLFiles();
+    console.log('aaron: SDK: Recreating runtime instance with files', files);
     const envVars = this.storage.getEnvVars();
     const featureFlags = this.storage.getFeatureFlags();
 
     // Create new runtime instance (WASM module is cached, only WasmProject/WasmRuntime recreated)
-    this.runtime = await this.runtimeFactory(this.currentFiles, envVars, featureFlags);
+    this.runtime = await this.runtimeFactory(files, envVars, featureFlags);
 
     // Store runtime instance - this automatically updates all derived atoms
     this.storage.setRuntime(this.runtime);
@@ -160,6 +169,7 @@ export class BAMLSDK {
     //     );
     //   });
     // });
+    console.log('aaron: SDK: Parsed files', parsedFiles);
     this.storage.setParsedBAMLFiles(parsedFiles);
 
     // Store last valid WASM instance if no errors
@@ -288,7 +298,7 @@ export class BAMLSDK {
       }
 
       // Efficiently detect if file contents have changed
-      const oldFiles = this.currentFiles;
+      const oldFiles = this.storage.getBAMLFiles();
       const oldKeys = Object.keys(oldFiles);
       const newKeys = Object.keys(files);
 
@@ -314,13 +324,11 @@ export class BAMLSDK {
       }
 
       if (!changed) {
-        console.log('files: SDK: No file content changes detected, skipping runtime update');
+        console.log('aaron: files: SDK: No file content changes detected, skipping runtime update');
         return;
       }
 
-
       // Update files in storage (updates atom)
-      this.currentFiles = files;
       this.storage.setBAMLFiles(files);
 
       // Recreate runtime with new files
@@ -328,7 +336,7 @@ export class BAMLSDK {
     },
 
     getCurrent: () => {
-      return { ...this.currentFiles };
+      return { ...this.storage.getBAMLFiles() };
     },
   };
 
@@ -843,7 +851,7 @@ export class BAMLSDK {
       const result = this.runtime.updateCursor(cursor, fileContents, currentSelection);
 
       if (!result.functionName) {
-        console.debug('aaron: [SDK] Cursor not on any function');
+        console.debug('[SDK] Cursor not on any function');
         return;
       }
 

--- a/typescript/packages/playground-common/src/sdk/storage/JotaiStorage.ts
+++ b/typescript/packages/playground-common/src/sdk/storage/JotaiStorage.ts
@@ -431,14 +431,18 @@ export class JotaiStorage implements SDKStorage {
     return this.store.get(testHistoryAtom);
   }
 
-  updateTestInHistory(runIndex: number, testIndex: number, update: TestState) {
-    console.log('[JotaiStorage] updateTestInHistory called:', { runIndex, testIndex, update });
+  updateTestInHistoryByRunId(runId: string, testIndex: number, update: TestState) {
+    console.log('[JotaiStorage] updateTestInHistoryByRunId called:', { runId, testIndex, update });
     this.store.set(testHistoryAtom, (prev) => {
-      console.log('[JotaiStorage] inside functional updater, prev length:', prev.length);
+      const runIndex = prev.findIndex((run) => run.runId === runId);
+      if (runIndex === -1) {
+        console.warn('[JotaiStorage] run not found with runId:', runId);
+        return prev;
+      }
+
       const newHistory = [...prev];
       const run = newHistory[runIndex];
       if (!run) {
-        console.warn('[JotaiStorage] run not found at index:', runIndex);
         return prev;
       }
 
@@ -454,7 +458,7 @@ export class JotaiStorage implements SDKStorage {
         timestamp: Date.now(),
       };
 
-      console.log('[JotaiStorage] updated test:', run.tests[testIndex]);
+      console.log('[JotaiStorage] updated test by runId:', run.tests[testIndex]);
       return newHistory;
     });
   }

--- a/typescript/packages/playground-common/src/sdk/storage/SDKStorage.ts
+++ b/typescript/packages/playground-common/src/sdk/storage/SDKStorage.ts
@@ -197,7 +197,7 @@ export interface SDKStorage {
   // Test History
   addTestHistoryRun(run: TestHistoryRun): void;
   getTestHistory(): TestHistoryRun[];
-  updateTestInHistory(runIndex: number, testIndex: number, update: TestState): void;
+  updateTestInHistoryByRunId(runId: string, testIndex: number, update: TestState): void;
   setSelectedHistoryIndex(index: number): void;
   getSelectedHistoryIndex(): number;
 

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/prompt-preview-content.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/prompt-preview/prompt-preview-content.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { useMemo } from 'react';
 import useSWR from 'swr';
 import { apiKeysAtom } from '../../../../components/api-keys-dialog/atoms';
-import { ctxAtom, diagnosticsAtom, filesAtom, runtimeAtom } from '../../atoms';
+import { ctxAtom, diagnosticsAtom } from '../../atoms';
 import { areTestsRunningAtom, selectionAtom } from '../atoms';
 import { Loader } from './components';
 import { vscode } from '../../vscode';
@@ -18,13 +18,13 @@ export const PromptPreviewContent = () => {
   const runtime = useAtomValue(runtimeInstanceAtom);
   const apiKeys = useAtomValue(apiKeysAtom);
   const ctx = useAtomValue(ctxAtom);
-  const files = useAtomValue(filesAtom);
   const { selectedFn, selectedTc } = useAtomValue(selectionAtom);
   const diagnostics = useAtomValue(diagnosticsAtom);
   const setPromptData = useSetAtom(renderedPromptAtom);
   const areTestsRunning = useAtomValue(areTestsRunningAtom);
 
   // Memoize the generatePreview function to prevent unnecessary re-renders
+  // Note: runtime is a new instance each time files change, so including it triggers re-memoization
   const generatePreview = useMemo(
     () => async () => {
       if (
@@ -63,7 +63,7 @@ export const PromptPreviewContent = () => {
         throw error;
       }
     },
-    [runtime, ctx, selectedFn, selectedTc, apiKeys, files, setPromptData],
+    [runtime, ctx, selectedFn, selectedTc, apiKeys, setPromptData],
   );
 
   const [lastKnownPreview, setLastKnownPreview] = useState<
@@ -76,14 +76,15 @@ export const PromptPreviewContent = () => {
     error,
     isLoading,
   } = useSWR(
-    // Include file content in the key so updates trigger when typing
+    // Include runtime in key to re-fetch when runtime is recreated (after file changes)
+    // Runtime is a new instance each time files change, so this triggers re-fetch
     runtime && selectedFn && selectedTc
       ? [
         'prompt-preview',
+        runtime, // Runtime instance changes when files change
         selectedFn.name,
         selectedTc.name,
         JSON.stringify(apiKeys),
-        JSON.stringify(files), // Add file content to trigger updates on typing
       ]
       : null,
     generatePreview,
@@ -97,11 +98,11 @@ export const PromptPreviewContent = () => {
 
   if (isLoading && !preview) {
     if (lastKnownPreview) {
-      console.log('[PromptPreview] Rendering last known preview');
       return <RenderPrompt prompt={lastKnownPreview} testCase={selectedTc ?? undefined} />;
     }
     return <Loader message="Loading..." />;
   }
+
 
   if (error) {
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Modernizes SDK initialization and test tracking while simplifying app wiring.
> 
> - **SDK/Provider:** Add `BAMLSDKProvider initialFiles` and initialize conditionally; make storage the single source of truth for files; recreate runtime from `storage.getBAMLFiles()`; add init guard; minor logging cleanup
> - **Test history:** Add `runId` to `TestHistoryRun` and switch updates to `updateTestInHistoryByRunId`; propagate through SDK `runAll` and `JotaiStorage` API
> - **App/embed integration:** `ProjectView` and embed wrapper now pass project `initialFiles` into provider and use `sdk.files.update` on editor changes (remove atom-based file bootstrapping)
> - **Prompt preview:** Revalidate on runtime instance changes instead of serializing files; minor cleanup
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23208c271ba26bbca234a66b03c1f9f97056ff98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->