### PR TITLE
fix issue with vscode proxy not updating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ _site/
 
 # claude
 .claude/
+
+rpi/

--- a/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/preview-toolbar.tsx
+++ b/typescript/packages/playground-common/src/shared/baml-project-panel/playground-panel/preview-toolbar.tsx
@@ -36,6 +36,7 @@ import { useRunBamlTests } from './prompt-preview/test-panel/test-runner';
 import { standaloneBetaFeatureEnabledAtom, isVSCodeEnvironment } from '../feature-flags';
 import { vscodeSettingsAtom } from '../atoms';
 import { useTheme } from 'next-themes';
+import { useBAMLSDK } from '../../../sdk/hooks';
 
 export const displaySettingsAtom = atom({
   showTokens: false,
@@ -114,6 +115,7 @@ export function PreviewToolbar() {
   const setVscodeSettings = useSetAtom(vscodeSettingsAtom);
   const { resolvedTheme, setTheme } = useTheme();
   const isLightMode = resolvedTheme === 'light';
+  const sdk = useBAMLSDK();
 
   // Beta feature flag settings
   const [betaFeatureEnabled, setBetaFeatureEnabled] = useAtom(standaloneBetaFeatureEnabledAtom);
@@ -124,6 +126,7 @@ export function PreviewToolbar() {
   const displayBetaEnabled = isInVSCode
     ? (vscodeSettings?.featureFlags?.includes('beta') ?? false)
     : betaFeatureEnabled;
+
 
   const handleBetaToggle = (enabled: boolean) => {
     // This function only runs in standalone mode (not VSCode)
@@ -248,11 +251,11 @@ export function PreviewToolbar() {
                 checked={proxySettings.proxyEnabled}
                 onCheckedChange={async (checked) => {
                   try {
-                    // Optimistically update vscodeSettingsAtom so proxyUrlAtom updates immediately
-                    setVscodeSettings((prev) => ({
-                      ...prev,
+
+
+                    sdk.settings.updateVSCodeSettings({
                       enablePlaygroundProxy: !!checked,
-                    }));
+                    });
                     // Also update bamlConfig for consistency
                     setBamlConfig((prev: BamlConfigAtom) => ({
                       ...prev,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensures the "VSCode Proxy (CORS bypass)" toggle reliably updates VSCode settings from the playground.
> 
> - Import and use `useBAMLSDK` to call `sdk.settings.updateVSCodeSettings({ enablePlaygroundProxy })` when toggling the proxy
> - Maintain local state consistency by updating `bamlConfig` and persisting via `vscode.setProxySettings`
> - Add `rpi/` to `.gitignore`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 112df75a47f2aec8ab3fdc90b9f9350f47e98a1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->