### PR TITLE
feat: implement jinja template rendering

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -808,6 +808,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bex_jinja_runtime"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "bex_external_types",
+ "bex_llm_types",
+ "bex_program",
+ "bex_vm_types",
+ "indexmap 2.13.0",
+ "minijinja",
+ "regex",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bex_llm_types"
+version = "0.0.0"
+dependencies = [
+ "bex_program",
+ "indexmap 2.13.0",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "bex_program"
 version = "0.0.0"
 dependencies = [
@@ -849,6 +874,8 @@ dependencies = [
  "colored",
  "indexmap 2.13.0",
  "paste",
+ "serde",
+ "serde_json",
  "sys_resource_types",
  "tokio",
 ]
@@ -2800,6 +2827,15 @@ checksum = "4869b6a491569605d66d3952bcdf03df789e5b536e5f0cf7758a7f08a55ae24d"
 dependencies = [
  "cc",
  "walkdir",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.11.0"
+source = "git+https://github.com/boundaryml/minijinja.git?branch=main#ee25c021c8bb78d7ca11fa99972918eea4585330"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -47,7 +47,18 @@ bex_vm = { path = "crates/bex_vm" }
 bex_vm_types = { path = "crates/bex_vm_types" }
 bex_external_types = { path = "crates/bex_external_types" }
 bex_heap = { path = "crates/bex_heap" }
+bex_llm_types = { path = "crates/bex_llm_types" }
+bex_jinja_runtime = { path = "crates/bex_jinja_runtime" }
 sys_resource_types = { path = "crates/sys_resource_types" }
+
+# External dependencies for bex_jinja_runtime
+minijinja = { git = "https://github.com/boundaryml/minijinja.git", branch = "main", default-features = false, features = [
+  "macros",
+  "builtins",
+  "debug",
+  "preserve_order",
+  "serde",
+] }
 baml_workspace = { path = "crates/baml_workspace" }
 
 #  External dependencies

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -329,10 +329,8 @@ impl BexHeap {
     fn add_prompt_ast_references(ast: &bex_vm_types::PromptAst, worklist: &mut Vec<HeapPtr>) {
         use bex_vm_types::PromptAst;
         match ast {
-            PromptAst::String(_) | PromptAst::PrintOutputFormat(_) => {}
-            PromptAst::Media(ptr) => {
-                worklist.push(*ptr);
-            }
+            // String and Media (now usize) have no heap references
+            PromptAst::String(_) | PromptAst::Media(_) => {}
             PromptAst::Message {
                 metadata, content, ..
             } => {
@@ -428,12 +426,8 @@ impl BexHeap {
     ) {
         use bex_vm_types::PromptAst;
         match ast {
-            PromptAst::String(_) | PromptAst::PrintOutputFormat(_) => {}
-            PromptAst::Media(ptr) => {
-                if let Some(&new_ptr) = forwarding.get(ptr) {
-                    *ptr = new_ptr;
-                }
-            }
+            // String and Media (now usize) have no heap references to fix
+            PromptAst::String(_) | PromptAst::Media(_) => {}
             PromptAst::Message {
                 metadata, content, ..
             } => {

--- a/baml_language/crates/bex_heap/src/heap_debugger/real.rs
+++ b/baml_language/crates/bex_heap/src/heap_debugger/real.rs
@@ -362,10 +362,8 @@ impl BexHeap {
     fn debug_assert_valid_prompt_ast(&self, ast: &bex_vm_types::PromptAst) {
         use bex_vm_types::PromptAst;
         match ast {
-            PromptAst::String(_) | PromptAst::PrintOutputFormat(_) => {}
-            PromptAst::Media(ptr) => {
-                self.debug_assert_valid_index(*ptr);
-            }
+            // String and Media (now usize) have no heap references to validate
+            PromptAst::String(_) | PromptAst::Media(_) => {}
             PromptAst::Message {
                 metadata, content, ..
             } => {

--- a/baml_language/crates/bex_jinja_runtime/Cargo.toml
+++ b/baml_language/crates/bex_jinja_runtime/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "bex_jinja_runtime"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+bex_external_types = { workspace = true }
+bex_llm_types = { workspace = true }
+bex_vm_types = { workspace = true }
+
+indexmap = { workspace = true }
+minijinja = { workspace = true }
+regex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+bex_program = { workspace = true }
+
+anyhow = { workspace = true }
+serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/baml_language/crates/bex_jinja_runtime/src/filters.rs
+++ b/baml_language/crates/bex_jinja_runtime/src/filters.rs
@@ -1,0 +1,31 @@
+use minijinja::value::Value;
+
+/// Filter: `regex_match` - Returns true if value matches regex pattern.
+pub(crate) fn regex_match(value: &str, pattern: &str) -> bool {
+    regex::Regex::new(pattern)
+        .map(|re| re.is_match(value))
+        .unwrap_or(false)
+}
+
+/// Filter: sum - Sum numeric values in a list.
+#[allow(clippy::cast_precision_loss)]
+pub(crate) fn sum(values: Vec<Value>) -> Value {
+    let mut int_sum: i64 = 0;
+    let mut float_sum: f64 = 0.0;
+    let mut has_float = false;
+
+    for val in values {
+        if let Ok(i) = i64::try_from(val.clone()) {
+            int_sum += i;
+        } else if let Ok(f) = f64::try_from(val) {
+            float_sum += f;
+            has_float = true;
+        }
+    }
+
+    if has_float {
+        Value::from(int_sum as f64 + float_sum)
+    } else {
+        Value::from(int_sum)
+    }
+}

--- a/baml_language/crates/bex_jinja_runtime/src/lib.rs
+++ b/baml_language/crates/bex_jinja_runtime/src/lib.rs
@@ -1,0 +1,22 @@
+//! Jinja template runtime for BAML prompts.
+//!
+//! This crate provides:
+//! - `render_prompt()` - Main entry point for rendering templates
+//! - `OutputFormatObject` - Template-accessible output format renderer
+//! - Value conversion from `BexExternalValue` to minijinja values
+//! - Magic delimiter handling for chat messages and media
+
+mod filters;
+mod output_format_object;
+mod render;
+mod value_conversion;
+
+pub use bex_llm_types::{OutputFormatContent, RenderOptions};
+pub use output_format_object::OutputFormatObject;
+pub use render::{RenderContext, RenderContextClient, render_prompt};
+
+/// Magic delimiter for chat role markers.
+pub const MAGIC_CHAT_ROLE_DELIMITER: &str = "BAML_CHAT_ROLE_MAGIC_STRING_DELIMITER";
+
+/// Magic delimiter for media content.
+pub const MAGIC_MEDIA_DELIMITER: &str = "BAML_MEDIA_MAGIC_STRING_DELIMITER";

--- a/baml_language/crates/bex_jinja_runtime/src/output_format_object.rs
+++ b/baml_language/crates/bex_jinja_runtime/src/output_format_object.rs
@@ -1,0 +1,195 @@
+//! `OutputFormat` object exposed to Jinja templates as `ctx.output_format`.
+//! Ported from engine/baml-lib/jinja-runtime/src/output_format/mod.rs
+
+use std::sync::Arc;
+
+use bex_llm_types::{HoistClasses, MapStyle, OutputFormatContent, RenderOptions, RenderSetting};
+use minijinja::{
+    ErrorKind,
+    value::{Kwargs, Value},
+};
+
+/// Wrapper around `OutputFormatContent` that implements `minijinja::value::Object`.
+#[derive(Debug)]
+pub struct OutputFormatObject {
+    content: OutputFormatContent,
+}
+
+impl OutputFormatObject {
+    pub fn new(content: OutputFormatContent) -> Self {
+        Self { content }
+    }
+}
+
+impl std::fmt::Display for OutputFormatObject {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let rendered = self
+            .content
+            .render(&RenderOptions::default())
+            .map_err(|_| std::fmt::Error)?;
+        match rendered {
+            Some(s) => write!(f, "{s}"),
+            None => Ok(()),
+        }
+    }
+}
+
+impl minijinja::value::Object for OutputFormatObject {
+    fn call(
+        self: &Arc<Self>,
+        _state: &minijinja::State<'_, '_>,
+        args: &[Value],
+    ) -> Result<Value, minijinja::Error> {
+        use minijinja::{Error, value::from_args};
+
+        let (args, kwargs): (&[Value], Kwargs) = from_args(args)?;
+        if !args.is_empty() {
+            return Err(Error::new(
+                ErrorKind::TooManyArguments,
+                "output_format() may only be called with named arguments",
+            ));
+        }
+
+        // Parse kwargs - matching engine/baml-lib/jinja-runtime/src/output_format/mod.rs
+        let prefix = parse_render_setting_string(&kwargs, "prefix")?;
+        let or_splitter = parse_render_setting_string(&kwargs, "or_splitter")?;
+        let enum_value_prefix = parse_render_setting_string(&kwargs, "enum_value_prefix")?;
+        let always_hoist_enums = parse_render_setting_bool(&kwargs, "always_hoist_enums")?;
+        let hoisted_class_prefix = parse_render_setting_string(&kwargs, "hoisted_class_prefix")?;
+        let hoist_classes = parse_hoist_classes_kwarg(&kwargs)?;
+        let map_style = parse_map_style_kwarg(&kwargs)?;
+        let quote_class_fields = parse_render_setting_bool(&kwargs, "quote_class_fields")?;
+
+        kwargs.assert_all_used().map_err(|_| {
+            Error::new(
+                ErrorKind::TooManyArguments,
+                "output_format() got an unexpected keyword argument",
+            )
+        })?;
+
+        let options = RenderOptions {
+            prefix,
+            or_splitter,
+            enum_value_prefix,
+            hoisted_class_prefix,
+            hoist_classes,
+            always_hoist_enums,
+            map_style,
+            quote_class_fields,
+        };
+
+        let rendered = self
+            .content
+            .render(&options)
+            .map_err(|e| Error::new(ErrorKind::BadSerialization, e.to_string()))?;
+
+        match rendered {
+            Some(s) => Ok(Value::from_safe_string(s)),
+            None => Ok(Value::from("")),
+        }
+    }
+
+    fn render(self: &Arc<Self>, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
+}
+
+// Helper functions for parsing kwargs
+
+/// Parse a kwarg that returns `RenderSetting<String>`:
+/// - Not present -> Auto
+/// - Present with null/None -> Never
+/// - Present with value -> Always(value)
+fn parse_render_setting_string(
+    kwargs: &Kwargs,
+    name: &str,
+) -> Result<RenderSetting<String>, minijinja::Error> {
+    if !kwargs.has(name) {
+        return Ok(RenderSetting::Auto);
+    }
+    match kwargs.get::<Option<String>>(name) {
+        Ok(Some(v)) => Ok(RenderSetting::Always(v)),
+        Ok(None) => Ok(RenderSetting::Never),
+        Err(e) => Err(minijinja::Error::new(
+            ErrorKind::SyntaxError,
+            format!("Invalid value for {name}: {e}"),
+        )),
+    }
+}
+
+/// Parse a kwarg that returns `RenderSetting<bool>`:
+/// - Not present -> Auto
+/// - Present with value -> Always(value)
+fn parse_render_setting_bool(
+    kwargs: &Kwargs,
+    name: &str,
+) -> Result<RenderSetting<bool>, minijinja::Error> {
+    if !kwargs.has(name) {
+        return Ok(RenderSetting::Auto);
+    }
+    match kwargs.get::<bool>(name) {
+        Ok(v) => Ok(RenderSetting::Always(v)),
+        Err(e) => Err(minijinja::Error::new(
+            ErrorKind::SyntaxError,
+            format!("Invalid value for {name}: {e}"),
+        )),
+    }
+}
+
+/// Parse `hoist_classes` kwarg:
+/// - Not present -> Auto
+/// - true -> All
+/// - false -> Auto
+/// - "auto" -> Auto
+/// - string[] -> Subset(classes)
+fn parse_hoist_classes_kwarg(kwargs: &Kwargs) -> Result<HoistClasses, minijinja::Error> {
+    if !kwargs.has("hoist_classes") {
+        return Ok(HoistClasses::Auto);
+    }
+    // Try bool first
+    if let Ok(b) = kwargs.get::<bool>("hoist_classes") {
+        return Ok(if b {
+            HoistClasses::All
+        } else {
+            HoistClasses::Auto
+        });
+    }
+    // Try "auto" string
+    if let Ok(s) = kwargs.get::<String>("hoist_classes") {
+        if s == "auto" {
+            return Ok(HoistClasses::Auto);
+        }
+    }
+    // Try array of strings
+    if let Ok(classes) = kwargs.get::<Vec<String>>("hoist_classes") {
+        return Ok(HoistClasses::Subset(classes));
+    }
+    Err(minijinja::Error::new(
+        ErrorKind::SyntaxError,
+        "Invalid value for hoist_classes (expected bool | \"auto\" | string[])",
+    ))
+}
+
+/// Parse `map_style` kwarg:
+/// - Not present -> `TypeParameters` (default)
+/// - "`type_parameters`" -> `TypeParameters`
+/// - "`object_literal`" -> `ObjectLiteral`
+fn parse_map_style_kwarg(kwargs: &Kwargs) -> Result<MapStyle, minijinja::Error> {
+    if !kwargs.has("map_style") {
+        return Ok(MapStyle::default());
+    }
+    match kwargs.get::<String>("map_style") {
+        Ok(s) => match s.as_str() {
+            "type_parameters" => Ok(MapStyle::TypeParameters),
+            "object_literal" => Ok(MapStyle::ObjectLiteral),
+            _ => Err(minijinja::Error::new(
+                ErrorKind::SyntaxError,
+                format!("Invalid map_style: {s} (expected 'type_parameters' or 'object_literal')"),
+            )),
+        },
+        Err(e) => Err(minijinja::Error::new(
+            ErrorKind::SyntaxError,
+            format!("Invalid value for map_style: {e}"),
+        )),
+    }
+}

--- a/baml_language/crates/bex_jinja_runtime/src/render.rs
+++ b/baml_language/crates/bex_jinja_runtime/src/render.rs
@@ -1,0 +1,445 @@
+use bex_external_types::BexExternalValue;
+use bex_llm_types::OutputFormatContent;
+use bex_vm_types::{PromptAst, Value};
+use indexmap::IndexMap;
+use minijinja::Environment;
+
+use crate::{
+    MAGIC_CHAT_ROLE_DELIMITER, MAGIC_MEDIA_DELIMITER, filters,
+    output_format_object::OutputFormatObject, value_conversion::external_value_to_jinja,
+};
+
+/// Client configuration for rendering.
+#[derive(Clone, Debug)]
+pub struct RenderContextClient {
+    pub name: String,
+    pub provider: String,
+    pub default_role: String,
+    pub allowed_roles: Vec<String>,
+}
+
+/// Context for rendering a prompt.
+#[derive(Clone, Debug)]
+pub struct RenderContext {
+    pub client: RenderContextClient,
+    pub output_format: OutputFormatContent,
+    pub tags: IndexMap<String, BexExternalValue>,
+}
+
+/// Render a Jinja template to a `PromptAst`.
+///
+/// # Arguments
+/// * `template` - The Jinja template string
+/// * `args` - Template arguments as pre-extracted `BexExternalValue` (no heap access needed)
+/// * `ctx` - Rendering context with client info and output format
+///
+/// # Returns
+/// A `PromptAst` representing the rendered prompt.
+pub fn render_prompt(
+    template: &str,
+    args: &IndexMap<String, BexExternalValue>,
+    ctx: &RenderContext,
+) -> Result<PromptAst, minijinja::Error> {
+    let mut env = create_environment();
+
+    // Preprocess template
+    let processed_template = preprocess_template(template);
+    env.add_template("prompt", &processed_template)?;
+
+    // Add globals
+    add_globals(&mut env, ctx);
+
+    // Build context - args are already extracted BexExternalValue
+    let jinja_args: minijinja::value::Value = args
+        .iter()
+        .map(|(k, v)| (k.clone(), external_value_to_jinja(v)))
+        .collect();
+    let tmpl = env.get_template("prompt")?;
+
+    // Render
+    let rendered = tmpl.render(jinja_args)?;
+
+    // Parse result into PromptAst
+    Ok(parse_rendered_output(&rendered, ctx))
+}
+
+fn create_environment() -> Environment<'static> {
+    let mut env = Environment::new();
+
+    // Configure environment
+    env.set_debug(true);
+    env.set_trim_blocks(true);
+    env.set_lstrip_blocks(true);
+
+    // Add filters
+    env.add_filter("regex_match", filters::regex_match);
+    env.add_filter("sum", filters::sum);
+
+    // Custom formatter: replace 'none' with 'null'
+    env.set_formatter(|out, _state, value| {
+        if value.is_none() || value.is_undefined() {
+            write!(out, "null").map_err(|e| {
+                minijinja::Error::new(minijinja::ErrorKind::WriteFailure, e.to_string())
+            })
+        } else {
+            write!(out, "{value}").map_err(|e| {
+                minijinja::Error::new(minijinja::ErrorKind::WriteFailure, e.to_string())
+            })
+        }
+    });
+
+    env
+}
+
+/// Preprocess template: dedent and trim.
+///
+/// Dedenting logic ported from engine/baml-lib/jinja-runtime/src/lib.rs:266-277
+fn preprocess_template(template: &str) -> String {
+    // Dedent: find minimum whitespace and remove from all lines
+    let lines: Vec<&str> = template.lines().collect();
+
+    let min_indent = lines
+        .iter()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| line.len() - line.trim_start().len())
+        .min()
+        .unwrap_or(0);
+
+    lines
+        .iter()
+        .map(|line| {
+            if line.len() >= min_indent {
+                &line[min_indent..]
+            } else {
+                line.trim()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+fn add_globals(env: &mut Environment, ctx: &RenderContext) {
+    use minijinja::context;
+
+    // Create role function - same function used for both _.role() and _.chat()
+    // Ported from engine/baml-lib/jinja-runtime/src/lib.rs:382-387
+    let default_role = ctx.client.default_role.clone();
+    let role_fn = minijinja::value::Value::from_function(move |role: Option<String>| -> String {
+        let r = role.unwrap_or_else(|| default_role.clone());
+        format!(
+            "{MAGIC_CHAT_ROLE_DELIMITER}:baml-start-role:{r}:baml-end-role:{MAGIC_CHAT_ROLE_DELIMITER}"
+        )
+    });
+
+    // Add _ namespace with chat and role functions
+    env.add_global(
+        "_",
+        context! {
+            chat => role_fn,
+            role => role_fn,
+        },
+    );
+
+    // Add ctx namespace with output_format
+    // Ported from engine/baml-lib/jinja-runtime/src/output_format/mod.rs
+    let output_format = OutputFormatObject::new(ctx.output_format.clone());
+    env.add_global(
+        "ctx",
+        context! {
+            client => context! {
+                name => ctx.client.name.clone(),
+                provider => ctx.client.provider.clone(),
+            },
+            tags => ctx.tags.iter().map(|(k, v)| (k.clone(), external_value_to_jinja(v))).collect::<minijinja::value::Value>(),
+            output_format => minijinja::value::Value::from_object(output_format),
+        },
+    );
+}
+
+fn parse_rendered_output(rendered: &str, ctx: &RenderContext) -> PromptAst {
+    // Check if this is a chat-style prompt (contains role delimiters)
+    if rendered.contains(MAGIC_CHAT_ROLE_DELIMITER) {
+        parse_chat_prompt(rendered, ctx)
+    } else {
+        // Simple completion prompt
+        PromptAst::String(rendered.to_string())
+    }
+}
+
+fn parse_chat_prompt(rendered: &str, _ctx: &RenderContext) -> PromptAst {
+    let mut messages = Vec::new();
+
+    // Split on role delimiter
+    let parts: Vec<&str> = rendered.split(MAGIC_CHAT_ROLE_DELIMITER).collect();
+
+    let mut current_role: Option<String> = None;
+    let mut current_content = String::new();
+
+    for part in parts {
+        if part.starts_with(":baml-start-role:") && part.ends_with(":baml-end-role:") {
+            // Save previous message if any
+            if let Some(role) = current_role.take() {
+                let content = parse_message_content(&current_content);
+                messages.push(PromptAst::Message {
+                    role,
+                    content: Box::new(content),
+                    metadata: Value::Null,
+                });
+                current_content.clear();
+            }
+
+            // Extract new role
+            let role = part
+                .strip_prefix(":baml-start-role:")
+                .and_then(|s| s.strip_suffix(":baml-end-role:"))
+                .unwrap_or("user")
+                .to_string();
+            current_role = Some(role);
+        } else {
+            current_content.push_str(part);
+        }
+    }
+
+    // Save last message
+    if let Some(role) = current_role {
+        let content = parse_message_content(&current_content);
+        messages.push(PromptAst::Message {
+            role,
+            content: Box::new(content),
+            metadata: Value::Null,
+        });
+    }
+
+    if messages.is_empty() {
+        PromptAst::String(rendered.to_string())
+    } else if messages.len() == 1 {
+        messages.pop().unwrap()
+    } else {
+        PromptAst::Vec(messages)
+    }
+}
+
+fn parse_message_content(content: &str) -> PromptAst {
+    // Check for media delimiters
+    if content.contains(MAGIC_MEDIA_DELIMITER) {
+        let mut parts = Vec::new();
+        let chunks: Vec<&str> = content.split(MAGIC_MEDIA_DELIMITER).collect();
+
+        for (i, chunk) in chunks.iter().enumerate() {
+            if i % 2 == 1 {
+                // This is a media chunk - parse the handle
+                // Format: :baml-start-media:{handle}:baml-end-media:
+                if let Some(handle) = parse_media_handle(chunk) {
+                    parts.push(PromptAst::Media(handle));
+                }
+            } else if !chunk.trim().is_empty() {
+                parts.push(PromptAst::String((*chunk).to_string()));
+            }
+        }
+
+        if parts.len() == 1 {
+            parts.pop().unwrap()
+        } else {
+            PromptAst::Vec(parts)
+        }
+    } else {
+        PromptAst::String(content.trim().to_string())
+    }
+}
+
+fn parse_media_handle(chunk: &str) -> Option<usize> {
+    // Extract handle from format: :baml-start-media:{handle}:baml-end-media:
+    chunk
+        .strip_prefix(":baml-start-media:")
+        .and_then(|s| s.strip_suffix(":baml-end-media:"))
+        .and_then(|s| s.parse().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use bex_program::Ty;
+
+    use super::*;
+
+    fn test_ctx() -> RenderContext {
+        RenderContext {
+            client: RenderContextClient {
+                name: "test".to_string(),
+                provider: "openai".to_string(),
+                default_role: "user".to_string(),
+                allowed_roles: vec![
+                    "user".to_string(),
+                    "assistant".to_string(),
+                    "system".to_string(),
+                ],
+            },
+            output_format: OutputFormatContent::new(Ty::String),
+            tags: IndexMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_simple_string() {
+        let template = "Hello, world!";
+        let args = IndexMap::new();
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+
+        assert_eq!(result, PromptAst::String("Hello, world!".to_string()));
+    }
+
+    #[test]
+    fn test_variable_substitution() {
+        let template = "Hello, {{ name }}!";
+
+        let mut args = IndexMap::new();
+        args.insert(
+            "name".to_string(),
+            BexExternalValue::String("Alice".to_string()),
+        );
+
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+
+        assert_eq!(result, PromptAst::String("Hello, Alice!".to_string()));
+    }
+
+    #[test]
+    fn test_nested_object() {
+        let template = "Name: {{ person.name }}, Age: {{ person.age }}";
+
+        let mut person_fields = IndexMap::new();
+        person_fields.insert(
+            "name".to_string(),
+            BexExternalValue::String("Bob".to_string()),
+        );
+        person_fields.insert("age".to_string(), BexExternalValue::Int(30));
+
+        let mut args = IndexMap::new();
+        args.insert(
+            "person".to_string(),
+            BexExternalValue::Instance {
+                class_name: "Person".to_string(),
+                fields: person_fields,
+            },
+        );
+
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+
+        assert_eq!(result, PromptAst::String("Name: Bob, Age: 30".to_string()));
+    }
+
+    #[test]
+    fn test_chat_with_roles() {
+        let template = r#"
+            {{ _.role("system") }}
+            You are a helpful assistant.
+            {{ _.role("user") }}
+            Hello!
+        "#;
+        let args = IndexMap::new();
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+
+        let expected = PromptAst::Vec(vec![
+            PromptAst::Message {
+                role: "system".to_string(),
+                content: Box::new(PromptAst::String(
+                    "You are a helpful assistant.".to_string(),
+                )),
+                metadata: Value::Null,
+            },
+            PromptAst::Message {
+                role: "user".to_string(),
+                content: Box::new(PromptAst::String("Hello!".to_string())),
+                metadata: Value::Null,
+            },
+        ]);
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_chat_default_role() {
+        let template = r#"
+            {{ _.chat() }}
+            Hello with default role!
+        "#;
+        let args = IndexMap::new();
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+
+        let expected = PromptAst::Message {
+            role: "user".to_string(),
+            content: Box::new(PromptAst::String("Hello with default role!".to_string())),
+            metadata: Value::Null,
+        };
+
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_dedent() {
+        let template = r#"
+            Hello,
+            World!
+        "#;
+        let args = IndexMap::new();
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+
+        assert_eq!(result, PromptAst::String("Hello,\nWorld!".to_string()));
+    }
+
+    #[test]
+    fn test_array_iteration() {
+        let template = "Items: {% for item in items %}{{ item }}{% if not loop.last %}, {% endif %}{% endfor %}";
+
+        let mut args = IndexMap::new();
+        args.insert(
+            "items".to_string(),
+            BexExternalValue::Array {
+                element_type: Ty::String,
+                items: vec![
+                    BexExternalValue::String("apple".to_string()),
+                    BexExternalValue::String("banana".to_string()),
+                    BexExternalValue::String("cherry".to_string()),
+                ],
+            },
+        );
+
+        let result = render_prompt(template, &args, &test_ctx()).unwrap();
+
+        assert_eq!(
+            result,
+            PromptAst::String("Items: apple, banana, cherry".to_string())
+        );
+    }
+
+    #[test]
+    fn test_output_format_in_template() {
+        let template = "{{ ctx.output_format }}";
+        let args = IndexMap::new();
+
+        // Create a context with an int output format
+        let mut ctx = test_ctx();
+        ctx.output_format = OutputFormatContent::new(Ty::Int);
+
+        let result = render_prompt(template, &args, &ctx).unwrap();
+
+        assert_eq!(result, PromptAst::String("Answer as an int".to_string()));
+    }
+
+    #[test]
+    fn test_output_format_with_kwargs() {
+        let template = "{{ ctx.output_format(prefix='Please respond with: ') }}";
+        let args = IndexMap::new();
+
+        let mut ctx = test_ctx();
+        ctx.output_format = OutputFormatContent::new(Ty::Int);
+
+        let result = render_prompt(template, &args, &ctx).unwrap();
+
+        assert_eq!(
+            result,
+            PromptAst::String("Please respond with: int".to_string())
+        );
+    }
+}

--- a/baml_language/crates/bex_jinja_runtime/src/value_conversion.rs
+++ b/baml_language/crates/bex_jinja_runtime/src/value_conversion.rs
@@ -1,0 +1,69 @@
+use bex_external_types::BexExternalValue;
+use indexmap::IndexMap;
+use minijinja::value::Value as JinjaValue;
+
+use crate::MAGIC_MEDIA_DELIMITER;
+
+/// Convert a `BexExternalValue` to a minijinja Value.
+///
+/// `BexExternalValue` is already fully extracted from the VM heap,
+/// so no heap access is needed here.
+pub(crate) fn external_value_to_jinja(value: &BexExternalValue) -> JinjaValue {
+    match value {
+        BexExternalValue::Null => JinjaValue::from(()), // Maps to None in Jinja
+        BexExternalValue::Int(i) => JinjaValue::from(*i),
+        BexExternalValue::Float(f) => JinjaValue::from(*f),
+        BexExternalValue::Bool(b) => JinjaValue::from(*b),
+        BexExternalValue::String(s) => JinjaValue::from(s.as_str()),
+
+        BexExternalValue::Array { items, .. } => {
+            let jinja_items: Vec<JinjaValue> = items.iter().map(external_value_to_jinja).collect();
+            JinjaValue::from(jinja_items)
+        }
+
+        BexExternalValue::Map { entries, .. } => {
+            let jinja_map: IndexMap<String, JinjaValue> = entries
+                .iter()
+                .map(|(k, v)| (k.clone(), external_value_to_jinja(v)))
+                .collect();
+            JinjaValue::from_iter(jinja_map)
+        }
+
+        BexExternalValue::Instance { fields, .. } => {
+            // Convert instance fields to a map for Jinja access
+            let jinja_map: IndexMap<String, JinjaValue> = fields
+                .iter()
+                .map(|(k, v)| (k.clone(), external_value_to_jinja(v)))
+                .collect();
+            JinjaValue::from_iter(jinja_map)
+        }
+
+        BexExternalValue::Variant {
+            variant_name,
+            enum_name: _,
+        } => {
+            // Enum variants are rendered as their variant name
+            JinjaValue::from(variant_name.as_str())
+        }
+
+        BexExternalValue::Union { value, .. } => {
+            // Unwrap the union and convert the inner value
+            external_value_to_jinja(value)
+        }
+
+        BexExternalValue::Media { .. } => {
+            // TODO: Media handling will be implemented in a separate pass.
+            // For now, stub out with a placeholder that will be parsed back.
+            // The actual media resolution mechanism needs to be designed.
+            let placeholder_handle: usize = 0; // Stubbed - real implementation TBD
+            JinjaValue::from(format!(
+                "{MAGIC_MEDIA_DELIMITER}:baml-start-media:{placeholder_handle}:baml-end-media:{MAGIC_MEDIA_DELIMITER}"
+            ))
+        }
+
+        BexExternalValue::Resource(_) => {
+            // Resources shouldn't appear in template arguments
+            JinjaValue::from("[Resource]")
+        }
+    }
+}

--- a/baml_language/crates/bex_llm_types/Cargo.toml
+++ b/baml_language/crates/bex_llm_types/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bex_llm_types"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+bex_program = { workspace = true }
+indexmap = { workspace = true }
+thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/baml_language/crates/bex_llm_types/src/lib.rs
+++ b/baml_language/crates/bex_llm_types/src/lib.rs
@@ -1,0 +1,14 @@
+//! Types for LLM prompt rendering in BAML.
+//!
+//! This crate contains:
+//! - `OutputFormatContent` - Schema for LLM output format rendering
+//! - `Enum`, `Class` - Simplified type definitions
+//! - `RenderOptions` - Configuration for output format rendering
+//! - `RenderError` - Error type for rendering failures
+
+mod output_format;
+
+pub use output_format::{
+    Class, Enum, HoistClasses, MapStyle, OutputFormatContent, RenderError, RenderOptions,
+    RenderSetting,
+};

--- a/baml_language/crates/bex_llm_types/src/output_format.rs
+++ b/baml_language/crates/bex_llm_types/src/output_format.rs
@@ -1,0 +1,539 @@
+use bex_program::{LiteralValue, Ty};
+use indexmap::IndexMap;
+use thiserror::Error;
+
+/// Error type for output format rendering.
+#[derive(Debug, Error)]
+pub enum RenderError {
+    #[error("Enum '{0}' not found")]
+    EnumNotFound(String),
+    #[error("Class '{0}' not found")]
+    ClassNotFound(String),
+    #[error("Type '{0}' is not supported in outputs")]
+    UnsupportedType(String),
+}
+
+/// An enum definition for output format rendering.
+#[derive(Clone, Debug)]
+pub struct Enum {
+    pub name: String,
+    pub values: Vec<(String, Option<String>)>, // (value_name, description)
+}
+
+/// A class definition for output format rendering.
+#[derive(Clone, Debug)]
+pub struct Class {
+    pub name: String,
+    pub description: Option<String>,
+    pub fields: Vec<(String, Ty, Option<String>)>, // (name, type, description)
+}
+
+/// Content for rendering output format schemas.
+#[derive(Clone, Debug)]
+pub struct OutputFormatContent {
+    pub enums: IndexMap<String, Enum>,
+    pub classes: IndexMap<String, Class>,
+    pub target: Ty,
+}
+
+impl OutputFormatContent {
+    /// Create a new `OutputFormatContent` with the given target type.
+    pub fn new(target: Ty) -> Self {
+        Self {
+            enums: IndexMap::new(),
+            classes: IndexMap::new(),
+            target,
+        }
+    }
+
+    /// Add an enum definition.
+    #[must_use]
+    pub fn with_enum(mut self, enm: Enum) -> Self {
+        self.enums.insert(enm.name.clone(), enm);
+        self
+    }
+
+    /// Add a class definition.
+    #[must_use]
+    pub fn with_class(mut self, cls: Class) -> Self {
+        self.classes.insert(cls.name.clone(), cls);
+        self
+    }
+
+    /// Find an enum by name.
+    pub fn find_enum(&self, name: &str) -> Option<&Enum> {
+        self.enums.get(name)
+    }
+
+    /// Find a class by name.
+    pub fn find_class(&self, name: &str) -> Option<&Class> {
+        self.classes.get(name)
+    }
+
+    /// Render the output format schema as a string.
+    pub fn render(&self, options: &RenderOptions) -> Result<Option<String>, RenderError> {
+        self.render_impl(options)
+    }
+
+    fn render_impl(&self, options: &RenderOptions) -> Result<Option<String>, RenderError> {
+        // For string target with no explicit prefix, return None
+        if matches!(self.target, Ty::String) && matches!(options.prefix, RenderSetting::Auto) {
+            return Ok(None);
+        }
+
+        let prefix = self.get_prefix(options);
+
+        // For simple primitives (int, float, bool) with Auto prefix, the prefix IS the full message
+        // But with explicit prefix, we need to append the type
+        if matches!(self.target, Ty::Int | Ty::Float | Ty::Bool)
+            && matches!(options.prefix, RenderSetting::Auto)
+        {
+            return Ok(prefix);
+        }
+
+        let rendered_type = self.render_type(&self.target, options)?;
+
+        match (prefix, rendered_type) {
+            (Some(p), Some(t)) => Ok(Some(format!("{p}{t}"))),
+            (Some(p), None) => Ok(Some(p)),
+            (None, Some(t)) => Ok(Some(t)),
+            (None, None) => Ok(None),
+        }
+    }
+
+    fn get_prefix(&self, options: &RenderOptions) -> Option<String> {
+        match &options.prefix {
+            RenderSetting::Always(p) => Some(p.clone()),
+            RenderSetting::Never => None,
+            RenderSetting::Auto => match &self.target {
+                Ty::String => None,
+                Ty::Int => Some("Answer as an int".to_string()),
+                Ty::Float => Some("Answer as a float".to_string()),
+                Ty::Bool => Some("Answer as a bool".to_string()),
+                Ty::List(_) => Some("Answer with a JSON Array using this schema:\n".to_string()),
+                Ty::Class(_) | Ty::Map { .. } => {
+                    Some("Answer in JSON using this schema:\n".to_string())
+                }
+                Ty::Enum(_) => None, // Enum prefix handled differently
+                Ty::Union(_) => Some("Answer in JSON using this schema:\n".to_string()),
+                Ty::Literal(_) => Some("Answer using this specific value:\n".to_string()),
+                _ => None,
+            },
+        }
+    }
+
+    fn render_type(&self, ty: &Ty, options: &RenderOptions) -> Result<Option<String>, RenderError> {
+        match ty {
+            Ty::String => Ok(Some("string".to_string())),
+            Ty::Int => Ok(Some("int".to_string())),
+            Ty::Float => Ok(Some("float".to_string())),
+            Ty::Bool => Ok(Some("bool".to_string())),
+            Ty::Null => Ok(Some("null".to_string())),
+
+            Ty::Optional(inner) => {
+                let inner_str = self
+                    .render_type(inner, options)?
+                    .unwrap_or_else(|| "unknown".to_string());
+                Ok(Some(format!("{inner_str} | null")))
+            }
+
+            Ty::List(inner) => {
+                let inner_str = self
+                    .render_type(inner, options)?
+                    .unwrap_or_else(|| "unknown".to_string());
+                Ok(Some(format!("{inner_str}[]")))
+            }
+
+            Ty::Map { key, value } => {
+                let key_str = self
+                    .render_type(key, options)?
+                    .unwrap_or_else(|| "string".to_string());
+                let value_str = self
+                    .render_type(value, options)?
+                    .unwrap_or_else(|| "unknown".to_string());
+                match options.map_style {
+                    MapStyle::TypeParameters => Ok(Some(format!("map<{key_str}, {value_str}>"))),
+                    MapStyle::ObjectLiteral => {
+                        Ok(Some(format!("{{ [key: {key_str}]: {value_str} }}")))
+                    }
+                }
+            }
+
+            Ty::Union(variants) => {
+                let rendered: Vec<String> = variants
+                    .iter()
+                    .filter_map(|v| self.render_type(v, options).ok().flatten())
+                    .collect();
+                let splitter = match &options.or_splitter {
+                    RenderSetting::Always(s) => s.as_str(),
+                    RenderSetting::Auto | RenderSetting::Never => " or ",
+                };
+                Ok(Some(rendered.join(splitter)))
+            }
+
+            Ty::Enum(name) => {
+                if let Some(enm) = self.find_enum(name) {
+                    Ok(Some(self.render_enum(enm, options)))
+                } else {
+                    Ok(Some(name.clone()))
+                }
+            }
+
+            Ty::Class(name) => {
+                if let Some(cls) = self.find_class(name) {
+                    Ok(Some(self.render_class(cls, options)?))
+                } else {
+                    Ok(Some(name.clone()))
+                }
+            }
+
+            Ty::Media(_) => Err(RenderError::UnsupportedType("media".to_string())),
+
+            // Literal rendering follows LiteralValue::Display from engine:
+            // - String: "value" (quoted with double quotes)
+            // - Int: 42 (plain number)
+            // - Bool: true/false
+            Ty::Literal(lit) => Ok(Some(render_literal(lit))),
+        }
+    }
+
+    #[allow(clippy::unused_self)]
+    fn render_enum(&self, enm: &Enum, _options: &RenderOptions) -> String {
+        let values: Vec<String> = enm
+            .values
+            .iter()
+            .map(|(name, desc)| match desc {
+                Some(d) => format!("{name} // {d}"),
+                None => name.clone(),
+            })
+            .collect();
+        values.join("\n")
+    }
+
+    fn render_class(&self, cls: &Class, options: &RenderOptions) -> Result<String, RenderError> {
+        use std::fmt::Write;
+
+        let mut fields_str = Vec::new();
+
+        for (name, ty, desc) in &cls.fields {
+            let ty_str = self
+                .render_type(ty, options)?
+                .unwrap_or_else(|| "unknown".to_string());
+            let quote_fields = matches!(options.quote_class_fields, RenderSetting::Always(true));
+            let field_name = if quote_fields {
+                format!("\"{name}\"")
+            } else {
+                name.clone()
+            };
+            let field = match desc {
+                Some(d) => format!("  {field_name}: {ty_str}, // {d}"),
+                None => format!("  {field_name}: {ty_str},"),
+            };
+            fields_str.push(field);
+        }
+
+        let mut output = String::new();
+        if let Some(ref d) = cls.description {
+            let _ = writeln!(output, "// {d}");
+        }
+        output.push_str("{\n");
+        output.push_str(&fields_str.join("\n"));
+        output.push_str("\n}");
+
+        Ok(output)
+    }
+}
+
+/// Render a literal value following engine's `LiteralValue::Display` convention.
+fn render_literal(lit: &LiteralValue) -> String {
+    match lit {
+        LiteralValue::String(s) => format!("\"{s}\""),
+        LiteralValue::Int(n) => n.to_string(),
+        LiteralValue::Bool(b) => b.to_string(),
+    }
+}
+
+/// Tri-state setting: Auto (default behavior), Always(value), or Never.
+/// Ported from engine/baml-lib/jinja-runtime/src/output_format/types.rs:193-199
+#[derive(Clone, Debug, Default)]
+pub enum RenderSetting<T> {
+    #[default]
+    Auto,
+    Always(T),
+    Never,
+}
+
+/// Map rendering style.
+/// Ported from engine/baml-lib/jinja-runtime/src/output_format/types.rs:201-208
+#[derive(Clone, Debug, Default)]
+pub enum MapStyle {
+    /// Render as `map<K, V>` (angle bracket style)
+    #[default]
+    TypeParameters,
+    /// Render as `{ [key: K]: V }` (object literal style)
+    ObjectLiteral,
+}
+
+/// Hoist classes setting.
+/// Ported from engine/baml-lib/jinja-runtime/src/output_format/types.rs:213-221
+#[derive(Clone, Debug, Default)]
+pub enum HoistClasses {
+    /// Hoist all classes.
+    All,
+    /// Hoist only the specified subset.
+    Subset(Vec<String>),
+    /// Default behavior (for now: don't hoist, since we don't track recursive classes).
+    #[default]
+    Auto,
+}
+
+/// Options for rendering output format.
+/// Ported from engine/baml-lib/jinja-runtime/src/output_format/types.rs:226-235
+#[derive(Clone, Debug)]
+pub struct RenderOptions {
+    /// Prefix for the output format (e.g., "Answer in JSON using this schema:")
+    pub prefix: RenderSetting<String>,
+    /// Separator for union/or types (default: " or ")
+    pub or_splitter: RenderSetting<String>,
+    /// Prefix for enum values
+    pub enum_value_prefix: RenderSetting<String>,
+    /// Prefix for hoisted class definitions
+    pub hoisted_class_prefix: RenderSetting<String>,
+    /// Which classes to hoist
+    pub hoist_classes: HoistClasses,
+    /// Whether to always hoist enums
+    pub always_hoist_enums: RenderSetting<bool>,
+    /// Map rendering style
+    pub map_style: MapStyle,
+    /// Whether to quote class field names
+    pub quote_class_fields: RenderSetting<bool>,
+}
+
+impl Default for RenderOptions {
+    fn default() -> Self {
+        Self {
+            prefix: RenderSetting::Auto,
+            or_splitter: RenderSetting::Auto,
+            enum_value_prefix: RenderSetting::Auto,
+            hoisted_class_prefix: RenderSetting::Auto,
+            hoist_classes: HoistClasses::Auto,
+            always_hoist_enums: RenderSetting::Auto,
+            map_style: MapStyle::TypeParameters,
+            quote_class_fields: RenderSetting::Auto,
+        }
+    }
+}
+
+impl RenderOptions {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_string() {
+        let content = OutputFormatContent::new(Ty::String);
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(rendered, None);
+    }
+
+    #[test]
+    fn test_render_int() {
+        let content = OutputFormatContent::new(Ty::Int);
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(rendered, Some("Answer as an int".to_string()));
+    }
+
+    #[test]
+    fn test_render_float() {
+        let content = OutputFormatContent::new(Ty::Float);
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(rendered, Some("Answer as a float".to_string()));
+    }
+
+    #[test]
+    fn test_render_bool() {
+        let content = OutputFormatContent::new(Ty::Bool);
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(rendered, Some("Answer as a bool".to_string()));
+    }
+
+    #[test]
+    fn test_render_list() {
+        let content = OutputFormatContent::new(Ty::List(Box::new(Ty::String)));
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some("Answer with a JSON Array using this schema:\nstring[]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_list_of_int() {
+        let content = OutputFormatContent::new(Ty::List(Box::new(Ty::Int)));
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some("Answer with a JSON Array using this schema:\nint[]".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_optional() {
+        let content = OutputFormatContent::new(Ty::Optional(Box::new(Ty::String)));
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(rendered, Some("string | null".to_string()));
+    }
+
+    #[test]
+    fn test_render_map() {
+        let content = OutputFormatContent::new(Ty::Map {
+            key: Box::new(Ty::String),
+            value: Box::new(Ty::Int),
+        });
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some("Answer in JSON using this schema:\nmap<string, int>".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_class() {
+        let cls = Class {
+            name: "Person".to_string(),
+            description: Some("A person".to_string()),
+            fields: vec![
+                ("name".to_string(), Ty::String, None),
+                ("age".to_string(), Ty::Int, Some("Age in years".to_string())),
+            ],
+        };
+
+        let content = OutputFormatContent::new(Ty::Class("Person".to_string())).with_class(cls);
+
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some(
+                "Answer in JSON using this schema:\n\
+                 // A person\n\
+                 {\n  \
+                   name: string,\n  \
+                   age: int, // Age in years\n\
+                 }"
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_render_class_no_description() {
+        let cls = Class {
+            name: "Point".to_string(),
+            description: None,
+            fields: vec![
+                ("x".to_string(), Ty::Int, None),
+                ("y".to_string(), Ty::Int, None),
+            ],
+        };
+
+        let content = OutputFormatContent::new(Ty::Class("Point".to_string())).with_class(cls);
+
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some(
+                "Answer in JSON using this schema:\n\
+                 {\n  \
+                   x: int,\n  \
+                   y: int,\n\
+                 }"
+                .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_render_enum() {
+        let enm = Enum {
+            name: "Color".to_string(),
+            values: vec![
+                ("Red".to_string(), None),
+                ("Green".to_string(), Some("Like grass".to_string())),
+                ("Blue".to_string(), None),
+            ],
+        };
+
+        let content = OutputFormatContent::new(Ty::Enum("Color".to_string())).with_enum(enm);
+
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some(
+                "Red\n\
+                 Green // Like grass\n\
+                 Blue"
+                    .to_string()
+            )
+        );
+    }
+
+    #[test]
+    fn test_render_union() {
+        let content = OutputFormatContent::new(Ty::Union(vec![Ty::String, Ty::Int, Ty::Bool]));
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some("Answer in JSON using this schema:\nstring or int or bool".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_with_custom_or_splitter() {
+        let content = OutputFormatContent::new(Ty::Union(vec![Ty::String, Ty::Int]));
+        let options = RenderOptions {
+            or_splitter: RenderSetting::Always(" | ".to_string()),
+            ..Default::default()
+        };
+        let rendered = content.render(&options).unwrap();
+        assert_eq!(
+            rendered,
+            Some("Answer in JSON using this schema:\nstring | int".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_literal_string() {
+        let content =
+            OutputFormatContent::new(Ty::Literal(LiteralValue::String("hello".to_string())));
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some("Answer using this specific value:\n\"hello\"".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_literal_int() {
+        let content = OutputFormatContent::new(Ty::Literal(LiteralValue::Int(42)));
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some("Answer using this specific value:\n42".to_string())
+        );
+    }
+
+    #[test]
+    fn test_render_literal_bool() {
+        let content = OutputFormatContent::new(Ty::Literal(LiteralValue::Bool(true)));
+        let rendered = content.render(&RenderOptions::default()).unwrap();
+        assert_eq!(
+            rendered,
+            Some("Answer using this specific value:\ntrue".to_string())
+        );
+    }
+}

--- a/baml_language/crates/bex_vm_types/Cargo.toml
+++ b/baml_language/crates/bex_vm_types/Cargo.toml
@@ -29,9 +29,12 @@ paste = { workspace = true }
 [dev-dependencies]
 baml_compiler_emit = { workspace = true }
 baml_tests = { workspace = true }
+
 anyhow = { workspace = true }
 divan = { workspace = true }
 indexmap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = [ "rt", "macros" ] }
 
 [features]

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -23,6 +23,5 @@ pub use heap_ptr::HeapPtr;
 pub use indexable::{GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, StackIndex};
 pub use types::{
     Class, ConstValue, Enum, ExternalOp, Function, FunctionKind, Future, Instance, Object,
-    ObjectType, PendingFuture, PrintOutputFormatOptions, Program, PromptAst, SysOp, Value, Variant,
-    type_tags,
+    ObjectType, PendingFuture, Program, PromptAst, SysOp, Value, Variant, type_tags,
 };

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -583,21 +583,15 @@ impl std::fmt::Display for MediaContent {
 // PromptAst - represents a structured prompt (recursive tree)
 // ============================================================================
 
-/// Options for printing an output format in a prompt.
-#[derive(Debug, Clone)]
-pub struct PrintOutputFormatOptions {
-    /// Separator for union/or types (e.g., " | " or " or ")
-    pub or_splitter: String,
-}
-
 /// A node in the prompt AST tree.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum PromptAst {
     /// A plain string.
     String(String),
 
-    /// A media value (image, audio, video, etc.) - references heap object.
-    Media(HeapPtr),
+    /// A media value - serializable opaque handle.
+    /// WARNING: usize is platform-dependent. Serialization must occur within the same platform.
+    Media(usize),
 
     /// A message with a role, content, and optional metadata.
     Message {
@@ -608,9 +602,6 @@ pub enum PromptAst {
 
     /// A sequence of prompt nodes.
     Vec(Vec<PromptAst>),
-
-    /// Output format - prints the expected output format for the LLM.
-    PrintOutputFormat(PrintOutputFormatOptions),
 }
 
 /// Types of values.

--- a/baml_language/stow.toml
+++ b/baml_language/stow.toml
@@ -77,6 +77,7 @@ name_exceptions = { "tools_stow" = "cargo-stow" }
 # bex namespace configuration
 [[namespaces]]
 name = "bex"
+approved_prefixes = ["jinja"]
 
 # bex namespace configuration
 [[namespaces]]


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Implements Jinja template rendering for BAML prompts with new `bex_jinja_runtime` and `bex_llm_types` crates. Adds template preprocessing, value conversion, output format rendering, and chat message parsing with magic delimiters.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 48a0b6e406aa48ae9490420376a9dabfb2f05c77.</sup>
<!-- /MENDRAL_SUMMARY -->