### PR TITLE
Fix type errors for types on enum variants

### DIFF
--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -1481,6 +1481,68 @@ impl<'a> Parser<'a> {
             // Variant name
             p.bump();
 
+            // Check if a type expression follows (which is invalid for enum variants)
+            // We need to distinguish between:
+            // - `A int | string` (type annotation - error)
+            // - `A\n    B` (next variant - OK)
+            // A type annotation is present if we see:
+            // 1. A word followed by type modifiers (|, [, ?, <)
+            // 2. String/integer/float literals (can't be variant names)
+            // 3. Left paren (tuple type)
+            let has_type_annotation = if p.at(TokenKind::Word) {
+                // Peek ahead to see if there's a type modifier after the word
+                // peek(1) skips trivia and gets the next non-trivia token
+                p.peek(1)
+                    .map(|t| {
+                        matches!(
+                            t.kind,
+                            TokenKind::Pipe
+                                | TokenKind::LBracket
+                                | TokenKind::Question
+                                | TokenKind::Less
+                        )
+                    })
+                    .unwrap_or(false)
+            } else {
+                // String literals, integer literals, float literals, or left paren
+                // These can't be variant names, so they must be type annotations
+                p.at(TokenKind::Quote)
+                    || p.at(TokenKind::Hash)
+                    || p.at(TokenKind::IntegerLiteral)
+                    || p.at(TokenKind::FloatLiteral)
+                    || p.at(TokenKind::LParen)
+            };
+
+            if has_type_annotation {
+                // Record the start position of the type expression
+                // SAFETY: has_type_annotation is only true when we've confirmed a token exists
+                // via p.at() checks or p.peek() calls, so current() is guaranteed to be Some.
+                if let Some(start_token) = p.current() {
+                    let start_span = start_token.span;
+
+                    // Consume the entire type expression for error recovery
+                    p.parse_type();
+
+                    // Calculate the span covering the entire type expression
+                    let end_span = p
+                        .tokens
+                        .get(p.current.saturating_sub(1))
+                        .map(|t| t.span)
+                        .unwrap_or(start_span);
+
+                    let type_span = baml_base::Span::new(
+                        start_span.file_id,
+                        TextRange::new(start_span.range.start(), end_span.range.end()),
+                    );
+
+                    // Emit a helpful error message
+                    p.error(
+                        "Enum variants cannot have type annotations".to_string(),
+                        type_span,
+                    );
+                }
+            }
+
             // Optional field attributes (@alias, etc.)
             while p.at(TokenKind::At) && !p.at(TokenKind::AtAt) {
                 p.parse_field_attribute();

--- a/baml_language/crates/baml_ide_tests/test_files/syntax/enum/invalid_value_expr.baml
+++ b/baml_language/crates/baml_ide_tests/test_files/syntax/enum/invalid_value_expr.baml
@@ -4,7 +4,7 @@ enum Test {
 
 // error: Error validating: Unexpected type specified for value `A`
 //   -->  enum/invalid_value_expr.baml:2
-//    | 
+//    |
 //  1 | enum Test {
 //  2 |     A int | string
 //  3 | }
@@ -12,12 +12,12 @@ enum Test {
 
 //----
 //- diagnostics
-// Error: Expected Unexpected token in enum body, found '|'
-//    ╭─[ enum_invalid_value_expr.baml:2:11 ]
+// Error: Enum variants cannot have type annotations
+//    ╭─[ enum_invalid_value_expr.baml:2:7 ]
 //    │
 //  2 │     A int | string
-//    │           ┬  
-//    │           ╰── Expected Unexpected token in enum body, found '|'
+//    │       ──────┬─────  
+//    │             ╰─────── Enum variants cannot have type annotations
 //    │ 
 //    │ Note: Error code: E0010
 // ───╯

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__02_parser__test.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__02_parser__test.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__03_hir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__05_diagnostics.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-bee4cf1d73080329/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__02_parser__types.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__02_parser__types.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-fbd0fe113b2fb574/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__03_hir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-fbd0fe113b2fb574/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__05_diagnostics.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-ddc6647912a5d7c4/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__02_parser__match_exhaustiveness.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__02_parser__match_exhaustiveness.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-a56cff903b8232b2/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__03_hir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_5_mir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-5af6b621dd74eb70/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === MIR ===

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__04_tir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === TYPE INFERENCE ===

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__05_diagnostics.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-267996652c5f418c/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__invalid_syntax.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__invalid_syntax.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-176fd1045f27e6d5/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__partial_input.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__02_parser__partial_input.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-1fb40547d0a1a115/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__03_hir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-fbd0fe113b2fb574/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__05_diagnostics.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-1fb40547d0a1a115/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__large_file.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__large_file.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-eb448e436f8a003a/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__rust.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__02_parser__rust.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-0a6cb66c091c7c00/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -1110,61 +1110,69 @@ impl SourceFile {
     KW_ENUM "enum"
     WORD "Item"
     L_BRACE "{"
-    ENUM_VARIANT "Function"
+    ENUM_VARIANT
       WORD "Function"
-    L_PAREN "("
-    ENUM_VARIANT "FunctionDef"
-      WORD "FunctionDef"
-    R_PAREN ")"
+      TYPE_EXPR
+        L_PAREN "("
+        TYPE_EXPR "FunctionDef"
+          WORD "FunctionDef"
+        R_PAREN ")"
     COMMA ","
-    ENUM_VARIANT "Class"
+    ENUM_VARIANT
       WORD "Class"
-    L_PAREN "("
-    ENUM_VARIANT "ClassDef"
-      WORD "ClassDef"
-    R_PAREN ")"
+      TYPE_EXPR
+        L_PAREN "("
+        TYPE_EXPR "ClassDef"
+          WORD "ClassDef"
+        R_PAREN ")"
     COMMA ","
-    ENUM_VARIANT "Enum"
+    ENUM_VARIANT
       WORD "Enum"
-    L_PAREN "("
-    ENUM_VARIANT "EnumDef"
-      WORD "EnumDef"
-    R_PAREN ")"
+      TYPE_EXPR
+        L_PAREN "("
+        TYPE_EXPR "EnumDef"
+          WORD "EnumDef"
+        R_PAREN ")"
     COMMA ","
-    ENUM_VARIANT "Client"
+    ENUM_VARIANT
       WORD "Client"
-    L_PAREN "("
-    ENUM_VARIANT "ClientDef"
-      WORD "ClientDef"
-    R_PAREN ")"
+      TYPE_EXPR
+        L_PAREN "("
+        TYPE_EXPR "ClientDef"
+          WORD "ClientDef"
+        R_PAREN ")"
     COMMA ","
-    ENUM_VARIANT "Test"
+    ENUM_VARIANT
       WORD "Test"
-    L_PAREN "("
-    ENUM_VARIANT "TestDef"
-      WORD "TestDef"
-    R_PAREN ")"
+      TYPE_EXPR
+        L_PAREN "("
+        TYPE_EXPR "TestDef"
+          WORD "TestDef"
+        R_PAREN ")"
     COMMA ","
-    ENUM_VARIANT "RetryPolicy"
+    ENUM_VARIANT
       WORD "RetryPolicy"
-    L_PAREN "("
-    ENUM_VARIANT "RetryPolicyDef"
-      WORD "RetryPolicyDef"
-    R_PAREN ")"
+      TYPE_EXPR
+        L_PAREN "("
+        TYPE_EXPR "RetryPolicyDef"
+          WORD "RetryPolicyDef"
+        R_PAREN ")"
     COMMA ","
-    ENUM_VARIANT "TemplateString"
+    ENUM_VARIANT
       WORD "TemplateString"
-    L_PAREN "("
-    ENUM_VARIANT "TemplateStringDef"
-      WORD "TemplateStringDef"
-    R_PAREN ")"
+      TYPE_EXPR
+        L_PAREN "("
+        TYPE_EXPR "TemplateStringDef"
+          WORD "TemplateStringDef"
+        R_PAREN ")"
     COMMA ","
-    ENUM_VARIANT "TypeAlias"
+    ENUM_VARIANT
       WORD "TypeAlias"
-    L_PAREN "("
-    ENUM_VARIANT "TypeAliasDef"
-      WORD "TypeAliasDef"
-    R_PAREN ")"
+      TYPE_EXPR
+        L_PAREN "("
+        TYPE_EXPR "TypeAliasDef"
+          WORD "TypeAliasDef"
+        R_PAREN ")"
     COMMA ","
     R_BRACE "}"
   WORD "impl"
@@ -5734,242 +5742,82 @@ Error: Expected top-level declaration, found identifier
      │ Note: Error code: E0010
 ─────╯
 
-Error: Expected Unexpected token in enum body, found '('
+Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:192:13 ]
      │
  192 │     Function(FunctionDef),
-     │             ┬  
-     │             ╰── Expected Unexpected token in enum body, found '('
+     │             ──────┬──────  
+     │                   ╰──────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:192:25 ]
-     │
- 192 │     Function(FunctionDef),
-     │                         ┬  
-     │                         ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:192:26 ]
-     │
- 192 │     Function(FunctionDef),
-     │                          ┬  
-     │                          ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found '('
+Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:193:10 ]
      │
  193 │     Class(ClassDef),
-     │          ┬  
-     │          ╰── Expected Unexpected token in enum body, found '('
+     │          ─────┬────  
+     │               ╰────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:193:19 ]
-     │
- 193 │     Class(ClassDef),
-     │                   ┬  
-     │                   ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:193:20 ]
-     │
- 193 │     Class(ClassDef),
-     │                    ┬  
-     │                    ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found '('
+Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:194:9 ]
      │
  194 │     Enum(EnumDef),
