### PR TITLE
Validate map key types

### DIFF
--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -56,6 +56,7 @@ pub enum DiagnosticId {
     NotCallable,
     NoSuchField,
     NotIndexable,
+    InvalidMapKeyType,
 
     // Name errors (E0011)
     DuplicateName,
@@ -130,6 +131,7 @@ impl DiagnosticId {
             DiagnosticId::NotCallable => "E0006",
             DiagnosticId::NoSuchField => "E0007",
             DiagnosticId::NotIndexable => "E0008",
+            DiagnosticId::InvalidMapKeyType => "E0067",
 
             // Name errors
             DiagnosticId::DuplicateName => "E0011",

--- a/baml_language/crates/baml_compiler_diagnostics/src/errors/type_error.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/errors/type_error.rs
@@ -107,4 +107,7 @@ pub enum TypeError<C: ErrorContext> {
         expected: C::Ty,
         location: C::Location,
     },
+    /// Map has keys that aren't valid. Only string, literal string, and enum are
+    /// valid may key types.
+    InvalidMapKeyType { ty: C::Ty, location: C::Location },
 }

--- a/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
@@ -57,10 +57,7 @@ impl<C: ErrorContext> TypeError<C> {
         &self,
         ty_fn: impl Fn(&C::Ty) -> String,
         loc_fn: impl Fn(&C::Location) -> Span,
-    ) -> Diagnostic
-    where
-        C::Ty: std::fmt::Display,
-    {
+    ) -> Diagnostic {
         let diag = match self {
             TypeError::TypeMismatch {
                 expected,
@@ -204,7 +201,8 @@ impl<C: ErrorContext> TypeError<C> {
             TypeError::InvalidMapKeyType { ty, location } => Diagnostic::error(
                 DiagnosticId::InvalidMapKeyType,
                 format!(
-                    "Invalid type {ty} for map key. Only strings, string literals and enums are valid map keys."
+                    "Invalid type {} for map key. Only strings, string literals and enums are valid map keys.",
+                    ty_fn(ty)
                 )
             ).with_primary_span(loc_fn(location)),
         };

--- a/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
@@ -57,7 +57,10 @@ impl<C: ErrorContext> TypeError<C> {
         &self,
         ty_fn: impl Fn(&C::Ty) -> String,
         loc_fn: impl Fn(&C::Location) -> Span,
-    ) -> Diagnostic {
+    ) -> Diagnostic
+    where
+        C::Ty: std::fmt::Display,
+    {
         let diag = match self {
             TypeError::TypeMismatch {
                 expected,
@@ -197,6 +200,13 @@ impl<C: ErrorContext> TypeError<C> {
                 ),
             )
             .with_primary_span(loc_fn(location)),
+
+            TypeError::InvalidMapKeyType { ty, location } => Diagnostic::error(
+                DiagnosticId::InvalidMapKeyType,
+                format!(
+                    "Invalid type {ty} for map key. Only strings, string literals and enums are valid map keys."
+                )
+            ).with_primary_span(loc_fn(location)),
         };
         diag.with_phase(DiagnosticPhase::Type)
     }

--- a/baml_language/crates/baml_compiler_hir/src/body.rs
+++ b/baml_language/crates/baml_compiler_hir/src/body.rs
@@ -97,6 +97,9 @@ pub struct ExprBody {
     /// Match arm arena
     pub match_arms: Arena<MatchArm>,
 
+    /// Type annotation arena (for let bindings, etc.)
+    pub types: Arena<crate::type_ref::TypeRef>,
+
     /// Root expression of the function body (usually a `BLOCK_EXPR`)
     pub root_expr: Option<ExprId>,
 
@@ -118,6 +121,8 @@ pub type ExprId = Idx<Expr>;
 pub type StmtId = Idx<Stmt>;
 pub type PatId = Idx<Pattern>;
 pub type MatchArmId = Idx<MatchArm>;
+/// ID for any syntactic occurrence of a type (annotations, generic arguments, etc.)
+pub type TypeId = Idx<crate::type_ref::TypeRef>;
 
 /// A spread element in an object constructor: `...expr`
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -216,8 +221,7 @@ pub enum Stmt {
     /// If `is_watched` is true, this is a `watch let` that tracks variable changes.
     Let {
         pattern: PatId,
-        type_annotation: Option<crate::type_ref::TypeRef>,
-        type_span: Option<TextRange>,
+        type_annotation: Option<TypeId>,
         initializer: Option<ExprId>,
         is_watched: bool,
     },
@@ -517,6 +521,7 @@ struct LoweringContext {
     stmts: Arena<Stmt>,
     patterns: Arena<Pattern>,
     match_arms: Arena<MatchArm>,
+    types: Arena<crate::type_ref::TypeRef>,
     /// File ID for creating spans
     file_id: FileId,
     /// All names used in this function, for generating unique synthetic variable names.
@@ -547,6 +552,7 @@ impl LoweringContext {
             stmts: Arena::new(),
             patterns: Arena::new(),
             match_arms: Arena::new(),
+            types: Arena::new(),
             file_id,
             names_in_scope: std::collections::HashSet::new(),
             source_map: HirSourceMap::new(),
@@ -612,12 +618,19 @@ impl LoweringContext {
         id
     }
 
+    fn alloc_type(&mut self, type_ref: crate::type_ref::TypeRef, range: TextRange) -> TypeId {
+        let id = self.types.alloc(type_ref);
+        self.source_map.insert_type(id, self.span_from_range(range));
+        id
+    }
+
     fn finish(self, root_expr: Option<ExprId>) -> (ExprBody, HirSourceMap) {
         let body = ExprBody {
             exprs: self.exprs,
             stmts: self.stmts,
             patterns: self.patterns,
             match_arms: self.match_arms,
+            types: self.types,
             root_expr,
             diagnostics: self.diagnostics,
         };
@@ -2303,10 +2316,11 @@ impl LoweringContext {
             .as_ref()
             .and_then(baml_compiler_syntax::LetStmt::ty);
 
-        // Extract type annotation if present
-        let type_annotation = type_node.as_ref().map(TypeRef::from_ast);
-
-        let type_span = type_node.map(|t: TypeExpr| t.text_range());
+        // Extract type annotation if present, allocating it in the arena
+        let type_annotation = type_node.map(|t: TypeExpr| {
+            let type_ref = TypeRef::from_ast(&t);
+            self.alloc_type(type_ref, t.text_range())
+        });
 
         // Extract initializer expression - first try as a node, then as a token
         let initializer = let_stmt
@@ -2325,7 +2339,6 @@ impl LoweringContext {
             Stmt::Let {
                 pattern,
                 type_annotation,
-                type_span,
                 initializer,
                 is_watched,
             },
@@ -2750,7 +2763,6 @@ impl LoweringContext {
         let arr_let = self.stmts.alloc(Stmt::Let {
             pattern: arr_pat,
             type_annotation: None,
-            type_span: None,
             initializer: Some(iterator_expr),
             is_watched: false,
         });
@@ -2771,7 +2783,6 @@ impl LoweringContext {
         let len_let = self.stmts.alloc(Stmt::Let {
             pattern: len_pat,
             type_annotation: None,
-            type_span: None,
             initializer: Some(length_call),
             is_watched: false,
         });
@@ -2782,7 +2793,6 @@ impl LoweringContext {
         let idx_let = self.stmts.alloc(Stmt::Let {
             pattern: idx_pat,
             type_annotation: None,
-            type_span: None,
             initializer: Some(zero),
             is_watched: false,
         });
@@ -2821,7 +2831,6 @@ impl LoweringContext {
         let elem_let = self.stmts.alloc(Stmt::Let {
             pattern: user_pattern,
             type_annotation: None,
-            type_span: None,
             initializer: Some(element_access),
             is_watched: false,
         });

--- a/baml_language/crates/baml_compiler_hir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_hir/src/pretty.rs
@@ -235,7 +235,6 @@ impl<'a> CodePrinter<'a> {
                 type_annotation,
                 initializer,
                 is_watched,
-                ..
             } => {
                 if *is_watched {
                     self.output.push_str("watch let ");
@@ -243,8 +242,9 @@ impl<'a> CodePrinter<'a> {
                     self.output.push_str("let ");
                 }
                 self.print_pattern(*pattern);
-                if let Some(ty) = type_annotation {
-                    write!(self.output, ": {}", type_ref_to_str(ty)).unwrap();
+                if let Some(type_id) = type_annotation {
+                    let type_ref = &self.body.types[*type_id];
+                    write!(self.output, ": {}", type_ref_to_str(type_ref)).unwrap();
                 }
                 if let Some(init) = initializer {
                     self.output.push_str(" = ");

--- a/baml_language/crates/baml_compiler_hir/src/source_map.rs
+++ b/baml_language/crates/baml_compiler_hir/src/source_map.rs
@@ -13,7 +13,7 @@ use baml_base::Span;
 use baml_compiler_diagnostics::ErrorContext;
 use rowan::TextRange;
 
-use crate::{ExprId, MatchArmId, MatchArmSpans, PatId, StmtId};
+use crate::{ExprId, MatchArmId, MatchArmSpans, PatId, StmtId, TypeId};
 
 // ============================================================================
 // Error Location for TIR
@@ -109,6 +109,9 @@ pub struct HirSourceMap {
 
     /// Match arm spans
     match_arm_spans: HashMap<MatchArmId, MatchArmSpans>,
+
+    /// Type annotation spans
+    type_spans: HashMap<TypeId, Span>,
 }
 
 impl HirSourceMap {
@@ -171,6 +174,20 @@ impl HirSourceMap {
     /// Get the spans for a match arm.
     pub fn match_arm_spans(&self, id: MatchArmId) -> Option<MatchArmSpans> {
         self.match_arm_spans.get(&id).copied()
+    }
+
+    // ========================================================================
+    // Type annotation mappings
+    // ========================================================================
+
+    /// Insert a type annotation span.
+    pub fn insert_type(&mut self, id: TypeId, span: Span) {
+        self.type_spans.insert(id, span);
+    }
+
+    /// Get the span for a type annotation.
+    pub fn type_span(&self, id: TypeId) -> Option<Span> {
+        self.type_spans.get(&id).copied()
     }
 }
 

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -1317,7 +1317,7 @@ impl<'a> Parser<'a> {
 
     /// Parse a type expression
     /// Examples: string, int, User, string[], map<string, int>, string | int
-    /// Can also use string literals: "user" | "assistant"
+    /// Can also use string literals: "user", "assistant"
     pub(crate) fn parse_type(&mut self) {
         self.with_node(SyntaxKind::TYPE_EXPR, |p| {
             p.parse_type_primary();

--- a/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
+++ b/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
@@ -35,7 +35,7 @@ use std::collections::{HashMap, HashSet};
 use baml_base::{Name, Span};
 use baml_compiler_hir::{ExprBody, Literal, MatchArmId, Pattern};
 
-use crate::{LiteralValue, Ty, lower_type_ref_validated_resolved};
+use crate::{LiteralValue, Ty, lower_type_ref};
 
 // ============================================================================
 // ValueSet: The Core Abstraction
@@ -166,8 +166,8 @@ pub struct ExhaustivenessChecker<'a> {
     /// Enum names for type resolution
     enum_names: &'a HashSet<Name>,
 
-    /// Known types for validation
-    known_types: &'a HashSet<Name>,
+    /// Type alias names for validation
+    type_alias_names: &'a HashSet<Name>,
 }
 
 /// Result of exhaustiveness checking.
@@ -190,14 +190,14 @@ impl<'a> ExhaustivenessChecker<'a> {
         type_aliases: &'a HashMap<Name, Ty>,
         class_names: &'a HashSet<Name>,
         enum_names: &'a HashSet<Name>,
-        known_types: &'a HashSet<Name>,
+        type_alias_names: &'a HashSet<Name>,
     ) -> Self {
         Self {
             enum_variants,
             type_aliases,
             class_names,
             enum_names,
-            known_types,
+            type_alias_names,
         }
     }
 
@@ -430,11 +430,12 @@ impl<'a> ExhaustivenessChecker<'a> {
 
             // Typed binding: matches all values of that type
             Pattern::TypedBinding { ty, .. } => {
-                let (lowered_ty, _) = lower_type_ref_validated_resolved(
+                let (lowered_ty, _) = lower_type_ref(
                     ty,
-                    self.known_types,
+                    self.type_alias_names,
                     self.class_names,
                     self.enum_names,
+                    self.type_aliases,
                     Span::default(),
                 );
                 Self::ty_to_value_set(&lowered_ty)

--- a/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
+++ b/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
@@ -435,7 +435,6 @@ impl<'a> ExhaustivenessChecker<'a> {
                     self.type_alias_names,
                     self.class_names,
                     self.enum_names,
-                    self.type_aliases,
                     Span::default(),
                 );
                 Self::ty_to_value_set(&lowered_ty)

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -46,7 +46,8 @@ pub use builtins::{
     method_return_type, substitute,
 };
 pub use exhaustiveness::{ExhaustivenessChecker, ExhaustivenessResult, ValueSet};
-pub use lower::{TypeLoweringContext, lower_type_ref};
+pub use lower::lower_type_ref;
+pub use normalize::find_invalid_map_keys;
 pub use pretty::{expr_to_string, render_body_tree, render_function_tree};
 pub use resolve::{ResolutionMap, ResolvedMethod, ResolvedValue, resolve_method};
 use text_size::TextRange;
@@ -402,7 +403,6 @@ impl TypeResolutionContext {
             &self.type_alias_names,
             &self.class_names,
             &self.enum_names,
-            &HashMap::new(),
             span,
         )
     }
@@ -647,7 +647,6 @@ impl<'db> TypeContext<'db> {
             &self.type_alias_names,
             &self.class_names,
             &self.enum_names,
-            &self.type_aliases,
             span,
         );
         // Note: errors are not accumulated here since they should have been
@@ -951,7 +950,6 @@ pub fn infer_function<'db>(
                 &type_alias_name_set,
                 &class_name_set,
                 &enum_name_set,
-                &type_aliases,
                 placeholder_span,
             );
             type_errors.extend(errors);
@@ -965,7 +963,6 @@ pub fn infer_function<'db>(
         &type_alias_name_set,
         &class_name_set,
         &enum_name_set,
-        &type_aliases,
         placeholder_span,
     );
     type_errors.extend(errors);
@@ -974,6 +971,37 @@ pub fn infer_function<'db>(
     let return_type_span = sig_source_map
         .and_then(SignatureSourceMap::return_type_span)
         .map(|range| Span::new(file_id, range));
+
+    // Validate map key types in function signature
+    // Check return type for invalid map keys
+    if let Some(span) = return_type_span {
+        let invalid_return_keys = normalize::find_invalid_map_keys(&expected_return, &type_aliases);
+        for invalid_key in invalid_return_keys {
+            type_errors.push(TypeError::InvalidMapKeyType {
+                ty: invalid_key,
+                location: ErrorLocation::Span(span),
+            });
+        }
+    }
+
+    // Check param types for invalid map keys
+    if let Some(source_map) = sig_source_map {
+        for (idx, param) in signature.params.iter().enumerate() {
+            if let Some(param_ty) = param_types.get(&param.name) {
+                if let Some(range) = source_map.param_span(idx) {
+                    let span = Span::new(file_id, range);
+                    let invalid_param_keys =
+                        normalize::find_invalid_map_keys(param_ty, &type_aliases);
+                    for invalid_key in invalid_param_keys {
+                        type_errors.push(TypeError::InvalidMapKeyType {
+                            ty: invalid_key,
+                            location: ErrorLocation::Span(span),
+                        });
+                    }
+                }
+            }
+        }
+    }
 
     // Delegate to the body inference function
     let mut result = infer_function_body(

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -18,8 +18,8 @@ use std::{
 use baml_base::{FileId, Name, Span};
 use baml_compiler_diagnostics::TypeError;
 use baml_compiler_hir::{
-    ErrorLocation, ExprBody, ExprId, FunctionBody, FunctionLoc, FunctionSignature, MatchArmId,
-    Pattern, SignatureSourceMap, StmtId, TirContext,
+    ErrorLocation, ExprBody, ExprId, FunctionBody, FunctionLoc, FunctionSignature, HirSourceMap,
+    MatchArmId, Pattern, SignatureSourceMap, StmtId, TirContext, TypeId,
 };
 use baml_workspace::Project;
 
@@ -491,6 +491,8 @@ pub struct TypeContext<'db> {
     expr_resolutions: ResolutionMap,
     /// Track where local variables were defined (for go-to-definition).
     local_definitions: HashMap<Name, DefinitionSite>,
+    /// Optional source map for looking up spans (for type annotation errors).
+    hir_source_map: Option<HirSourceMap>,
 }
 
 impl<'db> TypeContext<'db> {
@@ -506,6 +508,7 @@ impl<'db> TypeContext<'db> {
         enum_names: HashSet<Name>,
         type_alias_names: HashSet<Name>,
         file_id: FileId,
+        hir_source_map: Option<HirSourceMap>,
     ) -> Self {
         TypeContext {
             db,
@@ -526,6 +529,7 @@ impl<'db> TypeContext<'db> {
             watched_vars: HashSet::new(),
             expr_resolutions: HashMap::new(),
             local_definitions: HashMap::new(),
+            hir_source_map,
         }
     }
 
@@ -634,23 +638,45 @@ impl<'db> TypeContext<'db> {
         range.map(|s| self.build_span(s)).unwrap_or_default()
     }
 
+    /// Look up the span for a type from the source map.
+    pub fn type_span(&self, id: TypeId) -> Span {
+        self.hir_source_map
+            .as_ref()
+            .and_then(|sm| sm.type_span(id))
+            .unwrap_or_default()
+    }
+
     /// Check if `sub` is a subtype of `sup`, resolving type aliases.
     pub fn is_subtype_of(&self, sub: &Ty, sup: &Ty) -> bool {
         normalize::is_subtype_of(sub, sup, &self.type_aliases)
     }
 
-    /// CLAUDE: Do we need this?
-    /// Lower a `TypeRef` to a Ty with full resolution (classes/enums resolved to names).
-    pub fn lower_type_resolved(&self, type_ref: &baml_compiler_hir::TypeRef, span: Span) -> Ty {
-        let (ty, _errors) = lower_type_ref(
+    /// Lower a `TypeRef` to a `Ty` with full resolution and validation.
+    ///
+    /// This is the single entry point for type lowering during inference.
+    /// It resolves classes/enums to their concrete types, validates map key
+    /// types, and accumulates any errors.
+    pub fn lower_type(&mut self, type_ref: &baml_compiler_hir::TypeRef, span: Span) -> Ty {
+        let (ty, errors) = lower_type_ref(
             type_ref,
             &self.type_alias_names,
             &self.class_names,
             &self.enum_names,
             span,
         );
-        // Note: errors are not accumulated here since they should have been
-        // caught during earlier validation passes
+
+        // Accumulate lowering errors (e.g., unknown types)
+        self.errors.extend(errors);
+
+        // Validate map key types
+        let invalid_keys = normalize::find_invalid_map_keys(&ty, &self.type_aliases);
+        for invalid_key in invalid_keys {
+            self.errors.push(TypeError::InvalidMapKeyType {
+                ty: invalid_key,
+                location: ErrorLocation::Span(span),
+            });
+        }
+
         ty
     }
 
@@ -751,6 +777,13 @@ pub fn infer_function_body<'db>(
     function_loc: FunctionLoc<'db>,
 ) -> InferenceResult {
     let file_id = function_loc.file(db).file_id(db);
+
+    // Extract source map from body if available
+    let hir_source_map = match body {
+        FunctionBody::Expr(_, source_map) => Some(source_map.clone()),
+        _ => None,
+    };
+
     let mut ctx = TypeContext::with_type_info(
         db,
         globals.unwrap_or_default(),
@@ -761,6 +794,7 @@ pub fn infer_function_body<'db>(
         enum_names_opt.unwrap_or_default(),
         type_alias_names.unwrap_or_default(),
         file_id,
+        hir_source_map,
     );
 
     // Add parameters to the current scope (on top of globals)
@@ -1980,7 +2014,7 @@ fn check_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody, expec
 /// - `_` is a special case of binding that's semantically discarded later
 /// - Literals, enum variants, and union patterns don't introduce bindings
 fn extract_pattern_binding(
-    ctx: &TypeContext<'_>,
+    ctx: &mut TypeContext<'_>,
     pattern: &Pattern,
     scrutinee_ty: &Ty,
     _body: &ExprBody,
@@ -1988,7 +2022,8 @@ fn extract_pattern_binding(
     match pattern {
         // Typed binding: `s: Success` -> s has type Success
         Pattern::TypedBinding { name, ty } => {
-            let narrowed_ty = ctx.lower_type_resolved(ty, Span::default());
+            // TODO: Pattern types should use TypeId for proper span tracking
+            let narrowed_ty = ctx.lower_type(ty, Span::default());
             (Some(name.clone()), narrowed_ty)
         }
 
@@ -2523,15 +2558,15 @@ fn check_stmt_with_return(
         Stmt::Let {
             pattern,
             type_annotation,
-            type_span,
             initializer,
             is_watched,
         } => {
             let ty = if let Some(init) = initializer {
                 // If there's a type annotation, use check_expr for bidirectional typing
-                if let Some(annot) = type_annotation {
-                    let span = ctx.build_span_default(type_span);
-                    let annot_ty = ctx.lower_type_resolved(annot, span);
+                if let Some(type_id) = type_annotation {
+                    let type_ref = &body.types[*type_id];
+                    let span = ctx.type_span(*type_id);
+                    let annot_ty = ctx.lower_type(type_ref, span);
                     // Use check_expr when we have an expected type
                     // check_expr already reports any type mismatch errors
                     check_expr(ctx, *init, body, &annot_ty);
@@ -2542,8 +2577,10 @@ fn check_stmt_with_return(
                     let inferred = infer_expr(ctx, *init, body);
                     generalize(&inferred)
                 }
-            } else if let Some(annot) = type_annotation {
-                ctx.lower_type_resolved(annot, Span::default())
+            } else if let Some(type_id) = type_annotation {
+                let type_ref = &body.types[*type_id];
+                let span = ctx.type_span(*type_id);
+                ctx.lower_type(type_ref, span)
             } else {
                 Ty::Unknown
             };

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -46,7 +46,7 @@ pub use builtins::{
     method_return_type, substitute,
 };
 pub use exhaustiveness::{ExhaustivenessChecker, ExhaustivenessResult, ValueSet};
-pub use lower::{TypeLoweringContext, lower_type_ref_validated_resolved};
+pub use lower::{TypeLoweringContext, lower_type_ref};
 pub use pretty::{expr_to_string, render_body_tree, render_function_tree};
 pub use resolve::{ResolutionMap, ResolvedMethod, ResolvedValue, resolve_method};
 use text_size::TextRange;
@@ -183,9 +183,9 @@ pub struct EnumNamesSet<'db> {
     pub names: HashSet<Name>,
 }
 
-/// Tracked struct holding all known type names (classes, enums, type aliases).
+/// Tracked struct holding type alias names.
 #[salsa::tracked]
-pub struct KnownTypesSet<'db> {
+pub struct TypeAliasNamesSet<'db> {
     #[tracked]
     #[returns(ref)]
     pub names: HashSet<Name>,
@@ -353,37 +353,22 @@ pub fn enum_names(db: &dyn Db, project: Project) -> EnumNamesSet<'_> {
     EnumNamesSet::new(db, names)
 }
 
-/// Query: Get all known type names for a project (classes, enums, type aliases).
+/// Query: Get type alias names for a project.
 #[salsa::tracked]
-pub fn known_types(db: &dyn Db, project: Project) -> KnownTypesSet<'_> {
+pub fn type_alias_names(db: &dyn Db, project: Project) -> TypeAliasNamesSet<'_> {
     let items = baml_compiler_hir::project_items(db, project);
     let mut names = HashSet::new();
 
     for item in items.items(db) {
-        match item {
-            baml_compiler_hir::ItemId::Class(class_loc) => {
-                let file = class_loc.file(db);
-                let item_tree = baml_compiler_hir::file_item_tree(db, file);
-                let class_data = &item_tree[class_loc.id(db)];
-                names.insert(class_data.name.clone());
-            }
-            baml_compiler_hir::ItemId::Enum(enum_loc) => {
-                let file = enum_loc.file(db);
-                let item_tree = baml_compiler_hir::file_item_tree(db, file);
-                let enum_data = &item_tree[enum_loc.id(db)];
-                names.insert(enum_data.name.clone());
-            }
-            baml_compiler_hir::ItemId::TypeAlias(alias_loc) => {
-                let file = alias_loc.file(db);
-                let item_tree = baml_compiler_hir::file_item_tree(db, file);
-                let alias_data = &item_tree[alias_loc.id(db)];
-                names.insert(alias_data.name.clone());
-            }
-            _ => {}
+        if let baml_compiler_hir::ItemId::TypeAlias(alias_loc) = item {
+            let file = alias_loc.file(db);
+            let item_tree = baml_compiler_hir::file_item_tree(db, file);
+            let alias_data = &item_tree[alias_loc.id(db)];
+            names.insert(alias_data.name.clone());
         }
     }
 
-    KnownTypesSet::new(db, names)
+    TypeAliasNamesSet::new(db, names)
 }
 
 /// Context for type resolution across a project.
@@ -393,7 +378,7 @@ pub fn known_types(db: &dyn Db, project: Project) -> KnownTypesSet<'_> {
 pub struct TypeResolutionContext {
     pub class_names: HashSet<Name>,
     pub enum_names: HashSet<Name>,
-    pub known_types: HashSet<Name>,
+    pub type_alias_names: HashSet<Name>,
 }
 
 impl TypeResolutionContext {
@@ -402,7 +387,7 @@ impl TypeResolutionContext {
         Self {
             class_names: class_names(db, project).names(db).clone(),
             enum_names: enum_names(db, project).names(db).clone(),
-            known_types: known_types(db, project).names(db).clone(),
+            type_alias_names: type_alias_names(db, project).names(db).clone(),
         }
     }
 
@@ -412,11 +397,12 @@ impl TypeResolutionContext {
         type_ref: &baml_compiler_hir::TypeRef,
         span: Span,
     ) -> (Ty, Vec<TirTypeError>) {
-        lower_type_ref_validated_resolved(
+        lower_type_ref(
             type_ref,
-            &self.known_types,
+            &self.type_alias_names,
             &self.class_names,
             &self.enum_names,
+            &HashMap::new(),
             span,
         )
     }
@@ -482,8 +468,8 @@ pub struct TypeContext<'db> {
     class_names: HashSet<Name>,
     /// Enum names for type resolution
     enum_names: HashSet<Name>,
-    /// Known type names for validation
-    known_types: HashSet<Name>,
+    /// Type alias names for validation
+    type_alias_names: HashSet<Name>,
     /// Inferred types for expressions.
     expr_types: HashMap<ExprId, Ty>,
     /// For multi-segment paths, the type of each segment.
@@ -518,7 +504,7 @@ impl<'db> TypeContext<'db> {
         enum_variants: HashMap<Name, Vec<Name>>,
         class_names: HashSet<Name>,
         enum_names: HashSet<Name>,
-        known_types: HashSet<Name>,
+        type_alias_names: HashSet<Name>,
         file_id: FileId,
     ) -> Self {
         TypeContext {
@@ -529,7 +515,7 @@ impl<'db> TypeContext<'db> {
             enum_variants,
             class_names,
             enum_names,
-            known_types,
+            type_alias_names,
             expr_types: HashMap::new(),
             path_segment_types: HashMap::new(),
             enum_variant_exprs: HashMap::new(),
@@ -653,13 +639,15 @@ impl<'db> TypeContext<'db> {
         normalize::is_subtype_of(sub, sup, &self.type_aliases)
     }
 
+    /// CLAUDE: Do we need this?
     /// Lower a `TypeRef` to a Ty with full resolution (classes/enums resolved to names).
     pub fn lower_type_resolved(&self, type_ref: &baml_compiler_hir::TypeRef, span: Span) -> Ty {
-        let (ty, _errors) = lower_type_ref_validated_resolved(
+        let (ty, _errors) = lower_type_ref(
             type_ref,
-            &self.known_types,
+            &self.type_alias_names,
             &self.class_names,
             &self.enum_names,
+            &self.type_aliases,
             span,
         );
         // Note: errors are not accumulated here since they should have been
@@ -760,7 +748,7 @@ pub fn infer_function_body<'db>(
     enum_variants: Option<HashMap<Name, Vec<Name>>>,
     class_names_opt: Option<HashSet<Name>>,
     enum_names_opt: Option<HashSet<Name>>,
-    known_types: Option<HashSet<Name>>,
+    type_alias_names: Option<HashSet<Name>>,
     function_loc: FunctionLoc<'db>,
 ) -> InferenceResult {
     let file_id = function_loc.file(db).file_id(db);
@@ -772,7 +760,7 @@ pub fn infer_function_body<'db>(
         enum_variants.unwrap_or_default(),
         class_names_opt.unwrap_or_default(),
         enum_names_opt.unwrap_or_default(),
-        known_types.unwrap_or_default(),
+        type_alias_names.unwrap_or_default(),
         file_id,
     );
 
@@ -939,11 +927,9 @@ pub fn infer_function<'db>(
     enum_variants: Option<HashMap<Name, Vec<Name>>>,
     function_loc: FunctionLoc<'db>,
 ) -> InferenceResult {
-    // Query known type names from the project (Salsa-cached)
     let project = db.project();
-    let known_type_names = baml_compiler_hir::project_type_names(db, project);
-    let known_types: std::collections::HashSet<_> =
-        known_type_names.names(db).iter().cloned().collect();
+    let type_aliases = type_aliases.unwrap_or_default();
+    let type_alias_name_set: HashSet<Name> = type_aliases.keys().cloned().collect();
 
     // Get class and enum name sets for type resolution (Salsa-cached)
     let class_name_set = class_names(db, project).names(db).clone();
@@ -960,11 +946,12 @@ pub fn infer_function<'db>(
         .params
         .iter()
         .map(|param| {
-            let (ty, errors) = lower_type_ref_validated_resolved(
+            let (ty, errors) = lower_type_ref(
                 &param.type_ref,
-                &known_types,
+                &type_alias_name_set,
                 &class_name_set,
                 &enum_name_set,
+                &type_aliases,
                 placeholder_span,
             );
             type_errors.extend(errors);
@@ -973,11 +960,12 @@ pub fn infer_function<'db>(
         .collect();
 
     // Convert return type with validation and resolution
-    let (expected_return, errors) = lower_type_ref_validated_resolved(
+    let (expected_return, errors) = lower_type_ref(
         &signature.return_type,
-        &known_types,
+        &type_alias_name_set,
         &class_name_set,
         &enum_name_set,
+        &type_aliases,
         placeholder_span,
     );
     type_errors.extend(errors);
@@ -996,11 +984,11 @@ pub fn infer_function<'db>(
         return_type_span,
         globals,
         class_fields,
-        type_aliases,
+        Some(type_aliases),
         enum_variants,
         Some(class_name_set),
         Some(enum_name_set),
-        Some(known_types),
+        Some(type_alias_name_set),
         function_loc,
     );
 
@@ -2043,7 +2031,7 @@ fn check_match_exhaustiveness(
         &ctx.type_aliases,
         &ctx.class_names,
         &ctx.enum_names,
-        &ctx.known_types,
+        &ctx.type_alias_names,
     );
 
     let result = checker.check(scrutinee_ty, arm_ids, body);

--- a/baml_language/crates/baml_compiler_tir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lower.rs
@@ -5,24 +5,26 @@
 //! - Resolving named types to their definitions (classes, enums)
 //! - Converting type constructors (Optional, List, Union)
 //! - Handling primitive type names
-//! - Validating that named types exist (when `known_types` is provided)
+//! - Validating that named types exist (when `type_alias_names` is provided)
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use baml_base::{Name, Span};
 use baml_compiler_diagnostics::TypeError;
 use baml_compiler_hir::{ErrorLocation, TypeRef};
 
-use crate::{LiteralValue, TirTypeError, Ty};
+use crate::{LiteralValue, TirTypeError, Ty, normalize};
 
 /// Context for type lowering with validation.
 ///
-/// When `known_types` is provided, unknown type names will produce errors
+/// When `type_alias_names` is provided, unknown type names will produce errors
 /// and return `Ty::Error` to suppress downstream type mismatches.
 pub struct TypeLoweringContext<'a> {
-    /// Set of known type names (classes, enums, type aliases).
+    /// Set of type alias names.
     /// If None, no validation is performed.
-    pub known_types: Option<&'a HashSet<Name>>,
+    pub type_alias_names: Option<&'a HashSet<Name>>,
+    /// Type aliases.
+    pub type_aliases: Option<&'a HashMap<Name, Ty>>,
     /// Span to use for error reporting. If None, a default span is used.
     pub span: Option<Span>,
     /// Accumulated errors during lowering.
@@ -33,16 +35,22 @@ impl<'a> TypeLoweringContext<'a> {
     /// Create a new context without validation.
     pub fn new() -> Self {
         TypeLoweringContext {
-            known_types: None,
+            type_alias_names: None,
+            type_aliases: None,
             span: None,
             errors: Vec::new(),
         }
     }
 
     /// Create a new context with type name validation.
-    pub fn with_validation(known_types: &'a HashSet<Name>, span: Span) -> Self {
+    pub fn with_validation(
+        type_alias_names: &'a HashSet<Name>,
+        type_aliases: &'a HashMap<Name, Ty>,
+        span: Span,
+    ) -> Self {
         TypeLoweringContext {
-            known_types: Some(known_types),
+            type_alias_names: Some(type_alias_names),
+            type_aliases: Some(type_aliases),
             span: Some(span),
             errors: Vec::new(),
         }
@@ -62,45 +70,50 @@ impl Default for TypeLoweringContext<'_> {
 /// contexts where you need fully resolved types.
 ///
 /// Returns the lowered type and any errors encountered.
-pub fn lower_type_ref_validated_resolved(
+pub fn lower_type_ref(
     type_ref: &TypeRef,
-    known_types: &HashSet<Name>,
+    type_alias_names: &HashSet<Name>,
     class_names: &HashSet<Name>,
     enum_names: &HashSet<Name>,
+    type_aliases: &HashMap<Name, Ty>,
     span: Span,
 ) -> (Ty, Vec<TirTypeError>) {
-    let mut ctx = TypeLoweringContextResolved::new(known_types, class_names, enum_names, span);
+    let mut ctx =
+        TypeLoweringContextResolved::new(type_alias_names, class_names, enum_names, type_aliases, span);
     let ty = lower_type_ref_resolved_with_ctx(&mut ctx, type_ref);
     (ty, ctx.errors)
 }
 
 /// Context for type lowering with validation and resolution.
 struct TypeLoweringContextResolved<'a> {
-    known_types: &'a HashSet<Name>,
+    type_alias_names: &'a HashSet<Name>,
     class_names: &'a HashSet<Name>,
     enum_names: &'a HashSet<Name>,
+    type_aliases: &'a HashMap<Name, Ty>,
     span: Span,
     errors: Vec<TirTypeError>,
 }
 
 impl<'a> TypeLoweringContextResolved<'a> {
     fn new(
-        known_types: &'a HashSet<Name>,
+        type_alias_names: &'a HashSet<Name>,
         class_names: &'a HashSet<Name>,
         enum_names: &'a HashSet<Name>,
+        type_aliases: &'a HashMap<Name, Ty>,
         span: Span,
     ) -> Self {
         Self {
-            known_types,
+            type_alias_names,
             class_names,
             enum_names,
+            type_aliases,
             span,
             errors: Vec::new(),
         }
     }
 
-    fn is_known_type(&self, name: &Name) -> bool {
-        self.known_types.contains(name)
+    fn is_type_alias_name(&self, name: &Name) -> bool {
+        self.type_alias_names.contains(name)
     }
 
     fn unknown_type_error(&mut self, name: &Name) -> Ty {
@@ -120,6 +133,18 @@ impl<'a> TypeLoweringContextResolved<'a> {
         } else {
             None
         }
+    }
+
+    fn invalid_map_key_type(&mut self, ty: &Ty) -> Ty {
+        self.errors.push(TypeError::InvalidMapKeyType {
+            ty: ty.clone(),
+            location: ErrorLocation::Span(self.span),
+        });
+        Ty::Error
+    }
+
+    fn is_valid_map_key_type(&self, ty: &Ty) -> bool {
+        normalize::is_valid_map_key_type(ty, self.type_aliases)
     }
 }
 
@@ -156,6 +181,9 @@ fn lower_type_ref_resolved_with_ctx(
         TypeRef::Map { key, value } => {
             let key_ty = lower_type_ref_resolved_with_ctx(ctx, key);
             let value_ty = lower_type_ref_resolved_with_ctx(ctx, value);
+            if !ctx.is_valid_map_key_type(&key_ty) {
+                ctx.invalid_map_key_type(&key_ty);
+            }
             Ty::Map {
                 key: Box::new(key_ty),
                 value: Box::new(value_ty),
@@ -218,8 +246,8 @@ fn lower_path_type_resolved_with_ctx(
                         return resolved;
                     }
 
-                    // Check if it's a known type (could be a type alias)
-                    if ctx.is_known_type(name) {
+                    // Check if it's a type alias
+                    if ctx.is_type_alias_name(name) {
                         Ty::TypeAlias(FullyQualifiedName::local(name.clone()))
                     } else {
                         ctx.unknown_type_error(name)
@@ -237,7 +265,7 @@ fn lower_path_type_resolved_with_ctx(
                 .collect::<Vec<_>>()
                 .join(".");
             let name = Name::new(&full_path);
-            if !is_simple_type_name(&full_path) || ctx.is_known_type(&name) {
+            if !is_simple_type_name(&full_path) || ctx.is_type_alias_name(&name) {
                 Ty::TypeAlias(FullyQualifiedName::local(name))
             } else {
                 ctx.unknown_type_error(&name)

--- a/baml_language/crates/baml_compiler_tir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lower.rs
@@ -7,61 +7,13 @@
 //! - Handling primitive type names
 //! - Validating that named types exist (when `type_alias_names` is provided)
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use baml_base::{Name, Span};
 use baml_compiler_diagnostics::TypeError;
 use baml_compiler_hir::{ErrorLocation, TypeRef};
 
-use crate::{LiteralValue, TirTypeError, Ty, normalize};
-
-/// Context for type lowering with validation.
-///
-/// When `type_alias_names` is provided, unknown type names will produce errors
-/// and return `Ty::Error` to suppress downstream type mismatches.
-pub struct TypeLoweringContext<'a> {
-    /// Set of type alias names.
-    /// If None, no validation is performed.
-    pub type_alias_names: Option<&'a HashSet<Name>>,
-    /// Type aliases.
-    pub type_aliases: Option<&'a HashMap<Name, Ty>>,
-    /// Span to use for error reporting. If None, a default span is used.
-    pub span: Option<Span>,
-    /// Accumulated errors during lowering.
-    pub errors: Vec<TirTypeError>,
-}
-
-impl<'a> TypeLoweringContext<'a> {
-    /// Create a new context without validation.
-    pub fn new() -> Self {
-        TypeLoweringContext {
-            type_alias_names: None,
-            type_aliases: None,
-            span: None,
-            errors: Vec::new(),
-        }
-    }
-
-    /// Create a new context with type name validation.
-    pub fn with_validation(
-        type_alias_names: &'a HashSet<Name>,
-        type_aliases: &'a HashMap<Name, Ty>,
-        span: Span,
-    ) -> Self {
-        TypeLoweringContext {
-            type_alias_names: Some(type_alias_names),
-            type_aliases: Some(type_aliases),
-            span: Some(span),
-            errors: Vec::new(),
-        }
-    }
-}
-
-impl Default for TypeLoweringContext<'_> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+use crate::{LiteralValue, TirTypeError, Ty};
 
 /// Lower a `TypeRef` to a Ty with validation AND resolution of class/enum types.
 ///
@@ -75,11 +27,9 @@ pub fn lower_type_ref(
     type_alias_names: &HashSet<Name>,
     class_names: &HashSet<Name>,
     enum_names: &HashSet<Name>,
-    type_aliases: &HashMap<Name, Ty>,
     span: Span,
 ) -> (Ty, Vec<TirTypeError>) {
-    let mut ctx =
-        TypeLoweringContextResolved::new(type_alias_names, class_names, enum_names, type_aliases, span);
+    let mut ctx = TypeLoweringContextResolved::new(type_alias_names, class_names, enum_names, span);
     let ty = lower_type_ref_resolved_with_ctx(&mut ctx, type_ref);
     (ty, ctx.errors)
 }
@@ -89,7 +39,6 @@ struct TypeLoweringContextResolved<'a> {
     type_alias_names: &'a HashSet<Name>,
     class_names: &'a HashSet<Name>,
     enum_names: &'a HashSet<Name>,
-    type_aliases: &'a HashMap<Name, Ty>,
     span: Span,
     errors: Vec<TirTypeError>,
 }
@@ -99,14 +48,12 @@ impl<'a> TypeLoweringContextResolved<'a> {
         type_alias_names: &'a HashSet<Name>,
         class_names: &'a HashSet<Name>,
         enum_names: &'a HashSet<Name>,
-        type_aliases: &'a HashMap<Name, Ty>,
         span: Span,
     ) -> Self {
         Self {
             type_alias_names,
             class_names,
             enum_names,
-            type_aliases,
             span,
             errors: Vec::new(),
         }
@@ -133,18 +80,6 @@ impl<'a> TypeLoweringContextResolved<'a> {
         } else {
             None
         }
-    }
-
-    fn invalid_map_key_type(&mut self, ty: &Ty) -> Ty {
-        self.errors.push(TypeError::InvalidMapKeyType {
-            ty: ty.clone(),
-            location: ErrorLocation::Span(self.span),
-        });
-        Ty::Error
-    }
-
-    fn is_valid_map_key_type(&self, ty: &Ty) -> bool {
-        normalize::is_valid_map_key_type(ty, self.type_aliases)
     }
 }
 
@@ -181,9 +116,6 @@ fn lower_type_ref_resolved_with_ctx(
         TypeRef::Map { key, value } => {
             let key_ty = lower_type_ref_resolved_with_ctx(ctx, key);
             let value_ty = lower_type_ref_resolved_with_ctx(ctx, value);
-            if !ctx.is_valid_map_key_type(&key_ty) {
-                ctx.invalid_map_key_type(&key_ty);
-            }
             Ty::Map {
                 key: Box::new(key_ty),
                 value: Box::new(value_ty),

--- a/baml_language/crates/baml_compiler_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler_tir/src/normalize.rs
@@ -201,6 +201,42 @@ fn substitute(ty: &StructuralTy, var: &Name, replacement: &StructuralTy) -> Stru
     }
 }
 
+pub(crate) fn is_valid_map_key_type(ty: &Ty, aliases: &HashMap<Name, Ty>) -> bool {
+    fn can_be_key(structural_ty: &StructuralTy) -> bool {
+        match structural_ty {
+            StructuralTy::String => true,
+            StructuralTy::Literal(literal_value) => match literal_value {
+                LiteralValue::String(_) => true,
+                LiteralValue::Int(_) => false,
+                LiteralValue::Float(_) => false,
+                LiteralValue::Bool(_) => false,
+            },
+            StructuralTy::Error => true,
+            StructuralTy::Union(variants) => variants.iter().all(|v| can_be_key(&v)),
+            StructuralTy::Int => false,
+            StructuralTy::Float => false,
+            StructuralTy::Bool => false,
+            StructuralTy::Null => false,
+            StructuralTy::Media(_) => false,
+            StructuralTy::Class(_) => false,
+            StructuralTy::Enum(_) => false,
+            StructuralTy::Optional(_) => false,
+            StructuralTy::List(_) => false,
+            StructuralTy::Map { .. } => false,
+            StructuralTy::Function { .. } => false,
+            StructuralTy::Mu { .. } => false,
+            StructuralTy::TyVar(_) => false,
+            StructuralTy::Unknown => false,
+            StructuralTy::Void => false,
+            StructuralTy::WatchAccessor(_) => false,
+            StructuralTy::Builtin(_) => false,
+        }
+    }
+    let recursive = find_recursive_aliases(aliases);
+    let norm = normalize(ty, aliases, &recursive);
+    can_be_key(&norm)
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // NORMALIZATION (private)
 // ═══════════════════════════════════════════════════════════════════════════

--- a/baml_language/crates/baml_compiler_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler_tir/src/normalize.rs
@@ -201,7 +201,11 @@ fn substitute(ty: &StructuralTy, var: &Name, replacement: &StructuralTy) -> Stru
     }
 }
 
-pub(crate) fn is_valid_map_key_type(ty: &Ty, aliases: &HashMap<Name, Ty>) -> bool {
+/// Check if a type is valid as a map key.
+///
+/// Valid key types are: string, string literals, and unions of valid key types.
+/// Enums are NOT valid (they're structurally distinct from string literals).
+fn is_valid_map_key_type(ty: &Ty, aliases: &HashMap<Name, Ty>) -> bool {
     fn can_be_key(structural_ty: &StructuralTy) -> bool {
         match structural_ty {
             StructuralTy::String => true,
@@ -212,7 +216,7 @@ pub(crate) fn is_valid_map_key_type(ty: &Ty, aliases: &HashMap<Name, Ty>) -> boo
                 LiteralValue::Bool(_) => false,
             },
             StructuralTy::Error => true,
-            StructuralTy::Union(variants) => variants.iter().all(|v| can_be_key(&v)),
+            StructuralTy::Union(variants) => variants.iter().all(can_be_key),
             StructuralTy::Int => false,
             StructuralTy::Float => false,
             StructuralTy::Bool => false,
@@ -235,6 +239,42 @@ pub(crate) fn is_valid_map_key_type(ty: &Ty, aliases: &HashMap<Name, Ty>) -> boo
     let recursive = find_recursive_aliases(aliases);
     let norm = normalize(ty, aliases, &recursive);
     can_be_key(&norm)
+}
+
+/// Find all invalid map key types within a type (recursively).
+///
+/// Returns a list of the invalid key types found. The caller should create
+/// appropriate diagnostics for each.
+pub fn find_invalid_map_keys(ty: &Ty, aliases: &HashMap<Name, Ty>) -> Vec<Ty> {
+    let mut invalid_keys = Vec::new();
+    find_invalid_map_keys_recursive(ty, aliases, &mut invalid_keys);
+    invalid_keys
+}
+
+fn find_invalid_map_keys_recursive(ty: &Ty, aliases: &HashMap<Name, Ty>, invalid_keys: &mut Vec<Ty>) {
+    match ty {
+        Ty::Map { key, value } => {
+            if !is_valid_map_key_type(key, aliases) {
+                invalid_keys.push((**key).clone());
+            }
+            find_invalid_map_keys_recursive(key, aliases, invalid_keys);
+            find_invalid_map_keys_recursive(value, aliases, invalid_keys);
+        }
+        Ty::List(inner) => find_invalid_map_keys_recursive(inner, aliases, invalid_keys),
+        Ty::Optional(inner) => find_invalid_map_keys_recursive(inner, aliases, invalid_keys),
+        Ty::Union(types) => {
+            for t in types {
+                find_invalid_map_keys_recursive(t, aliases, invalid_keys);
+            }
+        }
+        Ty::Function { params, ret } => {
+            for p in params {
+                find_invalid_map_keys_recursive(p, aliases, invalid_keys);
+            }
+            find_invalid_map_keys_recursive(ret, aliases, invalid_keys);
+        }
+        _ => {}
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════

--- a/baml_language/crates/baml_compiler_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler_tir/src/normalize.rs
@@ -251,7 +251,11 @@ pub fn find_invalid_map_keys(ty: &Ty, aliases: &HashMap<Name, Ty>) -> Vec<Ty> {
     invalid_keys
 }
 
-fn find_invalid_map_keys_recursive(ty: &Ty, aliases: &HashMap<Name, Ty>, invalid_keys: &mut Vec<Ty>) {
+fn find_invalid_map_keys_recursive(
+    ty: &Ty,
+    aliases: &HashMap<Name, Ty>,
+    invalid_keys: &mut Vec<Ty>,
+) {
     match ty {
         Ty::Map { key, value } => {
             if !is_valid_map_key_type(key, aliases) {

--- a/baml_language/crates/baml_compiler_tir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_tir/src/pretty.rs
@@ -666,5 +666,8 @@ pub fn short_display(error: &TirTypeError) -> String {
                 "Missing return expression. Function expects `{expected}` but body has no final expression."
             )
         }
+        TypeError::InvalidMapKeyType { ty, .. } => {
+            format!("Invalid key type for map: {ty}.")
+        }
     }
 }

--- a/baml_language/crates/baml_compiler_tir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_tir/src/pretty.rs
@@ -395,7 +395,8 @@ impl<'a> TreeRenderer<'a> {
                     Pattern::Union(pats) => format!("union[{}]", pats.len()),
                 };
 
-                let ty_str = if let Some(type_ref) = type_annotation {
+                let ty_str = if let Some(type_id) = type_annotation {
+                    let type_ref = &body.types[*type_id];
                     let ty = self
                         .resolution_ctx
                         .lower_type_ref(type_ref, Span::default())

--- a/baml_language/crates/baml_compiler_vir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_vir/src/lower.rs
@@ -546,8 +546,9 @@ impl<'a> LoweringContext<'a> {
                 let pat_id = self.lower_pattern(*pattern, hir_body)?;
 
                 // Get the type from annotation or initializer
-                let ty = if let Some(annot) = type_annotation {
-                    self.lower_type_ref(annot)
+                let ty = if let Some(type_id) = type_annotation {
+                    let type_ref = &hir_body.types[*type_id];
+                    self.lower_type_ref(type_ref)
                 } else if let Some(init) = initializer {
                     self.inference
                         .expr_types

--- a/baml_language/crates/baml_ide_tests/test_files/syntax/maps/key_and_value_typecheck.baml
+++ b/baml_language/crates/baml_ide_tests/test_files/syntax/maps/key_and_value_typecheck.baml
@@ -55,11 +55,11 @@ function UseMapTypecheck() -> int {
 //    │ Note: Error code: E0010
 // ───╯
 // Error: Invalid type int for map key. Only strings, string literals and enums are valid map keys.
-//    ╭─[ maps_key_and_value_typecheck.baml:1:1 ]
+//    ╭─[ maps_key_and_value_typecheck.baml:2:28 ]
 //    │
-//  1 │ // For now, errors with 'map keys must be string literals'
-//    │ │ 
-//    │ ╰─ Invalid type int for map key. Only strings, string literals and enums are valid map keys.
+//  2 │ function CreateMapExpr() -> map<int, string> {
+//    │                            ────────┬────────  
+//    │                                    ╰────────── Invalid type int for map key. Only strings, string literals and enums are valid map keys.
 //    │ 
 //    │ Note: Error code: E0067
 // ───╯

--- a/baml_language/crates/baml_ide_tests/test_files/syntax/maps/key_and_value_typecheck.baml
+++ b/baml_language/crates/baml_ide_tests/test_files/syntax/maps/key_and_value_typecheck.baml
@@ -54,6 +54,15 @@ function UseMapTypecheck() -> int {
 //    │ 
 //    │ Note: Error code: E0010
 // ───╯
+// Error: Invalid type int for map key. Only strings, string literals and enums are valid map keys.
+//    ╭─[ maps_key_and_value_typecheck.baml:1:1 ]
+//    │
+//  1 │ // For now, errors with 'map keys must be string literals'
+//    │ │ 
+//    │ ╰─ Invalid type int for map key. Only strings, string literals and enums are valid map keys.
+//    │ 
+//    │ Note: Error code: E0067
+// ───╯
 // Error: Expected `map<int, string>`, found `string`
 //    ╭─[ maps_key_and_value_typecheck.baml:3:15 ]
 //    │

--- a/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__04_tir.snap
@@ -1,10 +1,12 @@
 ---
-source: target/debug/build/baml_tests-e89f2b4de47549a5/out/generated_tests.rs
+source: target/debug/build/baml_tests-50646ef7890fdaa2/out/generated_tests.rs
 expression: output
 ---
 === TYPE INFERENCE ===
   Function BadUnionPattern:
     Return: Union([Unknown, Literal(String("bad"))])
+    Errors:
+      - Unknown type b
   Function Invalid:
     Return: Void
   Function MixedLiteralAndTyped:

--- a/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/error_cases/baml_tests__error_cases__05_diagnostics.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
+source: target/debug/build/baml_tests-50646ef7890fdaa2/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
@@ -52,3 +52,13 @@ expression: output
     │ 
     │ Note: Error code: E0010
 ────╯
+
+  [type] Error: Unknown type `b`
+   ╭─[ syntax_errors.baml:1:1 ]
+   │
+ 1 │ // Missing closing brace
+   │ │ 
+   │ ╰─ Unknown type `b`
+   │ 
+   │ Note: Error code: E0002
+───╯

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-50646ef7890fdaa2/out/generated_tests.rs
 expression: output
 ---
 === MIR ===
@@ -751,11 +751,11 @@ fn ExhaustiveTypeAliasWithCatchAll(r: TypeAlias(FullyQualifiedName { namespace: 
     let _2: Bool
     let _3: Class(FullyQualifiedName { namespace: Local, name: "Success" }) // s
     let _4: Class(FullyQualifiedName { namespace: Local, name: "Success" })
-    let _5: TypeAlias(FullyQualifiedName { namespace: Local, name: "Result" }) // _
+    let _5: Error // _
 
     bb0: {
         _2 = is_type(copy _1, Class(FullyQualifiedName { namespace: Local, name: "Success" }));
-        branch copy _2 -> [bb6, bb5];
+        branch copy _2 -> [bb5, bb4];
     }
 
     bb1: {
@@ -767,27 +767,27 @@ fn ExhaustiveTypeAliasWithCatchAll(r: TypeAlias(FullyQualifiedName { namespace: 
     }
 
     bb3: {
-        unreachable;
-    }
-
-    bb4: {
         _4 = copy _3;
         _0 = copy _4.0;
         goto -> bb2;
     }
 
-    bb5: {
+    bb4: {
         _5 = copy _1;
-        goto -> bb7;
+        goto -> bb6;
+    }
+
+    bb5: {
+        _3 = copy _1;
+        goto -> bb3;
     }
 
     bb6: {
-        _3 = copy _1;
-        goto -> bb4;
+        _0 = const "fallback";
+        goto -> bb2;
     }
 
     bb7: {
-        _0 = const "fallback";
         goto -> bb2;
     }
 
@@ -3589,11 +3589,11 @@ fn StringLiteralWithCatchAll(role: TypeAlias(FullyQualifiedName { namespace: Loc
     let _1: TypeAlias(FullyQualifiedName { namespace: Local, name: "Role" }) // role // param
     let _2: Bool
     let _3: Bool
-    let _4: TypeAlias(FullyQualifiedName { namespace: Local, name: "Role" }) // _
+    let _4: Error // _
 
     bb0: {
         _2 = copy _1 == const "user";
-        branch copy _2 -> [bb4, bb5];
+        branch copy _2 -> [bb3, bb4];
     }
 
     bb1: {
@@ -3605,31 +3605,31 @@ fn StringLiteralWithCatchAll(role: TypeAlias(FullyQualifiedName { namespace: Loc
     }
 
     bb3: {
-        unreachable;
-    }
-
-    bb4: {
         _0 = const "User message";
         goto -> bb2;
     }
 
-    bb5: {
+    bb4: {
         _3 = copy _1 == const "assistant";
-        branch copy _3 -> [bb6, bb7];
+        branch copy _3 -> [bb5, bb6];
     }
 
-    bb6: {
+    bb5: {
         _0 = const "Assistant message";
         goto -> bb2;
     }
 
-    bb7: {
+    bb6: {
         _4 = copy _1;
-        goto -> bb8;
+        goto -> bb7;
+    }
+
+    bb7: {
+        _0 = const "Other";
+        goto -> bb2;
     }
 
     bb8: {
-        _0 = const "Other";
         goto -> bb2;
     }
 

--- a/baml_language/crates/bex_vm_types/src/heap_ptr.rs
+++ b/baml_language/crates/bex_vm_types/src/heap_ptr.rs
@@ -58,12 +58,12 @@ unsafe impl Send for HeapPtr {}
 unsafe impl Sync for HeapPtr {}
 
 impl HeapPtr {
-    /// Create a new HeapPtr from a raw pointer.
+    /// Create a new `HeapPtr` from a raw pointer.
     ///
     /// # Safety
     ///
     /// The pointer must point to a valid Object in the heap that will
-    /// remain valid for the lifetime of this HeapPtr (until GC collects it).
+    /// remain valid for the lifetime of this `HeapPtr` (until GC collects it).
     #[cfg(not(feature = "heap_debug"))]
     #[inline]
     pub unsafe fn from_ptr(ptr: *mut Object) -> Self {


### PR DESCRIPTION
 - Ensure that map types appearing in types use valid key types
 - Consolidate confusing lower_type_ref* into fewer variants
 - Remove TextRange from Stmt