### PR TITLE
Add README documentation for bex_vm, bex_heap, and bex_engine crates

### DIFF
--- a/baml_language/crates/bex_engine/README.md
+++ b/baml_language/crates/bex_engine/README.md
@@ -42,8 +42,8 @@ Async runtime for the BEX virtual machine, coordinating concurrent execution and
 │  │  • No dependencies (leaf crate)                                         │  │
 │  └─────────────────────────────────────────────────────────────────────────┘  │
 │                                                                               │
-│  KEY INSIGHT: bex_vm and bex_sys are SIBLINGS - they never depend on each    │
-│               other. BexEngine is the ONLY component that talks to both.     │
+│  KEY INSIGHT: bex_vm and bex_sys are SIBLINGS - they never depend on each     │
+│               other. BexEngine is the ONLY component that talks to both.      │
 │                                                                               │
 └───────────────────────────────────────────────────────────────────────────────┘
 ```

--- a/baml_language/crates/bex_engine/README.md
+++ b/baml_language/crates/bex_engine/README.md
@@ -1,0 +1,316 @@
+# BEX Engine
+
+Async runtime for the BEX virtual machine, coordinating concurrent execution and garbage collection.
+
+## Architecture Overview
+
+```
+┌───────────────────────────────────────────────────────────────────────────────┐
+│                                 ARCHITECTURE                                  │
+├───────────────────────────────────────────────────────────────────────────────┤
+│                                                                               │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │                              BexEngine                                  │  │
+│  │  • Owns: BexHeap (contains Arc internally)                              │  │
+│  │  • Owns: BytecodeProgram (Arc-shared)                                   │  │
+│  │  • Owns: OpContext (Arc-shared, contains ResourceRegistry)              │  │
+│  │  • Owns: env_vars                                                       │  │
+│  │  • Responsibility: Event loop, Handle↔Value conversion, VM↔Sys mediate  │  │
+│  │  • call_function(&self, ...) ← Note: &self, enables concurrency!        │  │
+│  └───────────────┬───────────────────────────────────────┬─────────────────┘  │
+│                  │ clones heap Arc, creates VM           │ calls              │
+│                  ▼                                       ▼                    │
+│  ┌──────────────────────────────────┐    ┌──────────────────────────────────┐ │
+│  │              BexVm               │    │             bex_sys              │ │
+│  │  • Has: BexHeap (cloned Arc)     │    │  • Provides: ops::fs, ops::net,  │ │
+│  │  • Owns: EvalStack               │    │              ops::sys, ops::llm  │ │
+│  │  • Owns: frames: Vec<Frame>      │    │  • Receives: BexValue args       │ │
+│  │  • Owns: globals: GlobalPool     │    │  • Returns: BexValue             │ │
+│  │  • Uses: ObjectIndex internally  │    │  • Uses: OpContext for resources │ │
+│  │  • Yields: VmExecState to engine │    │                                  │ │
+│  │                                  │    │  ResourceRegistry (in OpCtx):    │ │
+│  │  NO DEPENDENCY ON bex_sys!       │    │  • Files, Network, Shell         │ │
+│  │  (doesn't know about sys ops)    │    │                                  │ │
+│  └──────────────────────────────────┘    └──────────────────────────────────┘ │
+│                  │                                       │                    │
+│                  │ uses types from                       │ uses types from    │
+│                  ▼                                       ▼                    │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │                              bex_vm_types                               │  │
+│  │  • Defines: ObjectIndex, Value, Object                                  │  │
+│  │  • Defines: ExternalOp, SysOp enums (operation descriptors)             │  │
+│  │  • No dependencies (leaf crate)                                         │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│                                                                               │
+│  KEY INSIGHT: bex_vm and bex_sys are SIBLINGS - they never depend on each    │
+│               other. BexEngine is the ONLY component that talks to both.     │
+│                                                                               │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Async Execution Model
+
+The engine uses a Deno-inspired event loop where the VM executes synchronously until I/O:
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│                                      EVENT LOOP                                         │
+├─────────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                         │
+│  call_function(&self, name, args)                                                       │
+│        │                                                                                │
+│        ▼                                                                                │
+│  ┌────────────────────────────────────────────────────────────────────────────────┐     │
+│  │  Create VM with cloned heap Arc + TLAB, register with current epoch            │     │
+│  └────────────────────────────────────────────────────────────────────────────────┘     │
+│        │                                                                                │
+│        ▼                                                                                │
+│  ┌────────────────────────────────────────────────────────────────────────────────┐     │
+│  │  VM executes bytecode synchronously                                         ◄──┼──┐  │
+│  └────────────────────────────────────────────────────────────────────────────────┘  │  │
+│        │                                                                             │  │
+│        ├───────────────────┬───────────────────┬───────────────────┐                 │  │
+│        ▼                   ▼                   ▼                   ▼                 │  │
+│  ┌───────────┐      ┌────────────┐      ┌────────────┐      ┌────────────┐           │  │
+│  │ Complete  │      │ Schedule   │      │   Await    │      │  Notify    │           │  │
+│  │ (Value)   │      │ Future     │      │ (pending)  │      │  (watch)   │           │  │
+│  └─────┬─────┘      └─────┬──────┘      └─────┬──────┘      └─────┬──────┘           │  │
+│        │                  │                   │                   │                  │  │
+│        │                  ▼                   ▼                   ▼                  │  │
+│        │           ┌────────────┐      ┌────────────┐      ┌─────────────┐           │  │
+│        │           │ Spawn task │      │ Wait for   │      │ Call        │           │  │
+│        │           │ (tokio)    │      │ completion │      │ notification│           │  │
+│        │           └─────┬──────┘      └─────┬──────┘      │ callback    │           │  │
+│        │                 │                   │             └─────┬───────┘           │  │
+│        │                 │                   ▼                   │                   │  │
+│        │                 │             ┌────────────┐            │                   │  │
+│        │                 │             │ Fulfill    │            │                   │  │
+│        │                 │             │ future     │            │                   │  │
+│        │                 │             └─────┬──────┘            │                   │  │
+│        │                 │                   │                   │                   │  │
+│        │                 └───────────────────┴───────────────────┘───────────────────┘  │
+│        │                                                                                │
+│        ▼                                                                                │
+│  ┌────────────────────────────────────────────────────────────────────────────────┐     │
+│  │  Unregister from epoch, return BexValue                                        │     │
+│  └────────────────────────────────────────────────────────────────────────────────┘     │
+│                                                                                         │
+└─────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### VmExecState Variants
+
+| State | Meaning |
+|-------|---------|
+| `Complete(Value)` | Execution finished, return result |
+| `ScheduleFuture(ObjectIndex)` | Spawn async op, immediately resume VM |
+| `Await(ObjectIndex)` | Wait for future completion, fulfill, then resume VM |
+| `Notify(WatchNotification)` | Call notification callback, then resume VM |
+
+## Epoch-Based GC Coordination
+
+VMs register with an epoch at call start. GC advances the epoch, causing old-epoch VMs to park at safepoints:
+
+```
+┌───────────────────────────────────────────────────────────────────────────────┐
+│                         EPOCH-BASED SAFEPOINT COORDINATION                    │
+├───────────────────────────────────────────────────────────────────────────────┤
+│                                                                               │
+│  Engine State:                                                                │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │  current_epoch: AtomicU64 = 5                                           │  │
+│  │                                                                         │  │
+│  │  epoch_states: [EpochState; 2]                                          │  │
+│  │    [0]: { active: 0, parked: 0 }  ← slot for even epochs                │  │
+│  │    [1]: { active: 3, parked: 0 }  ← slot for odd epochs (epoch 5)       │  │
+│  │                                                                         │  │
+│  │  epoch_drained: Notify     ← VMs signal when they park                  │  │
+│  │  gc_complete: Notify       ← GC signals when done                       │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│                                                                               │
+│  TIMELINE: 3 VMs in epoch 5, GC requested                                     │
+│  ┌─────────────────────────────────────────────────────────────────────────┐  │
+│  │  T0: VM-A, VM-B, VM-C running (epoch 5)                                 │  │
+│  │                                                                         │  │
+│  │  T1: Engine calls collect_garbage()                                     │  │
+│  │      └─ current_epoch.fetch_add(1) → epoch becomes 6                    │  │
+│  │                                                                         │  │
+│  │  T2: New call VM-D starts (gets epoch 6, unaffected by GC)              │  │
+│  │                                                                         │  │
+│  │  T3: VM-A reaches await point                                           │  │
+│  │      ├─ Sees current_epoch(6) > my_epoch(5)                             │  │
+│  │      ├─ parked += 1, notify epoch_drained                               │  │
+│  │      └─ Waits on gc_complete                                            │  │
+│  │                                                                         │  │
+│  │  T4-T5: VM-B, VM-C reach await points and park                          │  │
+│  │         parked(3) >= active(3) → all old-epoch VMs parked               │  │
+│  │                                                                         │  │
+│  │  T6: GC runs (safe - all old-epoch VMs frozen)                          │  │
+│  │      ├─ Collect roots from handles + parked VM stacks                   │  │
+│  │      ├─ Run semi-space collection                                       │  │
+│  │      └─ gc_complete.notify_waiters()                                    │  │
+│  │                                                                         │  │
+│  │  T7: VM-A, VM-B, VM-C wake up and resume with forwarded references      │  │
+│  └─────────────────────────────────────────────────────────────────────────┘  │
+│                                                                               │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+### VM State Machine at Safepoints
+
+```
+┌───────────┐    await point    ┌─────────────────┐
+│  RUNNING  │ ─────────────────►│  CHECK EPOCH    │
+└───────────┘                   └────────┬────────┘
+     ▲                                   │
+     │                          ┌────────┴────────┐
+     │                    my_epoch ==        my_epoch <
+     │                    current            current
+     │                          │                 │
+     │                          ▼                 ▼
+     │                   ┌────────────┐   ┌─────────────────────┐
+     │                   │ maybe_gc() │   │ PARK                │
+     │                   │ if needed  │   │ ├─ incr parked      │
+     │                   └──────┬─────┘   │ ├─ notify drained   │
+     │                          │         │ └─ wait gc_complete │
+     │                          │         └──────────┬──────────┘
+     │                          │                    │
+     │                          └──────┬─────────────┘
+     │                                 ▼
+     └────────────────────────  CONTINUE EXECUTION
+```
+
+## Value Boundary Crossing
+
+Two value systems: VM-internal and external boundary:
+
+```
+┌───────────────────────────────────────────────────────────────────────────────────┐
+│                                VALUE TYPE HIERARCHY                               │
+├───────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                   │
+│  VM Internal                           FFI / External Boundary                    │
+│  ┌──────────────────────┐             ┌────────────────────────────────────────┐  │
+│  │   Value              │             │ BexValue (unified boundary type)       │  │
+│  │ ┌──────────────────┐ │             │ ┌────────────────────────────────────┐ │  │
+│  │ │ Null             │ │             │ │                                    │ │  │
+│  │ │ Int(i64)         │ │             │ │ Opaque(Handle)                     │ │  │
+│  │ │ Float(f64)       │ │             │ │   └─ live reference to heap        │ │  │
+│  │ │ Bool(bool)       │ │             │ │      resolve via to_bex_external() │ │  │
+│  │ │ Object(Index) ───┼─┼────────────►│ │                                    │ │  │
+│  │ └──────────────────┘ │             │ │ External(BexExternalValue)         │ │  │
+│  │                      │             │ │   └─ owned data:                   │ │  │
+│  │ Fast, uses indices   │             │ │      Null, Int, Float, Bool,       │ │  │
+│  │ into shared heap     │             │ │      String, Array, Map,           │ │  │
+│  │                      │             │ │      Instance, Variant, Union      │ │  │
+│  │                      │             │ │                                    │ │  │
+│  │                      │             │ └────────────────────────────────────┘ │  │
+│  └──────────────────────┘             └────────────────────────────────────────┘  │
+│                                                                                   │
+└───────────────────────────────────────────────────────────────────────────────────┘
+```
+
+### BexValue Variants
+
+- **`Opaque(Handle)`**: A live reference to a heap-allocated object. Use this when you want
+  to keep a reference without copying data. The handle acts as a GC root, keeping the object
+  alive. Resolve to owned data via `BexEngine::to_bex_external()` when needed.
+
+- **`External(BexExternalValue)`**: Fully owned data that doesn't reference the heap.
+  Use this when passing arguments to functions or when you've already converted a handle.
+  Contains all concrete value types: primitives (Null, Int, Float, Bool), collections
+  (String, Array, Map), and typed values (Instance, Variant, Union).
+
+### Conversion Flow
+
+```
+Arguments:   BexValue → resolve to Value (allocation in VM heap if needed)
+Returns:     Value → BexValue (Opaque for heap objects, External for primitives)
+External Op: BexValue args → perform I/O → BexValue result
+```
+
+## Concurrency Scenarios
+
+### Scenario 1: Independent Concurrent Calls
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Thread 1                          Thread 2                      │
+│  ┌─────────────────────────┐      ┌─────────────────────────┐    │
+│  │ engine.call("foo", [])  │      │ engine.call("bar", [])  │    │
+│  │   │                     │      │   │                     │    │
+│  │   ▼                     │      │   ▼                     │    │
+│  │ VM-1 (TLAB chunk 0-1023)│      │ VM-2 (TLAB chunk 1024+) │    │
+│  │   │                     │      │   │                     │    │
+│  │   │  No contention!     │      │   │  No contention!     │    │
+│  │   │  Exclusive TLAB     │      │   │  Exclusive TLAB     │    │
+│  │   ▼                     │      │   ▼                     │    │
+│  │ Result-1                │      │ Result-2                │    │
+│  └─────────────────────────┘      └─────────────────────────┘    │
+│                                                                  │
+│  Objects never shared between independent calls (no races)       │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Scenario 2: GC During Concurrent Execution
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  VM-1 (epoch 5)     VM-2 (epoch 5)     VM-3 (epoch 6, new)       │
+│  ┌───────────┐      ┌───────────┐      ┌───────────┐             │
+│  │ executing │      │ executing │      │ executing │             │
+│  └─────┬─────┘      └─────┬─────┘      └─────┬─────┘             │
+│        │                  │                  │                   │
+│        │  GC requested (epoch → 6)           │                   │
+│        │                  │                  │                   │
+│        ▼                  ▼                  │                   │
+│  ┌───────────┐      ┌───────────┐            │                   │
+│  │ await →   │      │ await →   │            │ continues         │
+│  │ PARK      │      │ PARK      │            │ normally          │
+│  └─────┬─────┘      └─────┬─────┘            │                   │
+│        │                  │                  │                   │
+│        └──────────┬───────┘                  │                   │
+│                   ▼                          │                   │
+│            ┌─────────────┐                   │                   │
+│            │ GC runs     │                   │                   │
+│            │ (safe)      │                   │                   │
+│            └──────┬──────┘                   │                   │
+│                   │                          │                   │
+│        ┌──────────┴───────┐                  │                   │
+│        ▼                  ▼                  │                   │
+│  ┌───────────┐      ┌───────────┐            │                   │
+│  │ RESUME    │      │ RESUME    │            │                   │
+│  │ (stacks   │      │ (stacks   │            │                   │
+│  │ updated)  │      │ updated)  │            │                   │
+│  └───────────┘      └───────────┘            │                   │
+│                                                                  │
+│  New-epoch calls proceed without waiting for old GC              │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Thread Safety Summary
+
+| Component | Mechanism | Notes |
+|-----------|-----------|-------|
+| Heap sharing | `Arc<BexHeap>` | Cheap clones for each VM |
+| Object writes | TLAB exclusivity | Lock-free within reserved region |
+| GC coordination | Epoch-based safepoints | VMs park at await points |
+| Handle access | `RwLock<HashMap>` | Concurrent reads, exclusive GC updates |
+| External ops | `Mutex<ResourceRegistry>` | Clone Arc before release |
+
+## Crate Dependencies
+
+```
+bex_vm_types (no deps, defines Value/Object/ObjectIndex)
+      │
+      ├──────────────┐
+      ▼              ▼
+  bex_heap       bex_sys (leaf, external operations)
+      │              │
+      ▼              │
+   bex_vm            │
+      │              │
+      └──────┬───────┘
+             ▼
+        bex_engine (orchestrates everything)
+```

--- a/baml_language/crates/bex_heap/README.md
+++ b/baml_language/crates/bex_heap/README.md
@@ -1,0 +1,190 @@
+# BEX Heap
+
+Shared memory management with semi-space copying garbage collection for the BEX runtime.
+
+## Architecture Overview
+
+```
+┌───────────────────────────────────────────────────────────────────────────┐
+│                              BexEngine                                    │
+│  • Owns BexHeap via Arc                                                   │
+│  • Coordinates GC via epoch-based safepoints                              │
+│  • call_function(&self) enables concurrent execution                      │
+└───────────────────────────────────────────────────────────────────────────┘
+                  │ clones heap Arc, creates VM per call
+                  ▼
+┌───────────────────────────────────────────────────────────────────────────┐
+│                               BexVm (per-call)                            │
+│  • Receives: BexHeap (cloned Arc)                                         │
+│  • Owns: TLAB for lock-free allocation                                    │
+│  • Uses: ObjectIndex internally                                           │
+└───────────────────────────────────────────────────────────────────────────┘
+                  │ allocates via TLAB
+                  ▼
+┌───────────────────────────────────────────────────────────────────────────┐
+│                          BexHeap (Shared via Arc)                         │
+├───────────────────────────────────────────────────────────────────────────┤
+│                                                                           │
+│  ┌─────────────────────────────────────────────────────────────────────┐  │
+│  │              compile_time: Vec<Object>                              │  │
+│  │  [0] [1] [2] ... [N-1]                                              │  │
+│  │   │   │   │       │                                                 │  │
+│  │   ↓   ↓   ↓       ↓                                                 │  │
+│  │  Fn  Cls Enum   ...     ← PERMANENT (functions, classes, enums)     │  │
+│  └─────────────────────────────────────────────────────────────────────┘  │
+│                               ▲                                           │
+│                    compile_time_boundary = N                              │
+│                               ▼                                           │
+│  ┌─────────────────────────────────────────────────────────────────────┐  │
+│  │          spaces[active]: ChunkedVec<Object>                         │  │
+│  │  [N] [N+1] [N+2] ...                                                │  │
+│  │   │    │     │                                                      │  │
+│  │   ↓    ↓     ↓                                                      │  │
+│  │  Arr  Map  Inst   ...   ← RUNTIME (arrays, maps, instances)         │  │
+│  │                                                                     │  │
+│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐                                │  │
+│  │  │ TLAB 1  │ │ TLAB 2  │ │ TLAB 3  │  ← Per-VM allocation chunks    │  │
+│  │  └─────────┘ └─────────┘ └─────────┘                                │  │
+│  └─────────────────────────────────────────────────────────────────────┘  │
+│                                                                           │
+│  ┌─────────────────────────────────────────────────────────────────────┐  │
+│  │          spaces[inactive]: ChunkedVec<Object>                       │  │
+│  │                   (empty until GC copies here)                      │  │
+│  └─────────────────────────────────────────────────────────────────────┘  │
+│                                                                           │
+│  handles: RwLock<HashMap<key, ObjectIndex>>  ← FFI boundary / GC roots    │
+│  active_space: AtomicUsize (0 or 1)                                       │
+│                                                                           │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+## Object Indexing
+
+Objects are referenced via `ObjectIndex` (a `usize` with optional epoch for debug):
+
+```
+ObjectIndex(raw)
+      │
+      ▼
+┌─────────────────┐
+│ raw < ct_len?   │
+└────────┬────────┘
+    YES  │  NO
+    ↓    │  ↓
+compile_time[raw]  │  spaces[active][raw - ct_len]
+```
+
+## TLAB Allocation (Fast Path)
+
+Each VM gets exclusive access to a TLAB chunk for lock-free allocation:
+
+```
+tlab.alloc(obj)
+      │
+      ▼
+┌───────────────────────┐
+│ alloc_ptr >= limit?   │
+└───────────┬───────────┘
+      YES   │   NO
+      ↓     │   ↓
+  refill()  │   1. global_idx = alloc_ptr
+  (atomic   │   2. alloc_ptr += 1
+   chunk    │   3. write object to heap
+   reserve) │   4. return ObjectIndex
+```
+
+- **Fast path**: Single pointer bump, no locks
+- **Cold path**: Atomic `fetch_add` to reserve next chunk (~every 1024 allocations)
+
+## Semi-Space Garbage Collection
+
+Cheney-style copying collector that alternates between two spaces:
+
+```
+BEFORE GC:                           AFTER GC:
+┌─────────────────────┐              ┌─────────────────────┐
+│ spaces[0] (ACTIVE)  │              │ spaces[0] (INACTIVE)│
+│ [A][B][C][D][E][F]  │              │      (cleared)      │
+│  ↑       ↑          │              │                     │
+│  └───────┴── roots  │              │                     │
+└─────────────────────┘              └─────────────────────┘
+┌─────────────────────┐              ┌─────────────────────┐
+│ spaces[1] (INACTIVE)│              │ spaces[1] (ACTIVE)  │
+│      (empty)        │              │ [A'][C']            │
+│                     │              │   ↑                 │
+│                     │              │   └── compacted     │
+└─────────────────────┘              └─────────────────────┘
+
+B, D, E, F collected (garbage)
+```
+
+### Collection Algorithm
+
+1. **Initialize**: Clear inactive space, create forwarding map
+2. **BFS Trace**: Starting from roots (VM stacks + handles)
+   - Skip if already forwarded or compile-time
+   - Copy live object to inactive space
+   - Record `forwarding[old_idx] = new_idx`
+   - Add object's references to worklist
+3. **Fix References**: Update all ObjectIndex fields in copied objects
+4. **Swap Spaces**: Atomic `active_space.store(to_space)`
+5. **Update Handles**: Remap handle table using forwarding map
+6. **Invalidate TLABs**: Force VMs to refill from new space
+
+## ChunkedVec: Stable Pointer Storage
+
+ChunkedVec stores objects in fixed-size chunks (4096 elements) to prevent pointer invalidation during concurrent growth:
+
+```
+Vec (problematic):              ChunkedVec (safe):
+┌──────────────────┐            Chunk 0: ┌──────────────┐
+│ [obj0][obj1]...  │                     │ [obj0][obj1] │ ← never moves
+└──────────────────┘                     └──────────────┘
+        │                       Chunk 1: ┌──────────────┐
+        ↓ resize                         │ [obj4096]... │ ← appended
+┌───────────────────────┐                └──────────────┘
+│ [obj0][obj1]... (NEW) │
+└───────────────────────┘
+  ↑ old pointers invalid!       Index N → chunk[N/4096][N%4096]
+```
+
+This fixed a race condition where concurrent TLAB refills could invalidate pointers held by other VMs.
+
+## Handle-Based FFI
+
+External code interacts through opaque handles that serve as GC roots:
+
+```
+External Code                        Heap
+┌─────────────────┐                 ┌──────────────────────────┐
+│  Handle         │  slab_key       │  handles: HashMap        │
+│  ┌───────────┐  │                 │  ┌────────────────────┐  │
+│  │ key: 42   │──┼────────────────►│  │ 42: ObjectIndex(N) │  │
+│  │ heap: Arc │  │                 │  └────────┬───────────┘  │
+│  └───────────┘  │                 │           │              │
+│                 │                 │           ▼              │
+│                 │                 │  [N]: Array([...])       │
+└─────────────────┘                 │       ↑                  │
+                                    │       └── protected      │
+                                    │           from GC        │
+                                    └──────────────────────────┘
+```
+
+After GC, handles are updated via the forwarding map to point to new locations.
+
+## Concurrency Model
+
+| Component | Mechanism | Purpose |
+|-----------|-----------|---------|
+| Object storage | `UnsafeCell<ChunkedVec>` + TLAB exclusivity | Lock-free writes within reserved regions |
+| Active space | `AtomicUsize` | Atomic space swaps during GC |
+| TLAB chunks | `AtomicUsize::fetch_add` | Lock-free chunk reservation |
+| Handles | `RwLock<HashMap>` | Concurrent reads, exclusive GC updates |
+| GC coordination | Epoch-based safepoints | VMs park at await points for collection |
+
+### Safety Invariants
+
+1. **TLAB exclusivity**: Each VM's TLAB region is never accessed by other VMs
+2. **Safepoint GC**: Collection only runs when all old-epoch VMs are parked
+3. **ChunkedVec stability**: Growing never moves existing elements
+4. **No global mutable state**: BAML has no global variables

--- a/baml_language/crates/bex_vm/README.md
+++ b/baml_language/crates/bex_vm/README.md
@@ -1,0 +1,449 @@
+# BEX VM
+
+Stack-based bytecode interpreter for the BAML language, inspired by CPython and Lox.
+
+## Architecture Overview
+
+```
+┌───────────────────────────────────────────────────────────────────────────────────────┐
+│                                        BexVm                                          │
+├───────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                       │
+│  ┌─────────────────────────────────────────────────────────────────────────────────┐  │
+│  │                             Call Stack (frames)                                 │  │
+│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐                                            │  │
+│  │  │ Frame 0 │ │ Frame 1 │ │ Frame 2 │ ...  (MAX_FRAMES = 256)                    │  │
+│  │  │ main()  │ │ foo()   │ │ bar()   │                                            │  │
+│  │  └─────────┘ └─────────┘ └─────────┘                                            │  │
+│  │                                                                                 │  │
+│  │  Each Frame contains:                                                           │  │
+│  │  • function: ObjectIndex      ← which function is running                       │  │
+│  │  • instruction_ptr: isize     ← next instruction to execute                     │  │
+│  │  • locals_offset: StackIndex  ← where locals start in eval stack                │  │
+│  └─────────────────────────────────────────────────────────────────────────────────┘  │
+│                                                                                       │
+│  ┌─────────────────────────────────────────────────────────────────────────────────┐  │
+│  │                             Evaluation Stack                                    │  │
+│  │                                                                                 │  │
+│  │    ┌────┬─────┬─────┬─────┬─────┬────────┬─────────────────┐                    │  │
+│  │    │ fn │arg1 │arg2 │loc1 │loc2 │ Int(3) │ HeapPtr("hello")│ ← values flow here │  │
+│  │    └────┴─────┴─────┴─────┴─────┴────────┴─────────────────┘                    │  │
+│  │    ▲                            ▲                          ▲                    │  │
+│  │    │                            │                          │                    │  │
+│  │ locals_offset               locals_end                  stack_top               │  │
+│  │                                                                                 │  │
+│  └─────────────────────────────────────────────────────────────────────────────────┘  │
+│                                                                                       │
+│  ┌────────────────────────┐  ┌────────────────────────┐  ┌────────────────────────┐   │
+│  │  tlab: Tlab            │  │  heap: Arc<BexHeap>    │  │  watch: Watch          │   │
+│  │  • alloc_ptr: usize    │  │                        │  │  (watch graph)         │   │
+│  │  • alloc_limit: usize  │  │                        │  │                        │   │
+│  └───────────┬────────────┘  └───────────┬────────────┘  └────────────────────────┘   │
+│              │                           │                                            │
+└──────────────│───────────────────────────│────────────────────────────────────────────┘
+               │                           │
+               │    ┌──────────────────────┘
+               │    │
+               ▼    ▼
+┌─────────────────────────────────────────────────────────────────────────────────────────┐
+│                              BexHeap (shared across VMs)                                │
+├─────────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────────────────────┐  │
+│  │  runtime spaces[2]: ChunkedVec<Object>  (semi-space GC, one active at a time)     │  │
+│  │                                                                                   │  │
+│  │  alloc_ptr                                                                        │  │
+│  │      │    alloc_limit                                                             │  │
+│  │      ▼        ▼                                                                   │  │
+│  │    ┌─────┬─────┬─────┬─────┐   ┌─────┬─────┬─────┬─────┐   ┌─────┬─────┬─────┐    │  │
+│  │    │ obj │ obj │ obj │     │   │ obj │ obj │     │     │   │     │     │     │    │  │
+│  │    └─────┴─────┴─────┴─────┘   └─────┴─────┴─────┴─────┘   └─────┴─────┴─────┘    │  │
+│  │    ├──── TLAB chunk ───────┤   ├──── TLAB chunk ───────┤   ├──── chunk ──────┤    │  │
+│  │          (VM 1)                      (VM 2)                   (available)         │  │
+│  │                                                                                   │  │
+│  │  Allocation: VM bumps alloc_ptr, writes object directly, no locks                 │  │
+│  │  When full: atomic fetch_add reserves next chunk                                  │  │
+│  │                                                                                   │  │
+│  └───────────────────────────────────────────────────────────────────────────────────┘  │
+│                                                                                         │
+│  ┌───────────────────────────────────────────────────────────────────────────────────┐  │
+│  │  compile_time: Vec<Object>  (permanent, never collected)                          │  │
+│  │                                                                                   │  │
+│  │ ┌───────────────────┬───────────────────┬───────────────────┬───────────────────┐ │  │
+│  │ │     Function      │       Class       │        Enum       │       String      │ │  │
+│  │ └──────────┬────────┴──────────┬────────┴──────────┬────────┴──────────┬────────┘ │  │
+│  │            │                   │                   │                   │          │  │
+│  │            ▼                   ▼                   ▼                   ▼          │  │
+│  │  ┌───────────────────┐ ┌───────────────────┐ ┌───────────────────┐ ┌───────────┐  │  │
+│  │  │ name: "add"       │ │ name: "Point"     │ │ name: "Status"    │ │  "hello"  │  │  │
+│  │  │ bytecode:         │ │ field_names:      │ │ variant_names:    │ └───────────┘  │  │
+│  │  │   LOAD_VAR 1      │ │   ["x", "y"]      │ │   ["Success",     │                │  │
+│  │  │   LOAD_VAR 2      │ └───────────────────┘ │    "Failure"]     │                │  │
+│  │  │   ADD             │                       └───────────────────┘                │  │
+│  │  │   RETURN          │                                                            │  │
+│  │  └───────────────────┘                                                            │  │
+│  │                                                                                   │  │
+│  └───────────────────────────────────────────────────────────────────────────────────┘  │
+│                                                                                         │
+└─────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Stack-Based Execution
+
+Unlike register-based VMs, a stack VM operates by pushing and popping values from an evaluation stack. All operations consume operands from the top of the stack and push results back.
+
+Example for the expression `result = (a + b) * c`:
+
+```
+Register VM (2 instructions):          Stack VM (6 instructions):    Eval Stack:
+
+  ADD r2, r1, r0   ; r2 = r1 + r0         LOAD_VAR a                   [a]
+  MUL r4, r2, r3   ; r4 = r2 * r3         LOAD_VAR b                   [a, b]
+                                          ADD                          [a+b]
+                                          LOAD_VAR c                   [a+b, c]
+                                          MUL                          [(a+b)*c]
+                                          STORE_VAR result             []
+```
+
+Trade-off: More instructions to execute, but simpler implementation (no register allocation).
+
+## Value Types
+
+The VM operates on a small set of value types:
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│                                     Value                                        │
+├──────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│  ┌────────┬──────────┬────────────┬────────────┬─────────────────────┐           │
+│  │  Null  │ Int(i64) │ Float(f64) │ Bool(bool) │ Object(ObjectIndex) │           │
+│  └────────┴──────────┴────────────┴────────────┴──────────┬──────────┘           │
+│                                                           │                      │
+└───────────────────────────────────────────────────────────│──────────────────────┘
+                                                            │
+                                                            ▼
+┌──────────────────────────────────────────────────────────────────────────────────┐
+│                                      Heap                                        │
+├──────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                  │
+│  String, Array, Map, Instance, Variant, Function, Class, Enum, Media, Future     │
+│                                                                                  │
+└──────────────────────────────────────────────────────────────────────────────────┘
+```
+
+## Memory Access Patterns
+
+The VM accesses heap memory through two mechanisms:
+
+| Access Type | Method | When Used |
+|-------------|--------|-----------|
+| Read | `get_object(idx)` | Type checks, field reads, method dispatch |
+| Write | `get_object_mut(idx)` | Field writes, array/map mutations |
+| Allocate | `tlab.alloc(obj)` | Creating new objects (strings, arrays, instances) |
+
+Safety invariants:
+- Single-threaded execution within a VM instance
+- TLAB provides exclusive write access to allocated regions
+- Only runtime objects (not compile-time) can be mutated
+- GC only runs when VM is yielded at safepoints
+
+## Execution Loop
+
+The main `exec()` loop fetches and executes one instruction per cycle:
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│                            exec() loop                                │
+├───────────────────────────────────────────────────────────────────────┤
+│                                                                       │
+│  ┌─────────────────────────────────────────────────────────────────┐  │
+│  │  1. Read instruction_ptr from current frame                     │  │
+│  │  2. Increment instruction_ptr (for next cycle)                  │  │
+│  │  3. Decode instruction at bytecode[instruction_ptr]             │  │
+│  └─────────────────────────────────────────────────────────────────┘  │
+│                              │                                        │
+│                              ▼                                        │
+│  ┌─────────────────────────────────────────────────────────────────┐  │
+│  │  match instruction {                                            │  │
+│  │      Push(val)      → stack.push(val)                           │  │
+│  │      Pop            → stack.pop()                               │  │
+│  │      Add            → a,b = pop2(); push(a+b)                   │  │
+│  │      LoadVar(i)     → push(stack[locals_offset + i])            │  │
+│  │      StoreVar(i)    → stack[locals_offset + i] = pop()          │  │
+│  │      Call(n)        → push new Frame, jump to function          │  │
+│  │      Return         → pop Frame, push return value              │  │
+│  │      Jump(offset)   → instruction_ptr += offset                 │  │
+│  │      DispatchFuture → return ScheduleFuture(idx)                │  │
+│  │      Await          → return Await(idx) if pending              │  │
+│  │      ...                                                        │  │
+│  │  }                                                              │  │
+│  └─────────────────────────────────────────────────────────────────┘  │
+│                              │                                        │
+│               ┌──────────────┼──────────────┐                         │
+│               │              │              │                         │
+│               ▼              ▼              ▼                         │
+│        ┌───────────┐  ┌───────────┐  ┌───────────┐                    │
+│        │ frames    │  │ Schedule  │  │  Await    │                    │
+│        │ empty?    │  │ Future    │  │ (pending) │                    │
+│        └─────┬─────┘  └─────┬─────┘  └─────┬─────┘                    │
+│          yes │ no           │              │                          │
+│              │              └──────────────┴────────────────┐         │
+│   ┌──────────┴──────────┐                                   │         │
+│   ▼                     ▼                                   ▼         │
+│ Complete(val)    (continue loop)                       VmExecState    │
+│                                                        returned to    │
+│                                                          engine       │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+## Function Call Convention
+
+When bytecode calls a function, it first loads the function reference, then pushes arguments.
+
+Illustration with source code `let result = add(x, y)`:
+
+```
+Bytecode:                       Stack after each instruction:
+  LOAD_GLOBAL "add"               [add_fn]
+  LOAD_VAR x                      [add_fn, x]
+  LOAD_VAR y                      [add_fn, x, y]
+  CALL 2                          → new frame created
+
+After CALL(2):
+┌─────────────────────────────────────────────────────┐
+│  ... │ add_fn │   x   │   y   │                     │
+└─────────────────────────────────────────────────────┘
+       ▲                        ▲
+       │                        │
+   locals_offset            stack_top
+   (new frame)
+
+Inside add(), locals are accessed relative to locals_offset:
+  LOAD_VAR 0  → add_fn (the function itself)
+  LOAD_VAR 1  → x (first argument)
+  LOAD_VAR 2  → y (second argument)
+```
+
+After `RETURN`, the frame is popped and result replaces the call site on stack.
+
+## Native Functions vs Bytecode Functions
+
+**Case 1: Calling a bytecode function** (stays inside VM)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│                                        VM                                           │
+├─────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                     │
+│  Instruction:               Eval Stack:                     Frames:                 │
+│                                                                                     │
+│  ┌──────────────────┐       ┌────────┐                      ┌──────┐                │
+│  │ LOAD_GLOBAL add  │       │ add_fn │                      │ main │                │
+│  │                  │       └────────┘                      └──────┘                │
+│  │                  │       ┌────────┬───┐                  ┌──────┐                │
+│  │ LOAD_VAR x       │       │ add_fn │ x │                  │ main │                │
+│  │                  │       └────────┴───┘                  └──────┘                │
+│  │                  │       ┌────────┬───┬───┐              ┌──────┐                │
+│  │ LOAD_VAR y       │       │ add_fn │ x │ y │              │ main │                │
+│  │                  │       └────────┴───┴───┘              └──────┘                │
+│  │                  │       ┌────────┬───┬───┐              ┌──────┬─────┐          │
+│  │ CALL 2           │       │ add_fn │ x │ y │              │ main │ add │          │
+│  │                  │       └────────┴───┴───┘              └──────┴─────┘          │
+│  └──────────────────┘                                                               │
+│           │                                                                         │
+│           │                 ... add() executes                                      │
+│           ▼                                                                         │
+│  ┌──────────────────┐       ┌────────┬───┬───┬───┐          ┌──────┬─────┐          │
+│  │ LOAD_VAR 1       │       │ add_fn │ x │ y │ x │          │ main │ add │          │
+│  │                  │       └────────┴───┴───┴───┘          └──────┴─────┘          │
+│  │                  │       ┌────────┬───┬───┬───┬───┐      ┌──────┬─────┐          │
+│  │ LOAD_VAR 2       │       │ add_fn │ x │ y │ x │ y │      │ main │ add │          │
+│  │                  │       └────────┴───┴───┴───┴───┘      └──────┴─────┘          │
+│  │                  │       ┌────────┬───┬───┬─────┐        ┌──────┬─────┐          │
+│  │ ADD              │       │ add_fn │ x │ y │ x+y │        │ main │ add │          │
+│  │                  │       └────────┴───┴───┴─────┘        └──────┴─────┘          │
+│  │                  │       ┌─────┐                         ┌──────┐                │
+│  │ RETURN           │       │ x+y │                         │ main │                │
+│  │                  │       └─────┘                         └──────┘                │
+│  └──────────────────┘                                                               │
+│                                                                                     │
+└─────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Case 2: Calling a native function** (calls out to Rust)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────────┐
+│                                        VM                                           │
+├─────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                     │
+│  Instruction:               Eval Stack:                     Frames:                 │
+│                                                                                     │
+│  ┌──────────────────┐       ┌───┐                           ┌──────┐                │
+│  │ LOAD_CONST 1     │       │ 1 │                           │ main │                │
+│  │                  │       └───┘                           └──────┘                │
+│  │                  │       ┌───┬───┐                       ┌──────┐                │
+│  │ LOAD_CONST 2     │       │ 1 │ 2 │                       │ main │                │
+│  │                  │       └───┴───┘                       └──────┘                │
+│  │                  │       ┌───┬───┬───┐                   ┌──────┐                │
+│  │ LOAD_CONST 3     │       │ 1 │ 2 │ 3 │                   │ main │                │
+│  │                  │       └───┴───┴───┘                   └──────┘                │
+│  │                  │       ┌─────────────┐                 ┌──────┐                │
+│  │ ALLOC_ARRAY 3    │       │ [1, 2, 3]   │                 │ main │                │
+│  │                  │       └─────────────┘                 └──────┘                │
+│  │                  │                                       ┌──────┐                │
+│  │ STORE_VAR arr    │       (arr stored at locals[0])       │ main │                │
+│  │                  │                                       └──────┘                │
+│  │                  │       ┌────────┐                      ┌──────┐                │
+│  │ LOAD_GLOBAL len  │       │ len_fn │                      │ main │                │
+│  │                  │       └────────┘                      └──────┘                │
+│  │                  │       ┌────────┬─────────────┐        ┌──────┐                │
+│  │ LOAD_VAR arr     │       │ len_fn │ [1, 2, 3]   │        │ main │                │
+│  │                  │       └────────┴─────────────┘        └──────┘                │
+│  │                  │                                                               │
+│  │ CALL 1           │                                                               │
+│  │                  │                                                               │
+│  │                  │       ┌───┐                           ┌──────┐                │
+│  │ ...              │       │ 3 │                           │ main │ (no new frame) │
+│  │                  │       └─▲─┘                           └──────┘                │
+│  └────────┬─────────┘         │                                                     │
+│           │                   │                                                     │
+└───────────│───────────────────│─────────────────────────────────────────────────────┘
+            │                   │
+            │                   │
+            ▼                   │
+   ┌─────────────────────────────────────────────────────────────────┐
+   │  fn rust_native_len(vm: &mut BexVm, args: &[Value]) -> Value {  │
+   │      let ptr = &args[0];                                        │
+   │      let Object::Array(arr) = vm.get_object(ptr);               │
+   │      Value::Int(arr.len())  // returns 3                        │
+   │  }                                                              │
+   └─────────────────────────────────────────────────────────────────┘
+```
+
+## Async Operations: DispatchFuture + Await
+
+The VM cannot perform I/O directly. External operations (LLM calls, file I/O) use a two-phase pattern.
+
+Example: `let content = fetch("http://example.com")`
+
+```
+┌──────────────────────────────────────────────────┐      ┌───────────────────────────────────────┐
+│                       VM                         │      │               Engine                  │
+├──────────────────────────────────────────────────┤      ├───────────────────────────────────────┤
+│                                                  │      │                                       │
+│  Instruction:          Eval Stack:               │      │                                       │
+│                                                  │      │  ┌───────────────────────────────┐    │
+│  ┌──────────────────┐  ┌──────────┐              │      │  │ tokio::spawn {                │    │
+│  │ LOAD_GLOBAL      │  │ fetch_fn │              │      │  │     SysOp::Fetch(url)         │    │
+│  │   fetch          │  └──────────┘              │      │  │ }                             │    │
+│  │                  │  ┌──────────┬────────────┐ │      │  │                               │    │
+│  │ LOAD_CONST url   │  │ fetch_fn │ "http://." │ │      │  │ // task running in background │    │
+│  │                  │  └──────────┴────────────┘ │      │  └───────────────────────────────┘    │
+│  │                  │  ┌────────────┐            │      │                 ▲                     │
+│  │ DISPATCH_FUTURE ─│──│ future_idx │ ───────────│──────│─────────────────┘                     │
+│  │                  │  └────────────┘            │      │                                       │
+│  │ ...              │  (vm continues working)    │      │                                       │
+│  │                  │                            │      │                                       │
+│  │                  │  ┌────────────┐            │      │                                       │
+│  │ AWAIT ───────────│──│ future_idx │            │      │                                       │
+│  │                  │  └────────────┘            │      │                                       │
+│  │                  │        │                   │      │                                       │
+│  └──────────────────┘        │ pending?          │      │  ┌───────────────────────────────┐    │
+│                              ▼                   │      │  │ let result = task.await;      │    │
+│                     VmExecState::Await ──────────│──────│─►│                               │    │
+│                                                  │      │  │ heap[idx] = Ready(result)     │    │
+│                        ┌───────────────┐         │      │  │ vm.exec()                     │    │
+│                        │ "<html>..."   │◄────────│──────│──│                               │    │
+│                        └───────────────┘         │      │  └───────────────────────────────┘    │
+│                                                  │      │                                       │
+└──────────────────────────────────────────────────┘      └───────────────────────────────────────┘
+```
+
+Key insight: DISPATCH_FUTURE returns immediately, allowing the VM to continue other work.
+AWAIT blocks only if the future is still pending.
+
+## Watch System
+
+The `watch` keyword enables reactive change notifications. The Watch module maintains a
+dependency graph tracking which heap objects are reachable from watched variables. When a
+watched variable or its nested fields change, the VM yields to the engine which calls a
+notification handler callback.
+
+Example: `watch let user = getUser(); ... user.email = "new@..."`
+
+```
+┌──────────────────────────────────────────────────────────────────────────────────────┐
+│                                          VM                                          │
+├──────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                      │
+│  Instruction:               Eval Stack:                     Frames:                  │
+│                                                                                      │
+│  ┌──────────────────────┐   ┌──────┐                        ┌──────┐                 │
+│  │ CALL getUser         │   │ user │                        │ main │                 │
+│  │                      │   └──────┘                        └──────┘                 │
+│  │ WATCH 0, "user"      │   (registers root)                                         │
+│  │ ...                  │                                   ┌──────┐                 │
+│  │                      │   ┌───────────┐                   │ main │                 │
+│  │ LOAD_CONST "new@..." │   │ "new@..." │                   └──────┘                 │
+│  │ LOAD_VAR user        │   └───────────┘                                            │
+│  │                      │                                   ┌──────┐                 │
+│  │ STORE_FIELD email    │   (triggers filter)               │ main │                 │
+│  │                      │                                   └──────┘                 │
+│  └──────────────────────┘                                                            │
+│                                                                                      │
+│  ┌─────────────────────────────────────────────────────────────────────────────────┐ │
+│  │ match filter:                                                                   │ │
+│  │   Default       → deep_equals(last_assigned, value)?                            │ │
+│  │   Function(f)   → interrupt(f, [value])                                         │ │
+│  │   Manual/Paused → skip                                                          │ │
+│  └─────────────────────────────────────────────────────────────────────────────────┘ │
+│                                                                                      │
+│  ─── interrupt(f, [value]) ────────────────────────────────────────────────────────  │
+│                                                                                      │
+│  ┌──────────────────────┐   ┌───────────┐                   ┌──────┬────────┐        │
+│  │ (filter bytecode)    │   │ filter_fn │                   │ main │ filter │        │
+│  │ LOAD_VAR 1           │   │ value     │                   └──────┴────────┘        │
+│  │ ...                  │   └───────────┘                                            │
+│  │                      │   ┌──────┐                        ┌──────┐                 │
+│  │ RETURN               │   │ bool │  ← should notify?      │ main │                 │
+│  │                      │   └──────┘                        └──────┘                 │
+│  └──────────────────────┘                                                            │
+│                                                                                      │
+│  ─── if should_notify ─────────────────────────────────────────────────────────────  │
+│                                                                                      │
+│                                        VmExecState::Notify                           │
+│                                               │                                      │
+│                                               │                          ▲           │
+│                                               │                 continues│           │
+└───────────────────────────────────────────────│──────────────────────────│───────────┘
+                                                │                          │
+                                                ▼                          │
+┌───────────────────────────────────┐      ┌───────────────────────────┐   │
+│ Python (Host Lang):               │      │ Engine:                   │   │
+│   def handle_watch_notification() │◄─────│   watch_handlers(roots)   │   │
+└───────────────────────────────────┘      │   vm.exec() ──────────────│───┘
+                                           └───────────────────────────┘
+```
+
+**Filters** control when notifications fire:
+- `Default`: deep_equals(last_assigned, value) - notify only if actually changed
+- `Function(f)`: calls `interrupt(f, [value])` which runs filter bytecode inline, returns bool
+- `Manual`: never auto-notifies, requires explicit NOTIFY instruction
+- `Paused`: disabled, never notifies
+
+## Crate Dependencies
+
+```
+bex_vm_types (defines Instruction, Value, Object, bytecode)
+      │
+      ▼
+  bex_heap (provides BexHeap, Tlab for allocation)
+      │
+      ▼
+   bex_vm (this crate - the interpreter)
+      │
+      ▼
+  bex_engine (orchestrates VM + async operations)
+```


### PR DESCRIPTION
## Summary
- Adds comprehensive architecture documentation with ASCII diagrams for the bex crates
- **bex_vm**: Stack-based execution, value types, memory access patterns, function call conventions, async operations (DispatchFuture + Await), and watch system
- **bex_heap**: Semi-space GC, TLAB allocation, ChunkedVec for stable pointers, compile-time vs runtime spaces
- **bex_engine**: VM orchestration, async task management, watch notifications with host language callbacks