-     │         ┬  
-     │         ╰── Expected Unexpected token in enum body, found '('
+     │         ────┬────  
+     │             ╰────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:194:17 ]
-     │
- 194 │     Enum(EnumDef),
-     │                 ┬  
-     │                 ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:194:18 ]
-     │
- 194 │     Enum(EnumDef),
-     │                  ┬  
-     │                  ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found '('
+Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:195:11 ]
      │
  195 │     Client(ClientDef),
-     │           ┬  
-     │           ╰── Expected Unexpected token in enum body, found '('
+     │           ─────┬─────  
+     │                ╰─────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:195:21 ]
-     │
- 195 │     Client(ClientDef),
-     │                     ┬  
-     │                     ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:195:22 ]
-     │
- 195 │     Client(ClientDef),
-     │                      ┬  
-     │                      ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found '('
+Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:196:9 ]
      │
  196 │     Test(TestDef),
-     │         ┬  
-     │         ╰── Expected Unexpected token in enum body, found '('
+     │         ────┬────  
+     │             ╰────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:196:17 ]
-     │
- 196 │     Test(TestDef),
-     │                 ┬  
-     │                 ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:196:18 ]
-     │
- 196 │     Test(TestDef),
-     │                  ┬  
-     │                  ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found '('
+Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:197:16 ]
      │
  197 │     RetryPolicy(RetryPolicyDef),
