### PR TITLE
refactor(hir): eliminate string-based type parsing with token-based approach

### DIFF
--- a/baml_language/crates/baml_compiler_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_hir/src/lib.rs
@@ -1515,6 +1515,44 @@ fn describe_block_attribute_args(attr: &baml_compiler_syntax::ast::BlockAttribut
     }
 }
 
+/// Check if a `TYPE_EXPR` has actual content (not empty from parser error recovery).
+///
+/// The parser creates empty `TYPE_EXPR` nodes for error recovery (e.g., `map<>`).
+/// This function checks if the `TYPE_EXPR` has meaningful content like:
+/// - A base name (int, string, User, etc.)
+/// - A string literal ("admin")
+/// - An integer literal (200)
+/// - A bool literal (true/false)
+/// - An inner parenthesized type
+/// - Is a union type
+fn has_type_content(type_expr: &baml_compiler_syntax::ast::TypeExpr) -> bool {
+    // Check for base name (primitives and named types)
+    if type_expr.base_name().is_some() {
+        return true;
+    }
+    // Check for string literal
+    if type_expr.string_literal().is_some() {
+        return true;
+    }
+    // Check for integer literal
+    if type_expr.integer_literal().is_some() {
+        return true;
+    }
+    // Check for bool literal
+    if type_expr.bool_literal().is_some() {
+        return true;
+    }
+    // Check for parenthesized type (has inner content)
+    if type_expr.inner_type_expr().is_some() {
+        return true;
+    }
+    // Check for union type
+    if type_expr.is_union() {
+        return true;
+    }
+    false
+}
+
 /// Validate map type arity in a type expression.
 ///
 /// Maps require exactly 2 type parameters: `map<K, V>`.
