### PR TITLE
feat: implement baml.http.fetch with Response API

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -193,6 +193,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +781,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]
@@ -1469,6 +1480,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,8 +1871,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1853,9 +1884,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if 1.0.4",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1987,6 +2020,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2119,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2663,6 +2703,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "lsp-server"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2890,6 +2936,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3344,6 +3400,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "socket2 0.6.1",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash 2.1.1",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.17",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.1",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,6 +3650,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -3546,6 +3659,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -3555,6 +3669,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -3710,6 +3825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -3722,6 +3838,7 @@ version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e6f2ab2928ca4291b86736a8bd920a277a399bba1589409d72154ff87c1282"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4222,6 +4339,8 @@ name = "sys_native"
 version = "0.0.0"
 dependencies = [
  "bex_external_types",
+ "indexmap 2.13.0",
+ "reqwest",
  "sys_resource_types",
  "sys_types",
  "tokio",
@@ -4433,6 +4552,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5116,6 +5250,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webbrowser"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5129,6 +5273,15 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5453,6 +5606,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -146,6 +146,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
 webbrowser = "1.0.5"
 wee_alloc = "0.4"
+wiremock = "0.6"
 [workspace.lints.rust]
 unsafe_code = "warn"
 unreachable_pub = "warn"

--- a/baml_language/crates/baml_builtins/src/lib.rs
+++ b/baml_language/crates/baml_builtins/src/lib.rs
@@ -198,6 +198,34 @@ macro_rules! with_builtins {
                     #[external]
                     fn connect(addr: String) -> Socket;
                 }
+
+                // =====================================================================
+                // HTTP operations
+                // =====================================================================
+                mod http {
+                    #[builtin]
+                    struct Response {
+                        /// Get response body as text (consumes body).
+                        #[external]
+                        fn text(self: Response) -> String;
+                        /// Get HTTP status code.
+                        #[external]
+                        fn status(self: Response) -> i64;
+                        /// Check if status is 2xx.
+                        #[external]
+                        fn ok(self: Response) -> bool;
+                        /// Get request URL (may differ if redirected).
+                        #[external]
+                        fn url(self: Response) -> String;
+                        /// Get response headers.
+                        #[external]
+                        fn headers(self: Response) -> Map<String, String>;
+                    }
+
+                    /// Fetch a URL via HTTP GET.
+                    #[external]
+                    fn fetch(url: String) -> Response;
+                }
             }
 
             mod env {

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -382,6 +382,12 @@ fn external_op_for_builtin_path(path: &str) -> Option<ExternalOp> {
         "baml.net.connect" => Some(ExternalOp::Sys(SysOp::NetConnect)),
         "baml.net.Socket.read" => Some(ExternalOp::Sys(SysOp::NetRead)),
         "baml.net.Socket.close" => Some(ExternalOp::Sys(SysOp::NetClose)),
+        "baml.http.fetch" => Some(ExternalOp::Sys(SysOp::HttpFetch)),
+        "baml.http.Response.text" => Some(ExternalOp::Sys(SysOp::HttpResponseText)),
+        "baml.http.Response.status" => Some(ExternalOp::Sys(SysOp::HttpResponseStatus)),
+        "baml.http.Response.ok" => Some(ExternalOp::Sys(SysOp::HttpResponseOk)),
+        "baml.http.Response.url" => Some(ExternalOp::Sys(SysOp::HttpResponseUrl)),
+        "baml.http.Response.headers" => Some(ExternalOp::Sys(SysOp::HttpResponseHeaders)),
         _ => None,
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
@@ -1,8 +1,8 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 0
-Objects: 37
-Globals: 31
+Objects: 43
+Globals: 37

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-fbd0fe113b2fb574/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 39
-Globals: 35
+Objects: 45
+Globals: 41
 
 Function GetMixedList (arity: 0, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 11
-Objects: 57
-Globals: 42
+Objects: 63
+Globals: 48
 
 Function ChainCommands (arity: 0, kind: Bytecode):
      0    LOAD_CONST 0        (null)

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
@@ -1,8 +1,8 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 0
-Objects: 31
-Globals: 31
+Objects: 37
+Globals: 37

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 2
-Objects: 33
-Globals: 33
+Objects: 39
+Globals: 39
 
 Function CommentAfterArrow (arity: 0, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
@@ -1,8 +1,8 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 0
-Objects: 31
-Globals: 31
+Objects: 37
+Globals: 37

--- a/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
@@ -1,8 +1,8 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 0
-Objects: 33
-Globals: 31
+Objects: 39
+Globals: 37

--- a/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 6
-Objects: 40
-Globals: 37
+Objects: 46
+Globals: 43
 
 Function Bar (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 35   (<fn Foo>)
+     0   LOAD_GLOBAL 41   (<fn Foo>)
      1   LOAD_CONST 0     (1)
      2   CALL 1           
      3   RETURN           
@@ -20,7 +20,7 @@ Function Foo (arity: 1, kind: Bytecode):
      3   RETURN         
 
 Function GreetBaz (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 32     (<fn Greeting>)
+     0   LOAD_GLOBAL 38     (<fn Greeting>)
      1   ALLOC_INSTANCE 0   (<class Baz>)
      2   COPY 0             
      3   LOAD_VAR 1         (n)

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 1
-Objects: 33
-Globals: 32
+Objects: 39
+Globals: 38
 
 Function GetUser (arity: 0, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 1
-Objects: 33
-Globals: 32
+Objects: 39
+Globals: 38
 
 Function FetchDatax (arity: 1, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 10
-Objects: 51
-Globals: 41
+Objects: 57
+Globals: 47
 
 Function ConsecutiveHeaders (arity: 0, kind: Bytecode):
      0   NOTIFY_BLOCK 0   (FirstHeader)

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 86
-Objects: 292
-Globals: 117
+Objects: 298
+Globals: 123
 
 Function BoolLiteralAfterTypedBool (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1             (b)
@@ -787,7 +787,7 @@ Function MatchComplexScrutinee (arity: 1, kind: Bytecode):
 
 Function MatchFunctionCallScrutinee (arity: 0, kind: Bytecode):
      0    LOAD_CONST 0           (null)
-     1    LOAD_GLOBAL 72         (<fn GetStatus>)
+     1    LOAD_GLOBAL 78         (<fn GetStatus>)
      2    CALL 0                 
      3    STORE_VAR 1            (_1)
      4    LOAD_VAR 1             (_1)

--- a/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 12
-Objects: 60
-Globals: 43
+Objects: 66
+Globals: 49
 
 Function boolArray (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0    (true)

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 41
-Globals: 34
+Objects: 47
+Globals: 40
 
 Function Foo (arity: 0, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 39
-Globals: 35
+Objects: 45
+Globals: 41
 
 Function Calculate (arity: 0, kind: Bytecode):
      0    LOAD_CONST 0   (null)

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 8
-Objects: 47
-Globals: 39
+Objects: 53
+Globals: 45
 
 Function Ambiguous (arity: 1, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 21
-Objects: 56
-Globals: 52
+Objects: 62
+Globals: 58
 
 Function ConditionalLogic (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (age)

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 103
-Objects: 1241
-Globals: 134
+Objects: 1247
+Globals: 140
 
 Function BodyTorture (arity: 0, kind: Bytecode):
      0    LOAD_CONST 0           (null)

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 39
-Globals: 34
+Objects: 45
+Globals: 40
 
 Function FormatMessage (arity: 1, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 2
-Objects: 35
-Globals: 33
+Objects: 41
+Globals: 39
 
 Function BadParam (arity: 1, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
@@ -1,8 +1,8 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 0
-Objects: 31
-Globals: 31
+Objects: 37
+Globals: 37

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 1
-Objects: 33
-Globals: 32
+Objects: 39
+Globals: 38
 
 Function HelloWorld (arity: 1, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 1
-Objects: 33
-Globals: 32
+Objects: 39
+Globals: 38
 
 Function Foo (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)

--- a/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 1
-Objects: 32
-Globals: 32
+Objects: 38
+Globals: 38
 
 Function Foo (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)

--- a/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
@@ -1,8 +1,8 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 0
-Objects: 31
-Globals: 31
+Objects: 37
+Globals: 37

--- a/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 5
-Objects: 39
-Globals: 36
+Objects: 45
+Globals: 42
 
 Function Bar (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (true)

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 1
-Objects: 34
-Globals: 32
+Objects: 40
+Globals: 38
 
 Function Fn (arity: 0, kind: External(Llm)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-01efb6cd2b70f9e6/out/generated_tests.rs
+source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 34
-Globals: 34
+Objects: 40
+Globals: 40
 
 Function Bar (arity: 1, kind: Bytecode):
      0   LOAD_CONST 0   (1)

--- a/baml_language/crates/bex_engine/Cargo.toml
+++ b/baml_language/crates/bex_engine/Cargo.toml
@@ -26,6 +26,7 @@ anyhow = { workspace = true }
 indexmap = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [ "rt-multi-thread", "macros" ] }
+wiremock = { workspace = true }
 
 [lints]
 workspace = true

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -1122,12 +1122,14 @@ impl BexEngine {
                         ExternalOp::Sys(sys_op) => {
                             match self.execute_sys_op(sys_op, args) {
                                 SysOpResult::Ready(result) => {
-                                    // Sync operation - fulfill immediately
+                                    // Sync operation - set future to Ready without touching stack.
+                                    // The VM will continue to the Await instruction which will
+                                    // extract the value from the Ready future.
                                     let value = Self::external_to_vm_value(
                                         vm,
                                         result.map_err(EngineError::from)?,
                                     );
-                                    vm.fulfil_future(id, value)?;
+                                    vm.set_future_ready(id, value)?;
                                 }
                                 SysOpResult::Async(fut) => {
                                     // Async operation - spawn task
@@ -1232,6 +1234,12 @@ impl BexEngine {
             SysOp::NetRead => (self.sys_ops.net_read)(args),
             SysOp::NetClose => (self.sys_ops.net_close)(args),
             SysOp::Shell => (self.sys_ops.shell)(args),
+            SysOp::HttpFetch => (self.sys_ops.http_fetch)(args),
+            SysOp::HttpResponseText => (self.sys_ops.http_response_text)(args),
+            SysOp::HttpResponseStatus => (self.sys_ops.http_response_status)(args),
+            SysOp::HttpResponseOk => (self.sys_ops.http_response_ok)(args),
+            SysOp::HttpResponseUrl => (self.sys_ops.http_response_url)(args),
+            SysOp::HttpResponseHeaders => (self.sys_ops.http_response_headers)(args),
         }
     }
 

--- a/baml_language/crates/bex_engine/tests/http.rs
+++ b/baml_language/crates/bex_engine/tests/http.rs
@@ -1,0 +1,212 @@
+//! Tests for HTTP operations (baml.http.fetch, Response methods).
+
+mod common;
+
+use bex_engine::BexExternalValue;
+use common::{EngineProgram, assert_engine_executes};
+use indexmap::indexmap;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+/// Test basic fetch and text extraction.
+#[tokio::test]
+async fn http_fetch_and_text() -> anyhow::Result<()> {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/data"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("Hello from HTTP!"))
+        .mount(&mock_server)
+        .await;
+
+    let source = format!(
+        r#"
+        function main() -> string {{
+            let response = baml.http.fetch("{}/data");
+            response.text()
+        }}
+    "#,
+        mock_server.uri()
+    );
+
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: Box::leak(source.into_boxed_str()),
+        entry: "main",
+        expected: Ok(BexExternalValue::String("Hello from HTTP!".to_string())),
+    })
+    .await
+}
+
+/// Test status code access.
+#[tokio::test]
+async fn http_response_status() -> anyhow::Result<()> {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/status"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&mock_server)
+        .await;
+
+    let source = format!(
+        r#"
+        function main() -> int {{
+            let response = baml.http.fetch("{}/status");
+            response.status()
+        }}
+    "#,
+        mock_server.uri()
+    );
+
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: Box::leak(source.into_boxed_str()),
+        entry: "main",
+        expected: Ok(BexExternalValue::Int(201)),
+    })
+    .await
+}
+
+/// Test `ok()` returns true for 2xx.
+#[tokio::test]
+async fn http_response_ok_true() -> anyhow::Result<()> {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/ok"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    let source = format!(
+        r#"
+        function main() -> bool {{
+            let response = baml.http.fetch("{}/ok");
+            response.ok()
+        }}
+    "#,
+        mock_server.uri()
+    );
+
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: Box::leak(source.into_boxed_str()),
+        entry: "main",
+        expected: Ok(BexExternalValue::Bool(true)),
+    })
+    .await
+}
+
+/// Test `ok()` returns false for 4xx.
+#[tokio::test]
+async fn http_response_ok_false() -> anyhow::Result<()> {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/notfound"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&mock_server)
+        .await;
+
+    let source = format!(
+        r#"
+        function main() -> bool {{
+            let response = baml.http.fetch("{}/notfound");
+            response.ok()
+        }}
+    "#,
+        mock_server.uri()
+    );
+
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: Box::leak(source.into_boxed_str()),
+        entry: "main",
+        expected: Ok(BexExternalValue::Bool(false)),
+    })
+    .await
+}
+
+/// Test `url()` returns the request URL.
+#[tokio::test]
+async fn http_response_url() -> anyhow::Result<()> {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/endpoint"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server)
+        .await;
+
+    let expected_url = format!("{}/endpoint", mock_server.uri());
+    let source = format!(
+        r#"
+        function main() -> string {{
+            let response = baml.http.fetch("{}/endpoint");
+            response.url()
+        }}
+    "#,
+        mock_server.uri()
+    );
+
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: Box::leak(source.into_boxed_str()),
+        entry: "main",
+        expected: Ok(BexExternalValue::String(expected_url)),
+    })
+    .await
+}
+
+/// Test network error handling.
+#[tokio::test]
+async fn http_fetch_network_error() -> anyhow::Result<()> {
+    // Use an address that will definitely fail to connect
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function main() -> string {
+                let response = baml.http.fetch("http://localhost:1");
+                response.text()
+            }
+        "#,
+        entry: "main",
+        expected: Err("HTTP request failed"),
+    })
+    .await
+}
+
+/// Test that calling `text()` twice fails.
+#[tokio::test]
+async fn http_response_text_consumed() -> anyhow::Result<()> {
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/once"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("body"))
+        .mount(&mock_server)
+        .await;
+
+    let source = format!(
+        r#"
+        function main() -> string {{
+            let response = baml.http.fetch("{}/once");
+            let first = response.text();
+            let second = response.text();
+            second
+        }}
+    "#,
+        mock_server.uri()
+    );
+
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: Box::leak(source.into_boxed_str()),
+        entry: "main",
+        expected: Err("already been consumed"),
+    })
+    .await
+}

--- a/baml_language/crates/bex_external_types/src/bex_external_value.rs
+++ b/baml_language/crates/bex_external_types/src/bex_external_value.rs
@@ -185,6 +185,7 @@ impl BexExternalValue {
             BexExternalValue::Resource(handle) => match handle.kind() {
                 sys_resource_types::ResourceType::File => "file",
                 sys_resource_types::ResourceType::Socket => "socket",
+                sys_resource_types::ResourceType::HttpResponse => "http-response",
             },
         }
     }

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -565,6 +565,7 @@ impl BexHeap {
         self.next_chunk.store(new_value, Ordering::Release);
     }
 
+    #[cfg(feature = "heap_debug")]
     pub(crate) fn next_chunk_value(&self) -> usize {
         self.next_chunk.load(Ordering::Acquire)
     }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -641,7 +641,12 @@ impl BexVm {
         }
     }
 
-    pub fn fulfil_future(
+    /// Set a future to Ready state without modifying the stack.
+    ///
+    /// Use this for sync operations that complete during `ScheduleFuture` handling,
+    /// before the VM reaches the `Await` instruction. The `Await` instruction will
+    /// extract the value from the Ready future.
+    pub fn set_future_ready(
         &mut self,
         future_ptr: HeapPtr,
         value: Value,
@@ -654,6 +659,20 @@ impl BexVm {
         };
 
         *future = Future::Ready(value);
+        Ok(())
+    }
+
+    /// Fulfill a future and replace the stack top if the VM is awaiting it.
+    ///
+    /// Use this for async operations that complete while the VM is blocked at
+    /// an `Await` instruction. This replaces the future on the stack with the
+    /// ready value so execution can continue.
+    pub fn fulfil_future(
+        &mut self,
+        future_ptr: HeapPtr,
+        value: Value,
+    ) -> Result<(), InternalError> {
+        self.set_future_ready(future_ptr, value)?;
 
         // At any given moment, the VM can only await a single future, because
         // we can only call the AWAIT instruction on a future on top of the

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -124,9 +124,18 @@ pub enum SysOp {
     NetRead,
     /// Close a socket: `Socket.close()`
     NetClose,
-    // Future operations:
-    // /// HTTP request
-    // HttpRequest,
+    /// HTTP fetch: `baml.http.fetch(url: String) -> Response`
+    HttpFetch,
+    /// Get response body as text: `Response.text() -> String`
+    HttpResponseText,
+    /// Get response status code: `Response.status() -> i64`
+    HttpResponseStatus,
+    /// Check if response is OK (2xx): `Response.ok() -> bool`
+    HttpResponseOk,
+    /// Get request URL: `Response.url() -> String`
+    HttpResponseUrl,
+    /// Get response headers: `Response.headers() -> Map<String, String>`
+    HttpResponseHeaders,
 }
 
 impl std::fmt::Display for ExternalOp {
@@ -148,6 +157,12 @@ impl std::fmt::Display for SysOp {
             SysOp::NetConnect => write!(f, "net.connect"),
             SysOp::NetRead => write!(f, "net.read"),
             SysOp::NetClose => write!(f, "net.close"),
+            SysOp::HttpFetch => write!(f, "http.fetch"),
+            SysOp::HttpResponseText => write!(f, "http.Response.text"),
+            SysOp::HttpResponseStatus => write!(f, "http.Response.status"),
+            SysOp::HttpResponseOk => write!(f, "http.Response.ok"),
+            SysOp::HttpResponseUrl => write!(f, "http.Response.url"),
+            SysOp::HttpResponseHeaders => write!(f, "http.Response.headers"),
         }
     }
 }

--- a/baml_language/crates/sys_native/Cargo.toml
+++ b/baml_language/crates/sys_native/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 bex_external_types = { workspace = true }
 sys_resource_types = { workspace = true }
 sys_types = { workspace = true }
+indexmap = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 tokio = { workspace = true, features = [ "sync", "fs", "net", "process", "io-util" ] }
 
 [lints]

--- a/baml_language/crates/sys_native/src/lib.rs
+++ b/baml_language/crates/sys_native/src/lib.rs
@@ -36,6 +36,12 @@ impl SysOpsExt for SysOps {
             net_read: ops::net::read,
             net_close: ops::net::close,
             shell: ops::sys::shell,
+            http_fetch: ops::http::fetch,
+            http_response_text: ops::http::text,
+            http_response_status: ops::http::status,
+            http_response_ok: ops::http::ok,
+            http_response_url: ops::http::url,
+            http_response_headers: ops::http::headers,
         }
     }
 }

--- a/baml_language/crates/sys_native/src/ops/http.rs
+++ b/baml_language/crates/sys_native/src/ops/http.rs
@@ -1,0 +1,197 @@
+//! HTTP operations.
+
+use std::{collections::HashMap, sync::LazyLock};
+
+use bex_external_types::BexExternalValue;
+use indexmap::IndexMap;
+use sys_types::{OpError, SysOpResult};
+
+use crate::registry::REGISTRY;
+
+/// Shared HTTP client with connection pooling.
+pub(crate) static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+
+/// Fetches a URL and returns a Response resource.
+///
+/// Signature: `fn fetch(url: String) -> Response`
+pub(crate) fn fetch(args: Vec<BexExternalValue>) -> SysOpResult {
+    SysOpResult::Async(Box::pin(fetch_async(args)))
+}
+
+async fn fetch_async(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
+    let url = match args.into_iter().next() {
+        Some(BexExternalValue::String(s)) => s,
+        other => {
+            return Err(OpError::TypeError {
+                expected: "string URL",
+                actual: format!("{other:?}"),
+            });
+        }
+    };
+
+    let response = HTTP_CLIENT
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| OpError::Other(format!("HTTP request failed for '{url}': {e}")))?;
+
+    // Capture metadata before storing
+    let status = response.status().as_u16();
+    let headers: HashMap<String, String> = response
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let final_url = response.url().to_string();
+
+    let handle = REGISTRY.register_http_response(response, status, headers, final_url);
+    Ok(BexExternalValue::Resource(handle))
+}
+
+/// Gets the response body as text (consumes the body).
+///
+/// Signature: `fn text(self: Response) -> String`
+pub(crate) fn text(args: Vec<BexExternalValue>) -> SysOpResult {
+    SysOpResult::Async(Box::pin(text_async(args)))
+}
+
+async fn text_async(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
+    let handle = match args.into_iter().next() {
+        Some(BexExternalValue::Resource(h)) => h,
+        other => {
+            return Err(OpError::TypeError {
+                expected: "Response resource",
+                actual: format!("{other:?}"),
+            });
+        }
+    };
+
+    let response_mutex = REGISTRY
+        .get_http_response_body(handle.key())
+        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+
+    let mut guard = response_mutex.lock().await;
+    let response = guard
+        .take()
+        .ok_or_else(|| OpError::Other("Response body has already been consumed".into()))?;
+
+    let text = response
+        .text()
+        .await
+        .map_err(|e| OpError::Other(format!("Failed to read response body: {e}")))?;
+
+    Ok(BexExternalValue::String(text))
+}
+
+/// Gets the response status code.
+///
+/// Signature: `fn status(self: Response) -> i64`
+pub(crate) fn status(args: Vec<BexExternalValue>) -> SysOpResult {
+    let result = status_sync(args);
+    SysOpResult::Ready(result)
+}
+
+fn status_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
+    let handle = match args.into_iter().next() {
+        Some(BexExternalValue::Resource(h)) => h,
+        other => {
+            return Err(OpError::TypeError {
+                expected: "Response resource",
+                actual: format!("{other:?}"),
+            });
+        }
+    };
+
+    let (status, _, _) = REGISTRY
+        .get_http_response_metadata(handle.key())
+        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+
+    Ok(BexExternalValue::Int(i64::from(status)))
+}
+
+/// Checks if the response status is OK (2xx).
+///
+/// Signature: `fn ok(self: Response) -> bool`
+pub(crate) fn ok(args: Vec<BexExternalValue>) -> SysOpResult {
+    let result = ok_sync(args);
+    SysOpResult::Ready(result)
+}
+
+fn ok_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
+    let handle = match args.into_iter().next() {
+        Some(BexExternalValue::Resource(h)) => h,
+        other => {
+            return Err(OpError::TypeError {
+                expected: "Response resource",
+                actual: format!("{other:?}"),
+            });
+        }
+    };
+
+    let (status, _, _) = REGISTRY
+        .get_http_response_metadata(handle.key())
+        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+
+    Ok(BexExternalValue::Bool((200..300).contains(&status)))
+}
+
+/// Gets the request URL (may differ from original if redirected).
+///
+/// Signature: `fn url(self: Response) -> String`
+pub(crate) fn url(args: Vec<BexExternalValue>) -> SysOpResult {
+    let result = url_sync(args);
+    SysOpResult::Ready(result)
+}
+
+fn url_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
+    let handle = match args.into_iter().next() {
+        Some(BexExternalValue::Resource(h)) => h,
+        other => {
+            return Err(OpError::TypeError {
+                expected: "Response resource",
+                actual: format!("{other:?}"),
+            });
+        }
+    };
+
+    let (_, _, url) = REGISTRY
+        .get_http_response_metadata(handle.key())
+        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+
+    Ok(BexExternalValue::String(url))
+}
+
+/// Gets the response headers as a map.
+///
+/// Signature: `fn headers(self: Response) -> Map<String, String>`
+pub(crate) fn headers(args: Vec<BexExternalValue>) -> SysOpResult {
+    let result = headers_sync(args);
+    SysOpResult::Ready(result)
+}
+
+fn headers_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
+    let handle = match args.into_iter().next() {
+        Some(BexExternalValue::Resource(h)) => h,
+        other => {
+            return Err(OpError::TypeError {
+                expected: "Response resource",
+                actual: format!("{other:?}"),
+            });
+        }
+    };
+
+    let (_, headers, _) = REGISTRY
+        .get_http_response_metadata(handle.key())
+        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+
+    let entries: IndexMap<String, BexExternalValue> = headers
+        .into_iter()
+        .map(|(k, v)| (k, BexExternalValue::String(v)))
+        .collect();
+
+    Ok(BexExternalValue::Map {
+        key_type: bex_external_types::Ty::String,
+        value_type: bex_external_types::Ty::String,
+        entries,
+    })
+}

