### PR TITLE
Emit Discriminant and TypeTag instructions for match optimization

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -496,6 +496,7 @@ dependencies = [
  "baml_compiler_hir",
  "baml_compiler_tir",
  "baml_compiler_vir",
+ "baml_typetags",
  "baml_workspace",
  "la-arena",
  "log",
@@ -709,6 +710,7 @@ dependencies = [
  "baml_compiler_tir",
  "baml_db",
  "baml_project",
+ "baml_typetags",
  "baml_workspace",
  "bex_program",
  "bex_vm",
@@ -724,6 +726,10 @@ dependencies = [
  "tempfile",
  "walkdir",
 ]
+
+[[package]]
+name = "baml_typetags"
+version = "0.1.0"
 
 [[package]]
 name = "baml_workspace"
@@ -870,6 +876,7 @@ dependencies = [
  "baml_builtins_macros",
  "baml_compiler_emit",
  "baml_tests",
+ "baml_typetags",
  "codspeed-divan-compat",
  "colored",
  "indexmap 2.13.0",
@@ -4827,6 +4834,7 @@ dependencies = [
  "baml_compiler_vir",
  "baml_db",
  "baml_project",
+ "baml_typetags",
  "baml_workspace",
  "bex_vm",
  "bex_vm_types",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -42,6 +42,7 @@ baml_lsp = { path = "crates/baml_lsp" }
 baml_lsp_types = { path = "crates/baml_lsp_types" }
 baml_project = { path = "crates/baml_project" }
 baml_tests = { path = "crates/baml_tests" }
+baml_typetags = { path = "crates/baml_typetags" }
 tools_onionskin = { path = "crates/tools_onionskin" }
 bex_vm = { path = "crates/bex_vm" }
 bex_vm_types = { path = "crates/bex_vm_types" }

--- a/baml_language/crates/baml_compiler_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler_emit/src/analysis.rs
@@ -569,7 +569,7 @@ fn collect_uses_in_rvalue(
                 collect_uses_in_operand(field, block, stmt_idx, def_use);
             }
         }
-        Rvalue::Discriminant(place) | Rvalue::Len(place) => {
+        Rvalue::Discriminant(place) | Rvalue::TypeTag(place) | Rvalue::Len(place) => {
             collect_uses_in_place(place, block, stmt_idx, def_use);
         }
         Rvalue::IsType { operand, .. } => {
@@ -1303,7 +1303,7 @@ fn collect_rvalue_reads(rvalue: &Rvalue, locals: &mut Vec<Local>) {
                 collect_operand_reads(op, locals);
             }
         }
-        Rvalue::Discriminant(place) | Rvalue::Len(place) => {
+        Rvalue::Discriminant(place) | Rvalue::TypeTag(place) | Rvalue::Len(place) => {
             collect_place_reads(place, locals);
         }
         Rvalue::IsType { operand, .. } => {

--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -672,7 +672,12 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
 
             Rvalue::Discriminant(place) => {
                 self.emit_place_value_pull(place, mir);
-                // TODO: Emit actual discriminant extraction instruction
+                self.emit(Instruction::Discriminant);
+            }
+
+            Rvalue::TypeTag(place) => {
+                self.emit_place_value_pull(place, mir);
+                self.emit(Instruction::TypeTag);
             }
 
             Rvalue::Len(place) => {

--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -860,6 +860,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 discriminant,
                 arms,
                 otherwise,
+                exhaustive,
             } => {
                 // Analyze the switch to determine the best emission strategy
                 let strategy = analyze_switch(arms);
@@ -869,10 +870,16 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                         self.emit_switch_jump_table(discriminant, arms, *otherwise, min, max, mir);
                     }
                     SwitchStrategy::BinarySearch => {
-                        self.emit_switch_binary_search(discriminant, arms, *otherwise, mir);
+                        self.emit_switch_binary_search(
+                            discriminant,
+                            arms,
+                            *otherwise,
+                            *exhaustive,
+                            mir,
+                        );
                     }
                     SwitchStrategy::IfElseChain => {
-                        self.emit_switch_if_else(discriminant, arms, *otherwise, mir);
+                        self.emit_switch_if_else(discriminant, arms, *otherwise, *exhaustive, mir);
                     }
                 }
             }
@@ -1011,16 +1018,30 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
     /// Emit switch using if-else chain (O(n) comparisons).
     ///
     /// This is the original linear emission strategy.
+    ///
+    /// If `exhaustive` is true, the last arm's comparison is skipped since
+    /// if all previous comparisons failed, the discriminant must match.
     fn emit_switch_if_else(
         &mut self,
         discriminant: &Operand,
         arms: &[(i64, BlockId)],
         otherwise: BlockId,
+        exhaustive: bool,
         mir: &MirFunction,
     ) {
         self.emit_operand_pull(discriminant, mir);
 
-        for (value, target) in arms {
+        let num_arms = arms.len();
+        for (i, (value, target)) in arms.iter().enumerate() {
+            let is_last = i == num_arms - 1;
+
+            // For exhaustive switches, skip the last arm's comparison
+            if exhaustive && is_last {
+                self.emit(Instruction::Pop(1)); // Pop discriminant
+                self.emit_jump_unless_fallthrough(*target);
+                return;
+            }
+
             self.emit(Instruction::Copy(0));
             let idx = self.add_constant(ConstValue::Int(*value));
             self.emit(Instruction::LoadConst(idx));
@@ -1074,11 +1095,16 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
     /// Emit switch using binary search (O(log n) comparisons).
     ///
     /// Creates a balanced binary search tree of comparisons.
+    ///
+    /// Note: The exhaustive optimization is not applied to binary search because
+    /// the savings are minimal (O(1) instruction in O(log n) total) and the
+    /// implementation would be complex (need to track rightmost leaf of tree).
     fn emit_switch_binary_search(
         &mut self,
         discriminant: &Operand,
         arms: &[(i64, BlockId)],
         otherwise: BlockId,
+        _exhaustive: bool,
         mir: &MirFunction,
     ) {
         // Push discriminant onto stack (will be popped by comparisons)

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -112,9 +112,11 @@ pub fn compile_files(
 
     // Build classes map (class name -> field name -> field index) and add Class objects to program
     // Also build class_field_types for type inference (class name -> field name -> Ty)
+    // Also build class_type_tags for TypeTag switch optimization (class name -> type tag)
     let mut classes: HashMap<String, HashMap<String, usize>> = HashMap::new();
     let mut class_field_types: HashMap<Name, HashMap<Name, baml_compiler_tir::Ty>> = HashMap::new();
     let mut class_object_indices: HashMap<String, usize> = HashMap::new();
+    let mut class_type_tags: HashMap<String, i64> = HashMap::new();
     let mut class_type_tag_counter = 0i64;
 
     for file in files {
@@ -136,11 +138,15 @@ pub fn compile_files(
                     field_types.insert(field.name.clone(), ty);
                 }
 
+                // Compute type tag for this class
+                let type_tag = type_tags::CLASS_BASE + class_type_tag_counter;
+                class_type_tags.insert(class_name.clone(), type_tag);
+
                 // Add Class object to program and record its index
                 let class_obj = Object::Class(Class {
                     name: class_name.clone(),
                     field_names,
-                    type_tag: type_tags::CLASS_BASE + class_type_tag_counter,
+                    type_tag,
                 });
                 class_type_tag_counter += 1;
                 let class_obj_idx = program.add_object(class_obj);
@@ -293,6 +299,8 @@ pub fn compile_files(
                             &vir,
                             db,
                             &classes,
+                            &enum_variants,
+                            &class_type_tags,
                             &resolution_ctx,
                         );
 

--- a/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
@@ -1579,7 +1579,8 @@ fn match_spanning_zero_jump_table() -> anyhow::Result<()> {
 // Enum Variant Switch Tests
 // ============================================================================
 
-/// Enum variant patterns should generate efficient switch-like code.
+/// Enum variant patterns with 3 arms use if-else chain with Discriminant extraction.
+/// (`JumpTable` requires 4+ arms)
 #[test]
 fn match_enum_variant_switch() -> anyhow::Result<()> {
     assert_compiles(Program {
@@ -1600,32 +1601,133 @@ fn match_enum_variant_switch() -> anyhow::Result<()> {
         "#,
         expected: vec![(
             "classify",
-            // Enum variants use AllocVariant to create variant values for comparison
-            // This is an exhaustive match, so last arm skips comparison
+            // With Discriminant instruction: extract variant index once, then compare integers
+            // This is more efficient than creating variant objects for each comparison
             vec![
-                // First arm: Status.Active
+                // Extract discriminant (variant index) from enum value
                 Instruction::LoadVar("s".to_string()),
-                Instruction::LoadConst(Value::Int(0)), // variant index
-                Instruction::AllocVariant(Value::enm("Status")),
+                Instruction::Discriminant,
+                // First arm: check if variant index == 0 (Active)
+                Instruction::Copy(0),
+                Instruction::LoadConst(Value::Int(0)),
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(2),
-                Instruction::Jump(12),
-                // Second arm: Status.Inactive
-                Instruction::LoadVar("s".to_string()),
-                Instruction::LoadConst(Value::Int(1)), // variant index
-                Instruction::AllocVariant(Value::enm("Status")),
+                Instruction::PopJumpIfFalse(3),
+                Instruction::Pop(1),
+                Instruction::Jump(18),
+                // Second arm: check if variant index == 1 (Inactive)
+                Instruction::Copy(0),
+                Instruction::LoadConst(Value::Int(1)),
                 Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(2),
-                Instruction::Jump(4),
-                // Third arm: Status.Pending (exhaustive - skips comparison)
-                Instruction::Jump(1),
+                Instruction::PopJumpIfFalse(3),
+                Instruction::Pop(1),
+                Instruction::Jump(10),
+                // Third arm: check if variant index == 2 (Pending)
+                Instruction::Copy(0),
+                Instruction::LoadConst(Value::Int(2)),
+                Instruction::CmpOp(CmpOp::Eq),
+                Instruction::PopJumpIfFalse(3),
+                Instruction::Pop(1),
+                Instruction::Jump(2),
+                // Fall through (pop discriminant and jump to unreachable -> pending body)
+                Instruction::Pop(1),
+                // Bodies in reverse order
                 Instruction::LoadConst(Value::string("pending")),
                 Instruction::Jump(4),
-                // Body for Inactive
                 Instruction::LoadConst(Value::string("inactive")),
                 Instruction::Jump(2),
-                // Body for Active
                 Instruction::LoadConst(Value::string("active")),
+                Instruction::Return,
+            ],
+        )],
+    })
+}
+
+/// Enum variant patterns with 4+ arms should use Discriminant + `JumpTable`.
+#[test]
+fn match_enum_four_variants_jump_table() -> anyhow::Result<()> {
+    assert_compiles(Program {
+        source: r#"
+            enum Direction {
+                North
+                East
+                South
+                West
+            }
+
+            function compass(d Direction) -> string {
+                match (d) {
+                    Direction.North => "N",
+                    Direction.East => "E",
+                    Direction.South => "S",
+                    Direction.West => "W"
+                }
+            }
+        "#,
+        expected: vec![(
+            "compass",
+            // With 4 enum variants, use Discriminant + JumpTable for O(1) dispatch
+            vec![
+                // Extract discriminant (variant index) from enum value
+                Instruction::LoadVar("d".to_string()),
+                Instruction::Discriminant,
+                // JumpTable: table_idx=0, default jumps +1 (to first body for exhaustive match)
+                Instruction::JumpTable {
+                    table_idx: 0,
+                    default: 1,
+                },
+                // Bodies in reverse order: West (3), South (2), East (1), North (0)
+                Instruction::LoadConst(Value::string("W")),
+                Instruction::Jump(6),
+                Instruction::LoadConst(Value::string("S")),
+                Instruction::Jump(4),
+                Instruction::LoadConst(Value::string("E")),
+                Instruction::Jump(2),
+                Instruction::LoadConst(Value::string("N")),
+                Instruction::Return,
+            ],
+        )],
+    })
+}
+
+// ============================================================================
+// TypeTag Switch Tests (Union Types with Typed Patterns)
+// ============================================================================
+
+/// Union type with 4+ typed primitive patterns should use `TypeTag` + `JumpTable`.
+#[test]
+fn match_union_type_four_patterns_type_tag() -> anyhow::Result<()> {
+    assert_compiles(Program {
+        source: r#"
+            function identify(x int | string | bool | float) -> string {
+                match (x) {
+                    n: int => "integer",
+                    s: string => "text",
+                    b: bool => "boolean",
+                    f: float => "decimal"
+                }
+            }
+        "#,
+        expected: vec![(
+            "identify",
+            // With 4 typed patterns, use TypeTag + JumpTable for O(1) dispatch
+            // Type tags: int=0, string=1, bool=2, float=4
+            vec![
+                // Extract type tag from union value
+                Instruction::LoadVar("x".to_string()),
+                Instruction::TypeTag,
+                // JumpTable: table_idx=0, default jumps +1 (exhaustive match)
+                Instruction::JumpTable {
+                    table_idx: 0,
+                    default: 1,
+                },
+                // Bodies in reverse order: float (4), bool (2), string (1), int (0)
+                Instruction::LoadConst(Value::string("decimal")),
+                Instruction::Jump(6),
+                Instruction::LoadConst(Value::string("boolean")),
+                Instruction::Jump(4),
+                Instruction::LoadConst(Value::string("text")),
+                Instruction::Jump(2),
+                Instruction::LoadConst(Value::string("integer")),
                 Instruction::Return,
             ],
         )],

--- a/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
@@ -1581,6 +1581,9 @@ fn match_spanning_zero_jump_table() -> anyhow::Result<()> {
 
 /// Enum variant patterns with 3 arms use if-else chain with Discriminant extraction.
 /// (`JumpTable` requires 4+ arms)
+///
+/// For exhaustive enum matches, the last arm's comparison is skipped since if all
+/// other comparisons failed, the value must be the remaining variant.
 #[test]
 fn match_enum_variant_switch() -> anyhow::Result<()> {
     assert_compiles(Program {
@@ -1602,7 +1605,8 @@ fn match_enum_variant_switch() -> anyhow::Result<()> {
         expected: vec![(
             "classify",
             // With Discriminant instruction: extract variant index once, then compare integers
-            // This is more efficient than creating variant objects for each comparison
+            // This is more efficient than creating variant objects for each comparison.
+            // For exhaustive matches, the last arm's comparison is skipped.
             vec![
                 // Extract discriminant (variant index) from enum value
                 Instruction::LoadVar("s".to_string()),
@@ -1613,23 +1617,17 @@ fn match_enum_variant_switch() -> anyhow::Result<()> {
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(3),
                 Instruction::Pop(1),
-                Instruction::Jump(18),
+                Instruction::Jump(13),
                 // Second arm: check if variant index == 1 (Inactive)
                 Instruction::Copy(0),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::CmpOp(CmpOp::Eq),
                 Instruction::PopJumpIfFalse(3),
                 Instruction::Pop(1),
-                Instruction::Jump(10),
-                // Third arm: check if variant index == 2 (Pending)
-                Instruction::Copy(0),
-                Instruction::LoadConst(Value::Int(2)),
-                Instruction::CmpOp(CmpOp::Eq),
-                Instruction::PopJumpIfFalse(3),
+                Instruction::Jump(5),
+                // Third arm: exhaustive match - skip comparison, value must be Pending
                 Instruction::Pop(1),
-                Instruction::Jump(2),
-                // Fall through (pop discriminant and jump to unreachable -> pending body)
-                Instruction::Pop(1),
+                Instruction::Jump(1),
                 // Bodies in reverse order
                 Instruction::LoadConst(Value::string("pending")),
                 Instruction::Jump(4),

--- a/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
@@ -4,7 +4,7 @@ use baml_tests::{
     codegen::{Program, assert_compiles},
     vm::{Instruction, Value},
 };
-use bex_vm_types::bytecode::CmpOp;
+use bex_vm_types::bytecode::{BinOp, CmpOp};
 
 // ============================================================================
 // Basic Catch-All Tests
@@ -1640,6 +1640,64 @@ fn match_enum_variant_switch() -> anyhow::Result<()> {
     })
 }
 
+/// Non-exhaustive enum match (with wildcard) should NOT get the exhaustive optimization.
+/// The last arm's comparison must still be emitted because the wildcard catches
+/// values that don't match any variant pattern.
+#[test]
+fn match_enum_variant_with_wildcard_not_exhaustive() -> anyhow::Result<()> {
+    assert_compiles(Program {
+        source: r#"
+            enum Status {
+                Active
+                Inactive
+                Pending
+            }
+
+            function classify(s Status) -> string {
+                match (s) {
+                    Status.Active => "active",
+                    Status.Inactive => "inactive",
+                    _ => "other"
+                }
+            }
+        "#,
+        expected: vec![(
+            "classify",
+            // Non-exhaustive: wildcard arm means we can't skip comparisons
+            // All comparisons must be emitted (no exhaustive optimization)
+            vec![
+                // Extract discriminant (variant index) from enum value
+                Instruction::LoadVar("s".to_string()),
+                Instruction::Discriminant,
+                // First arm: check if variant index == 0 (Active)
+                Instruction::Copy(0),
+                Instruction::LoadConst(Value::Int(0)),
+                Instruction::CmpOp(CmpOp::Eq),
+                Instruction::PopJumpIfFalse(3),
+                Instruction::Pop(1),
+                Instruction::Jump(12),
+                // Second arm: check if variant index == 1 (Inactive)
+                // NOT skipped because this is non-exhaustive (has wildcard)
+                Instruction::Copy(0),
+                Instruction::LoadConst(Value::Int(1)),
+                Instruction::CmpOp(CmpOp::Eq),
+                Instruction::PopJumpIfFalse(3),
+                Instruction::Pop(1),
+                Instruction::Jump(4),
+                // Fall through to wildcard (pop discriminant)
+                Instruction::Pop(1),
+                // Bodies in reverse order
+                Instruction::LoadConst(Value::string("other")),
+                Instruction::Jump(4),
+                Instruction::LoadConst(Value::string("inactive")),
+                Instruction::Jump(2),
+                Instruction::LoadConst(Value::string("active")),
+                Instruction::Return,
+            ],
+        )],
+    })
+}
+
 /// Enum variant patterns with 4+ arms should use Discriminant + `JumpTable`.
 #[test]
 fn match_enum_four_variants_jump_table() -> anyhow::Result<()> {
@@ -1681,6 +1739,124 @@ fn match_enum_four_variants_jump_table() -> anyhow::Result<()> {
                 Instruction::LoadConst(Value::string("E")),
                 Instruction::Jump(2),
                 Instruction::LoadConst(Value::string("N")),
+                Instruction::Return,
+            ],
+        )],
+    })
+}
+
+// ============================================================================
+// Exhaustive and Non-Exhaustive Class Type Tests
+// ============================================================================
+
+/// Exhaustive class type match (all classes covered, no wildcard) should use
+/// the exhaustive optimization for if-else chain (skips last instanceof check).
+#[test]
+fn match_class_types_exhaustive() -> anyhow::Result<()> {
+    assert_compiles(Program {
+        source: r#"
+            class Cat { name string }
+            class Dog { name string }
+            class Bird { name string }
+
+            function classify(animal Cat | Dog | Bird) -> string {
+                match (animal) {
+                    c: Cat => "cat: " + c.name,
+                    d: Dog => "dog: " + d.name,
+                    b: Bird => "bird: " + b.name
+                }
+            }
+        "#,
+        expected: vec![(
+            "classify",
+            // Exhaustive match: 3 classes with if-else chain
+            // Last arm (Bird) doesn't need instanceof check - exhaustive optimization
+            vec![
+                // c: Cat instanceof check
+                Instruction::LoadVar("animal".to_string()),
+                Instruction::LoadConst(Value::class("Cat")),
+                Instruction::CmpOp(CmpOp::InstanceOf),
+                Instruction::PopJumpIfFalse(2),
+                Instruction::Jump(17),
+                // d: Dog instanceof check
+                Instruction::LoadVar("animal".to_string()),
+                Instruction::LoadConst(Value::class("Dog")),
+                Instruction::CmpOp(CmpOp::InstanceOf),
+                Instruction::PopJumpIfFalse(2),
+                Instruction::Jump(7),
+                // b: Bird - no instanceof check (exhaustive optimization)
+                Instruction::Jump(1),
+                // Bird body
+                Instruction::LoadConst(Value::string("bird: ")),
+                Instruction::LoadVar("animal".to_string()),
+                Instruction::LoadField(0),
+                Instruction::BinOp(BinOp::Add),
+                Instruction::Jump(10),
+                // Dog body
+                Instruction::LoadConst(Value::string("dog: ")),
+                Instruction::LoadVar("animal".to_string()),
+                Instruction::LoadField(0),
+                Instruction::BinOp(BinOp::Add),
+                Instruction::Jump(5),
+                // Cat body
+                Instruction::LoadConst(Value::string("cat: ")),
+                Instruction::LoadVar("animal".to_string()),
+                Instruction::LoadField(0),
+                Instruction::BinOp(BinOp::Add),
+                Instruction::Return,
+            ],
+        )],
+    })
+}
+
+/// Non-exhaustive class type match (with wildcard) should NOT get the exhaustive
+/// optimization. All instanceof checks must be emitted.
+#[test]
+fn match_class_types_non_exhaustive() -> anyhow::Result<()> {
+    assert_compiles(Program {
+        source: r#"
+            class Cat { name string }
+            class Dog { name string }
+            class Bird { name string }
+
+            function classify(animal Cat | Dog | Bird) -> string {
+                match (animal) {
+                    c: Cat => "cat: " + c.name,
+                    d: Dog => "dog: " + d.name,
+                    _ => "other"
+                }
+            }
+        "#,
+        expected: vec![(
+            "classify",
+            // Non-exhaustive: wildcard means ALL instanceof checks required
+            vec![
+                // c: Cat instanceof check
+                Instruction::LoadVar("animal".to_string()),
+                Instruction::LoadConst(Value::class("Cat")),
+                Instruction::CmpOp(CmpOp::InstanceOf),
+                Instruction::PopJumpIfFalse(2),
+                Instruction::Jump(13),
+                // d: Dog instanceof check - NOT skipped (wildcard present)
+                Instruction::LoadVar("animal".to_string()),
+                Instruction::LoadConst(Value::class("Dog")),
+                Instruction::CmpOp(CmpOp::InstanceOf),
+                Instruction::PopJumpIfFalse(2),
+                Instruction::Jump(3),
+                // Fall through to wildcard
+                Instruction::LoadConst(Value::string("other")),
+                Instruction::Jump(10),
+                // Dog body
+                Instruction::LoadConst(Value::string("dog: ")),
+                Instruction::LoadVar("animal".to_string()),
+                Instruction::LoadField(0),
+                Instruction::BinOp(BinOp::Add),
+                Instruction::Jump(5),
+                // Cat body
+                Instruction::LoadConst(Value::string("cat: ")),
+                Instruction::LoadVar("animal".to_string()),
+                Instruction::LoadField(0),
+                Instruction::BinOp(BinOp::Add),
                 Instruction::Return,
             ],
         )],

--- a/baml_language/crates/baml_compiler_mir/Cargo.toml
+++ b/baml_language/crates/baml_compiler_mir/Cargo.toml
@@ -11,6 +11,7 @@ baml_base = { workspace = true }
 baml_compiler_hir = { workspace = true }
 baml_compiler_tir = { workspace = true }
 baml_compiler_vir = { workspace = true }
+baml_typetags = { workspace = true }
 baml_workspace = { workspace = true }
 la-arena = { workspace = true }
 log = { workspace = true }

--- a/baml_language/crates/baml_compiler_mir/src/builder.rs
+++ b/baml_language/crates/baml_compiler_mir/src/builder.rs
@@ -224,11 +224,21 @@ impl MirBuilder {
     }
 
     /// Emit a multi-way switch.
-    pub fn switch(&mut self, discriminant: Operand, arms: Vec<(i64, BlockId)>, otherwise: BlockId) {
+    ///
+    /// If `exhaustive` is true, the switch covers all possible discriminant values,
+    /// allowing the last arm's comparison to be skipped during codegen.
+    pub fn switch(
+        &mut self,
+        discriminant: Operand,
+        arms: Vec<(i64, BlockId)>,
+        otherwise: BlockId,
+        exhaustive: bool,
+    ) {
         self.set_terminator(Terminator::Switch {
             discriminant,
             arms,
             otherwise,
+            exhaustive,
         });
     }
 

--- a/baml_language/crates/baml_compiler_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler_mir/src/ir.rs
@@ -423,6 +423,14 @@ pub enum Rvalue {
     /// Read discriminant of enum/union: `discriminant(_1)`
     Discriminant(Place),
 
+    /// Extract runtime type tag from any value: `type_tag(_1)`
+    ///
+    /// Used for jump table dispatch on union types (instanceof patterns).
+    /// Type tags are global constants:
+    /// - Primitives: `int=0`, `string=1`, `bool=2`, `null=3`, `float=4`
+    /// - Classes: assigned unique IDs starting at 100
+    TypeTag(Place),
+
     /// Get length of array: `len(_1)`
     Len(Place),
 

--- a/baml_language/crates/baml_compiler_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler_mir/src/ir.rs
@@ -216,6 +216,10 @@ pub enum Terminator {
         arms: Vec<(i64, BlockId)>,
         /// Default target if no arm matches.
         otherwise: BlockId,
+        /// Whether this switch is exhaustive (all possible values covered).
+        /// When true, the last arm's comparison can be skipped since if all
+        /// other arms failed, the discriminant must match the last one.
+        exhaustive: bool,
     },
 
     /// Return from function.

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -877,6 +877,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                         switch_kind,
                         switch_values,
                         wildcard_arm_idx,
+                        *is_exhaustive,
                         join_block,
                         dest,
                         body,
@@ -1153,6 +1154,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
     ///
     /// For enum variants, emits a `Discriminant` instruction first to extract the
     /// variant index before the switch.
+    ///
+    /// If `is_exhaustive` is true and there's no wildcard arm, the switch is marked
+    /// as exhaustive, allowing the codegen to skip the last arm's comparison.
     #[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
     fn lower_match_as_switch(
         &mut self,
@@ -1162,6 +1166,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
         switch_kind: SwitchKind,
         switch_values: Vec<(i64, usize)>,
         wildcard_arm_idx: Option<usize>,
+        is_exhaustive: bool,
         join_block: BlockId,
         dest: Place,
         body: &ExprBody,
@@ -1214,9 +1219,18 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             .map(|(value, arm_idx)| (*value, arm_blocks[*arm_idx]))
             .collect();
 
+        // Switch is exhaustive when all values are explicitly enumerated (no wildcard)
+        // AND the type checker marked the match as exhaustive.
+        // This allows codegen to skip the last arm's comparison.
+        let exhaustive = wildcard_arm_idx.is_none() && is_exhaustive;
+
         // Emit the switch terminator
-        self.builder
-            .switch(switch_discriminant, switch_arms, otherwise_block);
+        self.builder.switch(
+            switch_discriminant,
+            switch_arms,
+            otherwise_block,
+            exhaustive,
+        );
 
         // Lower each arm's body
         for (i, arm) in arms.iter().enumerate() {

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -1112,6 +1112,13 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             return None;
         }
 
+        // Deduplicate switch arms - union patterns like `A | A` can create duplicates.
+        // We keep the first occurrence (earliest arm index) for each value.
+        // This is correct because if a value appears multiple times, they all
+        // map to the same arm anyway.
+        let mut seen_values = std::collections::HashSet::new();
+        switch_arms.retain(|(value, _)| seen_values.insert(*value));
+
         if matches!(kind, SwitchKind::TypeTag) && switch_arms.len() < MIN_TYPETAG_ARMS {
             return None;
         }
@@ -1133,6 +1140,18 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
     ///
     /// Returns the type tag for primitives (using `baml_typetags` constants)
     /// or for classes (using the pre-computed `class_type_tags` map).
+    ///
+    /// # `TypeAlias` handling
+    ///
+    /// `TypeAliases` are looked up by their alias name in `class_type_tags`.
+    /// This has limitations:
+    /// - `TypeAliases` to primitives won't be found and will return `None`
+    /// - `TypeAliases` to classes will only work if the alias name is registered
+    ///
+    /// When `None` is returned, the pattern falls back to non-switch optimization,
+    /// which is safe but may miss optimization opportunities. Full `TypeAlias`
+    /// resolution would require resolving through potentially recursive aliases,
+    /// which is not yet implemented.
     fn type_tag_for_vir_ty(&self, ty: &baml_compiler_vir::Ty) -> Option<i64> {
         use baml_compiler_vir::Ty;
         match ty {
@@ -1142,6 +1161,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             Ty::Null => Some(baml_typetags::NULL),
             Ty::Float => Some(baml_typetags::FLOAT),
             Ty::Class(fqn) => self.class_type_tags.get(fqn.name.as_str()).copied(),
+            // TypeAliases: look up by alias name. See doc comment for limitations.
             Ty::TypeAlias(fqn) => self.class_type_tags.get(fqn.name.as_str()).copied(),
             _ => None, // Not a type with a known tag
         }

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -36,6 +36,19 @@ enum FieldSource {
     Spread(Local, usize),
 }
 
+/// Kind of switch optimization being performed.
+///
+/// This determines how the scrutinee is transformed before the switch.
+enum SwitchKind {
+    /// Direct integer comparison - no transformation needed.
+    Integer,
+    /// Enum variant switch - emit `Discriminant` to extract variant index first.
+    EnumDiscriminant(Name),
+    /// Type tag switch for union types - emit `TypeTag` to extract runtime type first.
+    /// Only supports primitive types (int, string, bool, float, null) which have fixed tags.
+    TypeTag,
+}
+
 /// Lower a function from VIR to MIR.
 ///
 /// This is the main entry point for VIR → MIR lowering.
@@ -44,9 +57,18 @@ pub fn lower<'ctx>(
     typed_body: &ExprBody,
     db: &dyn crate::Db,
     class_fields: &'ctx HashMap<String, HashMap<String, usize>>,
+    enum_variants: &'ctx HashMap<String, HashMap<String, usize>>,
+    class_type_tags: &'ctx HashMap<String, i64>,
     resolution_ctx: &'ctx TypeResolutionContext,
 ) -> MirFunction {
-    let mut ctx = LoweringContext::new(db, signature.params.len(), class_fields, resolution_ctx);
+    let mut ctx = LoweringContext::new(
+        db,
+        signature.params.len(),
+        class_fields,
+        enum_variants,
+        class_type_tags,
+        resolution_ctx,
+    );
     ctx.lower_function(signature, typed_body);
     ctx.finish()
 }
@@ -62,6 +84,10 @@ struct LoweringContext<'a, 'ctx> {
     loop_context: Option<LoopContext>,
     /// Class field mappings (class name -> field name -> field index).
     class_fields: &'ctx HashMap<String, HashMap<String, usize>>,
+    /// Enum variant mappings (enum name -> variant name -> variant index).
+    enum_variants: &'ctx HashMap<String, HashMap<String, usize>>,
+    /// Class type tags (class name -> type tag) for `TypeTag` switch optimization.
+    class_type_tags: &'ctx HashMap<String, i64>,
     /// Type resolution context for lowering type refs.
     resolution_ctx: &'ctx TypeResolutionContext,
     /// Stack of watched locals for tracking scope exit.
@@ -120,6 +146,8 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
         db: &'a dyn crate::Db,
         arity: usize,
         class_fields: &'ctx HashMap<String, HashMap<String, usize>>,
+        enum_variants: &'ctx HashMap<String, HashMap<String, usize>>,
+        class_type_tags: &'ctx HashMap<String, i64>,
         resolution_ctx: &'ctx TypeResolutionContext,
     ) -> Self {
         Self {
@@ -128,6 +156,8 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             locals: HashMap::new(),
             loop_context: None,
             class_fields,
+            enum_variants,
+            class_type_tags,
             resolution_ctx,
             watched_locals_stack: Vec::new(),
             viz_context: VizContext {
@@ -835,15 +865,16 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                 // Create join block
                 let join_block = self.builder.create_block();
 
-                // Try switch optimization for integer literal patterns
+                // Try switch optimization for integer or enum patterns
                 // This enables jump table or binary search codegen
-                if let Some((switch_values, wildcard_arm_idx)) =
+                if let Some((switch_kind, switch_values, wildcard_arm_idx)) =
                     self.try_extract_switch_arms(arms, body)
                 {
                     self.lower_match_as_switch(
                         scrutinee_local,
                         &scrutinee_ty,
                         arms,
+                        switch_kind,
                         switch_values,
                         wildcard_arm_idx,
                         join_block,
@@ -954,19 +985,25 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
         }
     }
 
-    /// Try to extract integer literal values from arms for switch optimization.
+    /// Try to extract switch values from arms for switch optimization.
     ///
-    /// Returns Some(vec of (value, `arm_index`)) if all non-wildcard arms are integer literals
-    /// without guards, and there's at most one wildcard arm at the end.
+    /// Returns Some((kind, values, wildcard)) if all non-wildcard arms are switchable patterns
+    /// (integer literals or enum variants from the same enum) without guards.
     /// Returns None if the match cannot be optimized as a switch.
-    #[allow(clippy::unused_self, clippy::type_complexity)]
+    #[allow(clippy::type_complexity)]
     fn try_extract_switch_arms(
         &self,
         arms: &[baml_compiler_vir::MatchArm],
         body: &ExprBody,
-    ) -> Option<(Vec<(i64, usize)>, Option<usize>)> {
+    ) -> Option<(SwitchKind, Vec<(i64, usize)>, Option<usize>)> {
+        // TypeTag switch requires at least 4 arms to benefit from jump table optimization.
+        // For fewer arms, the InstanceOf if-else chain is more efficient since
+        // extracting TypeTag has overhead.
+        const MIN_TYPETAG_ARMS: usize = 4;
+
         let mut switch_arms = Vec::new();
         let mut wildcard_arm = None;
+        let mut detected_kind: Option<SwitchKind> = None;
 
         for (i, arm) in arms.iter().enumerate() {
             // Guards prevent switch optimization (need runtime evaluation)
@@ -977,8 +1014,35 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             let pat = body.pattern(arm.pattern);
             match pat {
                 Pattern::Literal(Literal::Int(value)) => {
-                    // Simple integer literal - can be part of switch
+                    // Integer literal - ensure we're in integer mode
+                    match &detected_kind {
+                        None => detected_kind = Some(SwitchKind::Integer),
+                        Some(SwitchKind::Integer) => {}
+                        Some(SwitchKind::EnumDiscriminant(_) | SwitchKind::TypeTag) => return None, // Mixed types
+                    }
                     switch_arms.push((*value, i));
+                }
+                Pattern::EnumVariant { enum_name, variant } => {
+                    // Enum variant - lookup variant index and ensure same enum
+                    let variant_idx = self.lookup_variant_index(enum_name, variant)?;
+                    match &detected_kind {
+                        None => {
+                            detected_kind = Some(SwitchKind::EnumDiscriminant(enum_name.clone()));
+                        }
+                        Some(SwitchKind::EnumDiscriminant(name)) if name == enum_name => {}
+                        _ => return None, // Mixed types or different enums
+                    }
+                    switch_arms.push((variant_idx, i));
+                }
+                Pattern::TypedBinding { name: _, ty } => {
+                    // TypedBinding - lookup type tag for primitive or class types
+                    let type_tag = self.type_tag_for_vir_ty(ty)?;
+                    match &detected_kind {
+                        None => detected_kind = Some(SwitchKind::TypeTag),
+                        Some(SwitchKind::TypeTag) => {}
+                        _ => return None, // Mixed switch kinds
+                    }
+                    switch_arms.push((type_tag, i));
                 }
                 Pattern::Binding(name) => {
                     // Wildcard/binding pattern - must be the last arm
@@ -994,48 +1058,140 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                     }
                 }
                 Pattern::Union(sub_pats) => {
-                    // Union of integer literals - extract each value
+                    // Union of patterns - extract each value
                     for sub_pat_id in sub_pats {
                         let sub_pat = body.pattern(*sub_pat_id);
                         match sub_pat {
                             Pattern::Literal(Literal::Int(value)) => {
+                                match &detected_kind {
+                                    None => detected_kind = Some(SwitchKind::Integer),
+                                    Some(SwitchKind::Integer) => {}
+                                    Some(SwitchKind::EnumDiscriminant(_) | SwitchKind::TypeTag) => {
+                                        return None;
+                                    }
+                                }
                                 switch_arms.push((*value, i));
                             }
-                            _ => return None, // Non-integer in union
+                            Pattern::EnumVariant { enum_name, variant } => {
+                                let variant_idx = self.lookup_variant_index(enum_name, variant)?;
+                                match &detected_kind {
+                                    None => {
+                                        detected_kind =
+                                            Some(SwitchKind::EnumDiscriminant(enum_name.clone()));
+                                    }
+                                    Some(SwitchKind::EnumDiscriminant(name))
+                                        if name == enum_name => {}
+                                    _ => return None,
+                                }
+                                switch_arms.push((variant_idx, i));
+                            }
+                            Pattern::TypedBinding { name: _, ty } => {
+                                let type_tag = self.type_tag_for_vir_ty(ty)?;
+                                match &detected_kind {
+                                    None => detected_kind = Some(SwitchKind::TypeTag),
+                                    Some(SwitchKind::TypeTag) => {}
+                                    _ => return None,
+                                }
+                                switch_arms.push((type_tag, i));
+                            }
+                            _ => return None, // Non-switchable in union
                         }
                     }
                 }
-                _ => {
-                    // Non-integer pattern (typed binding, enum, etc.) - can't optimize
+                Pattern::Literal(_) => {
+                    // Non-integer literals (strings, bools, null, etc.) - can't optimize as switch
                     return None;
                 }
             }
         }
 
-        // Need at least one integer arm for switch optimization
+        // Need at least one arm and a detected kind for switch optimization
+        let kind = detected_kind?;
         if switch_arms.is_empty() {
             return None;
         }
 
-        Some((switch_arms, wildcard_arm))
+        if matches!(kind, SwitchKind::TypeTag) && switch_arms.len() < MIN_TYPETAG_ARMS {
+            return None;
+        }
+
+        Some((kind, switch_arms, wildcard_arm))
+    }
+
+    /// Look up the index of an enum variant.
+    ///
+    /// Returns the 0-based index of the variant within the enum definition.
+    #[allow(clippy::cast_possible_wrap)]
+    fn lookup_variant_index(&self, enum_name: &Name, variant: &Name) -> Option<i64> {
+        let variants = self.enum_variants.get(enum_name.as_str())?;
+        let index = *variants.get(variant.as_str())?;
+        Some(index as i64)
+    }
+
+    /// Get the type tag for a VIR type (primitive or class).
+    ///
+    /// Returns the type tag for primitives (using `baml_typetags` constants)
+    /// or for classes (using the pre-computed `class_type_tags` map).
+    fn type_tag_for_vir_ty(&self, ty: &baml_compiler_vir::Ty) -> Option<i64> {
+        use baml_compiler_vir::Ty;
+        match ty {
+            Ty::Int => Some(baml_typetags::INT),
+            Ty::String => Some(baml_typetags::STRING),
+            Ty::Bool => Some(baml_typetags::BOOL),
+            Ty::Null => Some(baml_typetags::NULL),
+            Ty::Float => Some(baml_typetags::FLOAT),
+            Ty::Class(fqn) => self.class_type_tags.get(fqn.name.as_str()).copied(),
+            Ty::TypeAlias(fqn) => self.class_type_tags.get(fqn.name.as_str()).copied(),
+            _ => None, // Not a type with a known tag
+        }
     }
 
     /// Lower a match expression as a Switch terminator.
     ///
-    /// This emits a single Switch instruction with all integer arms,
+    /// This emits a single Switch instruction with all integer or enum variant arms,
     /// enabling jump table or binary search optimization in the codegen.
+    ///
+    /// For enum variants, emits a `Discriminant` instruction first to extract the
+    /// variant index before the switch.
     #[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
     fn lower_match_as_switch(
         &mut self,
         scrutinee_local: Local,
         scrutinee_ty: &Ty,
         arms: &[baml_compiler_vir::MatchArm],
+        switch_kind: SwitchKind,
         switch_values: Vec<(i64, usize)>,
         wildcard_arm_idx: Option<usize>,
         join_block: BlockId,
         dest: Place,
         body: &ExprBody,
     ) {
+        // Extract switch discriminant based on kind
+        let switch_discriminant = match switch_kind {
+            SwitchKind::Integer => {
+                // Direct integer comparison - use scrutinee directly
+                Operand::copy_local(scrutinee_local)
+            }
+            SwitchKind::EnumDiscriminant(_) => {
+                // Emit Discriminant to extract variant index
+                let discriminant_local = self.builder.temp(Ty::Int);
+                self.builder.assign(
+                    Place::local(discriminant_local),
+                    Rvalue::Discriminant(Place::local(scrutinee_local)),
+                );
+                Operand::copy_local(discriminant_local)
+            }
+            SwitchKind::TypeTag => {
+                // Emit TypeTag to extract runtime type tag
+                let type_tag_local = self.builder.temp(Ty::Int);
+                self.builder.assign(
+                    Place::local(type_tag_local),
+                    Rvalue::TypeTag(Place::local(scrutinee_local)),
+                );
+                Operand::copy_local(type_tag_local)
+            }
+        };
+
         // Create body blocks for each arm
         let arm_blocks: Vec<BlockId> = arms.iter().map(|_| self.builder.create_block()).collect();
 
@@ -1059,20 +1215,17 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             .collect();
 
         // Emit the switch terminator
-        self.builder.switch(
-            Operand::copy_local(scrutinee_local),
-            switch_arms,
-            otherwise_block,
-        );
+        self.builder
+            .switch(switch_discriminant, switch_arms, otherwise_block);
 
         // Lower each arm's body
         for (i, arm) in arms.iter().enumerate() {
             self.builder.set_current_block(arm_blocks[i]);
 
-            // If this is a binding arm (wildcard), bind the variable
+            // If this is a binding or typed binding arm, bind the variable
             let pat = body.pattern(arm.pattern);
-            if let Pattern::Binding(name) = pat {
-                if name.as_str() != "_" {
+            match pat {
+                Pattern::Binding(name) if name.as_str() != "_" => {
                     let local = self.builder.declare_local(
                         Some(name.clone()),
                         scrutinee_ty.clone(),
@@ -1084,6 +1237,21 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                         Rvalue::Use(Operand::copy_local(scrutinee_local)),
                     );
                     self.locals.insert(name.clone(), local);
+                }
+                Pattern::TypedBinding { name, ty } => {
+                    // Typed binding - bind the variable with its specific type
+                    let pattern_ty = Self::lower_typed_ir_ty(ty);
+                    let local =
+                        self.builder
+                            .declare_local(Some(name.clone()), pattern_ty, None, false);
+                    self.builder.assign(
+                        Place::local(local),
+                        Rvalue::Use(Operand::copy_local(scrutinee_local)),
+                    );
+                    self.locals.insert(name.clone(), local);
+                }
+                _ => {
+                    // No binding needed (e.g., literal patterns, enum variants, wildcards)
                 }
             }
 

--- a/baml_language/crates/baml_compiler_mir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_mir/src/pretty.rs
@@ -175,6 +175,7 @@ fn write_terminator(f: &mut impl Write, term: &Terminator) -> fmt::Result {
             discriminant,
             arms,
             otherwise,
+            exhaustive,
         } => {
             write!(f, "switch ")?;
             write_operand(f, discriminant)?;
@@ -185,7 +186,11 @@ fn write_terminator(f: &mut impl Write, term: &Terminator) -> fmt::Result {
                 }
                 write!(f, "{val}: {target}")?;
             }
-            write!(f, ", otherwise: {otherwise}];")
+            if *exhaustive {
+                write!(f, ", otherwise: {otherwise}] (exhaustive);")
+            } else {
+                write!(f, ", otherwise: {otherwise}];")
+            }
         }
         Terminator::Return => {
             write!(f, "return;")

--- a/baml_language/crates/baml_compiler_mir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_mir/src/pretty.rs
@@ -301,6 +301,9 @@ fn write_rvalue(f: &mut impl Write, rvalue: &Rvalue) -> fmt::Result {
         Rvalue::Discriminant(place) => {
             write!(f, "discriminant({place})")
         }
+        Rvalue::TypeTag(place) => {
+            write!(f, "type_tag({place})")
+        }
         Rvalue::Len(place) => {
             write!(f, "len({place})")
         }

--- a/baml_language/crates/baml_tests/Cargo.toml
+++ b/baml_language/crates/baml_tests/Cargo.toml
@@ -18,6 +18,7 @@ baml_compiler_mir = { workspace = true }
 baml_compiler_tir = { workspace = true }
 baml_db = { workspace = true }
 baml_project = { workspace = true }
+baml_typetags = { workspace = true }
 baml_workspace = { workspace = true }
 bex_program = { workspace = true }
 bex_vm = { workspace = true }
@@ -29,6 +30,7 @@ salsa = { workspace = true }
 tempfile = { workspace = true }
 
 [build-dependencies]
+baml_typetags = { workspace = true }
 prettyplease = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/baml_language/crates/baml_tests/build.rs
+++ b/baml_language/crates/baml_tests/build.rs
@@ -502,7 +502,12 @@ fn generate_mir_test(project: &TestProject) -> TokenStream {
             let resolution_ctx = baml_compiler_tir::TypeResolutionContext::new(&db, root);
 
             // Build class field indices map (class name -> field name -> field index)
+            // Also build class type tags for TypeTag switch optimization
             let mut classes: HashMap<String, HashMap<String, usize>> = HashMap::new();
+            let mut class_type_tags: HashMap<String, i64> = HashMap::new();
+            let mut class_type_tag_counter = 0i64;
+            // Build enum variant indices map (enum name -> variant name -> variant index)
+            let mut enums: HashMap<String, HashMap<String, usize>> = HashMap::new();
             for source_file in &source_files {
                 let item_tree = baml_compiler_hir::file_item_tree(&db, *source_file);
                 let items_struct = baml_compiler_hir::file_items(&db, *source_file);
@@ -514,7 +519,20 @@ fn generate_mir_test(project: &TestProject) -> TokenStream {
                         for (idx, field) in class.fields.iter().enumerate() {
                             field_indices.insert(field.name.to_string(), idx);
                         }
+                        // Compute type tag for this class (CLASS_BASE + counter)
+                        let type_tag = baml_typetags::CLASS_BASE + class_type_tag_counter;
+                        class_type_tag_counter += 1;
+                        class_type_tags.insert(class_name.clone(), type_tag);
                         classes.insert(class_name, field_indices);
+                    }
+                    if let baml_compiler_hir::ItemId::Enum(enum_loc) = item {
+                        let enum_def = &item_tree[enum_loc.id(&db)];
+                        let enum_name = enum_def.name.to_string();
+                        let mut variant_indices = HashMap::new();
+                        for (idx, variant) in enum_def.variants.iter().enumerate() {
+                            variant_indices.insert(variant.name.to_string(), idx);
+                        }
+                        enums.insert(enum_name, variant_indices);
                     }
                 }
             }
@@ -533,7 +551,7 @@ fn generate_mir_test(project: &TestProject) -> TokenStream {
                         // Lower HIR → VIR → MIR
                         let mir_output = match baml_compiler_vir::lower_from_hir(&body, &inference, &resolution_ctx) {
                             Ok(vir) => {
-                                let mir = baml_compiler_mir::lower(&signature, &vir, &db, &classes, &resolution_ctx);
+                                let mir = baml_compiler_mir::lower(&signature, &vir, &db, &classes, &enums, &class_type_tags, &resolution_ctx);
                                 baml_compiler_mir::pretty::display_function(&mir)
                             }
                             Err(baml_compiler_vir::LoweringError::LlmFunction) => {

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-50646ef7890fdaa2/out/generated_tests.rs
+source: target/debug/build/baml_tests-7b144ed8705f275d/out/generated_tests.rs
 expression: output
 ---
 === MIR ===
@@ -118,14 +118,11 @@ fn DuplicateEnumVariant(s: Enum(FullyQualifiedName { namespace: Local, name: "St
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
-    let _3: Bool
-    let _4: Bool
-    let _5: Bool
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb3, bb4];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, 0: bb4, 1: bb5, 2: bb6, otherwise: bb7];
     }
 
     bb1: {
@@ -142,37 +139,22 @@ fn DuplicateEnumVariant(s: Enum(FullyQualifiedName { namespace: Local, name: "St
     }
 
     bb4: {
-        _3 = copy _1 == const Status.Active;
-        branch copy _3 -> [bb5, bb6];
-    }
-
-    bb5: {
         _0 = const "second";
         goto -> bb2;
     }
 
-    bb6: {
-        _4 = copy _1 == const Status.Inactive;
-        branch copy _4 -> [bb7, bb8];
-    }
-
-    bb7: {
+    bb5: {
         _0 = const "inactive";
         goto -> bb2;
     }
 
-    bb8: {
-        _5 = copy _1 == const Status.Pending;
-        branch copy _5 -> [bb9, bb10];
-    }
-
-    bb9: {
+    bb6: {
         _0 = const "pending";
         goto -> bb2;
     }
 
-    bb10: {
-        goto -> bb2;
+    bb7: {
+        unreachable;
     }
 
 }
@@ -421,13 +403,11 @@ fn ExhaustiveEnumAllVariants(s: Enum(FullyQualifiedName { namespace: Local, name
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
-    let _3: Bool
-    let _4: Bool
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb3, bb4];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, 1: bb4, 2: bb5, otherwise: bb6];
     }
 
     bb1: {
@@ -444,27 +424,17 @@ fn ExhaustiveEnumAllVariants(s: Enum(FullyQualifiedName { namespace: Local, name
     }
 
     bb4: {
-        _3 = copy _1 == const Status.Inactive;
-        branch copy _3 -> [bb5, bb6];
-    }
-
-    bb5: {
         _0 = const "inactive";
         goto -> bb2;
     }
 
-    bb6: {
-        _4 = copy _1 == const Status.Pending;
-        branch copy _4 -> [bb7, bb8];
-    }
-
-    bb7: {
+    bb5: {
         _0 = const "pending";
         goto -> bb2;
     }
 
-    bb8: {
-        goto -> bb2;
+    bb6: {
+        unreachable;
     }
 
 }
@@ -927,13 +897,11 @@ fn NonExhaustiveNullableEnumMissingNull(s: Optional(Enum(FullyQualifiedName { na
     // Locals:
     let _0: String // return
     let _1: Optional(Enum(FullyQualifiedName { namespace: Local, name: "Status" })) // s // param
-    let _2: Bool
-    let _3: Bool
-    let _4: Bool
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb3, bb4];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, 1: bb4, 2: bb5, otherwise: bb6];
     }
 
     bb1: {
@@ -950,27 +918,17 @@ fn NonExhaustiveNullableEnumMissingNull(s: Optional(Enum(FullyQualifiedName { na
     }
 
     bb4: {
-        _3 = copy _1 == const Status.Inactive;
-        branch copy _3 -> [bb5, bb6];
-    }
-
-    bb5: {
         _0 = const "inactive";
         goto -> bb2;
     }
 
-    bb6: {
-        _4 = copy _1 == const Status.Pending;
-        branch copy _4 -> [bb7, bb8];
-    }
-
-    bb7: {
+    bb5: {
         _0 = const "pending";
         goto -> bb2;
     }
 
-    bb8: {
-        goto -> bb2;
+    bb6: {
+        unreachable;
     }
 
 }
@@ -1551,15 +1509,11 @@ fn MultipleUnreachableSpans(s: Enum(FullyQualifiedName { namespace: Local, name:
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
-    let _3: Bool
-    let _4: Bool
-    let _5: Bool
-    let _6: Bool
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb3, bb4];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, 0: bb4, 1: bb5, 0: bb6, 2: bb7, otherwise: bb8];
     }
 
     bb1: {
@@ -1576,47 +1530,27 @@ fn MultipleUnreachableSpans(s: Enum(FullyQualifiedName { namespace: Local, name:
     }
 
     bb4: {
-        _3 = copy _1 == const Status.Active;
-        branch copy _3 -> [bb5, bb6];
-    }
-
-    bb5: {
         _0 = const "duplicate 1";
         goto -> bb2;
     }
 
-    bb6: {
-        _4 = copy _1 == const Status.Inactive;
-        branch copy _4 -> [bb7, bb8];
-    }
-
-    bb7: {
+    bb5: {
         _0 = const "inactive";
         goto -> bb2;
     }
 
-    bb8: {
-        _5 = copy _1 == const Status.Active;
-        branch copy _5 -> [bb9, bb10];
-    }
-
-    bb9: {
+    bb6: {
         _0 = const "duplicate 2";
         goto -> bb2;
     }
 
-    bb10: {
-        _6 = copy _1 == const Status.Pending;
-        branch copy _6 -> [bb11, bb12];
-    }
-
-    bb11: {
+    bb7: {
         _0 = const "pending";
         goto -> bb2;
     }
 
-    bb12: {
-        goto -> bb2;
+    bb8: {
+        unreachable;
     }
 
 }
@@ -1667,16 +1601,12 @@ fn NestedEnumMatch(s1: Enum(FullyQualifiedName { namespace: Local, name: "Status
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s1 // param
     let _2: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s2 // param
-    let _3: Bool
-    let _4: Bool
-    let _5: Bool
-    let _6: Bool
-    let _7: Bool
-    let _8: Bool
+    let _3: Int
+    let _4: Int
 
     bb0: {
-        _3 = copy _1 == const Status.Active;
-        branch copy _3 -> [bb3, bb4];
+        _3 = discriminant(_1);
+        switch copy _3 [0: bb3, 1: bb4, 2: bb5, otherwise: bb6];
     }
 
     bb1: {
@@ -1688,65 +1618,45 @@ fn NestedEnumMatch(s1: Enum(FullyQualifiedName { namespace: Local, name: "Status
     }
 
     bb3: {
-        _4 = copy _2 == const Status.Active;
-        branch copy _4 -> [bb6, bb7];
+        _4 = discriminant(_2);
+        switch copy _4 [0: bb8, 1: bb9, 2: bb10, otherwise: bb11];
     }
 
     bb4: {
-        _7 = copy _1 == const Status.Inactive;
-        branch copy _7 -> [bb12, bb13];
-    }
-
-    bb5: {
-        goto -> bb2;
-    }
-
-    bb6: {
-        _0 = const "both active";
-        goto -> bb5;
-    }
-
-    bb7: {
-        _5 = copy _2 == const Status.Inactive;
-        branch copy _5 -> [bb8, bb9];
-    }
-
-    bb8: {
-        _0 = const "first active, second inactive";
-        goto -> bb5;
-    }
-
-    bb9: {
-        _6 = copy _2 == const Status.Pending;
-        branch copy _6 -> [bb10, bb11];
-    }
-
-    bb10: {
-        _0 = const "first active, second pending";
-        goto -> bb5;
-    }
-
-    bb11: {
-        goto -> bb5;
-    }
-
-    bb12: {
         _0 = const "first inactive";
         goto -> bb2;
     }
 
-    bb13: {
-        _8 = copy _1 == const Status.Pending;
-        branch copy _8 -> [bb14, bb15];
-    }
-
-    bb14: {
+    bb5: {
         _0 = const "first pending";
         goto -> bb2;
     }
 
-    bb15: {
+    bb6: {
+        unreachable;
+    }
+
+    bb7: {
         goto -> bb2;
+    }
+
+    bb8: {
+        _0 = const "both active";
+        goto -> bb7;
+    }
+
+    bb9: {
+        _0 = const "first active, second inactive";
+        goto -> bb7;
+    }
+
+    bb10: {
+        _0 = const "first active, second pending";
+        goto -> bb7;
+    }
+
+    bb11: {
+        unreachable;
     }
 
 }
@@ -2001,13 +1911,11 @@ fn EnumVariantUnion(s: Enum(FullyQualifiedName { namespace: Local, name: "Status
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
-    let _3: Bool
-    let _4: Bool
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb3, bb5];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, 2: bb3, 1: bb4, otherwise: bb5];
     }
 
     bb1: {
@@ -2024,22 +1932,12 @@ fn EnumVariantUnion(s: Enum(FullyQualifiedName { namespace: Local, name: "Status
     }
 
     bb4: {
-        _4 = copy _1 == const Status.Inactive;
-        branch copy _4 -> [bb6, bb7];
-    }
-
-    bb5: {
-        _3 = copy _1 == const Status.Pending;
-        branch copy _3 -> [bb3, bb4];
-    }
-
-    bb6: {
         _0 = const "inactive";
         goto -> bb2;
     }
 
-    bb7: {
-        goto -> bb2;
+    bb5: {
+        unreachable;
     }
 
 }
@@ -2383,12 +2281,11 @@ fn ExhaustiveEnumWithCatchAll(s: Enum(FullyQualifiedName { namespace: Local, nam
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
-    let _3: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // _
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb4, bb5];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, otherwise: bb4];
     }
 
     bb1: {
@@ -2400,20 +2297,11 @@ fn ExhaustiveEnumWithCatchAll(s: Enum(FullyQualifiedName { namespace: Local, nam
     }
 
     bb3: {
-        unreachable;
-    }
-
-    bb4: {
         _0 = const "active";
         goto -> bb2;
     }
 
-    bb5: {
-        _3 = copy _1;
-        goto -> bb6;
-    }
-
-    bb6: {
+    bb4: {
         _0 = const "other";
         goto -> bb2;
     }
@@ -2526,11 +2414,11 @@ fn HighLineNumberNonExhaustive(s: Enum(FullyQualifiedName { namespace: Local, na
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb3, bb4];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, otherwise: bb4];
     }
 
     bb1: {
@@ -2547,7 +2435,7 @@ fn HighLineNumberNonExhaustive(s: Enum(FullyQualifiedName { namespace: Local, na
     }
 
     bb4: {
-        goto -> bb2;
+        unreachable;
     }
 
 }
@@ -2869,12 +2757,11 @@ fn NonExhaustiveEnumMissingOne(s: Enum(FullyQualifiedName { namespace: Local, na
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
-    let _3: Bool
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb3, bb4];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, 1: bb4, otherwise: bb5];
     }
 
     bb1: {
@@ -2891,17 +2778,12 @@ fn NonExhaustiveEnumMissingOne(s: Enum(FullyQualifiedName { namespace: Local, na
     }
 
     bb4: {
-        _3 = copy _1 == const Status.Inactive;
-        branch copy _3 -> [bb5, bb6];
-    }
-
-    bb5: {
         _0 = const "inactive";
         goto -> bb2;
     }
 
-    bb6: {
-        goto -> bb2;
+    bb5: {
+        unreachable;
     }
 
 }
@@ -3340,13 +3222,11 @@ fn NestedEnumVariantUnions(s: Enum(FullyQualifiedName { namespace: Local, name: 
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
-    let _3: Bool
-    let _4: Bool
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb3, bb5];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, 2: bb3, 1: bb3, otherwise: bb4];
     }
 
     bb1: {
@@ -3363,17 +3243,7 @@ fn NestedEnumVariantUnions(s: Enum(FullyQualifiedName { namespace: Local, name: 
     }
 
     bb4: {
-        goto -> bb2;
-    }
-
-    bb5: {
-        _3 = copy _1 == const Status.Pending;
-        branch copy _3 -> [bb3, bb6];
-    }
-
-    bb6: {
-        _4 = copy _1 == const Status.Inactive;
-        branch copy _4 -> [bb3, bb4];
+        unreachable;
     }
 
 }
@@ -3530,9 +3400,7 @@ fn MatchFunctionCallScrutinee() -> String {
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" })
     let _2: Function { params: [], ret: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) }
-    let _3: Bool
-    let _4: Bool
-    let _5: Bool
+    let _3: Int
 
     bb0: {
         _2 = const fn GetStatus;
@@ -3544,8 +3412,8 @@ fn MatchFunctionCallScrutinee() -> String {
     }
 
     bb2: {
-        _3 = copy _1 == const Status.Active;
-        branch copy _3 -> [bb4, bb5];
+        _3 = discriminant(_1);
+        switch copy _3 [0: bb4, 1: bb5, 2: bb6, otherwise: bb7];
     }
 
     bb3: {
@@ -3558,27 +3426,17 @@ fn MatchFunctionCallScrutinee() -> String {
     }
 
     bb5: {
-        _4 = copy _1 == const Status.Inactive;
-        branch copy _4 -> [bb6, bb7];
-    }
-
-    bb6: {
         _0 = const "inactive";
         goto -> bb3;
     }
 
-    bb7: {
-        _5 = copy _1 == const Status.Pending;
-        branch copy _5 -> [bb8, bb9];
-    }
-
-    bb8: {
+    bb6: {
         _0 = const "pending";
         goto -> bb3;
     }
 
-    bb9: {
-        goto -> bb3;
+    bb7: {
+        unreachable;
     }
 
 }
@@ -3639,11 +3497,11 @@ fn NonExhaustiveEnumMissingMultiple(s: Enum(FullyQualifiedName { namespace: Loca
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb3, bb4];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, otherwise: bb4];
     }
 
     bb1: {
@@ -3660,7 +3518,7 @@ fn NonExhaustiveEnumMissingMultiple(s: Enum(FullyQualifiedName { namespace: Loca
     }
 
     bb4: {
-        goto -> bb2;
+        unreachable;
     }
 
 }
@@ -3828,13 +3686,11 @@ fn EnumVariantUnionWithCatchAll(s: Enum(FullyQualifiedName { namespace: Local, n
     // Locals:
     let _0: String // return
     let _1: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // s // param
-    let _2: Bool
-    let _3: Bool
-    let _4: Enum(FullyQualifiedName { namespace: Local, name: "Status" }) // _
+    let _2: Int
 
     bb0: {
-        _2 = copy _1 == const Status.Active;
-        branch copy _2 -> [bb4, bb6];
+        _2 = discriminant(_1);
+        switch copy _2 [0: bb3, 2: bb3, otherwise: bb4];
     }
 
     bb1: {
@@ -3846,25 +3702,11 @@ fn EnumVariantUnionWithCatchAll(s: Enum(FullyQualifiedName { namespace: Local, n
     }
 
     bb3: {
-        unreachable;
-    }
-
-    bb4: {
         _0 = const "actionable";
         goto -> bb2;
     }
 
-    bb5: {
-        _4 = copy _1;
-        goto -> bb7;
-    }
-
-    bb6: {
-        _3 = copy _1 == const Status.Pending;
-        branch copy _3 -> [bb4, bb5];
-    }
-
-    bb7: {
+    bb4: {
         _0 = const "other";
         goto -> bb2;
     }

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-7b144ed8705f275d/out/generated_tests.rs
+source: target/debug/build/baml_tests-5af6b621dd74eb70/out/generated_tests.rs
 expression: output
 ---
 === MIR ===
@@ -122,7 +122,7 @@ fn DuplicateEnumVariant(s: Enum(FullyQualifiedName { namespace: Local, name: "St
 
     bb0: {
         _2 = discriminant(_1);
-        switch copy _2 [0: bb3, 0: bb4, 1: bb5, 2: bb6, otherwise: bb7];
+        switch copy _2 [0: bb3, 1: bb5, 2: bb6, otherwise: bb7];
     }
 
     bb1: {
@@ -769,7 +769,7 @@ fn DuplicateIntLiteral(x: Int) -> String {
     let _1: Int // x // param
 
     bb0: {
-        switch copy _1 [1: bb3, 1: bb4, otherwise: bb5];
+        switch copy _1 [1: bb3, otherwise: bb5];
     }
 
     bb1: {
@@ -1513,7 +1513,7 @@ fn MultipleUnreachableSpans(s: Enum(FullyQualifiedName { namespace: Local, name:
 
     bb0: {
         _2 = discriminant(_1);
-        switch copy _2 [0: bb3, 0: bb4, 1: bb5, 0: bb6, 2: bb7, otherwise: bb8];
+        switch copy _2 [0: bb3, 1: bb5, 2: bb7, otherwise: bb8];
     }
 
     bb1: {

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -4,7 +4,7 @@ expression: output
 ---
 === BYTECODE ===
 Functions: 86
-Objects: 298
+Objects: 294
 Globals: 123
 
 Function BoolLiteralAfterTypedBool (arity: 1, kind: Bytecode):
@@ -83,17 +83,28 @@ Function DuplicateBoolLiteral (arity: 1, kind: Bytecode):
      16   RETURN                 
 
 Function DuplicateEnumVariant (arity: 1, kind: Bytecode):
-     0    LOAD_VAR 1         (s)
-     1    DISCRIMINANT       
-     2    JUMP_TABLE 0, +1   (table 0, default +1)
-     3    LOAD_CONST 0       ("pending")
-     4    JUMP +6            (to 10)
-     5    LOAD_CONST 1       ("inactive")
-     6    JUMP +4            (to 10)
-     7    LOAD_CONST 2       ("second")
-     8    JUMP +2            (to 10)
-     9    LOAD_CONST 3       ("first")
-     10   RETURN             
+     0    LOAD_VAR 1             (s)
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +13               (to 20)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (1)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +5                (to 18)
+     14   POP 1                  
+     15   JUMP +1                (to 16)
+     16   LOAD_CONST 2           ("pending")
+     17   JUMP +4                (to 21)
+     18   LOAD_CONST 3           ("inactive")
+     19   JUMP +2                (to 21)
+     20   LOAD_CONST 4           ("first")
+     21   RETURN                 
 
 Function DuplicateIntLiteral (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (x)
@@ -102,20 +113,12 @@ Function DuplicateIntLiteral (arity: 1, kind: Bytecode):
      3    CMP_OP ==              
      4    POP_JUMP_IF_FALSE +3   (to 7)
      5    POP 1                  
-     6    JUMP +12               (to 18)
-     7    COPY 0                 
-     8    LOAD_CONST 0           (1)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +3   (to 13)
-     11   POP 1                  
-     12   JUMP +4                (to 16)
-     13   POP 1                  
-     14   LOAD_CONST 1           ("other")
-     15   JUMP +4                (to 19)
-     16   LOAD_CONST 2           ("second one")
-     17   JUMP +2                (to 19)
-     18   LOAD_CONST 3           ("first one")
-     19   RETURN                 
+     6    JUMP +4                (to 10)
+     7    POP 1                  
+     8    LOAD_CONST 1           ("other")
+     9    JUMP +2                (to 11)
+     10   LOAD_CONST 2           ("first one")
+     11   RETURN                 
 
 Function DuplicateStringLiteral (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1              (role)
@@ -837,19 +840,28 @@ Function MixedPatterns (arity: 1, kind: Bytecode):
      25   RETURN                 
 
 Function MultipleUnreachableSpans (arity: 1, kind: Bytecode):
-     0    LOAD_VAR 1         (s)
-     1    DISCRIMINANT       
-     2    JUMP_TABLE 0, +1   (table 0, default +1)
-     3    LOAD_CONST 0       ("pending")
-     4    JUMP +8            (to 12)
-     5    LOAD_CONST 1       ("duplicate 2")
-     6    JUMP +6            (to 12)
-     7    LOAD_CONST 2       ("inactive")
-     8    JUMP +4            (to 12)
-     9    LOAD_CONST 3       ("duplicate 1")
-     10   JUMP +2            (to 12)
-     11   LOAD_CONST 4       ("active")
-     12   RETURN             
+     0    LOAD_VAR 1             (s)
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +13               (to 20)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (1)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +5                (to 18)
+     14   POP 1                  
+     15   JUMP +1                (to 16)
+     16   LOAD_CONST 2           ("pending")
+     17   JUMP +4                (to 21)
+     18   LOAD_CONST 3           ("inactive")
+     19   JUMP +2                (to 21)
+     20   LOAD_CONST 4           ("active")
+     21   RETURN                 
 
 Function NestedEnumMatch (arity: 2, kind: Bytecode):
      0    LOAD_VAR 1             (s1)

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-86d881872effcad8/out/generated_tests.rs
+source: target/debug/build/baml_tests-7b144ed8705f275d/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
@@ -83,33 +83,17 @@ Function DuplicateBoolLiteral (arity: 1, kind: Bytecode):
      16   RETURN                 
 
 Function DuplicateEnumVariant (arity: 1, kind: Bytecode):
-     0    LOAD_VAR 1             (s)
-     1    LOAD_CONST 0           (0)
-     2    ALLOC_VARIANT 3        (<enum Status>)
-     3    CMP_OP ==              
-     4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +20               (to 25)
-     6    LOAD_VAR 1             (s)
-     7    LOAD_CONST 0           (0)
-     8    ALLOC_VARIANT 3        (<enum Status>)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +12               (to 23)
-     12   LOAD_VAR 1             (s)
-     13   LOAD_CONST 1           (1)
-     14   ALLOC_VARIANT 3        (<enum Status>)
-     15   CMP_OP ==              
-     16   POP_JUMP_IF_FALSE +2   (to 18)
-     17   JUMP +4                (to 21)
-     18   JUMP +1                (to 19)
-     19   LOAD_CONST 2           ("pending")
-     20   JUMP +6                (to 26)
-     21   LOAD_CONST 3           ("inactive")
-     22   JUMP +4                (to 26)
-     23   LOAD_CONST 4           ("second")
-     24   JUMP +2                (to 26)
-     25   LOAD_CONST 5           ("first")
-     26   RETURN                 
+     0    LOAD_VAR 1         (s)
+     1    DISCRIMINANT       
+     2    JUMP_TABLE 0, +1   (table 0, default +1)
+     3    LOAD_CONST 0       ("pending")
+     4    JUMP +6            (to 10)
+     5    LOAD_CONST 1       ("inactive")
+     6    JUMP +4            (to 10)
+     7    LOAD_CONST 2       ("second")
+     8    JUMP +2            (to 10)
+     9    LOAD_CONST 3       ("first")
+     10   RETURN             
 
 Function DuplicateIntLiteral (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (x)
@@ -177,40 +161,51 @@ Function EnumVariantAfterTypedEnum (arity: 1, kind: Bytecode):
 
 Function EnumVariantUnion (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)
-     1    LOAD_CONST 0           (0)
-     2    ALLOC_VARIANT 3        (<enum Status>)
-     3    CMP_OP ==              
-     4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +10               (to 15)
-     6    LOAD_VAR 1             (s)
-     7    LOAD_CONST 1           (2)
-     8    ALLOC_VARIANT 3        (<enum Status>)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +4                (to 15)
-     12   JUMP +1                (to 13)
-     13   LOAD_CONST 2           ("inactive")
-     14   JUMP +2                (to 16)
-     15   LOAD_CONST 3           ("actionable")
-     16   RETURN                 
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +16               (to 23)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (2)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +10               (to 23)
+     14   COPY 0                 
+     15   LOAD_CONST 2           (1)
+     16   CMP_OP ==              
+     17   POP_JUMP_IF_FALSE +3   (to 20)
+     18   POP 1                  
+     19   JUMP +2                (to 21)
+     20   POP 1                  
+     21   LOAD_CONST 3           ("inactive")
+     22   JUMP +2                (to 24)
+     23   LOAD_CONST 4           ("actionable")
+     24   RETURN                 
 
 Function EnumVariantUnionWithCatchAll (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)
-     1    LOAD_CONST 0           (0)
-     2    ALLOC_VARIANT 3        (<enum Status>)
-     3    CMP_OP ==              
-     4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +9                (to 14)
-     6    LOAD_VAR 1             (s)
-     7    LOAD_CONST 1           (2)
-     8    ALLOC_VARIANT 3        (<enum Status>)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +3                (to 14)
-     12   LOAD_CONST 2           ("other")
-     13   JUMP +2                (to 15)
-     14   LOAD_CONST 3           ("actionable")
-     15   RETURN                 
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +10               (to 17)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (2)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +4                (to 17)
+     14   POP 1                  
+     15   LOAD_CONST 2           ("other")
+     16   JUMP +2                (to 18)
+     17   LOAD_CONST 3           ("actionable")
+     18   RETURN                 
 
 Function ExhaustiveAliasOfLiterals (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (code)
@@ -307,36 +302,47 @@ Function ExhaustiveDoubleMaybe (arity: 1, kind: Bytecode):
 
 Function ExhaustiveEnumAllVariants (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)
-     1    LOAD_CONST 0           (0)
-     2    ALLOC_VARIANT 3        (<enum Status>)
-     3    CMP_OP ==              
-     4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +12               (to 17)
-     6    LOAD_VAR 1             (s)
-     7    LOAD_CONST 1           (1)
-     8    ALLOC_VARIANT 3        (<enum Status>)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +4                (to 15)
-     12   JUMP +1                (to 13)
-     13   LOAD_CONST 2           ("pending")
-     14   JUMP +4                (to 18)
-     15   LOAD_CONST 3           ("inactive")
-     16   JUMP +2                (to 18)
-     17   LOAD_CONST 4           ("active")
-     18   RETURN                 
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +18               (to 25)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (1)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +10               (to 23)
+     14   COPY 0                 
+     15   LOAD_CONST 2           (2)
+     16   CMP_OP ==              
+     17   POP_JUMP_IF_FALSE +3   (to 20)
+     18   POP 1                  
+     19   JUMP +2                (to 21)
+     20   POP 1                  
+     21   LOAD_CONST 3           ("pending")
+     22   JUMP +4                (to 26)
+     23   LOAD_CONST 4           ("inactive")
+     24   JUMP +2                (to 26)
+     25   LOAD_CONST 5           ("active")
+     26   RETURN                 
 
 Function ExhaustiveEnumWithCatchAll (arity: 1, kind: Bytecode):
-     0   LOAD_VAR 1             (s)
-     1   LOAD_CONST 0           (0)
-     2   ALLOC_VARIANT 3        (<enum Status>)
-     3   CMP_OP ==              
-     4   POP_JUMP_IF_FALSE +2   (to 6)
-     5   JUMP +3                (to 8)
-     6   LOAD_CONST 1           ("other")
-     7   JUMP +2                (to 9)
-     8   LOAD_CONST 2           ("active")
-     9   RETURN                 
+     0    LOAD_VAR 1             (s)
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +4                (to 11)
+     8    POP 1                  
+     9    LOAD_CONST 1           ("other")
+     10   JUMP +2                (to 12)
+     11   LOAD_CONST 2           ("active")
+     12   RETURN                 
 
 Function ExhaustiveEnumWithTypedPattern (arity: 1, kind: Bytecode):
      0   JUMP +1        (to 1)
@@ -650,15 +656,17 @@ Function GuardedWithFallback (arity: 1, kind: Bytecode):
      13   RETURN                 
 
 Function HighLineNumberNonExhaustive (arity: 1, kind: Bytecode):
-     0   LOAD_VAR 1             (s)
-     1   LOAD_CONST 0           (0)
-     2   ALLOC_VARIANT 3        (<enum Status>)
-     3   CMP_OP ==              
-     4   POP_JUMP_IF_FALSE +3   (to 7)
-     5   JUMP +2                (to 7)
-     6   JUMP +1                (to 7)
-     7   LOAD_CONST 1           ("active only")
-     8   RETURN                 
+     0    LOAD_VAR 1             (s)
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +2                (to 9)
+     8    POP 1                  
+     9    LOAD_CONST 1           ("active only")
+     10   RETURN                 
 
 Function IntLiteralUnionPattern (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (code)
@@ -786,29 +794,34 @@ Function MatchComplexScrutinee (arity: 1, kind: Bytecode):
      23   RETURN                 
 
 Function MatchFunctionCallScrutinee (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_GLOBAL 78         (<fn GetStatus>)
-     2    CALL 0                 
-     3    STORE_VAR 1            (_1)
-     4    LOAD_VAR 1             (_1)
-     5    LOAD_CONST 1           (0)
-     6    ALLOC_VARIANT 3        (<enum Status>)
-     7    CMP_OP ==              
-     8    POP_JUMP_IF_FALSE +2   (to 10)
-     9    JUMP +12               (to 21)
-     10   LOAD_VAR 1             (_1)
-     11   LOAD_CONST 2           (1)
-     12   ALLOC_VARIANT 3        (<enum Status>)
-     13   CMP_OP ==              
-     14   POP_JUMP_IF_FALSE +2   (to 16)
-     15   JUMP +4                (to 19)
-     16   JUMP +1                (to 17)
-     17   LOAD_CONST 3           ("pending")
-     18   JUMP +4                (to 22)
-     19   LOAD_CONST 4           ("inactive")
+     0    LOAD_GLOBAL 78         (<fn GetStatus>)
+     1    CALL 0                 
+     2    DISCRIMINANT           
+     3    COPY 0                 
+     4    LOAD_CONST 0           (0)
+     5    CMP_OP ==              
+     6    POP_JUMP_IF_FALSE +3   (to 9)
+     7    POP 1                  
+     8    JUMP +18               (to 26)
+     9    COPY 0                 
+     10   LOAD_CONST 1           (1)
+     11   CMP_OP ==              
+     12   POP_JUMP_IF_FALSE +3   (to 15)
+     13   POP 1                  
+     14   JUMP +10               (to 24)
+     15   COPY 0                 
+     16   LOAD_CONST 2           (2)
+     17   CMP_OP ==              
+     18   POP_JUMP_IF_FALSE +3   (to 21)
+     19   POP 1                  
      20   JUMP +2                (to 22)
-     21   LOAD_CONST 5           ("active")
-     22   RETURN                 
+     21   POP 1                  
+     22   LOAD_CONST 3           ("pending")
+     23   JUMP +4                (to 27)
+     24   LOAD_CONST 4           ("inactive")
+     25   JUMP +2                (to 27)
+     26   LOAD_CONST 5           ("active")
+     27   RETURN                 
 
 Function MixedPatterns (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (x)
@@ -839,96 +852,98 @@ Function MixedPatterns (arity: 1, kind: Bytecode):
      25   RETURN                 
 
 Function MultipleUnreachableSpans (arity: 1, kind: Bytecode):
-     0    LOAD_VAR 1             (s)
-     1    LOAD_CONST 0           (0)
-     2    ALLOC_VARIANT 3        (<enum Status>)
-     3    CMP_OP ==              
-     4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +28               (to 33)
-     6    LOAD_VAR 1             (s)
-     7    LOAD_CONST 0           (0)
-     8    ALLOC_VARIANT 3        (<enum Status>)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +20               (to 31)
-     12   LOAD_VAR 1             (s)
-     13   LOAD_CONST 1           (1)
-     14   ALLOC_VARIANT 3        (<enum Status>)
-     15   CMP_OP ==              
-     16   POP_JUMP_IF_FALSE +2   (to 18)
-     17   JUMP +12               (to 29)
-     18   LOAD_VAR 1             (s)
-     19   LOAD_CONST 0           (0)
-     20   ALLOC_VARIANT 3        (<enum Status>)
-     21   CMP_OP ==              
-     22   POP_JUMP_IF_FALSE +2   (to 24)
-     23   JUMP +4                (to 27)
-     24   JUMP +1                (to 25)
-     25   LOAD_CONST 2           ("pending")
-     26   JUMP +8                (to 34)
-     27   LOAD_CONST 3           ("duplicate 2")
-     28   JUMP +6                (to 34)
-     29   LOAD_CONST 4           ("inactive")
-     30   JUMP +4                (to 34)
-     31   LOAD_CONST 5           ("duplicate 1")
-     32   JUMP +2                (to 34)
-     33   LOAD_CONST 6           ("active")
-     34   RETURN                 
+     0    LOAD_VAR 1         (s)
+     1    DISCRIMINANT       
+     2    JUMP_TABLE 0, +1   (table 0, default +1)
+     3    LOAD_CONST 0       ("pending")
+     4    JUMP +8            (to 12)
+     5    LOAD_CONST 1       ("duplicate 2")
+     6    JUMP +6            (to 12)
+     7    LOAD_CONST 2       ("inactive")
+     8    JUMP +4            (to 12)
+     9    LOAD_CONST 3       ("duplicate 1")
+     10   JUMP +2            (to 12)
+     11   LOAD_CONST 4       ("active")
+     12   RETURN             
 
 Function NestedEnumMatch (arity: 2, kind: Bytecode):
      0    LOAD_VAR 1             (s1)
-     1    LOAD_CONST 0           (0)
-     2    ALLOC_VARIANT 3        (<enum Status>)
-     3    CMP_OP ==              
-     4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +12               (to 17)
-     6    LOAD_VAR 1             (s1)
-     7    LOAD_CONST 1           (1)
-     8    ALLOC_VARIANT 3        (<enum Status>)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +4                (to 15)
-     12   JUMP +1                (to 13)
-     13   LOAD_CONST 2           ("first pending")
-     14   JUMP +21               (to 35)
-     15   LOAD_CONST 3           ("first inactive")
-     16   JUMP +19               (to 35)
-     17   LOAD_VAR 2             (s2)
-     18   LOAD_CONST 0           (0)
-     19   ALLOC_VARIANT 3        (<enum Status>)
-     20   CMP_OP ==              
-     21   POP_JUMP_IF_FALSE +2   (to 23)
-     22   JUMP +12               (to 34)
-     23   LOAD_VAR 2             (s2)
-     24   LOAD_CONST 1           (1)
-     25   ALLOC_VARIANT 3        (<enum Status>)
-     26   CMP_OP ==              
-     27   POP_JUMP_IF_FALSE +2   (to 29)
-     28   JUMP +4                (to 32)
-     29   JUMP +1                (to 30)
-     30   LOAD_CONST 4           ("first active, second pending")
-     31   JUMP +4                (to 35)
-     32   LOAD_CONST 5           ("first active, second inactive")
-     33   JUMP +2                (to 35)
-     34   LOAD_CONST 6           ("both active")
-     35   RETURN                 
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +18               (to 25)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (1)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +10               (to 23)
+     14   COPY 0                 
+     15   LOAD_CONST 2           (2)
+     16   CMP_OP ==              
+     17   POP_JUMP_IF_FALSE +3   (to 20)
+     18   POP 1                  
+     19   JUMP +2                (to 21)
+     20   POP 1                  
+     21   LOAD_CONST 3           ("first pending")
+     22   JUMP +29               (to 51)
+     23   LOAD_CONST 4           ("first inactive")
+     24   JUMP +27               (to 51)
+     25   LOAD_VAR 2             (s2)
+     26   DISCRIMINANT           
+     27   COPY 0                 
+     28   LOAD_CONST 0           (0)
+     29   CMP_OP ==              
+     30   POP_JUMP_IF_FALSE +3   (to 33)
+     31   POP 1                  
+     32   JUMP +18               (to 50)
+     33   COPY 0                 
+     34   LOAD_CONST 1           (1)
+     35   CMP_OP ==              
+     36   POP_JUMP_IF_FALSE +3   (to 39)
+     37   POP 1                  
+     38   JUMP +10               (to 48)
+     39   COPY 0                 
+     40   LOAD_CONST 2           (2)
+     41   CMP_OP ==              
+     42   POP_JUMP_IF_FALSE +3   (to 45)
+     43   POP 1                  
+     44   JUMP +2                (to 46)
+     45   POP 1                  
+     46   LOAD_CONST 5           ("first active, second pending")
+     47   JUMP +4                (to 51)
+     48   LOAD_CONST 6           ("first active, second inactive")
+     49   JUMP +2                (to 51)
+     50   LOAD_CONST 7           ("both active")
+     51   RETURN                 
 
 Function NestedEnumVariantUnions (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)
-     1    LOAD_CONST 0           (0)
-     2    ALLOC_VARIANT 3        (<enum Status>)
-     3    CMP_OP ==              
-     4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +8                (to 13)
-     6    LOAD_VAR 1             (s)
-     7    LOAD_CONST 1           (2)
-     8    ALLOC_VARIANT 3        (<enum Status>)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +2                (to 13)
-     12   JUMP +1                (to 13)
-     13   LOAD_CONST 2           ("all statuses")
-     14   RETURN                 
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +14               (to 21)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (2)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +8                (to 21)
+     14   COPY 0                 
+     15   LOAD_CONST 2           (1)
+     16   CMP_OP ==              
+     17   POP_JUMP_IF_FALSE +3   (to 20)
+     18   POP 1                  
+     19   JUMP +2                (to 21)
+     20   POP 1                  
+     21   LOAD_CONST 3           ("all statuses")
+     22   RETURN                 
 
 Function NestedLiteralUnions (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1              (code)
@@ -1162,34 +1177,38 @@ Function NonExhaustiveDoubleMaybeMissingNull (arity: 1, kind: Bytecode):
      16   RETURN                 
 
 Function NonExhaustiveEnumMissingMultiple (arity: 1, kind: Bytecode):
-     0   LOAD_VAR 1             (s)
-     1   LOAD_CONST 0           (0)
-     2   ALLOC_VARIANT 3        (<enum Status>)
-     3   CMP_OP ==              
-     4   POP_JUMP_IF_FALSE +3   (to 7)
-     5   JUMP +2                (to 7)
-     6   JUMP +1                (to 7)
-     7   LOAD_CONST 1           ("active")
-     8   RETURN                 
+     0    LOAD_VAR 1             (s)
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +2                (to 9)
+     8    POP 1                  
+     9    LOAD_CONST 1           ("active")
+     10   RETURN                 
 
 Function NonExhaustiveEnumMissingOne (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)
-     1    LOAD_CONST 0           (0)
-     2    ALLOC_VARIANT 3        (<enum Status>)
-     3    CMP_OP ==              
-     4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +10               (to 15)
-     6    LOAD_VAR 1             (s)
-     7    LOAD_CONST 1           (1)
-     8    ALLOC_VARIANT 3        (<enum Status>)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +6   (to 16)
-     11   JUMP +2                (to 13)
-     12   JUMP +4                (to 16)
-     13   LOAD_CONST 2           ("inactive")
-     14   JUMP +2                (to 16)
-     15   LOAD_CONST 3           ("active")
-     16   RETURN                 
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +10               (to 17)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (1)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +2                (to 15)
+     14   POP 1                  
+     15   LOAD_CONST 2           ("inactive")
+     16   JUMP +2                (to 18)
+     17   LOAD_CONST 3           ("active")
+     18   RETURN                 
 
 Function NonExhaustiveFullResultMissingOne (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (r)
@@ -1249,30 +1268,32 @@ Function NonExhaustiveMixedLiterals (arity: 1, kind: Bytecode):
 
 Function NonExhaustiveNullableEnumMissingNull (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)
-     1    LOAD_CONST 0           (0)
-     2    ALLOC_VARIANT 3        (<enum Status>)
-     3    CMP_OP ==              
-     4    POP_JUMP_IF_FALSE +2   (to 6)
-     5    JUMP +18               (to 23)
-     6    LOAD_VAR 1             (s)
-     7    LOAD_CONST 1           (1)
-     8    ALLOC_VARIANT 3        (<enum Status>)
-     9    CMP_OP ==              
-     10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +10               (to 21)
-     12   LOAD_VAR 1             (s)
-     13   LOAD_CONST 2           (2)
-     14   ALLOC_VARIANT 3        (<enum Status>)
-     15   CMP_OP ==              
-     16   POP_JUMP_IF_FALSE +8   (to 24)
-     17   JUMP +2                (to 19)
-     18   JUMP +6                (to 24)
-     19   LOAD_CONST 3           ("pending")
-     20   JUMP +4                (to 24)
-     21   LOAD_CONST 4           ("inactive")
-     22   JUMP +2                (to 24)
-     23   LOAD_CONST 5           ("active")
-     24   RETURN                 
+     1    DISCRIMINANT           
+     2    COPY 0                 
+     3    LOAD_CONST 0           (0)
+     4    CMP_OP ==              
+     5    POP_JUMP_IF_FALSE +3   (to 8)
+     6    POP 1                  
+     7    JUMP +18               (to 25)
+     8    COPY 0                 
+     9    LOAD_CONST 1           (1)
+     10   CMP_OP ==              
+     11   POP_JUMP_IF_FALSE +3   (to 14)
+     12   POP 1                  
+     13   JUMP +10               (to 23)
+     14   COPY 0                 
+     15   LOAD_CONST 2           (2)
+     16   CMP_OP ==              
+     17   POP_JUMP_IF_FALSE +3   (to 20)
+     18   POP 1                  
+     19   JUMP +2                (to 21)
+     20   POP 1                  
+     21   LOAD_CONST 3           ("pending")
+     22   JUMP +4                (to 26)
+     23   LOAD_CONST 4           ("inactive")
+     24   JUMP +2                (to 26)
+     25   LOAD_CONST 5           ("active")
+     26   RETURN                 
 
 Function NonExhaustiveNullableEnumMissingVariant (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-7b144ed8705f275d/out/generated_tests.rs
+source: target/debug/build/baml_tests-5af6b621dd74eb70/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
@@ -167,24 +167,19 @@ Function EnumVariantUnion (arity: 1, kind: Bytecode):
      4    CMP_OP ==              
      5    POP_JUMP_IF_FALSE +3   (to 8)
      6    POP 1                  
-     7    JUMP +16               (to 23)
+     7    JUMP +11               (to 18)
      8    COPY 0                 
      9    LOAD_CONST 1           (2)
      10   CMP_OP ==              
      11   POP_JUMP_IF_FALSE +3   (to 14)
      12   POP 1                  
-     13   JUMP +10               (to 23)
-     14   COPY 0                 
-     15   LOAD_CONST 2           (1)
-     16   CMP_OP ==              
-     17   POP_JUMP_IF_FALSE +3   (to 20)
-     18   POP 1                  
-     19   JUMP +2                (to 21)
-     20   POP 1                  
-     21   LOAD_CONST 3           ("inactive")
-     22   JUMP +2                (to 24)
-     23   LOAD_CONST 4           ("actionable")
-     24   RETURN                 
+     13   JUMP +5                (to 18)
+     14   POP 1                  
+     15   JUMP +1                (to 16)
+     16   LOAD_CONST 2           ("inactive")
+     17   JUMP +2                (to 19)
+     18   LOAD_CONST 3           ("actionable")
+     19   RETURN                 
 
 Function EnumVariantUnionWithCatchAll (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)
@@ -308,26 +303,21 @@ Function ExhaustiveEnumAllVariants (arity: 1, kind: Bytecode):
      4    CMP_OP ==              
      5    POP_JUMP_IF_FALSE +3   (to 8)
      6    POP 1                  
-     7    JUMP +18               (to 25)
+     7    JUMP +13               (to 20)
      8    COPY 0                 
      9    LOAD_CONST 1           (1)
      10   CMP_OP ==              
      11   POP_JUMP_IF_FALSE +3   (to 14)
      12   POP 1                  
-     13   JUMP +10               (to 23)
-     14   COPY 0                 
-     15   LOAD_CONST 2           (2)
-     16   CMP_OP ==              
-     17   POP_JUMP_IF_FALSE +3   (to 20)
-     18   POP 1                  
+     13   JUMP +5                (to 18)
+     14   POP 1                  
+     15   JUMP +1                (to 16)
+     16   LOAD_CONST 2           ("pending")
+     17   JUMP +4                (to 21)
+     18   LOAD_CONST 3           ("inactive")
      19   JUMP +2                (to 21)
-     20   POP 1                  
-     21   LOAD_CONST 3           ("pending")
-     22   JUMP +4                (to 26)
-     23   LOAD_CONST 4           ("inactive")
-     24   JUMP +2                (to 26)
-     25   LOAD_CONST 5           ("active")
-     26   RETURN                 
+     20   LOAD_CONST 4           ("active")
+     21   RETURN                 
 
 Function ExhaustiveEnumWithCatchAll (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)
@@ -802,26 +792,21 @@ Function MatchFunctionCallScrutinee (arity: 0, kind: Bytecode):
      5    CMP_OP ==              
      6    POP_JUMP_IF_FALSE +3   (to 9)
      7    POP 1                  
-     8    JUMP +18               (to 26)
+     8    JUMP +13               (to 21)
      9    COPY 0                 
      10   LOAD_CONST 1           (1)
      11   CMP_OP ==              
      12   POP_JUMP_IF_FALSE +3   (to 15)
      13   POP 1                  
-     14   JUMP +10               (to 24)
-     15   COPY 0                 
-     16   LOAD_CONST 2           (2)
-     17   CMP_OP ==              
-     18   POP_JUMP_IF_FALSE +3   (to 21)
-     19   POP 1                  
+     14   JUMP +5                (to 19)
+     15   POP 1                  
+     16   JUMP +1                (to 17)
+     17   LOAD_CONST 2           ("pending")
+     18   JUMP +4                (to 22)
+     19   LOAD_CONST 3           ("inactive")
      20   JUMP +2                (to 22)
-     21   POP 1                  
-     22   LOAD_CONST 3           ("pending")
-     23   JUMP +4                (to 27)
-     24   LOAD_CONST 4           ("inactive")
-     25   JUMP +2                (to 27)
-     26   LOAD_CONST 5           ("active")
-     27   RETURN                 
+     21   LOAD_CONST 4           ("active")
+     22   RETURN                 
 
 Function MixedPatterns (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (x)
@@ -874,51 +859,41 @@ Function NestedEnumMatch (arity: 2, kind: Bytecode):
      4    CMP_OP ==              
      5    POP_JUMP_IF_FALSE +3   (to 8)
      6    POP 1                  
-     7    JUMP +18               (to 25)
+     7    JUMP +13               (to 20)
      8    COPY 0                 
      9    LOAD_CONST 1           (1)
      10   CMP_OP ==              
      11   POP_JUMP_IF_FALSE +3   (to 14)
      12   POP 1                  
-     13   JUMP +10               (to 23)
-     14   COPY 0                 
-     15   LOAD_CONST 2           (2)
-     16   CMP_OP ==              
-     17   POP_JUMP_IF_FALSE +3   (to 20)
-     18   POP 1                  
-     19   JUMP +2                (to 21)
-     20   POP 1                  
-     21   LOAD_CONST 3           ("first pending")
-     22   JUMP +29               (to 51)
-     23   LOAD_CONST 4           ("first inactive")
-     24   JUMP +27               (to 51)
-     25   LOAD_VAR 2             (s2)
-     26   DISCRIMINANT           
-     27   COPY 0                 
-     28   LOAD_CONST 0           (0)
-     29   CMP_OP ==              
-     30   POP_JUMP_IF_FALSE +3   (to 33)
-     31   POP 1                  
-     32   JUMP +18               (to 50)
-     33   COPY 0                 
-     34   LOAD_CONST 1           (1)
-     35   CMP_OP ==              
-     36   POP_JUMP_IF_FALSE +3   (to 39)
-     37   POP 1                  
-     38   JUMP +10               (to 48)
-     39   COPY 0                 
-     40   LOAD_CONST 2           (2)
-     41   CMP_OP ==              
-     42   POP_JUMP_IF_FALSE +3   (to 45)
-     43   POP 1                  
-     44   JUMP +2                (to 46)
-     45   POP 1                  
-     46   LOAD_CONST 5           ("first active, second pending")
-     47   JUMP +4                (to 51)
-     48   LOAD_CONST 6           ("first active, second inactive")
-     49   JUMP +2                (to 51)
-     50   LOAD_CONST 7           ("both active")
-     51   RETURN                 
+     13   JUMP +5                (to 18)
+     14   POP 1                  
+     15   JUMP +1                (to 16)
+     16   LOAD_CONST 2           ("first pending")
+     17   JUMP +24               (to 41)
+     18   LOAD_CONST 3           ("first inactive")
+     19   JUMP +22               (to 41)
+     20   LOAD_VAR 2             (s2)
+     21   DISCRIMINANT           
+     22   COPY 0                 
+     23   LOAD_CONST 0           (0)
+     24   CMP_OP ==              
+     25   POP_JUMP_IF_FALSE +3   (to 28)
+     26   POP 1                  
+     27   JUMP +13               (to 40)
+     28   COPY 0                 
+     29   LOAD_CONST 1           (1)
+     30   CMP_OP ==              
+     31   POP_JUMP_IF_FALSE +3   (to 34)
+     32   POP 1                  
+     33   JUMP +5                (to 38)
+     34   POP 1                  
+     35   JUMP +1                (to 36)
+     36   LOAD_CONST 4           ("first active, second pending")
+     37   JUMP +4                (to 41)
+     38   LOAD_CONST 5           ("first active, second inactive")
+     39   JUMP +2                (to 41)
+     40   LOAD_CONST 6           ("both active")
+     41   RETURN                 
 
 Function NestedEnumVariantUnions (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (s)
@@ -928,22 +903,17 @@ Function NestedEnumVariantUnions (arity: 1, kind: Bytecode):
      4    CMP_OP ==              
      5    POP_JUMP_IF_FALSE +3   (to 8)
      6    POP 1                  
-     7    JUMP +14               (to 21)
+     7    JUMP +9                (to 16)
      8    COPY 0                 
      9    LOAD_CONST 1           (2)
      10   CMP_OP ==              
      11   POP_JUMP_IF_FALSE +3   (to 14)
      12   POP 1                  
-     13   JUMP +8                (to 21)
-     14   COPY 0                 
-     15   LOAD_CONST 2           (1)
-     16   CMP_OP ==              
-     17   POP_JUMP_IF_FALSE +3   (to 20)
-     18   POP 1                  
-     19   JUMP +2                (to 21)
-     20   POP 1                  
-     21   LOAD_CONST 3           ("all statuses")
-     22   RETURN                 
+     13   JUMP +3                (to 16)
+     14   POP 1                  
+     15   JUMP +1                (to 16)
+     16   LOAD_CONST 2           ("all statuses")
+     17   RETURN                 
 
 Function NestedLiteralUnions (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1              (code)

--- a/baml_language/crates/baml_typetags/Cargo.toml
+++ b/baml_language/crates/baml_typetags/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "baml_typetags"
+version = "0.1.0"
+edition = "2021"
+description = "Type tag constants for BAML runtime type identification"
+license = "MIT"
+
+[dependencies]
+# No dependencies - this is a leaf crate containing only constants

--- a/baml_language/crates/baml_typetags/src/lib.rs
+++ b/baml_language/crates/baml_typetags/src/lib.rs
@@ -1,0 +1,60 @@
+//! Type tag constants for BAML runtime type identification.
+//!
+//! This crate defines global type tag constants used by both the compiler
+//! (for generating type-discriminated switch statements) and the VM
+//! (for runtime type identification).
+//!
+//! # Type Tag Assignment
+//!
+//! - **Primitives** (0-99): Fixed tags for built-in types
+//! - **Classes** (100+): Dynamically assigned at compile time as `CLASS_BASE + index`
+//!
+//! # Usage
+//!
+//! The `TypeTag` instruction extracts a type identifier from any value,
+//! enabling efficient jump table dispatch on union types.
+
+/// Integer type tag.
+pub const INT: i64 = 0;
+
+/// String type tag.
+pub const STRING: i64 = 1;
+
+/// Boolean type tag.
+pub const BOOL: i64 = 2;
+
+/// Null type tag.
+pub const NULL: i64 = 3;
+
+/// Float type tag.
+pub const FLOAT: i64 = 4;
+
+/// Enum variant type tag (all variants share this).
+pub const ENUM: i64 = 5;
+
+/// List/array type tag.
+pub const LIST: i64 = 6;
+
+/// Map type tag.
+pub const MAP: i64 = 7;
+
+/// Function type tag.
+pub const FUNCTION: i64 = 8;
+
+/// Future type tag.
+pub const FUTURE: i64 = 9;
+
+/// Media type tag.
+pub const MEDIA: i64 = 10;
+
+/// Resource type tag (file handle, socket, etc.).
+pub const RESOURCE: i64 = 11;
+
+/// `PromptAst` type tag.
+pub const PROMPT_AST: i64 = 12;
+
+/// Base value for class type tags (classes start at 100).
+pub const CLASS_BASE: i64 = 100;
+
+/// Unknown/invalid type tag.
+pub const UNKNOWN: i64 = -1;

--- a/baml_language/crates/bex_vm/tests/match_expr.rs
+++ b/baml_language/crates/bex_vm/tests/match_expr.rs
@@ -1159,6 +1159,26 @@ fn match_union_client_error() -> anyhow::Result<()> {
     })
 }
 
+#[test]
+fn match_union_with_duplicates() -> anyhow::Result<()> {
+    // Duplicate values in union patterns should be handled correctly
+    // (deduplicated, not cause undefined behavior)
+    assert_vm_executes(Program {
+        source: r#"
+            function main() -> string {
+                let x = 1;
+                match (x) {
+                    1 | 1 | 2 => "one or two",
+                    3 | 3 => "three",
+                    _ => "other"
+                }
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::string("one or two")),
+    })
+}
+
 // ============================================================================
 // Catch-All Binding with Integer Patterns
 // ============================================================================

--- a/baml_language/crates/bex_vm/tests/match_expr.rs
+++ b/baml_language/crates/bex_vm/tests/match_expr.rs
@@ -1772,6 +1772,168 @@ fn match_enum_variant_last() -> anyhow::Result<()> {
 }
 
 // ============================================================================
+// Non-Exhaustive Enum Tests (with wildcard)
+// ============================================================================
+
+#[test]
+fn match_enum_variant_with_wildcard() -> anyhow::Result<()> {
+    // Non-exhaustive: wildcard catches unmatched variants
+    assert_vm_executes(Program {
+        source: r#"
+            enum Status {
+                Active
+                Inactive
+                Pending
+            }
+
+            function classify(s Status) -> string {
+                match (s) {
+                    Status.Active => "active",
+                    Status.Inactive => "inactive",
+                    _ => "other"
+                }
+            }
+            function main() -> string {
+                classify(Status.Pending)
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::string("other")),
+    })
+}
+
+#[test]
+fn match_enum_variant_with_wildcard_matched() -> anyhow::Result<()> {
+    // Non-exhaustive: explicit variant matched
+    assert_vm_executes(Program {
+        source: r#"
+            enum Status {
+                Active
+                Inactive
+                Pending
+            }
+
+            function classify(s Status) -> string {
+                match (s) {
+                    Status.Active => "active",
+                    Status.Inactive => "inactive",
+                    _ => "other"
+                }
+            }
+            function main() -> string {
+                classify(Status.Active)
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::string("active")),
+    })
+}
+
+// ============================================================================
+// Exhaustive and Non-Exhaustive Class Type Tests
+// ============================================================================
+
+#[test]
+fn match_class_types_exhaustive_first() -> anyhow::Result<()> {
+    // Exhaustive: all classes covered, matches first
+    assert_vm_executes(Program {
+        source: r#"
+            class Cat { name string }
+            class Dog { name string }
+            class Bird { name string }
+
+            function classify(animal Cat | Dog | Bird) -> string {
+                match (animal) {
+                    c: Cat => "cat: " + c.name,
+                    d: Dog => "dog: " + d.name,
+                    b: Bird => "bird: " + b.name
+                }
+            }
+            function main() -> string {
+                classify(Cat { name: "Whiskers" })
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::string("cat: Whiskers")),
+    })
+}
+
+#[test]
+fn match_class_types_exhaustive_last() -> anyhow::Result<()> {
+    // Exhaustive: all classes covered, matches last
+    assert_vm_executes(Program {
+        source: r#"
+            class Cat { name string }
+            class Dog { name string }
+            class Bird { name string }
+
+            function classify(animal Cat | Dog | Bird) -> string {
+                match (animal) {
+                    c: Cat => "cat: " + c.name,
+                    d: Dog => "dog: " + d.name,
+                    b: Bird => "bird: " + b.name
+                }
+            }
+            function main() -> string {
+                classify(Bird { name: "Tweety" })
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::string("bird: Tweety")),
+    })
+}
+
+#[test]
+fn match_class_types_non_exhaustive_wildcard() -> anyhow::Result<()> {
+    // Non-exhaustive: wildcard catches unmatched class
+    assert_vm_executes(Program {
+        source: r#"
+            class Cat { name string }
+            class Dog { name string }
+            class Bird { name string }
+
+            function classify(animal Cat | Dog | Bird) -> string {
+                match (animal) {
+                    c: Cat => "cat: " + c.name,
+                    d: Dog => "dog: " + d.name,
+                    _ => "other"
+                }
+            }
+            function main() -> string {
+                classify(Bird { name: "Tweety" })
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::string("other")),
+    })
+}
+
+#[test]
+fn match_class_types_non_exhaustive_matched() -> anyhow::Result<()> {
+    // Non-exhaustive: explicit class matched
+    assert_vm_executes(Program {
+        source: r#"
+            class Cat { name string }
+            class Dog { name string }
+            class Bird { name string }
+
+            function classify(animal Cat | Dog | Bird) -> string {
+                match (animal) {
+                    c: Cat => "cat: " + c.name,
+                    d: Dog => "dog: " + d.name,
+                    _ => "other"
+                }
+            }
+            function main() -> string {
+                classify(Dog { name: "Rex" })
+            }
+        "#,
+        function: "main",
+        expected: ExecState::Complete(Value::string("dog: Rex")),
+    })
+}
+
+// ============================================================================
 // Complex Scrutinee Expressions
 // ============================================================================
 

--- a/baml_language/crates/bex_vm_types/Cargo.toml
+++ b/baml_language/crates/bex_vm_types/Cargo.toml
@@ -21,6 +21,7 @@ workspace = true
 baml_base = { workspace = true }
 baml_builtins = { workspace = true }
 baml_builtins_macros = { workspace = true }
+baml_typetags = { workspace = true }
 sys_resource_types = { workspace = true }
 colored = { workspace = true }
 indexmap = { workspace = true }

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -11,41 +11,11 @@ use crate::{bytecode::Bytecode, heap_ptr::HeapPtr, indexable::ObjectPool};
 
 /// Global type tag constants for runtime type identification.
 ///
+/// Re-exported from `baml_typetags` crate to maintain backwards compatibility.
 /// These are used by the `TypeTag` instruction to extract a type identifier
 /// from any value for jump table dispatch on union types.
-///
-/// Primitives have fixed tags (0-10 reserved), classes start at 100.
 pub mod type_tags {
-    /// Integer type tag.
-    pub const INT: i64 = 0;
-    /// String type tag.
-    pub const STRING: i64 = 1;
-    /// Boolean type tag.
-    pub const BOOL: i64 = 2;
-    /// Null type tag.
-    pub const NULL: i64 = 3;
-    /// Float type tag.
-    pub const FLOAT: i64 = 4;
-    /// Enum variant type tag (all variants share this).
-    pub const ENUM: i64 = 5;
-    /// List/array type tag.
-    pub const LIST: i64 = 6;
-    /// Map type tag.
-    pub const MAP: i64 = 7;
-    /// Function type tag.
-    pub const FUNCTION: i64 = 8;
-    /// Future type tag.
-    pub const FUTURE: i64 = 9;
-    /// Media type tag.
-    pub const MEDIA: i64 = 10;
-    /// Resource type tag (file handle, socket, etc.).
-    pub const RESOURCE: i64 = 11;
-    /// `PromptAst` type tag.
-    pub const PROMPT_AST: i64 = 12;
-    /// Base value for class type tags (classes start at 100).
-    pub const CLASS_BASE: i64 = 100;
-    /// Unknown/invalid type tag.
-    pub const UNKNOWN: i64 = -1;
+    pub use baml_typetags::*;
 }
 
 /// Compiled program ready for execution.

--- a/baml_language/crates/tools_onionskin/Cargo.toml
+++ b/baml_language/crates/tools_onionskin/Cargo.toml
@@ -26,6 +26,7 @@ baml_compiler_tir = { workspace = true }
 baml_compiler_vir = { workspace = true }
 baml_db = { workspace = true }
 baml_project = { workspace = true }
+baml_typetags = { workspace = true }
 baml_workspace = { workspace = true }
 bex_vm = { workspace = true }
 bex_vm_types = { workspace = true }

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -1036,7 +1036,12 @@ impl CompilerRunner {
             .clone();
 
         // Build classes map (class name -> field name -> field index) for MIR lowering
+        // Also build class type tags for TypeTag switch optimization
         let mut classes: HashMap<String, HashMap<String, usize>> = HashMap::new();
+        let mut class_type_tags: HashMap<String, i64> = HashMap::new();
+        let mut class_type_tag_counter = 0i64;
+        // Build enums map (enum name -> variant name -> variant index) for MIR lowering
+        let mut enums: HashMap<String, HashMap<String, usize>> = HashMap::new();
         for file in &file_list {
             let item_tree = baml_compiler_hir::file_item_tree(&self.db, *file);
             let items_struct = baml_compiler_hir::file_items(&self.db, *file);
@@ -1049,7 +1054,21 @@ impl CompilerRunner {
                     for (idx, field) in class.fields.iter().enumerate() {
                         field_indices.insert(field.name.to_string(), idx);
                     }
+                    // Compute type tag for this class (CLASS_BASE + counter)
+                    let type_tag = baml_typetags::CLASS_BASE + class_type_tag_counter;
+                    class_type_tag_counter += 1;
+                    class_type_tags.insert(class_name.clone(), type_tag);
                     classes.insert(class_name, field_indices);
+                }
+                if let ItemId::Enum(enum_loc) = item {
+                    let enum_def = &item_tree[enum_loc.id(&self.db)];
+                    let enum_name = enum_def.name.to_string();
+
+                    let mut variant_indices = HashMap::new();
+                    for (idx, variant) in enum_def.variants.iter().enumerate() {
+                        variant_indices.insert(variant.name.to_string(), idx);
+                    }
+                    enums.insert(enum_name, variant_indices);
                 }
             }
         }
@@ -1104,6 +1123,8 @@ impl CompilerRunner {
                                 &vir,
                                 &self.db,
                                 &classes,
+                                &enums,
+                                &class_type_tags,
                                 &resolution_ctx,
                             );
                             baml_compiler_mir::pretty::display_function(&mir)


### PR DESCRIPTION
## Summary

Implements proper emission of `Instruction::Discriminant` and `Instruction::TypeTag` for efficient pattern matching on enums and union types.

- Create `baml_typetags` crate with shared type tag constants
- Emit `Discriminant` instruction for enum variant pattern matching
- Emit `TypeTag` instruction for union type pattern matching (4+ typed patterns)
- Add `SwitchKind` enum to differentiate Integer/EnumDiscriminant/TypeTag switches
- Extend `try_extract_switch_arms()` to detect enum variants and typed patterns
- Add `class_type_tags` parameter to MIR lowering for class type tag lookup
- Fix variable binding for `TypedBinding` patterns in switch optimization
- Update snapshots to reflect new bytecode patterns

The optimization enables:
- **JumpTable dispatch** for 4+ dense enum variants (O(1) lookup)
- **Binary search** for sparse patterns (O(log n) lookup)
- Single discriminant/type_tag extraction followed by efficient dispatch

## Test plan

- [x] All 45 `match_expr` tests pass
- [x] All 354 `baml_tests` pass
- [x] Snapshots updated and verified for `match_exhaustiveness` tests

---

Missing piece after #2926

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Implements proper emission of Instruction::Discriminant and Instruction::TypeTag for efficient pattern matching on enums and union types, enabling O(1) jump table dispatch for 4+ dense patterns and exhaustive match optimization.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 627ff1ca0ec6dd8d8ce75d692d110831a0fdbbfb.</sup>
<!-- /MENDRAL_SUMMARY -->