### PR TITLE
baml-language: allow passing inputs into assert_engine_executes calls

### DIFF
--- a/baml_language/crates/bex_engine/tests/common/mod.rs
+++ b/baml_language/crates/bex_engine/tests/common/mod.rs
@@ -9,7 +9,7 @@
 use std::{collections::HashMap, io::Write};
 
 use baml_tests::bytecode::compile_source_with_schema;
-use bex_engine::{BexEngine, BexExternalValue};
+use bex_engine::{BexEngine, BexExternalValue, BexValue};
 use bex_program::BexProgram;
 use indexmap::IndexMap;
 use sys_native::SysOpsExt;
@@ -23,6 +23,8 @@ pub(crate) struct EngineProgram {
     pub source: &'static str,
     /// The function name to execute.
     pub entry: &'static str,
+    /// Input arguments to pass to the function.
+    pub inputs: Vec<BexExternalValue>,
     /// Expected result: Ok(value) for success, Err(message) for expected error.
     pub expected: Result<BexExternalValue, &'static str>,
 }
@@ -33,6 +35,7 @@ impl Default for EngineProgram {
             fs: IndexMap::new(),
             source: "",
             entry: "main",
+            inputs: Vec::new(),
             expected: Ok(BexExternalValue::Null),
         }
     }
@@ -70,7 +73,13 @@ pub(crate) async fn assert_engine_executes(input: EngineProgram) -> anyhow::Resu
     let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
         .expect("Failed to create engine");
 
-    let result = engine.call_function(input.entry, &[]).await;
+    // Convert BexExternalValue inputs to BexValue for call_function
+    let args: Vec<BexValue> = input
+        .inputs
+        .into_iter()
+        .map(std::convert::Into::into)
+        .collect();
+    let result = engine.call_function(input.entry, &args).await;
 
     match (result, input.expected) {
         (Ok(value), Ok(expected)) => {

--- a/baml_language/crates/bex_engine/tests/fs.rs
+++ b/baml_language/crates/bex_engine/tests/fs.rs
@@ -20,6 +20,7 @@ async fn fs_open_only() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Int(42)),
     })
     .await
@@ -38,6 +39,7 @@ async fn fs_open_and_read() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::String("Hello from BAML!".to_string())),
     })
     .await
@@ -54,6 +56,7 @@ async fn fs_open_nonexistent_file() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Err("Failed to open file"),
     })
     .await

--- a/baml_language/crates/bex_engine/tests/http.rs
+++ b/baml_language/crates/bex_engine/tests/http.rs
@@ -35,6 +35,7 @@ async fn http_fetch_and_text() -> anyhow::Result<()> {
         fs: indexmap! {},
         source: Box::leak(source.into_boxed_str()),
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::String("Hello from HTTP!".to_string())),
     })
     .await
@@ -65,6 +66,7 @@ async fn http_response_status() -> anyhow::Result<()> {
         fs: indexmap! {},
         source: Box::leak(source.into_boxed_str()),
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Int(201)),
     })
     .await
@@ -95,6 +97,7 @@ async fn http_response_ok_true() -> anyhow::Result<()> {
         fs: indexmap! {},
         source: Box::leak(source.into_boxed_str()),
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Bool(true)),
     })
     .await
@@ -125,6 +128,7 @@ async fn http_response_ok_false() -> anyhow::Result<()> {
         fs: indexmap! {},
         source: Box::leak(source.into_boxed_str()),
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Bool(false)),
     })
     .await
@@ -156,6 +160,7 @@ async fn http_response_url() -> anyhow::Result<()> {
         fs: indexmap! {},
         source: Box::leak(source.into_boxed_str()),
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::String(expected_url)),
     })
     .await
@@ -174,6 +179,7 @@ async fn http_fetch_network_error() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Err("HTTP request failed"),
     })
     .await
@@ -206,6 +212,7 @@ async fn http_response_text_consumed() -> anyhow::Result<()> {
         fs: indexmap! {},
         source: Box::leak(source.into_boxed_str()),
         entry: "main",
+        inputs: vec![],
         expected: Err("already been consumed"),
     })
     .await