--- a/baml_language/crates/sys_native/src/ops/mod.rs
+++ b/baml_language/crates/sys_native/src/ops/mod.rs
@@ -1,5 +1,6 @@
 //! Native system operation implementations.
 
 pub(crate) mod fs;
+pub(crate) mod http;
 pub(crate) mod net;
 pub(crate) mod sys;

--- a/baml_language/crates/sys_native/src/registry.rs
+++ b/baml_language/crates/sys_native/src/registry.rs
@@ -23,10 +23,23 @@ pub struct SocketResource {
     pub addr: String,
 }
 
+/// An HTTP response resource with lazy body consumption.
+pub struct ResponseResource {
+    /// The underlying reqwest response (None after body consumed).
+    pub response: Arc<TokioMutex<Option<reqwest::Response>>>,
+    /// HTTP status code (captured at fetch time).
+    pub status: u16,
+    /// Response headers (captured at fetch time).
+    pub headers: HashMap<String, String>,
+    /// Request URL (captured at fetch time).
+    pub url: String,
+}
+
 /// Registry entry for a resource.
 pub enum RegistryEntry {
     File(FileResource),
     Socket(SocketResource),
+    HttpResponse(ResponseResource),
 }
 
 /// Global resource registry.
@@ -103,6 +116,61 @@ impl ResourceRegistry {
         let entries = self.entries.read().unwrap();
         match entries.get(&key) {
             Some(RegistryEntry::Socket(s)) => Some(s.stream.clone()),
+            _ => None,
+        }
+    }
+
+    /// Register an HTTP response and return an opaque handle.
+    pub fn register_http_response(
+        self: &Arc<Self>,
+        response: reqwest::Response,
+        status: u16,
+        headers: HashMap<String, String>,
+        url: String,
+    ) -> ResourceHandle {
+        let key = self.next_key.fetch_add(1, Ordering::SeqCst);
+        let resource = ResponseResource {
+            response: Arc::new(TokioMutex::new(Some(response))),
+            status,
+            headers,
+            url: url.clone(),
+        };
+
+        self.entries
+            .write()
+            .unwrap()
+            .insert(key, RegistryEntry::HttpResponse(resource));
+
+        ResourceHandle::new(
+            key,
+            ResourceType::HttpResponse,
+            url,
+            Arc::clone(self) as Arc<dyn ResourceRegistryRef>,
+        )
+    }
+
+    /// Get HTTP response metadata (status, headers, url) by handle key.
+    pub fn get_http_response_metadata(
+        &self,
+        key: usize,
+    ) -> Option<(u16, HashMap<String, String>, String)> {
+        let entries = self.entries.read().unwrap();
+        match entries.get(&key) {
+            Some(RegistryEntry::HttpResponse(r)) => {
+                Some((r.status, r.headers.clone(), r.url.clone()))
+            }
+            _ => None,
+        }
+    }
+
+    /// Get the HTTP response mutex for body consumption.
+    pub fn get_http_response_body(
+        &self,
+        key: usize,
+    ) -> Option<Arc<TokioMutex<Option<reqwest::Response>>>> {
+        let entries = self.entries.read().unwrap();
+        match entries.get(&key) {
+            Some(RegistryEntry::HttpResponse(r)) => Some(r.response.clone()),
             _ => None,
         }
     }