-     │                ┬  
-     │                ╰── Expected Unexpected token in enum body, found '('
+     │                ────────┬───────  
+     │                        ╰───────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:197:31 ]
-     │
- 197 │     RetryPolicy(RetryPolicyDef),
-     │                               ┬  
-     │                               ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:197:32 ]
-     │
- 197 │     RetryPolicy(RetryPolicyDef),
-     │                                ┬  
-     │                                ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found '('
+Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:198:19 ]
      │
  198 │     TemplateString(TemplateStringDef),
-     │                   ┬  
-     │                   ╰── Expected Unexpected token in enum body, found '('
+     │                   ─────────┬─────────  
+     │                            ╰─────────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:198:37 ]
-     │
- 198 │     TemplateString(TemplateStringDef),
-     │                                     ┬  
-     │                                     ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:198:38 ]
-     │
- 198 │     TemplateString(TemplateStringDef),
-     │                                      ┬  
-     │                                      ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found '('
+Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:199:14 ]
      │
  199 │     TypeAlias(TypeAliasDef),
-     │              ┬  
-     │              ╰── Expected Unexpected token in enum body, found '('
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:199:27 ]
-     │
- 199 │     TypeAlias(TypeAliasDef),
-     │                           ┬  
-     │                           ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:199:28 ]
-     │
- 199 │     TypeAlias(TypeAliasDef),
-     │                            ┬  
-     │                            ╰── Expected Unexpected token in enum body, found ','
+     │              ───────┬──────  
+     │                     ╰──────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__03_hir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-1fb40547d0a1a115/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===
@@ -7043,21 +7043,13 @@ enum Status95 {
 
 enum Item {
   Function
-  FunctionDef
   Class
-  ClassDef
   Enum
-  EnumDef
   Client
-  ClientDef
   Test
-  TestDef
   RetryPolicy
-  RetryPolicyDef
   TemplateString
-  TemplateStringDef
   TypeAlias
-  TypeAliasDef
 }
 
 type Language = crate

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__05_diagnostics.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-1fb40547d0a1a115/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===
@@ -4213,242 +4213,82 @@ expression: output
      │ Note: Error code: E0010
 ─────╯
 
-  [parse] Error: Expected Unexpected token in enum body, found '('
+  [parse] Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:192:13 ]
      │
  192 │     Function(FunctionDef),
-     │             ┬  
-     │             ╰── Expected Unexpected token in enum body, found '('
+     │             ──────┬──────  
+     │                   ╰──────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-  [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:192:25 ]
-     │
- 192 │     Function(FunctionDef),
-     │                         ┬  
-     │                         ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:192:26 ]
-     │
- 192 │     Function(FunctionDef),
-     │                          ┬  
-     │                          ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found '('
+  [parse] Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:193:10 ]
      │
  193 │     Class(ClassDef),