--- a/baml_language/crates/bex_engine/tests/shell.rs
+++ b/baml_language/crates/bex_engine/tests/shell.rs
@@ -16,6 +16,7 @@ async fn shell_echo() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         // Note: echo adds a newline
         expected: Ok(BexExternalValue::String("Hello From Shell!\n".to_string())),
     })
@@ -32,6 +33,7 @@ async fn shell_with_pipe() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::String("HELLO WORLD\n".to_string())),
     })
     .await
@@ -47,6 +49,7 @@ async fn shell_failing_command() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Err("failed with exit code 1"),
     })
     .await
@@ -62,6 +65,7 @@ async fn shell_nonexistent_command() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Err("not found"),
     })
     .await
@@ -78,6 +82,7 @@ async fn shell_with_variable() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::String("dynamic\n".to_string())),
     })
     .await

--- a/baml_language/crates/bex_engine/tests/typed_inputs.rs
+++ b/baml_language/crates/bex_engine/tests/typed_inputs.rs
@@ -1,0 +1,208 @@
+//! Tests for function input argument handling.
+//!
+//! These tests verify that `call_function` properly passes external arguments
+//! to BAML functions via `BexExternalValue`.
+
+mod common;
+
+use bex_engine::{BexExternalValue, Ty};
+use common::{EngineProgram, assert_engine_executes};
+use indexmap::indexmap;
+
+#[tokio::test]
+async fn int_input() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function double(x: int) -> int {
+                x * 2
+            }
+        "#,
+        entry: "double",
+        inputs: vec![BexExternalValue::Int(21)],
+        expected: Ok(BexExternalValue::Int(42)),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn string_input() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function greet(name: string) -> string {
+                "Hello, " + name + "!"
+            }
+        "#,
+        entry: "greet",
+        inputs: vec![BexExternalValue::String("World".to_string())],
+        expected: Ok(BexExternalValue::String("Hello, World!".to_string())),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn multiple_inputs() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function add(a: int, b: int) -> int {
+                a + b
+            }
+        "#,
+        entry: "add",
+        inputs: vec![BexExternalValue::Int(10), BexExternalValue::Int(32)],
+        expected: Ok(BexExternalValue::Int(42)),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn bool_input() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function negate(b: bool) -> bool {
+                !b
+            }
+        "#,
+        entry: "negate",
+        inputs: vec![BexExternalValue::Bool(true)],
+        expected: Ok(BexExternalValue::Bool(false)),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn float_input() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function half(x: float) -> float {
+                x / 2.0
+            }
+        "#,
+        entry: "half",
+        inputs: vec![BexExternalValue::Float(10.0)],
+        expected: Ok(BexExternalValue::Float(5.0)),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn array_input() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function sum(arr: int[]) -> int {
+                let total = 0;
+                for (let x in arr) {
+                    total += x;
+                }
+                total
+            }
+        "#,
+        entry: "sum",
+        inputs: vec![BexExternalValue::Array {
+            element_type: Ty::Int,
+            items: vec![
+                BexExternalValue::Int(1),
+                BexExternalValue::Int(2),
+                BexExternalValue::Int(3),
+                BexExternalValue::Int(4),
+            ],
+        }],
+        expected: Ok(BexExternalValue::Int(10)),
+    })
+    .await
+}
+
+// TODO: Enable when Instance allocation from BexExternalValue is implemented
+// #[tokio::test]
+// async fn class_input() -> anyhow::Result<()> {
+//     assert_engine_executes(EngineProgram {
+//         fs: indexmap! {},
+//         source: r#"
+//             class Point {
+//                 x int
+//                 y int
+//             }
+//
+//             function magnitude_squared(p: Point) -> int {
+//                 p.x * p.x + p.y * p.y
+//             }
+//         "#,
+//         entry: "magnitude_squared",
+//         inputs: vec![BexExternalValue::Instance {
+//             class_name: "Point".to_string(),
+//             fields: indexmap! {
+//                 "x".to_string() => BexExternalValue::Int(3),
+//                 "y".to_string() => BexExternalValue::Int(4),
+//             },
+//         }],
+//         expected: Ok(BexExternalValue::Int(25)),
+//     })
+//     .await
+// }
+
+#[tokio::test]
+async fn map_input() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function get_value(m: map<string, int>, key: string) -> int {
+                m[key]
+            }
+        "#,
+        entry: "get_value",
+        inputs: vec![
+            BexExternalValue::Map {
+                key_type: Ty::String,
+                value_type: Ty::Int,
+                entries: indexmap! {
+                    "foo".to_string() => BexExternalValue::Int(42),
+                    "bar".to_string() => BexExternalValue::Int(100),
+                },
+            },
+            BexExternalValue::String("foo".to_string()),
+        ],
+        expected: Ok(BexExternalValue::Int(42)),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn null_input() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function is_null(x: int?) -> bool {
+                x == null
+            }
+        "#,
+        entry: "is_null",
+        inputs: vec![BexExternalValue::Null],
+        expected: Ok(BexExternalValue::Bool(true)),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn mixed_types_inputs() -> anyhow::Result<()> {
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function concat(a: string, b: string, c: string) -> string {
+                a + " " + b + " " + c
+            }
+        "#,
+        entry: "concat",
+        inputs: vec![
+            BexExternalValue::String("Hello".to_string()),
+            BexExternalValue::String("from".to_string()),
+            BexExternalValue::String("BAML".to_string()),
+        ],
+        expected: Ok(BexExternalValue::String("Hello from BAML".to_string())),
+    })
+    .await
+}