--- a/baml_language/crates/sys_resource_types/src/lib.rs
+++ b/baml_language/crates/sys_resource_types/src/lib.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 pub enum ResourceType {
     File,
     Socket,
+    HttpResponse,
 }
 
 /// Trait for releasing resource handles back to the registry.
@@ -121,6 +122,7 @@ impl std::fmt::Display for ResourceHandle {
         match self.kind() {
             ResourceType::File => write!(f, "file:{}", self.display_name()),
             ResourceType::Socket => write!(f, "socket:{}", self.display_name()),
+            ResourceType::HttpResponse => write!(f, "http-response:{}", self.display_name()),
         }
     }
 }

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -88,6 +88,14 @@ pub struct SysOps {
 
     // System operations
     pub shell: SysOpFn,
+
+    // HTTP operations
+    pub http_fetch: SysOpFn,
+    pub http_response_text: SysOpFn,
+    pub http_response_status: SysOpFn,
+    pub http_response_ok: SysOpFn,
+    pub http_response_url: SysOpFn,
+    pub http_response_headers: SysOpFn,
 }
 
 impl SysOps {
@@ -144,6 +152,36 @@ impl SysOps {
                     operation: SysOp::Shell,
                 }))
             },
+            SysOp::HttpFetch => |_| {
+                SysOpResult::Ready(Err(OpError::Unsupported {
+                    operation: SysOp::HttpFetch,
+                }))
+            },
+            SysOp::HttpResponseText => |_| {
+                SysOpResult::Ready(Err(OpError::Unsupported {
+                    operation: SysOp::HttpResponseText,
+                }))
+            },
+            SysOp::HttpResponseStatus => |_| {
+                SysOpResult::Ready(Err(OpError::Unsupported {
+                    operation: SysOp::HttpResponseStatus,
+                }))
+            },
+            SysOp::HttpResponseOk => |_| {
+                SysOpResult::Ready(Err(OpError::Unsupported {
+                    operation: SysOp::HttpResponseOk,
+                }))
+            },
+            SysOp::HttpResponseUrl => |_| {
+                SysOpResult::Ready(Err(OpError::Unsupported {
+                    operation: SysOp::HttpResponseUrl,
+                }))
+            },
+            SysOp::HttpResponseHeaders => |_| {
+                SysOpResult::Ready(Err(OpError::Unsupported {
+                    operation: SysOp::HttpResponseHeaders,
+                }))
+            },
         }
     }
 
