### PR TITLE
Fix streaming retry not yielding chunks from retried requests

### DIFF
--- a/engine/baml-runtime/src/internal/llm_client/orchestrator/stream.rs
+++ b/engine/baml-runtime/src/internal/llm_client/orchestrator/stream.rs
@@ -479,6 +479,14 @@ where
                 // We must NOT emit failure events for intermediate retries because the
                 // TypeScript/Python client will throw immediately on receiving an error event,
                 // even though we're about to retry and may succeed.
+                //
+                // TODO: If a stream yields partial chunks before failing mid-stream, those
+                // chunks have already been emitted via on_event in run_parser_loop. When the
+                // retry starts, fresh chunks will also be emitted. Users iterating over the
+                // stream would see partials from both attempts (the stream may appear to
+                // "reset" or go backwards). The final response from getFinalResponse() will
+                // be correct. To fully handle mid-stream failures, we'd need to buffer chunks
+                // until the stream completes successfully, which would hurt streaming latency.
                 let is_success = matches!(final_response, LLMResponse::Success(_));
                 let should_emit_event = is_success || is_last_node;
 

--- a/engine/baml-runtime/src/internal/llm_client/orchestrator/stream.rs
+++ b/engine/baml-runtime/src/internal/llm_client/orchestrator/stream.rs
@@ -185,7 +185,9 @@ where
     tokio::pin!(cancel_future);
 
     //advanced curl viewing, use render_raw_curl on each node. TODO