--- a/baml_language/crates/bex_engine/tests/typed_outputs.rs
+++ b/baml_language/crates/bex_engine/tests/typed_outputs.rs
@@ -19,6 +19,7 @@ async fn union_int_or_string_returns_int() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Int(42)),
             metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::Int),
@@ -37,6 +38,7 @@ async fn union_int_or_string_returns_string() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::String("hello".to_string())),
             metadata: UnionMetadata::new(Ty::Union(vec![Ty::Int, Ty::String]), Ty::String),
@@ -55,6 +57,7 @@ async fn optional_int_returns_value() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Int(42)),
             metadata: UnionMetadata::new(Ty::Optional(Box::new(Ty::Int)), Ty::Int),
@@ -73,6 +76,7 @@ async fn optional_int_returns_null() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Null),
             metadata: UnionMetadata::new(Ty::Optional(Box::new(Ty::Int)), Ty::Null),
@@ -95,6 +99,7 @@ async fn class_with_union_field() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Instance {
             class_name: "Response".to_string(),
             fields: indexmap! {
@@ -126,6 +131,7 @@ async fn union_of_classes_returns_success() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Instance {
                 class_name: "Success".to_string(),
@@ -163,6 +169,7 @@ async fn union_of_classes_returns_failure() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Instance {
                 class_name: "Failure".to_string(),
@@ -192,6 +199,7 @@ async fn union_of_arrays() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Array {
                 element_type: Ty::Int,
@@ -223,6 +231,7 @@ async fn array_of_unions() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Array {
             element_type: Ty::Union(vec![Ty::Int, Ty::String]),
             items: vec![
@@ -258,6 +267,7 @@ async fn optional_class() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Instance {
                 class_name: "Data".to_string(),
@@ -288,6 +298,7 @@ async fn optional_class_returns_null() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Null),
             metadata: UnionMetadata::new(
@@ -314,6 +325,7 @@ async fn class_with_optional_field() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Instance {
             class_name: "Person".to_string(),
             fields: indexmap! {
@@ -338,6 +350,7 @@ async fn map_with_union_values() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Map {
             key_type: Ty::String,
             value_type: Ty::Union(vec![Ty::Int, Ty::String]),
@@ -368,6 +381,7 @@ async fn union_of_array_with_union_elements_or_string() -> anyhow::Result<()> {
             }
         "#,
         entry: "main",
+        inputs: vec![],
         expected: Ok(BexExternalValue::Union {
             value: Box::new(BexExternalValue::Array {
                 element_type: Ty::Union(vec![Ty::Int, Ty::Bool]),


### PR DESCRIPTION
Known limitations discovered:
  - BexExternalValue::Instance cannot be passed as input yet (there's a todo!() in allocate_from_external)
  - String + int concatenation requires explicit conversion (no implicit coercion)

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Extends test infrastructure to support passing input arguments to BAML functions via BexExternalValue, enabling comprehensive testing of function parameter handling across all supported types.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit d97bf2a4bbe61b928447f2bf3c8d8bd1cfc1d25d.</sup>
<!-- /MENDRAL_SUMMARY -->