-     │          ┬  
-     │          ╰── Expected Unexpected token in enum body, found '('
+     │          ─────┬────  
+     │               ╰────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-  [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:193:19 ]
-     │
- 193 │     Class(ClassDef),
-     │                   ┬  
-     │                   ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:193:20 ]
-     │
- 193 │     Class(ClassDef),
-     │                    ┬  
-     │                    ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found '('
+  [parse] Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:194:9 ]
      │
  194 │     Enum(EnumDef),
-     │         ┬  
-     │         ╰── Expected Unexpected token in enum body, found '('
+     │         ────┬────  
+     │             ╰────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-  [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:194:17 ]
-     │
- 194 │     Enum(EnumDef),
-     │                 ┬  
-     │                 ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:194:18 ]
-     │
- 194 │     Enum(EnumDef),
-     │                  ┬  
-     │                  ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found '('
+  [parse] Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:195:11 ]
      │
  195 │     Client(ClientDef),
-     │           ┬  
-     │           ╰── Expected Unexpected token in enum body, found '('
+     │           ─────┬─────  
+     │                ╰─────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-  [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:195:21 ]
-     │
- 195 │     Client(ClientDef),
-     │                     ┬  
-     │                     ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:195:22 ]
-     │
- 195 │     Client(ClientDef),
-     │                      ┬  
-     │                      ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found '('
+  [parse] Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:196:9 ]
      │
  196 │     Test(TestDef),
-     │         ┬  
-     │         ╰── Expected Unexpected token in enum body, found '('
+     │         ────┬────  
+     │             ╰────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-  [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:196:17 ]
-     │
- 196 │     Test(TestDef),
-     │                 ┬  
-     │                 ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:196:18 ]
-     │
- 196 │     Test(TestDef),
-     │                  ┬  
-     │                  ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found '('
+  [parse] Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:197:16 ]
      │
  197 │     RetryPolicy(RetryPolicyDef),
-     │                ┬  
-     │                ╰── Expected Unexpected token in enum body, found '('
+     │                ────────┬───────  
+     │                        ╰───────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-  [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:197:31 ]
-     │
- 197 │     RetryPolicy(RetryPolicyDef),
-     │                               ┬  
-     │                               ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:197:32 ]
-     │
- 197 │     RetryPolicy(RetryPolicyDef),
-     │                                ┬  
-     │                                ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found '('
+  [parse] Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:198:19 ]
      │
  198 │     TemplateString(TemplateStringDef),
-     │                   ┬  
-     │                   ╰── Expected Unexpected token in enum body, found '('
+     │                   ─────────┬─────────  
+     │                            ╰─────────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯
 
-  [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:198:37 ]
-     │
- 198 │     TemplateString(TemplateStringDef),
-     │                                     ┬  
-     │                                     ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:198:38 ]
-     │
- 198 │     TemplateString(TemplateStringDef),
-     │                                      ┬  
-     │                                      ╰── Expected Unexpected token in enum body, found ','
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found '('
+  [parse] Error: Enum variants cannot have type annotations
      ╭─[ rust.baml:199:14 ]
      │
  199 │     TypeAlias(TypeAliasDef),
-     │              ┬  
-     │              ╰── Expected Unexpected token in enum body, found '('
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found ')'
-     ╭─[ rust.baml:199:27 ]
-     │
- 199 │     TypeAlias(TypeAliasDef),
-     │                           ┬  
-     │                           ╰── Expected Unexpected token in enum body, found ')'
-     │ 
-     │ Note: Error code: E0010
-─────╯
-
-  [parse] Error: Expected Unexpected token in enum body, found ','
-     ╭─[ rust.baml:199:28 ]
-     │
- 199 │     TypeAlias(TypeAliasDef),
-     │                            ┬  
-     │                            ╰── Expected Unexpected token in enum body, found ','
+     │              ───────┬──────  
+     │                     ╰──────── Enum variants cannot have type annotations
      │ 
      │ Note: Error code: E0010
 ─────╯

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__02_parser__test.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__02_parser__test.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-0a6cb66c091c7c00/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__03_hir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-0a6cb66c091c7c00/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__05_diagnostics.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-0a6cb66c091c7c00/out/generated_tests.rs
+source: target/debug/build/baml_tests-3c66388e75d3efcb/out/generated_tests.rs
 expression: output
 ---
 === DIAGNOSTICS ===


### PR DESCRIPTION
<img width="1095" height="288" alt="Screenshot 2026-01-27 at 3 25 44 PM" src="https://github.com/user-attachments/assets/3bb3a5ec-e61d-404a-99e1-2eacfb14001a" />

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Improves parser error messages for enum variants with type annotations. The parser now detects when users incorrectly add type annotations to enum variants (e.g., `A int | string`) and provides a clear error message instead of multiple confusing token errors.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 0e8e78494d8338f0f2a183531a10a7bf40ad6772.</sup>
<!-- /MENDRAL_SUMMARY -->