-    for node in iter {
+    let total_nodes = iter.len();
+    for (node_index, node) in iter.into_iter().enumerate() {
+        let is_last_node = node_index == total_nodes - 1;
         // Check for cancellation at the start of each iteration
         let cancel_scope = node.scope.clone();
         tokio::select! {
@@ -470,25 +472,35 @@ where
                     Some(Err(e)) => Some(Err(e)),
                     None => None,
                 };
-                // Call on_event for the final response (success or failure)
-                // We need to do this before moving response_value_without_flags into result
-                if let Some(ref on_event_cb) = on_event {
-                    // We can't clone anyhow::Error, so we need to check the response type
-                    // and only send on_event for responses we can represent
-                    let event_result = match &response_value_without_flags {
-                        Some(Ok(val)) => Some(Ok(val.clone())),
-                        Some(Err(e)) => {
-                            // print the type of the error
-                            Some(Err(anyhow::anyhow!(e.to_string())))
-                        }
-                        None => None,
-                    };
+                // Call on_event for the final response, but only for:
+                // 1. Success responses (always emit)
+                // 2. Failure responses when this is the last node (all retries exhausted)
+                //
+                // We must NOT emit failure events for intermediate retries because the
+                // TypeScript/Python client will throw immediately on receiving an error event,
+                // even though we're about to retry and may succeed.
+                let is_success = matches!(final_response, LLMResponse::Success(_));
+                let should_emit_event = is_success || is_last_node;
 
-                    on_event_cb(FunctionResult::new(
-                        node.scope.clone(),
-                        final_response.clone(),
-                        event_result,
-                    ));
+                if should_emit_event {
+                    if let Some(ref on_event_cb) = on_event {
+                        // We can't clone anyhow::Error, so we need to check the response type
+                        // and only send on_event for responses we can represent
+                        let event_result = match &response_value_without_flags {
+                            Some(Ok(val)) => Some(Ok(val.clone())),
+                            Some(Err(e)) => {
+                                // print the type of the error
+                                Some(Err(anyhow::anyhow!(e.to_string())))
+                            }
+                            None => None,
+                        };
+
+                        on_event_cb(FunctionResult::new(
+                            node.scope.clone(),
+                            final_response.clone(),
+                            event_result,
+                        ));
+                    }
                 }
 
                 let result = (node.scope, final_response, response_value_without_flags);

--- a/integ-tests/typescript/tests/streaming-retry.test.ts
+++ b/integ-tests/typescript/tests/streaming-retry.test.ts
@@ -6,7 +6,7 @@ import * as http from "http";
  * When a streaming request fails and BAML retries, the chunks from the retried
  * stream should be yielded to the user.
  *
- * Bug report: Discord (Anders - 2025-01-26)
+ * Bug report: Discord
  * - Using plain string streaming with Anthropic provider
  * - Ephemeral errors like "bad MAC" cause retries
  * - b.stream will RETRY the request, but will NOT yield the text chunks

--- a/integ-tests/typescript/tests/streaming-retry.test.ts
+++ b/integ-tests/typescript/tests/streaming-retry.test.ts
@@ -1,0 +1,271 @@
+import { b, ClientRegistry } from "./test-setup";
+import * as http from "http";
+
+/**
+ * Test for streaming retry bug:
+ * When a streaming request fails and BAML retries, the chunks from the retried
+ * stream should be yielded to the user.
+ *
+ * Bug report: Discord (Anders - 2025-01-26)
+ * - Using plain string streaming with Anthropic provider
+ * - Ephemeral errors like "bad MAC" cause retries
+ * - b.stream will RETRY the request, but will NOT yield the text chunks
+ *   of the restarted stream. It yields nothing (silent fail).
+ */
+
+/**
+ * Mock OpenAI-compatible streaming server that:
+ * - Fails on the first N requests with a 500 error
+ * - Succeeds on subsequent requests with a streaming response
+ */
+function createMockRetryServer(failCount: number = 1): {
+  server: http.Server;
+  getRequestCount: () => number;
+} {
+  let requestCount = 0;
+
+  const server = http.createServer(async (req, res) => {
+    // Handle OPTIONS for CORS
+    if (req.method === "OPTIONS") {
+      res.writeHead(200, {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+      });
+      res.end();
+      return;
+    }
+
+    // Only handle POST to /v1/chat/completions
+    if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+
+    requestCount++;
+    console.log(`Mock server: Request #${requestCount}`);
+
+    // Fail the first N requests
+    if (requestCount <= failCount) {
+      console.log(`Mock server: Returning 500 error for request #${requestCount}`);
+      res.writeHead(500, {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*",
+      });
+      res.end(JSON.stringify({
+        error: {
+          message: "Internal Server Error (simulated failure for retry test)",
+          type: "server_error",
+          code: "internal_error"
+        }
+      }));
+      return;
+    }
+
+    // Success case: return streaming response
+    console.log(`Mock server: Returning streaming response for request #${requestCount}`);
+    res.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "Access-Control-Allow-Origin": "*",
+    });
+
+    // Send first chunk with role
+    res.write(
+      'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}\n\n',
+    );
+
+    // Send content chunks with small delays
+    const chunks = ["Hello", " from", " retry", " success", "!"];
+    for (let i = 0; i < chunks.length; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      res.write(
+        `data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{"content":"${chunks[i]}"},"finish_reason":null}]}\n\n`,
+      );
+    }
+
+    // Send final chunk with stop reason
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    res.write(
+      'data: {"id":"chatcmpl-mock","object":"chat.completion.chunk","created":1234567890,"model":"gpt-4","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+    );
+    res.write("data: [DONE]\n\n");
+    res.end();
+  });
+
+  return {
+    server,
+    getRequestCount: () => requestCount,
+  };
+}
+
+describe("Streaming Retry Bug", () => {
+  it("should receive chunks from retried stream after first attempt fails", async () => {
+    // Create mock server that fails once then succeeds
+    const { server, getRequestCount } = createMockRetryServer(1);
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Failed to get server address");
+    }
+    const port = address.port;
+    const baseUrl = `http://localhost:${port}/v1`;
+
+    try {
+      // Create a client registry with our mock server and retry policy
+      // Note: "Constant" retry policy is defined in retry.baml with max_retries: 3
+      const registry = new ClientRegistry();
+      registry.addLlmClient("MockRetryClient", "openai", {
+        base_url: baseUrl,
+        api_key: "mock-key",
+        model: "gpt-4",
+      }, "Constant"); // Use the Constant retry policy from retry.baml
+      registry.setPrimary("MockRetryClient");
+
+      // Use streaming with the mock client
+      const stream = b.stream.TestStreamingTimeout("test retry streaming", {
+        clientRegistry: registry,
+      });
+
+      // Collect all chunks
+      const chunks: string[] = [];
+      let chunkCount = 0;
+
+      console.log("Starting to iterate over stream...");
+      for await (const partial of stream) {
+        chunkCount++;
+        console.log(`Received chunk ${chunkCount}:`, partial);
+        if (partial) {
+          chunks.push(String(partial));
+        }
+      }
+
+      console.log(`Total chunks received: ${chunkCount}`);
+      console.log(`Total requests made: ${getRequestCount()}`);
+
+      // Get final response
+      const final = await stream.getFinalResponse();
+      console.log("Final response:", final);
+
+      // Verify we made 2 requests (1 failed + 1 succeeded)
+      expect(getRequestCount()).toBe(2);
+
+      // Verify we received chunks from the retry
+      expect(chunkCount).toBeGreaterThan(0);
+
+      // Verify the final response contains expected content
+      expect(final).toContain("retry");
+      expect(final).toContain("success");
+
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("should receive chunks from retried stream after multiple failures", async () => {
+    // Create mock server that fails twice then succeeds
+    const { server, getRequestCount } = createMockRetryServer(2);
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Failed to get server address");
+    }
+    const port = address.port;
+    const baseUrl = `http://localhost:${port}/v1`;
+
+    try {
+      const registry = new ClientRegistry();
+      registry.addLlmClient("MockRetryClient", "openai", {
+        base_url: baseUrl,
+        api_key: "mock-key",
+        model: "gpt-4",
+      }, "Constant");
+      registry.setPrimary("MockRetryClient");
+
+      const stream = b.stream.TestStreamingTimeout("test multiple retry streaming", {
+        clientRegistry: registry,
+      });
+
+      const chunks: string[] = [];
+      let chunkCount = 0;
+
+      for await (const partial of stream) {
+        chunkCount++;
+        if (partial) {
+          chunks.push(String(partial));
+        }
+      }
+
+      const final = await stream.getFinalResponse();
+
+      // Verify we made 3 requests (2 failed + 1 succeeded)
+      expect(getRequestCount()).toBe(3);
+
+      // Verify we received chunks from the successful retry
+      expect(chunkCount).toBeGreaterThan(0);
+      expect(final).toContain("retry");
+
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+
+  it("should throw error only after all retries are exhausted", async () => {
+    // Create mock server that always fails (more failures than retries)
+    const { server, getRequestCount } = createMockRetryServer(10);
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, () => resolve());
+    });
+
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Failed to get server address");
+    }
+    const port = address.port;
+    const baseUrl = `http://localhost:${port}/v1`;
+
+    try {
+      const registry = new ClientRegistry();
+      registry.addLlmClient("MockRetryClient", "openai", {
+        base_url: baseUrl,
+        api_key: "mock-key",
+        model: "gpt-4",
+      }, "Constant"); // max_retries: 3, so 4 total attempts
+      registry.setPrimary("MockRetryClient");
+
+      const stream = b.stream.TestStreamingTimeout("test exhausted retries", {
+        clientRegistry: registry,
+      });
+
+      // Should throw after all retries exhausted
+      await expect(async () => {
+        for await (const partial of stream) {
+          // Should not receive any successful chunks
+        }
+      }).rejects.toThrow();
+
+      // Verify all retry attempts were made (1 initial + 3 retries = 4)
+      expect(getRequestCount()).toBe(4);
+
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

When a streaming request failed and BAML retried, the TypeScript/Python client would throw immediately on receiving the error event, even though the Rust side was about to retry and potentially succeed. This resulted in users seeing errors instead of receiving chunks from the successful retry.

**Bug report**: https://discord.com/channels/1119368998161752075/1462597239099883600/1462597239099883600

> Using plain string streaming, Anthropic provider.
> Anthropic likes to have random ephemeral errors sometimes, e.g.:
> `reqwest::Error { kind: Request, url: "https://api.anthropic.com/v1/messages", source: hyper_util::client::legacy::Error(SendRequest, hyper::Error(Io, Custom { kind: Other, error: "bad MAC" })) }`
>
> In these cases, b.stream will RETRY the request, but will NOT yield the text chunks of the restarted stream. It will instead yield nothing (silent fail).

## Changes

- Modified `orchestrate_stream()` in `engine/baml-runtime/src/internal/llm_client/orchestrator/stream.rs`
- Only emit `on_event` for:
  1. Success responses (always emit)
  2. Failure responses **only when it's the last node** (all retries exhausted)
- Added integration tests that verify:
  - Chunks are received from retried stream after first attempt fails
  - Chunks are received after multiple failures
  - Error is thrown only after all retries are exhausted

## Known Limitation

If a stream yields partial chunks **before** failing mid-stream (not immediate failure), those chunks have already been emitted to the client. When the retry starts, fresh chunks will also be emitted. Users iterating over the stream would see partials from both attempts—the stream may appear to "reset" or go backwards mid-iteration.

However:
- **`getFinalResponse()` will always return the correct final value** from the successful retry
- The jsonish parser properly resets state per retry (each attempt gets fresh `ParserState` and channels)
- This edge case only affects users who iterate over partial chunks AND experience mid-stream failures (not immediate failures)

To fully handle mid-stream failures, we'd need to buffer chunks until the stream completes successfully, which would hurt streaming latency. This is left as a TODO for future consideration.

## Test plan

- [x] New tests in `integ-tests/typescript/tests/streaming-retry.test.ts` pass
- [x] Existing integration tests unaffected (failures are pre-existing AWS credential issues, provider API changes, etc.)