@@ -159,6 +197,12 @@ impl SysOps {
             net_read: Self::unsupported(SysOp::NetRead),
             net_close: Self::unsupported(SysOp::NetClose),
             shell: Self::unsupported(SysOp::Shell),
+            http_fetch: Self::unsupported(SysOp::HttpFetch),
+            http_response_text: Self::unsupported(SysOp::HttpResponseText),
+            http_response_status: Self::unsupported(SysOp::HttpResponseStatus),
+            http_response_ok: Self::unsupported(SysOp::HttpResponseOk),
+            http_response_url: Self::unsupported(SysOp::HttpResponseUrl),
+            http_response_headers: Self::unsupported(SysOp::HttpResponseHeaders),
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements HTTP fetch system operation with TypeScript/Bun-aligned Response interface:

- `baml.http.fetch(url)` - HTTP GET request
- `response.text()` - get body as string (consumes body)
- `response.status()` - get HTTP status code
- `response.ok()` - check if 2xx
- `response.url()` - get final URL (after redirects)
- `response.headers()` - get headers as Map<String, String>

### Implementation Details

- Add `HttpResponse` resource type and 6 `SysOp` variants
- Add reqwest-based native implementation with connection pooling (`LazyLock<reqwest::Client>`)
- Add `http` module to `baml_builtins` DSL with `Response` builtin type
- Wire up compiler path-to-SysOp mappings in `baml_compiler_emit`

### Bug Fix

Fixed sync sys ops returning primitives failing with "type error: expected any, got bool/int/string". The issue was that `fulfil_future()` was prematurely replacing the stack when handling sync ops during `ScheduleFuture` (before VM reaches `Await` instruction). Added `set_future_ready()` method for sync ops.

See `rpi/tasks/sys-fetch/sync-ops-architecture-notes.md` for detailed analysis and future optimization options.

## Test plan

- [x] Add 7 integration tests using wiremock mock server
- [x] `cargo test -p bex_engine --test http` passes all tests
- [x] `cargo test --workspace` passes
- [x] Update codegen snapshots (6 new HTTP builtins)

🤖 Generated with [Claude Code](https://claude.ai/code)