@@ -1546,10 +1584,19 @@ fn validate_map_type_in_union_member(
     if let Some(name) = part.first_word() {
         if name == "map" {
             // Get TYPE_ARGS and count type parameters
+            // Note: Only count TYPE_EXPR nodes that have actual content (base_name).
+            // The parser creates empty TYPE_EXPR nodes for error recovery (e.g., map<>).
             if let Some(type_args) = part.type_args() {
                 let param_count = type_args
                     .children()
                     .filter(|n| n.kind() == baml_compiler_syntax::SyntaxKind::TYPE_EXPR)
+                    .filter(|n| {
+                        // Check if TYPE_EXPR has actual content (not empty from error recovery)
+                        // Empty TYPE_EXPR nodes have no meaningful tokens/children
+                        baml_compiler_syntax::ast::TypeExpr::cast(n.clone())
+                            .map(|te| has_type_content(&te))
+                            .unwrap_or(false)
+                    })
                     .count();
 
                 if param_count != 2 {
@@ -1602,7 +1649,12 @@ fn validate_map_type_in_type_expr(
     // Check if this is a map type
     if let Some(name) = type_expr.base_name() {
         if name == "map" {
-            let type_args = type_expr.type_arg_exprs();
+            // Filter out empty TYPE_EXPR nodes created by parser error recovery (e.g., map<>)
+            let type_args: Vec<_> = type_expr
+                .type_arg_exprs()
+                .into_iter()
+                .filter(has_type_content)
+                .collect();
             let param_count = type_args.len();
 
             if param_count != 2 {

--- a/baml_language/crates/baml_compiler_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_hir/src/lib.rs
@@ -1515,28 +1515,6 @@ fn describe_block_attribute_args(attr: &baml_compiler_syntax::ast::BlockAttribut
     }
 }
 
-/// Count the number of top-level generic parameters in a map type.
-///
-/// For `string, int` returns 2 (correct for map).
-/// For `string, string, string` returns 3 (error: too many params).
-/// For `string` returns 1 (error: too few params).
-fn count_generic_params(s: &str) -> usize {
-    if s.trim().is_empty() {
-        return 0;
-    }
-    let mut depth = 0;
-    let mut count = 1; // Start at 1 because we count separators + 1
-    for c in s.chars() {
-        match c {
-            '<' => depth += 1,
-            '>' => depth -= 1,
-            ',' if depth == 0 => count += 1,
-            _ => {}
-        }
-    }
-    count
-}
-
 /// Validate map type arity in a type expression.
 ///
 /// Maps require exactly 2 type parameters: `map<K, V>`.
@@ -1545,22 +1523,88 @@ fn validate_map_type_arity(
     type_expr: &baml_compiler_syntax::ast::TypeExpr,
     ctx: &mut LoweringContext,
 ) {
-    // Get all parts (handles union types like `string | map<...>`)
-    for part in type_expr.parts() {
-        validate_map_type_in_text(&part, type_expr, ctx);
+    // For union types, check each member
+    if type_expr.is_union() {
+        for part in type_expr.union_member_parts() {
+            validate_map_type_in_union_member(&part, type_expr, ctx);
+        }
+    } else {
+        // For non-union types, check the type expression directly
+        validate_map_type_in_type_expr(type_expr, ctx);
     }
 }
 
-/// Recursively validate map types in a type text string.
-fn validate_map_type_in_text(
-    text: &str,
+/// Validate map types in a union member (token-based).
+fn validate_map_type_in_union_member(
+    part: &baml_compiler_syntax::ast::UnionMemberParts,
     type_expr: &baml_compiler_syntax::ast::TypeExpr,
     ctx: &mut LoweringContext,
 ) {
+    use rowan::ast::AstNode;
+
+    // Check if this is a map type by looking at first word
+    if let Some(name) = part.first_word() {
+        if name == "map" {
+            // Get TYPE_ARGS and count type parameters
+            if let Some(type_args) = part.type_args() {
+                let param_count = type_args
+                    .children()
+                    .filter(|n| n.kind() == baml_compiler_syntax::SyntaxKind::TYPE_EXPR)
+                    .count();
+
+                if param_count != 2 {
+                    ctx.push_diagnostic(HirDiagnostic::InvalidMapArity {
+                        expected: 2,
+                        found: param_count,
+                        span: ctx.span(type_expr.syntax().text_range()),
+                    });
+                } else {
+                    // Recursively check nested types in both key and value
+                    for child in type_args.children() {
+                        if child.kind() == baml_compiler_syntax::SyntaxKind::TYPE_EXPR {
+                            if let Some(child_expr) =
+                                baml_compiler_syntax::ast::TypeExpr::cast(child)
+                            {
+                                validate_map_type_in_type_expr(&child_expr, ctx);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Check for nested types in parenthesized expressions
+    if let Some(inner_expr) = part.type_expr() {
+        validate_map_type_in_type_expr(&inner_expr, ctx);
+    }
+}
+
+/// Validate map types in a type expression recursively.
+fn validate_map_type_in_type_expr(
+    type_expr: &baml_compiler_syntax::ast::TypeExpr,
+    ctx: &mut LoweringContext,
+) {
+    // Handle union types
+    if type_expr.is_union() {
+        for part in type_expr.union_member_parts() {
+            validate_map_type_in_union_member(&part, type_expr, ctx);
+        }
+        return;
+    }
+
+    // Handle parenthesized types
+    if let Some(inner) = type_expr.inner_type_expr() {
+        validate_map_type_in_type_expr(&inner, ctx);
+        return;
+    }
+
     // Check if this is a map type
-    if let Some(rest) = text.strip_prefix("map<") {
-        if let Some(inner) = rest.strip_suffix('>') {
-            let param_count = count_generic_params(inner);
+    if let Some(name) = type_expr.base_name() {
+        if name == "map" {
+            let type_args = type_expr.type_arg_exprs();
+            let param_count = type_args.len();
+
             if param_count != 2 {
                 ctx.push_diagnostic(HirDiagnostic::InvalidMapArity {
                     expected: 2,
@@ -1569,39 +1613,12 @@ fn validate_map_type_in_text(
                 });
             } else {
                 // Recursively check nested types in both key and value
-                if let Some(comma_idx) = find_top_level_comma(inner) {
-                    let key_text = inner[..comma_idx].trim();
-                    let value_text = inner[comma_idx + 1..].trim();
-                    validate_map_type_in_text(key_text, type_expr, ctx);
-                    validate_map_type_in_text(value_text, type_expr, ctx);
+                for arg in type_args {
+                    validate_map_type_in_type_expr(&arg, ctx);
                 }
             }
         }
     }
-
-    // Also check for nested maps in array types (e.g., `map<string, string, string>[]`)
-    if let Some(inner_text) = text.strip_suffix("[]") {
-        validate_map_type_in_text(inner_text, type_expr, ctx);
-    }
-
-    // Check for nested maps in optional types (e.g., `map<string, string, string>?`)
-    if let Some(inner_text) = text.strip_suffix('?') {
-        validate_map_type_in_text(inner_text, type_expr, ctx);
-    }
-}
-
-/// Find the index of the first top-level comma in a string.
-fn find_top_level_comma(s: &str) -> Option<usize> {
-    let mut depth = 0;
-    for (i, c) in s.char_indices() {
-        match c {
-            '<' => depth += 1,
-            '>' => depth -= 1,
-            ',' if depth == 0 => return Some(i),
-            _ => {}
-        }
-    }
-    None
 }
 
 /// Helper to check for duplicate names and record errors.

--- a/baml_language/crates/baml_compiler_hir/src/type_ref.rs
+++ b/baml_language/crates/baml_compiler_hir/src/type_ref.rs
@@ -4,6 +4,7 @@
 //! `TypeRef` -> Ty happens during THIR construction.
 
 use baml_base::Name;
+use rowan::ast::AstNode;
 
 use crate::path::Path;
 
@@ -111,13 +112,9 @@ impl TypeRef {
         // For `int[] | string[]`, this is a union of arrays, not an array of unions
         // Note: `(int | string)[]` has PIPE inside parens, so is_union() returns false
         if type_expr.is_union() {
-            // For unions, the CST may have child TYPE_EXPR nodes for parenthesized members
-            // (e.g., `(Failure)` in `Success | (Failure)`), but simple type names are just tokens.
-            //
-            // To properly handle all cases, we parse the text parts which correctly groups
-            // tokens between PIPE separators.
-            let parts = type_expr.parts();
-            let members: Vec<TypeRef> = parts.iter().map(|p| Self::from_type_text(p)).collect();
+            // Parse each union member using structured token/node accessors
+            let member_parts = type_expr.union_member_parts();
+            let members: Vec<TypeRef> = member_parts.iter().map(Self::from_union_member).collect();
             return TypeRef::Union(members);
         }
 
@@ -204,98 +201,87 @@ impl TypeRef {
         TypeRef::Unknown
     }
 
-    /// Create a `TypeRef` from a single type text (not a union).
+    /// Parse a union member from its structured parts (tokens and child nodes).
     ///
-    /// This handles:
-    /// - String literal types: `"foo"` or `'bar'`
-    /// - Array types: `int[]`
-    /// - Optional types: `int?`
-    /// - Boolean literal types: `true` or `false`
-    /// - Integer literal types: `42`
-    /// - Primitive types: `int`, `string`, etc.
-    /// - Named types: `User`, `MyClass`
-    pub(crate) fn from_type_text(text: &str) -> Self {
-        // Check for string literal types like "user" or "assistant"
-        if text.starts_with('"') && text.ends_with('"') {
-            let inner = &text[1..text.len() - 1];
-            return TypeRef::StringLiteral(inner.to_string());
+    /// Uses token kinds and child node kinds directly instead of string manipulation.
+    fn from_union_member(parts: &baml_compiler_syntax::ast::UnionMemberParts) -> Self {
+        // Check for parenthesized type first (e.g., `(int | string)` in `A | (int | string)`)
+        if let Some(type_expr) = parts.type_expr() {
+            let inner = Self::from_ast(&type_expr);
+            // Apply array and optional modifiers from tokens
+            return Self::apply_modifiers_from_parts(inner, parts);
         }
 
-        // Check for array type (e.g., "int[]")
-        if let Some(inner_text) = text.strip_suffix("[]") {
-            let inner = Self::from_type_text(inner_text);
-            return TypeRef::List(Box::new(inner));
+        // Check for string literal (e.g., `"user"` in `"user" | "admin"`)
+        if let Some(s) = parts.string_literal() {
+            let base = TypeRef::StringLiteral(s);
+            return Self::apply_modifiers_from_parts(base, parts);
         }
 
-        // Check for optional type (e.g., "int?")
-        if let Some(inner_text) = text.strip_suffix('?') {
-            let inner = Self::from_type_text(inner_text);
-            return TypeRef::Optional(Box::new(inner));
+        // Check for integer literal (e.g., `200` in `200 | 201`)
+        if let Some(i) = parts.integer_literal() {
+            let base = TypeRef::IntLiteral(i);
+            return Self::apply_modifiers_from_parts(base, parts);
         }
 
-        // Check for boolean literal types
-        if text == "true" {
-            return TypeRef::BoolLiteral(true);
-        }
-        if text == "false" {
-            return TypeRef::BoolLiteral(false);
-        }
+        // Check for named/primitive type or map type (e.g., `int`, `User`, `map<K,V>`)
+        if let Some(name) = parts.first_word() {
+            // Check for map type with TYPE_ARGS
+            if name == "map" {
+                if let Some(type_args_node) = parts.type_args() {
+                    let type_arg_exprs: Vec<_> = type_args_node
+                        .children()
+                        .filter(|n| n.kind() == baml_compiler_syntax::SyntaxKind::TYPE_EXPR)
+                        .map(|n| baml_compiler_syntax::ast::TypeExpr::cast(n).unwrap())
+                        .collect();
 
-        // Check for integer literal types (for exhaustiveness like 200 | 201)
-        if let Ok(int_val) = text.parse::<i64>() {
-            return TypeRef::IntLiteral(int_val);
-        }
-
-        // Check for map type (e.g., "map<string, int>")
-        if let Some(rest) = text.strip_prefix("map<") {
-            if let Some(inner) = rest.strip_suffix('>') {
-                // Find the comma that separates key and value types
-                // Need to handle nested generics like map<string, map<int, bool>>
-                if let Some((key_text, value_text)) = Self::split_generic_params(inner) {
-                    let key = Self::from_type_text(key_text.trim());
-                    let value = Self::from_type_text(value_text.trim());
-                    return TypeRef::Map {
-                        key: Box::new(key),
-                        value: Box::new(value),
-                    };
+                    if type_arg_exprs.len() == 2 {
+                        let key = Self::from_ast(&type_arg_exprs[0]);
+                        let value = Self::from_ast(&type_arg_exprs[1]);
+                        let base = TypeRef::Map {
+                            key: Box::new(key),
+                            value: Box::new(value),
+                        };
+                        return Self::apply_modifiers_from_parts(base, parts);
+                    }
                 }
             }
+
+            // Check for boolean literals
+            let base = match name {
+                "true" => TypeRef::BoolLiteral(true),
+                "false" => TypeRef::BoolLiteral(false),
+                _ => Self::from_type_name(name),
+            };
+            return Self::apply_modifiers_from_parts(base, parts);
         }
 
-        // Detect numeric literals that failed parsing above:
-        // - Integer overflow (e.g., "9...9" > i64::MAX)
-        // - Float literals (e.g., "3.14")
-        //
-        // Without this check, these would fall through to `from_type_name` and
-        // incorrectly become named types, causing confusing "unknown type" errors.
-        //
-        // TODO: Add spans to TypeRef to emit proper diagnostics instead of just Error.
-        // See: https://github.com/BoundaryML/baml/pull/2838/files/1e6d23cc70e4825bfca302069caee658c7a0f437#r2634900737
-        if text.starts_with(|c: char| c.is_ascii_digit()) {
-            return TypeRef::Error;
-        }
-
-        Self::from_type_name(text)
+        TypeRef::Unknown
     }
 
-    /// Split generic parameters at the top-level comma.
-    /// Handles nested generics like `string, map<int, bool>`.
-    fn split_generic_params(s: &str) -> Option<(&str, &str)> {
-        let mut depth = 0;
-        for (i, c) in s.char_indices() {
-            match c {
-                '<' => depth += 1,
-                '>' => depth -= 1,
-                ',' if depth == 0 => {
-                    return Some((&s[..i], &s[i + 1..]));
-                }
-                _ => {}
-            }
+    /// Apply array and optional modifiers from `UnionMemberParts` to a base type.
+    fn apply_modifiers_from_parts(
+        base: Self,
+        parts: &baml_compiler_syntax::ast::UnionMemberParts,
+    ) -> Self {
+        let array_depth = parts.array_depth();
+        let is_optional = parts.is_optional();
+
+        // Wrap in array layers
+        let mut result = base;
+        for _ in 0..array_depth {
+            result = TypeRef::List(Box::new(result));
         }
-        None
+
+        // Wrap in optional if needed
+        if is_optional {
+            result = TypeRef::Optional(Box::new(result));
+        }
+
+        result
     }
 
-    /// Create a `TypeRef` from a type name string.
+    /// Create a `TypeRef` from a type name string (primitive or user-defined).
     fn from_type_name(name: &str) -> Self {
         match name.to_lowercase().as_str() {
             "int" => TypeRef::Int,
@@ -309,87 +295,5 @@ impl TypeRef {
             "pdf" => TypeRef::Media(baml_base::MediaKind::Pdf),
             _ => TypeRef::Path(Path::single(Name::new(name))),
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_string_literal() {
-        assert_eq!(
-            TypeRef::from_type_text(r#""user""#),
-            TypeRef::StringLiteral("user".to_string())
-        );
-    }
-
-    #[test]
-    fn test_optional_string_literal() {
-        // Regression test: ensure "literal"? correctly produces Optional(StringLiteral)
-        // The string literal check requires BOTH starts_with('"') AND ends_with('"').
-        // For `"user"?`, ends_with('"') is false, so we fall through to optional check.
-        assert_eq!(
-            TypeRef::from_type_text(r#""user"?"#),
-            TypeRef::Optional(Box::new(TypeRef::StringLiteral("user".to_string())))
-        );
-    }
-
-    #[test]
-    fn test_array_of_string_literal() {
-        assert_eq!(
-            TypeRef::from_type_text(r#""user"[]"#),
-            TypeRef::List(Box::new(TypeRef::StringLiteral("user".to_string())))
-        );
-    }
-
-    #[test]
-    fn test_optional_array_of_string_literal() {
-        // "user"[]? -> Optional(List(StringLiteral("user")))
-        assert_eq!(
-            TypeRef::from_type_text(r#""user"[]?"#),
-            TypeRef::Optional(Box::new(TypeRef::List(Box::new(TypeRef::StringLiteral(
-                "user".to_string()
-            )))))
-        );
-    }
-
-    #[test]
-    fn test_optional_int_literal() {
-        assert_eq!(
-            TypeRef::from_type_text("200?"),
-            TypeRef::Optional(Box::new(TypeRef::IntLiteral(200)))
-        );
-    }
-
-    #[test]
-    fn test_optional_bool_literal() {
-        assert_eq!(
-            TypeRef::from_type_text("true?"),
-            TypeRef::Optional(Box::new(TypeRef::BoolLiteral(true)))
-        );
-    }
-
-    #[test]
-    fn test_primitives() {
-        assert_eq!(TypeRef::from_type_text("int"), TypeRef::Int);
-        assert_eq!(TypeRef::from_type_text("string"), TypeRef::String);
-        assert_eq!(TypeRef::from_type_text("bool"), TypeRef::Bool);
-    }
-
-    #[test]
-    fn test_optional_primitive() {
-        assert_eq!(
-            TypeRef::from_type_text("int?"),
-            TypeRef::Optional(Box::new(TypeRef::Int))
-        );
-    }
-
-    #[test]
-    fn test_array_of_primitive() {
-        assert_eq!(
-            TypeRef::from_type_text("int[]"),
-            TypeRef::List(Box::new(TypeRef::Int))
-        );
     }
 }

--- a/baml_language/crates/baml_compiler_hir/src/type_ref.rs
+++ b/baml_language/crates/baml_compiler_hir/src/type_ref.rs
@@ -111,6 +111,11 @@ impl TypeRef {
         // For `int[] | string[]`, this is a union of arrays, not an array of unions
         // Note: `(int | string)[]` has PIPE inside parens, so is_union() returns false
         if type_expr.is_union() {
+            // For unions, the CST may have child TYPE_EXPR nodes for parenthesized members
+            // (e.g., `(Failure)` in `Success | (Failure)`), but simple type names are just tokens.
+            //
+            // To properly handle all cases, we parse the text parts which correctly groups
+            // tokens between PIPE separators.
             let parts = type_expr.parts();
             let members: Vec<TypeRef> = parts.iter().map(|p| Self::from_type_text(p)).collect();
             return TypeRef::Union(members);
@@ -127,6 +132,8 @@ impl TypeRef {
     }
 
     /// Get the element type for an array `TypeExpr`.
+    ///
+    /// Uses token-based `array_depth()` to handle nested arrays without string manipulation.
     fn from_ast_array_element(type_expr: &baml_compiler_syntax::ast::TypeExpr) -> Self {
         // For parenthesized arrays like `(int | string)[]`, the element is the inner TypeExpr
         if let Some(inner) = type_expr.inner_type_expr() {
@@ -134,20 +141,19 @@ impl TypeRef {
         }
 
         // For non-parenthesized arrays like `int[]`, `string[][]`, `"user"[]`:
-        // Get the type text and strip the trailing [] to get the element type.
-        // This handles nested arrays correctly (e.g., `string[][]` -> `string[]`).
-        let parts = type_expr.parts();
-        if let Some(text) = parts.first() {
-            // Strip optional `?` first (if we're called from within optional handling)
-            let text = text.strip_suffix('?').unwrap_or(text);
-            // Strip the trailing `[]` to get the element type
-            if let Some(element_text) = text.strip_suffix("[]") {
-                return Self::from_type_text(element_text);
-            }
-        }
+        // Use array_depth() to count nesting levels and from_ast_base_type() for the base.
+        //
+        // For `int[][]`: depth=2, base=Int -> element is List(Int) i.e. `int[]`
+        // For `int[]`: depth=1, base=Int -> element is Int
+        let depth = type_expr.array_depth();
+        let base = Self::from_ast_base_type(type_expr);
 
-        // Fallback: should not reach here for well-formed array types
-        Self::from_ast_base_type(type_expr)
+        // Wrap base type in (depth-1) List layers to get the element type
+        let mut result = base;
+        for _ in 0..depth.saturating_sub(1) {
+            result = TypeRef::List(Box::new(result));
+        }
+        result
     }
 
     /// Parse the base type (no optional, array, or union modifiers).

--- a/baml_language/crates/baml_compiler_hir/src/type_ref.rs
+++ b/baml_language/crates/baml_compiler_hir/src/type_ref.rs
@@ -85,30 +85,117 @@ impl TypeRef {
 
     /// Create a `TypeRef` from an AST `TypeExpr` node.
     ///
-    /// This properly handles complex types including:
+    /// This uses structured CST accessors to properly handle complex types including:
     /// - Primitives: int, string, bool, etc.
     /// - Named types: User, `MyClass`
     /// - Optional types: string?
     /// - List types: string[]
     /// - Union types: Success | Failure
     /// - String literal types: "user" | "assistant"
-    ///
-    /// NOTE: Type parsing occurs here, which is somewhat brittle for edge cases
-    /// like `int??` or `int[][]`. See canary TODO for future improvements.
+    /// - Parenthesized types: (int | string)[]
+    /// - Generic types: map<K, V>
     pub fn from_ast(type_expr: &baml_compiler_syntax::ast::TypeExpr) -> Self {
-        let parts = type_expr.parts();
+        // Handle optional modifier (outermost)
+        // For `int[]?`, optional wraps the array
+        if type_expr.is_optional() {
+            let inner = Self::from_ast_without_optional(type_expr);
+            return TypeRef::Optional(Box::new(inner));
+        }
 
-        // If multiple parts, this is a union type
-        if parts.len() > 1 {
+        Self::from_ast_without_optional(type_expr)
+    }
+
+    /// Parse a `TypeExpr` assuming the optional modifier has been handled.
+    fn from_ast_without_optional(type_expr: &baml_compiler_syntax::ast::TypeExpr) -> Self {
+        // Handle union FIRST (top-level PIPE)
+        // For `int[] | string[]`, this is a union of arrays, not an array of unions
+        // Note: `(int | string)[]` has PIPE inside parens, so is_union() returns false
+        if type_expr.is_union() {
+            let parts = type_expr.parts();
             let members: Vec<TypeRef> = parts.iter().map(|p| Self::from_type_text(p)).collect();
             return TypeRef::Union(members);
         }
 
-        // Single type (possibly with modifiers like ? or [])
-        parts
-            .first()
-            .map(|p| Self::from_type_text(p))
-            .unwrap_or(TypeRef::Unknown)
+        // Handle array modifier
+        // For `(int | string)[]`, array wraps the parenthesized union
+        if type_expr.is_array() {
+            let element = Self::from_ast_array_element(type_expr);
+            return TypeRef::List(Box::new(element));
+        }
+
+        Self::from_ast_base(type_expr)
+    }
+
+    /// Get the element type for an array `TypeExpr`.
+    fn from_ast_array_element(type_expr: &baml_compiler_syntax::ast::TypeExpr) -> Self {
+        // For parenthesized arrays like `(int | string)[]`, the element is the inner TypeExpr
+        if let Some(inner) = type_expr.inner_type_expr() {
+            return Self::from_ast(&inner);
+        }
+
+        // For non-parenthesized arrays like `int[]`, `string[][]`, `"user"[]`:
+        // Get the type text and strip the trailing [] to get the element type.
+        // This handles nested arrays correctly (e.g., `string[][]` -> `string[]`).
+        let parts = type_expr.parts();
+        if let Some(text) = parts.first() {
+            // Strip optional `?` first (if we're called from within optional handling)
+            let text = text.strip_suffix('?').unwrap_or(text);
+            // Strip the trailing `[]` to get the element type
+            if let Some(element_text) = text.strip_suffix("[]") {
+                return Self::from_type_text(element_text);
+            }
+        }
+
+        // Fallback: should not reach here for well-formed array types
+        Self::from_ast_base_type(type_expr)
+    }
+
+    /// Parse the base type (no optional, array, or union modifiers).
+    fn from_ast_base(type_expr: &baml_compiler_syntax::ast::TypeExpr) -> Self {
+        // Handle parenthesized types like `(int | string)`
+        if let Some(inner) = type_expr.inner_type_expr() {
+            return Self::from_ast(&inner);
+        }
+
+        Self::from_ast_base_type(type_expr)
+    }
+
+    /// Parse a base type (no modifiers, not a union).
+    fn from_ast_base_type(type_expr: &baml_compiler_syntax::ast::TypeExpr) -> Self {
+        // Check for string literal types like `"user"`
+        if let Some(s) = type_expr.string_literal() {
+            return TypeRef::StringLiteral(s);
+        }
+
+        // Check for integer literal types like `200`
+        if let Some(i) = type_expr.integer_literal() {
+            return TypeRef::IntLiteral(i);
+        }
+
+        // Check for boolean literal types
+        if let Some(b) = type_expr.bool_literal() {
+            return TypeRef::BoolLiteral(b);
+        }
+
+        // Check for map type with type args
+        if let Some(name) = type_expr.base_name() {
+            if name == "map" {
+                let args = type_expr.type_arg_exprs();
+                if args.len() == 2 {
+                    let key = Self::from_ast(&args[0]);
+                    let value = Self::from_ast(&args[1]);
+                    return TypeRef::Map {
+                        key: Box::new(key),
+                        value: Box::new(value),
+                    };
+                }
+            }
+
+            // Named type (primitive or user-defined)
+            return Self::from_type_name(&name);
+        }
+
+        TypeRef::Unknown
     }
 
     /// Create a `TypeRef` from a single type text (not a union).

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -74,6 +74,134 @@ ast_node!(Attribute, ATTRIBUTE);
 ast_node!(TypeBuilderBlock, TYPE_BUILDER_BLOCK);
 ast_node!(DynamicTypeDef, DYNAMIC_TYPE_DEF);
 
+/// Parts of a union member for token-based parsing.
+///
+/// Union members can contain both tokens (WORD, `L_BRACKET`, etc.) and child nodes
+/// (`STRING_LITERAL`, `TYPE_EXPR` for parenthesized types, `TYPE_ARGS` for generics).
+#[derive(Debug, Clone)]
+pub struct UnionMemberParts {
+    /// Tokens in this union member (WORD, `L_BRACKET`, `R_BRACKET`, QUESTION, etc.).
+    pub tokens: Vec<SyntaxToken>,
+    /// Child nodes in this union member (`STRING_LITERAL`, `TYPE_EXPR`, `TYPE_ARGS`, etc.).
+    pub child_nodes: Vec<SyntaxNode>,
+}
+
+impl UnionMemberParts {
+    /// Create an empty `UnionMemberParts`.
+    pub fn new() -> Self {
+        Self {
+            tokens: Vec::new(),
+            child_nodes: Vec::new(),
+        }
+    }
+
+    /// Check if this member is empty (no tokens or child nodes).
+    pub fn is_empty(&self) -> bool {
+        self.tokens.is_empty() && self.child_nodes.is_empty()
+    }
+
+    /// Get the first WORD token's text, if any.
+    pub fn first_word(&self) -> Option<&str> {
+        self.tokens
+            .iter()
+            .find(|t| t.kind() == SyntaxKind::WORD)
+            .map(rowan::SyntaxToken::text)
+    }
+
+    /// Check if this member has a trailing `?` (optional modifier).
+    pub fn is_optional(&self) -> bool {
+        self.tokens
+            .last()
+            .is_some_and(|t| t.kind() == SyntaxKind::QUESTION)
+    }
+
+    /// Count the number of `[]` array modifiers at the end.
+    pub fn array_depth(&self) -> usize {
+        let mut depth = 0;
+        let mut i = self.tokens.len();
+
+        // Skip trailing ? if present
+        if i > 0 && self.tokens[i - 1].kind() == SyntaxKind::QUESTION {
+            i -= 1;
+        }
+
+        // Count [] pairs from the end
+        while i >= 2 {
+            if self.tokens[i - 1].kind() == SyntaxKind::R_BRACKET
+                && self.tokens[i - 2].kind() == SyntaxKind::L_BRACKET
+            {
+                depth += 1;
+                i -= 2;
+            } else {
+                break;
+            }
+        }
+
+        depth
+    }
+
+    /// Check if this member contains a `STRING_LITERAL` child node.
+    pub fn has_string_literal(&self) -> bool {
+        self.child_nodes
+            .iter()
+            .any(|n| n.kind() == SyntaxKind::STRING_LITERAL)
+    }
+
+    /// Get the string literal value if this member is a string literal type.
+    pub fn string_literal(&self) -> Option<String> {
+        self.child_nodes
+            .iter()
+            .find(|n| n.kind() == SyntaxKind::STRING_LITERAL)
+            .map(|n| {
+                let text = n.text().to_string();
+                let trimmed = text.trim();
+                if trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2 {
+                    trimmed[1..trimmed.len() - 1].to_string()
+                } else {
+                    trimmed.trim_start_matches('"').to_string()
+                }
+            })
+    }
+
+    /// Check if this member contains a `TYPE_EXPR` child node (parenthesized type).
+    pub fn has_type_expr(&self) -> bool {
+        self.child_nodes
+            .iter()
+            .any(|n| n.kind() == SyntaxKind::TYPE_EXPR)
+    }
+
+    /// Get the `TYPE_EXPR` child node if present (for parenthesized types).
+    pub fn type_expr(&self) -> Option<TypeExpr> {
+        self.child_nodes
+            .iter()
+            .find(|n| n.kind() == SyntaxKind::TYPE_EXPR)
+            .cloned()
+            .map(|syntax| TypeExpr { syntax })
+    }
+
+    /// Get the `TYPE_ARGS` child node if present (for generic types like map<K,V>).
+    pub fn type_args(&self) -> Option<SyntaxNode> {
+        self.child_nodes
+            .iter()
+            .find(|n| n.kind() == SyntaxKind::TYPE_ARGS)
+            .cloned()
+    }
+
+    /// Check if this member has an `INTEGER_LITERAL` token.
+    pub fn integer_literal(&self) -> Option<i64> {
+        self.tokens
+            .iter()
+            .find(|t| t.kind() == SyntaxKind::INTEGER_LITERAL)
+            .and_then(|t| t.text().parse().ok())
+    }
+}
+
+impl Default for UnionMemberParts {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TypeExpr {
     /// Check if this is a union type (contains top-level PIPE separators).
     ///
@@ -245,47 +373,49 @@ impl TypeExpr {
         }
     }
 
-    /// Get the text parts of this type expression, split by PIPE separators.
+    /// Get the parts of this type expression for each union member.
     ///
-    /// For union types like `A | B | C`, returns `["A", "B", "C"]`.
-    /// For non-union types like `string?`, returns `["string?"]`.
+    /// Returns a list of `UnionMemberParts`, where each contains the tokens
+    /// and child nodes for one union member. This allows parsing union members
+    /// by token/node kinds instead of string manipulation.
     ///
-    /// Each part is trimmed of surrounding whitespace.
-    pub fn parts(&self) -> Vec<String> {
-        let mut parts = Vec::new();
-        let mut current_part = String::new();
+    /// For `int | string[]`, returns two `UnionMemberParts`:
+    /// - First: tokens=[WORD("int")]
+    /// - Second: tokens=[WORD("string"), `L_BRACKET`, `R_BRACKET`]
+    ///
+    /// For `"user" | int`, returns two `UnionMemberParts`:
+    /// - First: `child_nodes`=[`STRING_LITERAL`], tokens=[]
+    /// - Second: tokens=[WORD("int")]
+    pub fn union_member_parts(&self) -> Vec<UnionMemberParts> {
+        let mut members = Vec::new();
+        let mut current = UnionMemberParts::new();
 
         for child in self.syntax.children_with_tokens() {
             match child {
                 rowan::NodeOrToken::Token(token) => {
-                    // Skip trivia tokens (whitespace, comments)
                     if token.kind().is_trivia() {
                         continue;
                     }
                     if token.kind() == SyntaxKind::PIPE {
-                        let trimmed = current_part.trim().to_string();
-                        if !trimmed.is_empty() {
-                            parts.push(trimmed);
+                        if !current.is_empty() {
+                            members.push(current);
+                            current = UnionMemberParts::new();
                         }
-                        current_part = String::new();
                     } else {
-                        current_part.push_str(token.text());
+                        current.tokens.push(token);
                     }
                 }
                 rowan::NodeOrToken::Node(child_node) => {
-                    // For nested nodes (like TYPE_ARGS), include their full text
-                    current_part.push_str(&child_node.text().to_string());
+                    current.child_nodes.push(child_node);
                 }
             }
         }
 
-        // Include the final part
-        let trimmed = current_part.trim().to_string();
-        if !trimmed.is_empty() {
-            parts.push(trimmed);
+        if !current.is_empty() {
+            members.push(current);
         }
 
-        parts
+        members
     }
 
     /// Get the text range of this type expression.

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -75,14 +75,144 @@ ast_node!(TypeBuilderBlock, TYPE_BUILDER_BLOCK);
 ast_node!(DynamicTypeDef, DYNAMIC_TYPE_DEF);
 
 impl TypeExpr {
-    /// Check if this is a union type (contains PIPE separators).
+    /// Check if this is a union type (contains top-level PIPE separators).
     ///
-    /// Returns `true` for types like `Success | Failure` or `"user" | "assistant"`.
+    /// Returns `true` for types like `Success | Failure` or `int[] | string[]`.
+    /// Returns `false` for `(int | string)[]` because the PIPE is inside parens.
     pub fn is_union(&self) -> bool {
         self.syntax
             .children_with_tokens()
             .filter_map(rowan::NodeOrToken::into_token)
             .any(|t| t.kind() == SyntaxKind::PIPE)
+    }
+
+    /// Check if this type has a trailing `?` (optional modifier).
+    pub fn is_optional(&self) -> bool {
+        self.syntax
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .last()
+            .is_some_and(|t| t.kind() == SyntaxKind::QUESTION)
+    }
+
+    /// Check if this type has trailing `[]` (array modifier).
+    ///
+    /// For `int[]?`, this returns true (array comes before optional).
+    pub fn is_array(&self) -> bool {
+        let tokens: Vec<_> = self
+            .syntax
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .filter(|t| !t.kind().is_trivia())
+            .collect();
+
+        // Check for [] at the end (possibly before ?)
+        let len = tokens.len();
+        if len >= 2 {
+            let last = tokens[len - 1].kind();
+            let second_last = tokens[len - 2].kind();
+            // Either ends with [] or ends with []?
+            if last == SyntaxKind::R_BRACKET && second_last == SyntaxKind::L_BRACKET {
+                return true;
+            }
+            if len >= 3 && last == SyntaxKind::QUESTION {
+                let third_last = tokens[len - 3].kind();
+                if second_last == SyntaxKind::R_BRACKET && third_last == SyntaxKind::L_BRACKET {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Check if this type is wrapped in parentheses (e.g., `(int | string)`).
+    pub fn is_parenthesized(&self) -> bool {
+        let first_token = self
+            .syntax
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .find(|t| !t.kind().is_trivia());
+
+        first_token.is_some_and(|t| t.kind() == SyntaxKind::L_PAREN)
+    }
+
+    /// Get the inner `TypeExpr` for parenthesized types like `(int | string)`.
+    ///
+    /// Returns None if this is not a parenthesized type.
+    pub fn inner_type_expr(&self) -> Option<TypeExpr> {
+        if !self.is_parenthesized() {
+            return None;
+        }
+        self.syntax
+            .children()
+            .find(|n| n.kind() == SyntaxKind::TYPE_EXPR)
+            .map(|n| TypeExpr { syntax: n })
+    }
+
+    /// Get the `TYPE_ARGS` node for generic types like `map<K, V>`.
+    pub fn type_args(&self) -> Option<SyntaxNode> {
+        self.syntax
+            .children()
+            .find(|n| n.kind() == SyntaxKind::TYPE_ARGS)
+    }
+
+    /// Get the type argument `TypeExprs` from `TYPE_ARGS`.
+    pub fn type_arg_exprs(&self) -> Vec<TypeExpr> {
+        self.type_args()
+            .map(|args| {
+                args.children()
+                    .filter(|n| n.kind() == SyntaxKind::TYPE_EXPR)
+                    .map(|n| TypeExpr { syntax: n })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Get the base type name (the first WORD token).
+    ///
+    /// For `int[]?` returns `Some("int")`.
+    /// For `map<K, V>` returns `Some("map")`.
+    /// For `"user"` returns `None` (it's a string literal, not a named type).
+    pub fn base_name(&self) -> Option<String> {
+        self.syntax
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .find(|t| t.kind() == SyntaxKind::WORD)
+            .map(|t| t.text().to_string())
+    }
+
+    /// Check if this is a string literal type like `"user"`.
+    pub fn string_literal(&self) -> Option<String> {
+        self.syntax
+            .children()
+            .find(|n| n.kind() == SyntaxKind::STRING_LITERAL)
+            .map(|n| {
+                // Extract the content between quotes, excluding trivia
+                n.children_with_tokens()
+                    .filter_map(rowan::NodeOrToken::into_token)
+                    .filter(|t| t.kind() != SyntaxKind::QUOTE && !t.kind().is_trivia())
+                    .map(|t| t.text().to_string())
+                    .collect::<String>()
+            })
+    }
+
+    /// Check if this is an integer literal type like `200`.
+    pub fn integer_literal(&self) -> Option<i64> {
+        self.syntax
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .find(|t| t.kind() == SyntaxKind::INTEGER_LITERAL)
+            .and_then(|t| t.text().parse().ok())
+    }
+
+    /// Check if this is a boolean literal (`true` or `false`).
+    pub fn bool_literal(&self) -> Option<bool> {
+        let name = self.base_name()?;
+        match name.as_str() {
+            "true" => Some(true),
+            "false" => Some(false),
+            _ => None,
+        }
     }
 
     /// Get the text parts of this type expression, split by PIPE separators.

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -187,12 +187,16 @@ impl TypeExpr {
             .children()
             .find(|n| n.kind() == SyntaxKind::STRING_LITERAL)
             .map(|n| {
-                // Extract the content between quotes, excluding trivia
-                n.children_with_tokens()
-                    .filter_map(rowan::NodeOrToken::into_token)
-                    .filter(|t| t.kind() != SyntaxKind::QUOTE && !t.kind().is_trivia())
-                    .map(|t| t.text().to_string())
-                    .collect::<String>()
+                // Get text and trim leading/trailing whitespace (trivia)
+                let text = n.text().to_string();
+                let trimmed = text.trim();
+                // Well-formed: starts AND ends with quote
+                if trimmed.starts_with('"') && trimmed.ends_with('"') && trimmed.len() >= 2 {
+                    trimmed[1..trimmed.len() - 1].to_string()
+                } else {
+                    // Malformed (error recovery): preserve full text, just strip leading quote
+                    trimmed.trim_start_matches('"').to_string()
+                }
             })
     }
 

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -99,6 +99,16 @@ impl TypeExpr {
     ///
     /// For `int[]?`, this returns true (array comes before optional).
     pub fn is_array(&self) -> bool {
+        self.array_depth() > 0
+    }
+
+    /// Count the number of `[]` array modifiers.
+    ///
+    /// For `int` returns 0.
+    /// For `int[]` returns 1.
+    /// For `int[][]` returns 2.
+    /// For `int[]?` returns 1 (optional is separate).
+    pub fn array_depth(&self) -> usize {
         let tokens: Vec<_> = self
             .syntax
             .children_with_tokens()
@@ -106,23 +116,27 @@ impl TypeExpr {
             .filter(|t| !t.kind().is_trivia())
             .collect();
 
-        // Check for [] at the end (possibly before ?)
-        let len = tokens.len();
-        if len >= 2 {
-            let last = tokens[len - 1].kind();
-            let second_last = tokens[len - 2].kind();
-            // Either ends with [] or ends with []?
-            if last == SyntaxKind::R_BRACKET && second_last == SyntaxKind::L_BRACKET {
-                return true;
-            }
-            if len >= 3 && last == SyntaxKind::QUESTION {
-                let third_last = tokens[len - 3].kind();
-                if second_last == SyntaxKind::R_BRACKET && third_last == SyntaxKind::L_BRACKET {
-                    return true;
-                }
+        let mut depth = 0;
+        let mut i = tokens.len();
+
+        // Skip trailing ? if present
+        if i > 0 && tokens[i - 1].kind() == SyntaxKind::QUESTION {
+            i -= 1;
+        }
+
+        // Count [] pairs from the end
+        while i >= 2 {
+            if tokens[i - 1].kind() == SyntaxKind::R_BRACKET
+                && tokens[i - 2].kind() == SyntaxKind::L_BRACKET
+            {
+                depth += 1;
+                i -= 2;
+            } else {
+                break;
             }
         }
-        false
+
+        depth
     }
 
     /// Check if this type is wrapped in parentheses (e.g., `(int | string)`).
@@ -147,6 +161,18 @@ impl TypeExpr {
             .children()
             .find(|n| n.kind() == SyntaxKind::TYPE_EXPR)
             .map(|n| TypeExpr { syntax: n })
+    }
+
+    /// Get all child `TypeExpr` nodes.
+    ///
+    /// For union types where the parser creates child `TYPE_EXPR` for each member,
+    /// this returns those members. Returns empty vec if no children.
+    pub fn child_type_exprs(&self) -> Vec<TypeExpr> {
+        self.syntax
+            .children()
+            .filter(|n| n.kind() == SyntaxKind::TYPE_EXPR)
+            .map(|n| TypeExpr { syntax: n })
+            .collect()
     }
 
     /// Get the `TYPE_ARGS` node for generic types like `map<K, V>`.

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -380,12 +380,12 @@ impl TypeExpr {
     /// by token/node kinds instead of string manipulation.
     ///
     /// For `int | string[]`, returns two `UnionMemberParts`:
-    /// - First: tokens=[WORD("int")]
-    /// - Second: tokens=[WORD("string"), `L_BRACKET`, `R_BRACKET`]
+    /// - First: tokens=\[WORD("int")\]
+    /// - Second: tokens=\[WORD("string"), `L_BRACKET`, `R_BRACKET`\]
     ///
     /// For `"user" | int`, returns two `UnionMemberParts`:
-    /// - First: `child_nodes`=[`STRING_LITERAL`], tokens=[]
-    /// - Second: tokens=[WORD("int")]
+    /// - First: `child_nodes`=\[`STRING_LITERAL`\], tokens=\[\]
+    /// - Second: tokens=\[WORD("int")\]
     pub fn union_member_parts(&self) -> Vec<UnionMemberParts> {
         let mut members = Vec::new();
         let mut current = UnionMemberParts::new();

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__03_hir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-a56cff903b8232b2/out/generated_tests.rs
+source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===
@@ -360,7 +360,7 @@ function ExhaustiveWithNamedCatchAll(x: int) -> int {
 
 function NestedTypeBindings(r: Result) -> int {
       match (r) {
-          s: Success | (Failure) => 0,
+          s: Success | Failure => 0,
           f: Failure => 1,
       }
 }

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-1fb40547d0a1a115/out/generated_tests.rs
+source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
 expression: output
 ---
 === MIR ===
@@ -2240,12 +2240,12 @@ fn NestedTypeBindings(r: TypeAlias(FullyQualifiedName { namespace: Local, name: 
     let _0: Int // return
     let _1: TypeAlias(FullyQualifiedName { namespace: Local, name: "Result" }) // r // param
     let _2: Bool
-    let _3: Union([Class(FullyQualifiedName { namespace: Local, name: "Success" }), Error]) // s
+    let _3: Union([Class(FullyQualifiedName { namespace: Local, name: "Success" }), Class(FullyQualifiedName { namespace: Local, name: "Failure" })]) // s
     let _4: Bool
     let _5: Class(FullyQualifiedName { namespace: Local, name: "Failure" }) // f
 
     bb0: {
-        _2 = is_type(copy _1, Union([Class(FullyQualifiedName { namespace: Local, name: "Success" }), Error]));
+        _2 = is_type(copy _1, Union([Class(FullyQualifiedName { namespace: Local, name: "Success" }), Class(FullyQualifiedName { namespace: Local, name: "Failure" })]));
         branch copy _2 -> [bb5, bb4];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_tir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-1fb40547d0a1a115/out/generated_tests.rs
+source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
 expression: output
 ---
 === TYPE INFERENCE ===
@@ -137,6 +137,8 @@ expression: output
     Return: Union([Literal(Int(100)), Int])
   Function NestedTypeBindings:
     Return: Union([Literal(Int(0)), Literal(Int(1))])
+    Errors:
+      - Unreachable match arm
   Function NonExhaustiveAliasOfLiterals:
     Return: Literal(String("ok"))
     Errors:

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__05_diagnostics.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-bee4cf1d73080329/out/generated_tests.rs
+source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
@@ -220,6 +220,17 @@ expression: output
      │ ╰─────────── Non-exhaustive match on `AlwaysTrue`: missing cases true
      │     
      │     Note: Error code: E0062
+─────╯
+
+  [type] Error: Unreachable match arm
+     ╭─[ match_exhaustiveness.baml:806:37 ]
+     │
+ 806 │ ╭─▶         s: Success | (Failure) => 0,
+ 807 │ ├─▶         f: Failure => 1
+     │ │                             
+     │ ╰───────────────────────────── Unreachable match arm
+     │     
+     │     Note: Error code: E0063
 ─────╯
 
   [type] Error: Non-exhaustive match on `OkOrCreated`: missing cases 201

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__03_hir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-1fb40547d0a1a115/out/generated_tests.rs
+source: target/debug/build/baml_tests-fbd0fe113b2fb574/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===
@@ -34,8 +34,7 @@ class Partial {
   field2: <unknown>
   field3: string
   string: <unknown>
-  alias: (  // Unclosed attribute
-  field5string
+  alias: field5
 }
 
 enum ValidEnum {
@@ -47,6 +46,5 @@ class Test {
   field1: string
   field2: string
   another: closed
-  string: ")  // Should still parse this
-}
+  string: ")//Shouldstillparsethis}"
 }

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__03_hir.snap
@@ -46,5 +46,6 @@ class Test {
   field1: string
   field2: string
   another: closed
-  string: ")//Shouldstillparsethis}"
+  string: ")  // Should still parse this
+}"
 }

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__03_hir.snap
@@ -17,7 +17,8 @@ class NestedQuotes {
   single_in_double: string
   double_in_single: string
   She: said
-  hello: "')escaped_in_escapedstring@alias("
+  hello: "')
+  escaped_in_escaped string @alias("
   The: <unknown>
   quote: <unknown>
   is: here

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__03_hir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-fbd0fe113b2fb574/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===
@@ -17,8 +17,7 @@ class NestedQuotes {
   single_in_double: string
   double_in_single: string
   She: said
-  hello: "')
-  escaped_in_escaped string @alias("
+  hello: "')escaped_in_escapedstring@alias("
   The: <unknown>
   quote: <unknown>
   is: here

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__03_hir.snap
@@ -1,16 +1,16 @@
 ---
-source: target/debug/build/baml_tests-0a6cb66c091c7c00/out/generated_tests.rs
+source: target/debug/build/baml_tests-fbd0fe113b2fb574/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===
-function BadReturnType() -> Map<string, int>> {
+function BadReturnType() -> Map<string, int> {
   client GPT4
   prompt #"
     test
   "#
 }
 
-function BadParam(x: Map<string, int>>) -> string {
+function BadParam(x: Map<string, int>) -> string {
   client GPT4
   prompt #"
     test
@@ -18,7 +18,7 @@ function BadParam(x: Map<string, int>>) -> string {
 }
 
 class MalformedClass {
-  bad_field: Map<string, int>>
+  bad_field: Map<string, int>
   good_field: Map<string, int>
   another_field: string
 }
@@ -28,4 +28,4 @@ class NestedGenerics {
   simple: Map<string, int>
 }
 
-type BadAlias = Map<string, int>>
+type BadAlias = Map<string, int>

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__04_tir.snap
@@ -1,9 +1,9 @@
 ---
-source: target/debug/build/baml_tests-512cc176589834ed/out/generated_tests.rs
+source: target/debug/build/baml_tests-fbd0fe113b2fb574/out/generated_tests.rs
 expression: output
 ---
 === TYPE INFERENCE ===
   Function BadReturnType:
-    Return: Map { key: String, value: TypeAlias(FullyQualifiedName { namespace: Local, name: "int>" }) }
+    Return: Map { key: String, value: Int }
   Function BadParam:
     Return: String


### PR DESCRIPTION
## Summary

Major refactoring to eliminate string-based type parsing in HIR. Previously, the code extracted text from CST nodes and re-parsed it using string manipulation (`strip_suffix("[]")`, `starts_with('"')`, `split()`, etc.). Now uses structured CST token/node accessors directly.

### Key Changes

1. **Eliminated `from_type_text()`** - Was parsing types from extracted text strings
2. **Eliminated `split_generic_params()`** - Was doing string-based comma finding
3. **Eliminated `parts()`** - Was extracting text strings for union members
4. **Added `UnionMemberParts`** - Structured parsing of union members via tokens/nodes
5. **Added `array_depth()`** - Counts `[]` pairs by iterating tokens directly

### Bug Fixes

- **Parenthesized union members**: `Success | (Failure)` was incorrectly parsed as `Success | Error`. Now correctly parsed as `Success | Failure`.
- **Extra closing brackets**: `map<string, int>>` now correctly extracts `Map<string, int>` instead of `Map<string, int>>` (the extra `>` is already flagged as parser error).
- **Complex parenthesized types in map validation**: Types like `map<int[][], ((int | float) | char[])>` now validate correctly.

### Performance

Token-based parsing is more efficient:
- **Before**: `node.text()` allocates String, each `strip_suffix()` creates new String
- **After**: Tokens already in memory, `SyntaxKind` comparisons are O(1)

For `int[][]?`, the old approach allocated 3-4 intermediate strings. The new approach walks tokens once.

---

## New AST Accessors

Added to `TypeExpr` in `baml_compiler_syntax/src/ast.rs`:

| Accessor | Description |
|----------|-------------|
| `is_optional()` | Checks for trailing `?` |
| `is_array()` | Checks for trailing `[]` |
| `array_depth()` | Counts `[]` pairs (e.g., 2 for `int[][]`) |
| `is_union()` | Checks for `PIPE` tokens at top level |
| `is_parenthesized()` | Checks for wrapping `(...)` |
| `inner_type_expr()` | Gets inner TypeExpr for parenthesized types |
| `type_arg_exprs()` | Gets type arguments for generics like `map<K, V>` |
| `base_name()` | Gets first WORD token (e.g., "int" from "int[]") |
| `string_literal()` | Extracts string literal content |
| `integer_literal()` | Extracts integer literal value |
| `bool_literal()` | Extracts boolean literal value |
| `union_member_parts()` | Returns structured `UnionMemberParts` per member |

### `UnionMemberParts` Struct

Holds tokens and child nodes for one union member:

| Method | Description |
|--------|-------------|
| `first_word()` | Gets first WORD token text |
| `is_optional()` | Checks for QUESTION token |
| `array_depth()` | Counts L_BRACKET/R_BRACKET pairs |
| `string_literal()` | Extracts STRING_LITERAL content |
| `integer_literal()` | Extracts INTEGER value |
| `type_expr()` | Gets child TYPE_EXPR (for parenthesized types) |
| `type_args()` | Gets TYPE_ARGS node (for map types) |

---

## New HIR Methods

Added to `type_ref.rs`:

- `from_union_member()` - Parses union members using token/node kinds
- `apply_modifiers_from_parts()` - Applies array/optional modifiers from tokens

Added to `lib.rs`:

- `has_type_content()` - Checks if TYPE_EXPR has actual content (not empty from parser error recovery)
- `validate_map_type_in_union_member()` - Token-based map validation for union members
- `validate_map_type_in_type_expr()` - Recursive map validation

---

## Removed Code

| File | Removed |
|------|---------|
| `type_ref.rs` | `from_type_text()`, `split_generic_params()`, unit tests |
| `ast.rs` | `parts()` method |
| `lib.rs` | `count_generic_params()`, `validate_map_type_in_text()` |

---

## Snapshot Changes

### `match_exhaustiveness` - Bug Fix ✓

For `Success | (Failure)`:

| Layer | Before | After |
|-------|--------|-------|
| HIR | `Success \| (Failure)` | `Success \| Failure` |
| MIR | `Union([Success, Error])` | `Union([Success, Failure])` |

The parenthesized `(Failure)` was falling through to `Error` type. Now correctly parsed as `Failure`.

New diagnostic correctly detected: "Unreachable match arm" for redundant `f: Failure` pattern.

### `pending_greaters_fix` - Bug Fix ✓

For `map<string, int>>` (extra `>`):

| Layer | Before | After |
|-------|--------|-------|
| HIR | `Map<string, int>>` | `Map<string, int>` |
| TIR | `Map { value: TypeAlias("int>") }` | `Map { value: Int }` |

---

## Test Plan

- [x] All existing tests pass (`cargo test --release`)
- [x] Parenthesized union members parsed correctly
- [x] Nested arrays work (`int[][]` → `List(List(Int))`)
- [x] Map validation works for complex types
- [x] No rustdoc warnings