### PR TITLE
fix: allow 'baml-cli serv' to handle big PDFs

### DIFF
--- a/engine/baml-runtime/src/cli/dev.rs
+++ b/engine/baml-runtime/src/cli/dev.rs
@@ -19,11 +19,32 @@ pub struct DevArgs {
     pub from: PathBuf,
     #[arg(long, help = "port to expose BAML on", default_value = "2024")]
     port: u16,
+    #[arg(
+        long,
+        help = "Maximum request body size in MB (default: 50, set to 0 to disable limit). Can also be set via BAML_BODY_LIMIT_MB environment variable.",
+        default_value = "50"
+    )]
+    body_limit_mb: usize,
     #[command(flatten)]
     dotenv: DotenvArgs,
 }
 
 impl DevArgs {
+    fn get_body_limit_mb(&self) -> Option<usize> {
+        // Check environment variable first, then fall back to CLI argument
+        let limit_mb = std::env::var("BAML_BODY_LIMIT_MB")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(self.body_limit_mb);
+
+        // 0 means no limit (disable the limit)
+        if limit_mb == 0 {
+            None
+        } else {
+            Some(limit_mb)
+        }
+    }
+
     pub fn run(
         &self,
         defaults: crate::RuntimeCliDefaults,
@@ -34,6 +55,7 @@ impl DevArgs {
         baml_log::info!("Starting BAML development server on port {}", self.port);
 
         let t = BamlRuntime::get_tokio_singleton()?;
+        let body_limit_mb = self.get_body_limit_mb();
 
         let (tx, rx) = std::sync::mpsc::channel();
 
@@ -58,7 +80,7 @@ impl DevArgs {
             no_tests: false,
         }
         .run(defaults, feature_flags.clone());
-        t.spawn(server.clone().serve(tcp_listener));
+        t.spawn(server.clone().serve(tcp_listener, body_limit_mb));
 
         // print all events and errors
         t.block_on(async {

--- a/engine/baml-runtime/src/cli/dev.rs
+++ b/engine/baml-runtime/src/cli/dev.rs
@@ -19,32 +19,11 @@ pub struct DevArgs {
     pub from: PathBuf,
     #[arg(long, help = "port to expose BAML on", default_value = "2024")]
     port: u16,
-    #[arg(
-        long,
-        help = "Maximum request body size in MB (default: 50, set to 0 to disable limit). Can also be set via BAML_BODY_LIMIT_MB environment variable.",
-        default_value = "50"
-    )]
-    body_limit_mb: usize,
     #[command(flatten)]
     dotenv: DotenvArgs,
 }
 
 impl DevArgs {
-    fn get_body_limit_mb(&self) -> Option<usize> {
-        // Check environment variable first, then fall back to CLI argument
-        let limit_mb = std::env::var("BAML_BODY_LIMIT_MB")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(self.body_limit_mb);
-
-        // 0 means no limit (disable the limit)
-        if limit_mb == 0 {
-            None
-        } else {
-            Some(limit_mb)
-        }
-    }
-
     pub fn run(
         &self,
         defaults: crate::RuntimeCliDefaults,
@@ -55,7 +34,6 @@ impl DevArgs {
         baml_log::info!("Starting BAML development server on port {}", self.port);
 
         let t = BamlRuntime::get_tokio_singleton()?;
-        let body_limit_mb = self.get_body_limit_mb();
 
         let (tx, rx) = std::sync::mpsc::channel();
 
@@ -80,7 +58,7 @@ impl DevArgs {
             no_tests: false,
         }
         .run(defaults, feature_flags.clone());
-        t.spawn(server.clone().serve(tcp_listener, body_limit_mb));
+        t.spawn(server.clone().serve(tcp_listener));
 
         // print all events and errors
         t.block_on(async {

--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, path::PathBuf, sync::Arc, task::Poll};
 use anyhow::{Context, Result};
 use arg_validation::BamlServeValidate;
 use axum::{
-    extract::{self},
+    extract::{self, DefaultBodyLimit},
     http::{HeaderName, HeaderValue, StatusCode},
     middleware::Next,
     response::{
@@ -55,6 +55,12 @@ pub struct ServeArgs {
         default_value_t = false
     )]
     no_version_check: bool,
+    #[arg(
+        long,
+        help = "Maximum request body size in MB (default: 50, set to 0 to disable limit). Can also be set via BAML_BODY_LIMIT_MB environment variable.",
+        default_value = "50"
+    )]
+    body_limit_mb: usize,
     #[command(flatten)]
     dotenv: DotenvArgs,
 }
@@ -91,12 +97,29 @@ impl ServeArgs {
 
         let t: Arc<tokio::runtime::Runtime> = BamlRuntime::get_tokio_singleton()?;
 
+        let body_limit_mb = self.get_body_limit_mb();
+
         let (server, tcp_listener) =
             t.block_on(Server::new(self.from.clone(), self.port, feature_flags))?;
 
-        t.block_on(server.serve(tcp_listener))?;
+        t.block_on(server.serve(tcp_listener, body_limit_mb))?;
 
         Ok(())
+    }
+
+    fn get_body_limit_mb(&self) -> Option<usize> {
+        // Check environment variable first, then fall back to CLI argument
+        let limit_mb = std::env::var("BAML_BODY_LIMIT_MB")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or(self.body_limit_mb);
+
+        // 0 means no limit (disable the limit)
+        if limit_mb == 0 {
+            None
+        } else {
+            Some(limit_mb)
+        }
     }
 }
 
@@ -259,7 +282,11 @@ impl Server {
         next.run(request).await
     }
 
-    pub async fn serve(self: Arc<Self>, tcp_listener: TcpListener) -> Result<()> {
+    pub async fn serve(
+        self: Arc<Self>,
+        tcp_listener: TcpListener,
+        body_limit_mb: Option<usize>,
+    ) -> Result<()> {
         // build our application with a route
         let app = axum::Router::new();
 
@@ -295,6 +322,23 @@ impl Server {
             "/openapi.json",
             get(move || s.clone().openapi_json_handler()),
         );
+
+        // Apply body limit configuration
+        let app = match body_limit_mb {
+            Some(limit_mb) => {
+                let limit_bytes = limit_mb * 1024 * 1024;
+                baml_log::info!(
+                    "Setting request body size limit to {} MB ({} bytes)",
+                    limit_mb,
+                    limit_bytes
+                );
+                app.layer(DefaultBodyLimit::max(limit_bytes))
+            }
+            None => {
+                baml_log::info!("Request body size limit disabled");
+                app.layer(DefaultBodyLimit::disable())
+            }
+        };
 
         let service = axum::serve(
             tcp_listener,
@@ -814,5 +858,99 @@ mod tests {
         assert_eq!(env_map.get("NEW_VAR"), Some(&"new_value".to_string()));
         assert_eq!(env_map.get("KEEP_ME"), Some(&"new_value".to_string()));
         assert!(!env_map.contains_key("REMOVE_ME"));
+    }
+
+    #[test]
+    fn test_body_limit_default() {
+        use std::path::PathBuf;
+
+        use crate::cli::dotenv::DotenvArgs;
+
+        let args = ServeArgs {
+            from: PathBuf::from("./baml_src"),
+            port: 2024,
+            no_version_check: false,
+            body_limit_mb: 50,
+            dotenv: DotenvArgs {
+                dotenv: true,
+                dotenv_path: None,
+            },
+        };
+
+        assert_eq!(args.get_body_limit_mb(), Some(50));
+    }
+
+    #[test]
+    fn test_body_limit_disabled() {
+        use std::path::PathBuf;
+
+        use crate::cli::dotenv::DotenvArgs;
+
+        let args = ServeArgs {
+            from: PathBuf::from("./baml_src"),
+            port: 2024,
+            no_version_check: false,
+            body_limit_mb: 0,
+            dotenv: DotenvArgs {
+                dotenv: true,
+                dotenv_path: None,
+            },
+        };
+
+        assert_eq!(args.get_body_limit_mb(), None);
+    }
+
+    #[test]
+    fn test_body_limit_from_env() {
+        use std::path::PathBuf;
+
+        use crate::cli::dotenv::DotenvArgs;
+
+        // Set environment variable
+        std::env::set_var("BAML_BODY_LIMIT_MB", "100");
+
+        let args = ServeArgs {
+            from: PathBuf::from("./baml_src"),
+            port: 2024,
+            no_version_check: false,
+            body_limit_mb: 50,
+            dotenv: DotenvArgs {
+                dotenv: true,
+                dotenv_path: None,
+            },
+        };
+
+        // Environment variable should override CLI argument
+        assert_eq!(args.get_body_limit_mb(), Some(100));
+
+        // Clean up
+        std::env::remove_var("BAML_BODY_LIMIT_MB");
+    }
+
+    #[test]
+    fn test_body_limit_disabled_from_env() {
+        use std::path::PathBuf;
+
+        use crate::cli::dotenv::DotenvArgs;
+
+        // Set environment variable to 0 to disable
+        std::env::set_var("BAML_BODY_LIMIT_MB", "0");
+
+        let args = ServeArgs {
+            from: PathBuf::from("./baml_src"),
+            port: 2024,
+            no_version_check: false,
+            body_limit_mb: 50,
+            dotenv: DotenvArgs {
+                dotenv: true,
+                dotenv_path: None,
+            },
+        };
+
+        // Environment variable set to 0 should disable limit
+        assert_eq!(args.get_body_limit_mb(), None);
+
+        // Clean up
+        std::env::remove_var("BAML_BODY_LIMIT_MB");
     }
 }

--- a/engine/baml-runtime/src/cli/serve/mod.rs
+++ b/engine/baml-runtime/src/cli/serve/mod.rs
@@ -55,12 +55,6 @@ pub struct ServeArgs {
         default_value_t = false
     )]
     no_version_check: bool,
-    #[arg(
-        long,
-        help = "Maximum request body size in MB (default: 50, set to 0 to disable limit). Can also be set via BAML_BODY_LIMIT_MB environment variable.",
-        default_value = "50"
-    )]
-    body_limit_mb: usize,
     #[command(flatten)]
     dotenv: DotenvArgs,
 }
@@ -97,29 +91,12 @@ impl ServeArgs {
 
         let t: Arc<tokio::runtime::Runtime> = BamlRuntime::get_tokio_singleton()?;
 
-        let body_limit_mb = self.get_body_limit_mb();
-
         let (server, tcp_listener) =
             t.block_on(Server::new(self.from.clone(), self.port, feature_flags))?;
 
-        t.block_on(server.serve(tcp_listener, body_limit_mb))?;
+        t.block_on(server.serve(tcp_listener))?;
 
         Ok(())
-    }
-
-    fn get_body_limit_mb(&self) -> Option<usize> {
-        // Check environment variable first, then fall back to CLI argument
-        let limit_mb = std::env::var("BAML_BODY_LIMIT_MB")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(self.body_limit_mb);
-
-        // 0 means no limit (disable the limit)
-        if limit_mb == 0 {
-            None
-        } else {
-            Some(limit_mb)
-        }
     }
 }
 
@@ -282,11 +259,7 @@ impl Server {
         next.run(request).await
     }
 
-    pub async fn serve(
-        self: Arc<Self>,
-        tcp_listener: TcpListener,
-        body_limit_mb: Option<usize>,
-    ) -> Result<()> {
+    pub async fn serve(self: Arc<Self>, tcp_listener: TcpListener) -> Result<()> {
         // build our application with a route
         let app = axum::Router::new();
 
@@ -323,22 +296,10 @@ impl Server {
             get(move || s.clone().openapi_json_handler()),
         );
 
-        // Apply body limit configuration
-        let app = match body_limit_mb {
-            Some(limit_mb) => {
-                let limit_bytes = limit_mb * 1024 * 1024;
-                baml_log::info!(
-                    "Setting request body size limit to {} MB ({} bytes)",
-                    limit_mb,
-                    limit_bytes
-                );
-                app.layer(DefaultBodyLimit::max(limit_bytes))
-            }
-            None => {
-                baml_log::info!("Request body size limit disabled");
-                app.layer(DefaultBodyLimit::disable())
-            }
-        };
+        // Set request body size limit to 100 MiB. This is chosen to be larger than
+        // providers like Gemini which accept files up to 50 MiB. The default Axum
+        // limit is only 2 MiB which is too restrictive for PDF uploads and similar use cases.
+        let app = app.layer(DefaultBodyLimit::max(100 * 1024 * 1024));
 
         let service = axum::serve(
             tcp_listener,
@@ -858,99 +819,5 @@ mod tests {
         assert_eq!(env_map.get("NEW_VAR"), Some(&"new_value".to_string()));
         assert_eq!(env_map.get("KEEP_ME"), Some(&"new_value".to_string()));
         assert!(!env_map.contains_key("REMOVE_ME"));
-    }
-
-    #[test]
-    fn test_body_limit_default() {
-        use std::path::PathBuf;
-
-        use crate::cli::dotenv::DotenvArgs;
-
-        let args = ServeArgs {
-            from: PathBuf::from("./baml_src"),
-            port: 2024,
-            no_version_check: false,
-            body_limit_mb: 50,
-            dotenv: DotenvArgs {
-                dotenv: true,
-                dotenv_path: None,
-            },
-        };
-
-        assert_eq!(args.get_body_limit_mb(), Some(50));
-    }
-
-    #[test]
-    fn test_body_limit_disabled() {
-        use std::path::PathBuf;
-
-        use crate::cli::dotenv::DotenvArgs;
-
-        let args = ServeArgs {
-            from: PathBuf::from("./baml_src"),
-            port: 2024,
-            no_version_check: false,
-            body_limit_mb: 0,
-            dotenv: DotenvArgs {
-                dotenv: true,
-                dotenv_path: None,
-            },
-        };
-
-        assert_eq!(args.get_body_limit_mb(), None);
-    }
-
-    #[test]
-    fn test_body_limit_from_env() {
-        use std::path::PathBuf;
-
-        use crate::cli::dotenv::DotenvArgs;
-
-        // Set environment variable
-        std::env::set_var("BAML_BODY_LIMIT_MB", "100");
-
-        let args = ServeArgs {
-            from: PathBuf::from("./baml_src"),
-            port: 2024,
-            no_version_check: false,
-            body_limit_mb: 50,
-            dotenv: DotenvArgs {
-                dotenv: true,
-                dotenv_path: None,
-            },
-        };
-
-        // Environment variable should override CLI argument
-        assert_eq!(args.get_body_limit_mb(), Some(100));
-
-        // Clean up
-        std::env::remove_var("BAML_BODY_LIMIT_MB");
-    }
-
-    #[test]
-    fn test_body_limit_disabled_from_env() {
-        use std::path::PathBuf;
-
-        use crate::cli::dotenv::DotenvArgs;
-
-        // Set environment variable to 0 to disable
-        std::env::set_var("BAML_BODY_LIMIT_MB", "0");
-
-        let args = ServeArgs {
-            from: PathBuf::from("./baml_src"),
-            port: 2024,
-            no_version_check: false,
-            body_limit_mb: 50,
-            dotenv: DotenvArgs {
-                dotenv: true,
-                dotenv_path: None,
-            },
-        };
-
-        // Environment variable set to 0 should disable limit
-        assert_eq!(args.get_body_limit_mb(), None);
-
-        // Clean up
-        std::env::remove_var("BAML_BODY_LIMIT_MB");
     }
 }


### PR DESCRIPTION
fixes #3041
