### PR TITLE
Detect class and type alias cycles in the new compiler

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "baml_compiler_diagnostics",
  "baml_compiler_hir",
  "baml_workspace",
+ "rowan 0.16.1",
  "salsa",
  "smol_str",
  "text-size",

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -127,6 +127,10 @@ pub enum DiagnosticId {
     DuplicateTypeBuilderBlock,
     IncompleteDynamicDefinition,
     TypeBuilderSyntaxError,
+
+    // Cycle detection diagnostics (E0068-E0069)
+    AliasCycle,
+    ClassCycle,
 }
 
 impl DiagnosticId {
@@ -213,6 +217,10 @@ impl DiagnosticId {
             DiagnosticId::DuplicateTypeBuilderBlock => "E0041",
             DiagnosticId::IncompleteDynamicDefinition => "E0042",
             DiagnosticId::TypeBuilderSyntaxError => "E0043",
+
+            // Cycle detection diagnostics
+            DiagnosticId::AliasCycle => "E0068",
+            DiagnosticId::ClassCycle => "E0069",
         }
     }
 }

--- a/baml_language/crates/baml_compiler_diagnostics/src/errors/mod.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/errors/mod.rs
@@ -6,7 +6,7 @@
 //! ## Error Types
 //!
 //! - [`ParseError`] - Syntax errors from the parser
-//! - [`TypeError`] - Type checking errors (generic over the type representation)
+//! - [`TypeError`] - Type checking and type-level validation errors (generic over the type representation)
 //! - [`NameError`] - Name resolution errors (duplicates across files)
 //! - [`HirDiagnostic`] - HIR lowering errors (per-file validation)
 

--- a/baml_language/crates/baml_compiler_diagnostics/src/errors/type_error.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/errors/type_error.rs
@@ -110,4 +110,16 @@ pub enum TypeError<C: ErrorContext> {
     /// Map has keys that aren't valid. Only string, literal string, and enum are
     /// valid may key types.
     InvalidMapKeyType { ty: C::Ty, location: C::Location },
+
+    // ============ Type Structure Validation Errors ============
+    /// Type aliases form a dependency cycle (non-structural recursion).
+    AliasCycle {
+        cycle_path: String,
+        location: C::Location,
+    },
+    /// Classes form a dependency cycle (infinite recursion).
+    ClassCycle {
+        cycle_path: String,
+        location: C::Location,
+    },
 }

--- a/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
@@ -205,6 +205,18 @@ impl<C: ErrorContext> TypeError<C> {
                     ty_fn(ty)
                 )
             ).with_primary_span(loc_fn(location)),
+
+            TypeError::AliasCycle { cycle_path, location } => Diagnostic::error(
+                DiagnosticId::AliasCycle,
+                format!("These aliases form a dependency cycle: {cycle_path}"),
+            )
+            .with_primary_span(loc_fn(location)),
+
+            TypeError::ClassCycle { cycle_path, location } => Diagnostic::error(
+                DiagnosticId::ClassCycle,
+                format!("These classes form a dependency cycle: {cycle_path}"),
+            )
+            .with_primary_span(loc_fn(location)),
         };
         diag.with_phase(DiagnosticPhase::Type)
     }

--- a/baml_language/crates/baml_compiler_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_hir/src/lib.rs
@@ -496,6 +496,57 @@ pub fn project_type_names(db: &dyn Db, root: baml_workspace::Project) -> Project
     ProjectTypeNames::new(db, names)
 }
 
+/// Returns a map of type item names to their spans.
+///
+/// This is a cached query that provides efficient Name -> Span lookups for
+/// type-level error reporting (type aliases and classes). Used by `ErrorLocation::to_span`
+/// to resolve `TypeItem(Name)` locations during diagnostic rendering.
+///
+/// Note: This query recomputes when file contents change (including whitespace),
+/// since spans must be extracted from the syntax tree. The incrementality benefit
+/// comes from storing `ErrorLocation::TypeItem(Name)` in type errors instead of
+/// spans directly - type checking results remain cached even when this query invalidates.
+#[salsa::tracked]
+pub fn project_type_item_spans(
+    db: &dyn Db,
+    root: baml_workspace::Project,
+) -> std::sync::Arc<std::collections::HashMap<Name, Span>> {
+    let items = project_items(db, root);
+    let mut spans = std::collections::HashMap::new();
+
+    for item in items.items(db) {
+        match item {
+            ItemId::Class(loc) => {
+                let file = loc.file(db);
+                let item_tree = file_item_tree(db, file);
+                let class = &item_tree[loc.id(db)];
+                let name = class.name.clone();
+
+                if let Some(span) =
+                    get_item_name_span(db, file, "class", name.as_str(), loc.id(db).index())
+                {
+                    spans.insert(name, span);
+                }
+            }
+            ItemId::TypeAlias(loc) => {
+                let file = loc.file(db);
+                let item_tree = file_item_tree(db, file);
+                let alias = &item_tree[loc.id(db)];
+                let name = alias.name.clone();
+
+                if let Some(span) =
+                    get_item_name_span(db, file, "type alias", name.as_str(), loc.id(db).index())
+                {
+                    spans.insert(name, span);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    std::sync::Arc::new(spans)
+}
+
 /// Returns the names and spans of all functions defined in the project.
 ///
 /// This is a convenience function for WASM/external consumers that just need

--- a/baml_language/crates/baml_compiler_hir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_hir/src/lib.rs
@@ -1282,8 +1282,10 @@ pub struct HirValidationResult {
 /// - Reserved name validation (field names that are keywords in target languages)
 /// - Field name matches type name validation (Python-specific)
 pub fn validate_hir(db: &dyn Db, root: baml_workspace::Project) -> HirValidationResult {
+    let hir_diagnostics = validate_reserved_names(db, root);
+
     HirValidationResult {
-        hir_diagnostics: validate_reserved_names(db, root),
+        hir_diagnostics,
         name_errors: validate_duplicate_names(db, root),
     }
 }
@@ -1885,7 +1887,7 @@ fn get_enum_variant_info(
 /// The `occurrence` parameter specifies which occurrence to return (0 = first, 1 = second, etc.)
 /// when there are multiple items of the same kind with the same name in the file.
 /// This corresponds to the collision index in `LocalItemId`.
-fn get_item_name_span(
+pub fn get_item_name_span(
     db: &dyn Db,
     file: baml_base::files::SourceFile,
     kind: &str,

--- a/baml_language/crates/baml_compiler_hir/src/source_map.rs
+++ b/baml_language/crates/baml_compiler_hir/src/source_map.rs
@@ -44,21 +44,34 @@ pub enum ErrorLocation {
 }
 
 impl ErrorLocation {
-    /// Resolve this location to a `Span` using the provided source map.
+    /// Resolve this location to a `Span`.
     ///
-    /// Note: This method doesn't handle `TypeItem` because those require project-level
-    /// context to resolve. Use a custom resolver in check.rs for type-level errors.
-    pub fn to_span(&self, source_map: &HirSourceMap) -> Span {
+    /// For function body locations (Expr, `MatchArm`), uses the `HirSourceMap`.
+    /// For type-level locations (`TypeItem`), looks up the name in the type spans map.
+    ///
+    /// # Parameters
+    /// - `source_map`: Maps expression/statement IDs to spans within a function body
+    /// - `type_spans`: Maps type item names to spans (from `project_type_item_spans` query)
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let type_spans = project_type_item_spans(db, project);
+    /// let span = loc.to_span(hir_source_map, &type_spans);
+    /// ```
+    pub fn to_span(
+        &self,
+        source_map: &HirSourceMap,
+        type_spans: &std::collections::HashMap<Name, Span>,
+    ) -> Span {
         match self {
             ErrorLocation::Expr(id) => source_map.expr_span(*id).unwrap_or_default(),
             ErrorLocation::MatchArm(id) => source_map
                 .match_arm_spans(*id)
                 .map(|s| s.arm_span)
                 .unwrap_or_default(),
-            ErrorLocation::TypeItem(_) => {
-                panic!(
-                    "TypeItem locations require project context - use a custom resolver in check.rs"
-                )
+            ErrorLocation::TypeItem(name) => {
+                type_spans.get(name).copied().unwrap_or_else(Span::default)
             }
             ErrorLocation::Span(span) => *span,
         }

--- a/baml_language/crates/baml_compiler_hir/src/source_map.rs
+++ b/baml_language/crates/baml_compiler_hir/src/source_map.rs
@@ -9,7 +9,7 @@
 
 use std::{collections::HashMap, hash::Hash};
 
-use baml_base::Span;
+use baml_base::{Name, Span};
 use baml_compiler_diagnostics::ErrorContext;
 use rowan::TextRange;
 
@@ -27,12 +27,17 @@ use crate::{ExprId, MatchArmId, MatchArmSpans, PatId, StmtId, TypeId};
 ///
 /// At diagnostic rendering time, these locations are resolved to `Span` via
 /// the `HirSourceMap`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ErrorLocation {
     /// Error at an expression.
     Expr(ExprId),
     /// Error at a match arm (for unreachable arm errors).
     MatchArm(MatchArmId),
+    /// Error at a top-level type item (type alias or class).
+    ///
+    /// Used for validation errors about type definitions (e.g., cycle detection).
+    /// The Name is resolved to a span during diagnostic rendering.
+    TypeItem(Name),
     /// Fallback to a direct span (for errors from signatures or other non-body contexts).
     /// This should be minimized over time as we add more ID-based tracking.
     Span(Span),
@@ -40,6 +45,9 @@ pub enum ErrorLocation {
 
 impl ErrorLocation {
     /// Resolve this location to a `Span` using the provided source map.
+    ///
+    /// Note: This method doesn't handle `TypeItem` because those require project-level
+    /// context to resolve. Use a custom resolver in check.rs for type-level errors.
     pub fn to_span(&self, source_map: &HirSourceMap) -> Span {
         match self {
             ErrorLocation::Expr(id) => source_map.expr_span(*id).unwrap_or_default(),
@@ -47,6 +55,11 @@ impl ErrorLocation {
                 .match_arm_spans(*id)
                 .map(|s| s.arm_span)
                 .unwrap_or_default(),
+            ErrorLocation::TypeItem(_) => {
+                panic!(
+                    "TypeItem locations require project context - use a custom resolver in check.rs"
+                )
+            }
             ErrorLocation::Span(span) => *span,
         }
     }

--- a/baml_language/crates/baml_compiler_tir/Cargo.toml
+++ b/baml_language/crates/baml_compiler_tir/Cargo.toml
@@ -22,7 +22,7 @@ baml_builtins = { workspace = true }
 baml_compiler_diagnostics = { workspace = true }
 baml_compiler_hir = { workspace = true }
 baml_workspace = { workspace = true }
+rowan = { workspace = true }
 salsa = { workspace = true }
 smol_str = { workspace = true }
 text-size = { workspace = true }
-

--- a/baml_language/crates/baml_compiler_tir/src/cycles.rs
+++ b/baml_language/crates/baml_compiler_tir/src/cycles.rs
@@ -1,0 +1,422 @@
+//! Cycle detection for type aliases and classes at the TIR level.
+//!
+//! This module validates that type aliases and classes don't form infinite dependency
+//! cycles. It distinguishes between structural recursion (through maps/lists, which is
+//! allowed) and non-structural recursion (which is an error).
+//!
+//! This validation happens at the TIR level (after type resolution) rather than HIR
+//! because:
+//! 1. It requires resolved types to properly detect cycles (e.g., `RecAlias` → Recursive)
+//! 2. Uses position-independent identifiers (`ErrorLocation::TypeItem`) for incrementality
+//! 3. It's validation about type structure, not syntax structure
+
+use std::collections::{HashMap, HashSet};
+
+use baml_base::Name;
+use baml_compiler_diagnostics::TypeError;
+use baml_compiler_hir::{ErrorLocation, TirContext};
+
+use crate::Ty;
+
+/// Type alias for TIR type errors (position-independent).
+type TirTypeError = TypeError<TirContext<Ty>>;
+
+/// Tarjan's algorithm for finding strongly connected components (cycles).
+fn find_cycles<T>(graph: &HashMap<T, HashSet<T>>) -> Vec<Vec<T>>
+where
+    T: Clone + Eq + std::hash::Hash + Ord,
+{
+    struct TarjanState<T> {
+        indices: HashMap<T, usize>,
+        lowlinks: HashMap<T, usize>,
+        on_stack: HashSet<T>,
+        stack: Vec<T>,
+        index: usize,
+    }
+
+    impl<T: Clone + Eq + std::hash::Hash> TarjanState<T> {
+        fn new() -> Self {
+            Self {
+                indices: HashMap::new(),
+                lowlinks: HashMap::new(),
+                on_stack: HashSet::new(),
+                stack: Vec::new(),
+                index: 0,
+            }
+        }
+    }
+
+    fn tarjan_visit<T>(
+        node: &T,
+        graph: &HashMap<T, HashSet<T>>,
+        state: &mut TarjanState<T>,
+        components: &mut Vec<Vec<T>>,
+    ) where
+        T: Clone + Eq + std::hash::Hash,
+    {
+        state.indices.insert(node.clone(), state.index);
+        state.lowlinks.insert(node.clone(), state.index);
+        state.index += 1;
+        state.stack.push(node.clone());
+        state.on_stack.insert(node.clone());
+
+        if let Some(successors) = graph.get(node) {
+            for successor in successors {
+                if !state.indices.contains_key(successor) {
+                    tarjan_visit(successor, graph, state, components);
+                    let successor_lowlink = state.lowlinks[successor];
+                    let node_lowlink = state.lowlinks.get_mut(node).unwrap();
+                    *node_lowlink = (*node_lowlink).min(successor_lowlink);
+                } else if state.on_stack.contains(successor) {
+                    let successor_index = state.indices[successor];
+                    let node_lowlink = state.lowlinks.get_mut(node).unwrap();
+                    *node_lowlink = (*node_lowlink).min(successor_index);
+                }
+            }
+        }
+
+        let node_lowlink = state.lowlinks[node];
+        let node_index = state.indices[node];
+        if node_lowlink == node_index {
+            let mut component = Vec::new();
+            loop {
+                let w = state.stack.pop().unwrap();
+                state.on_stack.remove(&w);
+                component.push(w.clone());
+                if w == *node {
+                    break;
+                }
+            }
+            components.push(component);
+        }
+    }
+
+    let mut state = TarjanState::new();
+    let mut components = Vec::new();
+
+    for node in graph.keys() {
+        if !state.indices.contains_key(node) {
+            tarjan_visit(node, graph, &mut state, &mut components);
+        }
+    }
+
+    // Filter to only cycles (SCCs with more than one node, or self-loops)
+    components
+        .into_iter()
+        .filter(|component| {
+            match component.len().cmp(&1) {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Equal => {
+                    // Check for self-loop
+                    let node = &component[0];
+                    graph
+                        .get(node)
+                        .map(|deps| deps.contains(node))
+                        .unwrap_or(false)
+                }
+                std::cmp::Ordering::Less => false,
+            }
+        })
+        .map(|mut cycle| {
+            // Sort to get deterministic output starting with min element
+            cycle.sort();
+            cycle
+        })
+        .collect()
+}
+
+/// Extract all type alias dependencies from a resolved type.
+/// Returns (non-structural deps, structural deps) where structural means through maps/lists.
+fn extract_type_alias_deps(ty: &Ty) -> (HashSet<Name>, HashSet<Name>) {
+    fn visit(
+        ty: &Ty,
+        non_structural_deps: &mut HashSet<Name>,
+        structural_deps: &mut HashSet<Name>,
+        in_structural_context: bool,
+    ) {
+        match ty {
+            Ty::TypeAlias(fqn) => {
+                // Type aliases in Ty are kept unexpanded - this is what we want to track
+                let name = fqn.name.clone();
+                if in_structural_context {
+                    structural_deps.insert(name);
+                } else {
+                    non_structural_deps.insert(name);
+                }
+            }
+            Ty::Optional(inner) => {
+                // Optional doesn't make it structural for type aliases
+                visit(
+                    inner,
+                    non_structural_deps,
+                    structural_deps,
+                    in_structural_context,
+                );
+            }
+            Ty::List(inner) => {
+                // List makes it structural
+                visit(inner, non_structural_deps, structural_deps, true);
+            }
+            Ty::Map { key, value } => {
+                // Map makes it structural
+                visit(key, non_structural_deps, structural_deps, true);
+                visit(value, non_structural_deps, structural_deps, true);
+            }
+            Ty::Union(variants) => {
+                for variant in variants {
+                    visit(
+                        variant,
+                        non_structural_deps,
+                        structural_deps,
+                        in_structural_context,
+                    );
+                }
+            }
+            // Classes, enums, primitives, and literals don't create alias dependencies
+            _ => {}
+        }
+    }
+
+    let mut non_structural_deps = HashSet::new();
+    let mut structural_deps = HashSet::new();
+
+    visit(ty, &mut non_structural_deps, &mut structural_deps, false);
+    (non_structural_deps, structural_deps)
+}
+
+struct GraphResult {
+    graph: HashMap<Name, HashSet<Name>>,
+    structural_edges: HashSet<(Name, Name)>,
+}
+
+/// Build a graph of type alias dependencies, tracking which edges are structural.
+///
+/// This is position-independent - works only with the resolved types, no file access.
+fn build_type_alias_graph(type_aliases: &HashMap<Name, Ty>) -> GraphResult {
+    let mut graph: HashMap<Name, HashSet<Name>> = HashMap::new();
+    let mut structural_edges: HashSet<(Name, Name)> = HashSet::new();
+
+    for (alias_name, ty) in type_aliases {
+        let (mut non_structural_deps, structural_deps) = extract_type_alias_deps(ty);
+
+        // Mark structural edges (we need to iterate before consuming structural_deps)
+        for dep in &structural_deps {
+            structural_edges.insert((alias_name.clone(), dep.clone()));
+        }
+
+        // Combine all dependencies for the graph (move structural_deps to avoid clone)
+        non_structural_deps.extend(structural_deps);
+
+        // Add to graph (move the combined deps to avoid clone)
+        graph.insert(alias_name.clone(), non_structural_deps);
+    }
+
+    GraphResult {
+        graph,
+        structural_edges,
+    }
+}
+
+/// Extract class dependencies from a resolved type for class cycle detection.
+/// Only considers required (non-optional) dependencies.
+/// Type aliases in Ty are kept unexpanded, so we need to resolve them.
+fn extract_class_deps(ty: &Ty, type_aliases: &HashMap<Name, Ty>) -> HashSet<Name> {
+    fn visit(
+        ty: &Ty,
+        deps: &mut HashSet<Name>,
+        optional: bool,
+        in_list_or_map: bool,
+        type_aliases: &HashMap<Name, Ty>,
+        visiting: &mut HashSet<Name>,
+    ) {
+        match ty {
+            Ty::Class(fqn) => {
+                // Only add if not optional and not in list/map
+                if !optional && !in_list_or_map {
+                    deps.insert(fqn.name.clone());
+                }
+            }
+            Ty::TypeAlias(fqn) => {
+                // Type aliases are kept unexpanded in Ty - resolve them
+                if !optional && !in_list_or_map {
+                    let name = &fqn.name;
+                    // Prevent infinite recursion on cyclic type aliases
+                    if !visiting.contains(name) {
+                        if let Some(alias_ty) = type_aliases.get(name) {
+                            visiting.insert(name.clone());
+                            visit(
+                                alias_ty,
+                                deps,
+                                optional,
+                                in_list_or_map,
+                                type_aliases,
+                                visiting,
+                            );
+                            visiting.remove(name);
+                        }
+                    }
+                }
+            }
+            Ty::Optional(inner) => {
+                // Optional breaks cycles
+                visit(inner, deps, true, in_list_or_map, type_aliases, visiting);
+            }
+            Ty::List(inner) => {
+                // Lists break cycles - mark as in structural context
+                visit(inner, deps, optional, true, type_aliases, visiting);
+            }
+            Ty::Map { key, value } => {
+                // Maps break cycles - mark as in structural context
+                visit(key, deps, optional, true, type_aliases, visiting);
+                visit(value, deps, optional, true, type_aliases, visiting);
+            }
+            Ty::Union(variants) => {
+                // For unions, we need to check if ALL variants lead to the same class
+                let mut union_deps = Vec::new();
+                for variant in variants {
+                    let mut variant_deps = HashSet::new();
+                    visit(
+                        variant,
+                        &mut variant_deps,
+                        optional,
+                        in_list_or_map,
+                        type_aliases,
+                        visiting,
+                    );
+                    union_deps.push(variant_deps);
+                }
+
+                // Only add deps if all variants lead to same single class
+                if !union_deps.is_empty() {
+                    let first = &union_deps[0];
+                    if first.len() == 1 && union_deps.iter().all(|d| d == first) {
+                        deps.extend(first.iter().cloned());
+                    }
+                }
+            }
+            // Primitives, literals, enums, etc. don't create class dependencies
+            _ => {}
+        }
+    }
+
+    let mut deps = HashSet::new();
+    let mut visiting = HashSet::new();
+
+    visit(ty, &mut deps, false, false, type_aliases, &mut visiting);
+    deps
+}
+
+/// Build a graph of class dependencies (only required fields).
+///
+/// This is position-independent - works only with the resolved types.
+fn build_class_graph(
+    class_field_types: &HashMap<Name, HashMap<Name, Ty>>,
+    type_aliases: &HashMap<Name, Ty>,
+) -> HashMap<Name, HashSet<Name>> {
+    let mut graph: HashMap<Name, HashSet<Name>> = HashMap::new();
+
+    for (class_name, fields) in class_field_types {
+        let mut deps = HashSet::new();
+
+        for field_ty in fields.values() {
+            // Extract class dependencies from the resolved type
+            let field_deps = extract_class_deps(field_ty, type_aliases);
+            deps.extend(field_deps);
+        }
+
+        graph.insert(class_name.clone(), deps);
+    }
+
+    graph
+}
+
+/// Format a cycle path for error messages.
+///
+/// For cycles with more than one element, shows the complete cycle by adding
+/// the first element at the end: "A -> B -> C -> A"
+fn format_cycle_path(cycle: &[Name]) -> String {
+    if cycle.len() == 1 {
+        // Self-referential cycle: "A"
+        cycle[0].to_string()
+    } else {
+        // Multi-element cycle: show complete path back to start
+        let mut path: Vec<String> = cycle.iter().map(std::string::ToString::to_string).collect();
+        path.push(cycle[0].to_string()); // Add first element at end to close the cycle
+        path.join(" -> ")
+    }
+}
+
+/// Validate type alias cycles.
+///
+/// Returns type errors with position-independent locations (`ErrorLocation::TypeItem`).
+pub fn validate_type_alias_cycles(type_aliases: &HashMap<Name, Ty>) -> Vec<TirTypeError> {
+    let GraphResult {
+        graph,
+        structural_edges,
+    } = build_type_alias_graph(type_aliases);
+
+    // Find all cycles
+    let mut cycles = find_cycles(&graph);
+
+    // Sort cycles for deterministic output
+    cycles.sort();
+
+    let mut errors = Vec::new();
+
+    for cycle in cycles {
+        // Check if this cycle has at least one structural edge (goes through map/list)
+        // If so, the cycle is allowed because the structural type provides a base case
+        let mut has_structural_edge = false;
+        for i in 0..cycle.len() {
+            let from = &cycle[i];
+            let to = &cycle[(i + 1) % cycle.len()];
+            if structural_edges.contains(&(from.clone(), to.clone())) {
+                has_structural_edge = true;
+                break;
+            }
+        }
+
+        // Only report cycles without any structural edges as errors
+        if !has_structural_edge {
+            let cycle_path = format_cycle_path(&cycle);
+            let first_in_cycle = cycle[0].clone();
+
+            errors.push(TypeError::AliasCycle {
+                cycle_path,
+                location: ErrorLocation::TypeItem(first_in_cycle),
+            });
+        }
+    }
+
+    errors
+}
+
+/// Validate class cycles.
+///
+/// Returns type errors with position-independent locations (`ErrorLocation::TypeItem`).
+pub fn validate_class_cycles(
+    class_field_types: &HashMap<Name, HashMap<Name, Ty>>,
+    type_aliases: &HashMap<Name, Ty>,
+) -> Vec<TirTypeError> {
+    let graph = build_class_graph(class_field_types, type_aliases);
+
+    // Find all cycles
+    let mut cycles = find_cycles(&graph);
+
+    // Sort cycles for deterministic output
+    cycles.sort();
+
+    let mut errors = Vec::new();
+
+    for cycle in cycles {
+        let cycle_path = format_cycle_path(&cycle);
+        let first_in_cycle = cycle[0].clone();
+
+        errors.push(TypeError::ClassCycle {
+            cycle_path,
+            location: ErrorLocation::TypeItem(first_in_cycle),
+        });
+    }
+
+    errors
+}

--- a/baml_language/crates/baml_compiler_tir/src/cycles.rs
+++ b/baml_language/crates/baml_compiler_tir/src/cycles.rs
@@ -9,8 +9,16 @@
 //! 1. It requires resolved types to properly detect cycles (e.g., `RecAlias` → Recursive)
 //! 2. Uses position-independent identifiers (`ErrorLocation::TypeItem`) for incrementality
 //! 3. It's validation about type structure, not syntax structure
+//!
+//! ## Implementation
+//!
+//! Uses Tarjan's strongly connected components algorithm, adapted from engine/tarjan.rs.
+//! The algorithm finds all cycles in a directed graph efficiently in O(V + E) time.
 
-use std::collections::{HashMap, HashSet};
+use std::{
+    cmp,
+    collections::{HashMap, HashSet},
+};
 
 use baml_base::Name;
 use baml_compiler_diagnostics::TypeError;
@@ -21,112 +29,211 @@ use crate::Ty;
 /// Type alias for TIR type errors (position-independent).
 type TirTypeError = TypeError<TirContext<Ty>>;
 
-/// Tarjan's algorithm for finding strongly connected components (cycles).
-fn find_cycles<T>(graph: &HashMap<T, HashSet<T>>) -> Vec<Vec<T>>
-where
-    T: Clone + Eq + std::hash::Hash + Ord,
-{
-    struct TarjanState<T> {
-        indices: HashMap<T, usize>,
-        lowlinks: HashMap<T, usize>,
-        on_stack: HashSet<T>,
-        stack: Vec<T>,
-        index: usize,
-    }
+/// Dependency graph represented as an adjacency list.
+type Graph<V> = HashMap<V, HashSet<V>>;
 
-    impl<T: Clone + Eq + std::hash::Hash> TarjanState<T> {
-        fn new() -> Self {
-            Self {
-                indices: HashMap::new(),
-                lowlinks: HashMap::new(),
-                on_stack: HashSet::new(),
-                stack: Vec::new(),
-                index: 0,
+// ============================================================================
+// TARJAN'S ALGORITHM
+// ============================================================================
+
+/// State of each node for Tarjan's algorithm.
+#[derive(Clone, Copy)]
+struct NodeState {
+    /// Node unique index.
+    index: usize,
+    /// Low link value.
+    ///
+    /// Represents the smallest index of any node on the stack known to be
+    /// reachable from `self` through `self`'s DFS subtree.
+    low_link: usize,
+    /// Whether the node is on the stack.
+    on_stack: bool,
+}
+
+/// Tarjan's strongly connected components algorithm implementation.
+///
+/// This algorithm finds and returns all the cycles in a graph. Read more about
+/// it [here](https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm).
+///
+/// Adapted from engine/baml-lib/parser-database/src/tarjan.rs with modifications
+/// for use with `Name` instead of opaque IDs.
+struct Tarjan<'g> {
+    /// Ref to the dependency graph.
+    graph: &'g Graph<Name>,
+    /// Node number counter.
+    index: usize,
+    /// Nodes are placed on a stack in the order in which they are visited.
+    stack: Vec<Name>,
+    /// State of each node.
+    state: HashMap<Name, NodeState>,
+    /// Strongly connected components (cycles).
+    components: Vec<Vec<Name>>,
+}
+
+impl<'g> Tarjan<'g> {
+    /// Unvisited node marker.
+    ///
+    /// Technically we should use [`Option<usize>`] and [`None`] for
+    /// [`NodeState::index`] and [`NodeState::low_link`] but that would require
+    /// some ugly and repetitive [`Option::unwrap`] calls. [`usize::MAX`] won't
+    /// be reached as an index anyway, the algorithm will stack overflow much
+    /// sooner than that :/
+    const UNVISITED: usize = usize::MAX;
+
+    /// Public entry point for the algorithm.
+    ///
+    /// Loops through all the nodes in the graph and visits them if they haven't
+    /// been visited already. When the algorithm is done, [`Self::components`]
+    /// will contain all the cycles in the graph.
+    fn components(graph: &'g Graph<Name>) -> Vec<Vec<Name>> {
+        let mut tarjan = Self {
+            graph,
+            index: 0,
+            stack: Vec::new(),
+            state: graph
+                .keys()
+                .map(|node| {
+                    let state = NodeState {
+                        index: Self::UNVISITED,
+                        low_link: Self::UNVISITED,
+                        on_stack: false,
+                    };
+
+                    (node.clone(), state)
+                })
+                .collect(),
+            components: Vec::new(),
+        };
+
+        // Always start at the same node to avoid randomness in the cycle path.
+        // Sort nodes to ensure deterministic traversal order.
+        let mut nodes: Vec<_> = graph.keys().cloned().collect();
+        nodes.sort();
+
+        for node in nodes {
+            if tarjan.state[&node].index == Self::UNVISITED {
+                tarjan.strong_connect(&node);
             }
         }
+
+        // Sort components by the first element in each cycle (which is already
+        // sorted as well). This should get rid of all the randomness caused by
+        // hash maps and hash sets.
+        tarjan.components.sort_by(|a, b| a[0].cmp(&b[0]));
+
+        tarjan.components
     }
 
-    fn tarjan_visit<T>(
-        node: &T,
-        graph: &HashMap<T, HashSet<T>>,
-        state: &mut TarjanState<T>,
-        components: &mut Vec<Vec<T>>,
-    ) where
-        T: Clone + Eq + std::hash::Hash,
-    {
-        state.indices.insert(node.clone(), state.index);
-        state.lowlinks.insert(node.clone(), state.index);
-        state.index += 1;
-        state.stack.push(node.clone());
-        state.on_stack.insert(node.clone());
+    /// Recursive DFS.
+    ///
+    /// This is where the "algorithm" runs. Could be implemented iteratively if
+    /// needed at some point.
+    fn strong_connect(&mut self, node_id: &Name) {
+        // Initialize node state. This node has not yet been visited so we don't
+        // have to grab the state from the hash map. And if we did, then we'd
+        // have to fight the borrow checker by taking mut refs and read-only
+        // refs over and over again as needed (which requires hashing the same
+        // entry many times and is not as readable).
+        let mut node = NodeState {
+            index: self.index,
+            low_link: self.index,
+            on_stack: true,
+        };
 
-        if let Some(successors) = graph.get(node) {
-            for successor in successors {
-                if !state.indices.contains_key(successor) {
-                    tarjan_visit(successor, graph, state, components);
-                    let successor_lowlink = state.lowlinks[successor];
-                    let node_lowlink = state.lowlinks.get_mut(node).unwrap();
-                    *node_lowlink = (*node_lowlink).min(successor_lowlink);
-                } else if state.on_stack.contains(successor) {
-                    let successor_index = state.indices[successor];
-                    let node_lowlink = state.lowlinks.get_mut(node).unwrap();
-                    *node_lowlink = (*node_lowlink).min(successor_index);
-                }
+        // Increment index and push node to stack.
+        self.index += 1;
+
+        // Update state. We store this in a hash map
+        // so we have to run the hashing algorithm every time we update the
+        // state. Keep it to a minimum :)
+        self.state.insert(node_id.clone(), node);
+        self.stack.push(node_id.clone());
+
+        // Sort successors to ensure deterministic traversal order.
+        // HashSet iteration is non-deterministic, so we must sort to avoid
+        // reporting different cycle paths on each run.
+        let mut successors: Vec<_> = self.graph[node_id].iter().collect();
+        successors.sort();
+
+        // Visit neighbors to find strongly connected components.
+        for successor_id in successors {
+            // Grab owned state to circumvent borrow checker.
+            let mut successor = self.state[successor_id];
+            if successor.index == Self::UNVISITED {
+                self.strong_connect(successor_id);
+                // Grab updated state after recursive call.
+                successor = self.state[successor_id];
+                node.low_link = cmp::min(node.low_link, successor.low_link);
+            } else if successor.on_stack {
+                node.low_link = cmp::min(node.low_link, successor.index);
             }
         }
 
-        let node_lowlink = state.lowlinks[node];
-        let node_index = state.indices[node];
-        if node_lowlink == node_index {
+        // Re-insert the node's state as the state might have changed.
+        self.state.insert(node_id.clone(), node);
+
+        // Root node of a strongly connected component.
+        if node.low_link == node.index {
             let mut component = Vec::new();
-            loop {
-                let w = state.stack.pop().unwrap();
-                state.on_stack.remove(&w);
-                component.push(w.clone());
-                if w == *node {
+
+            while let Some(parent_id) = self.stack.pop() {
+                // This should not fail since all nodes should be stored in
+                // the state hash map.
+                if let Some(parent) = self.state.get_mut(&parent_id) {
+                    parent.on_stack = false;
+                }
+
+                component.push(parent_id.clone());
+
+                if &parent_id == node_id {
                     break;
                 }
             }
-            components.push(component);
-        }
-    }
 
-    let mut state = TarjanState::new();
-    let mut components = Vec::new();
+            // Path should be shown as parent -> child not child -> parent.
+            component.reverse();
 
-    for node in graph.keys() {
-        if !state.indices.contains_key(node) {
-            tarjan_visit(node, graph, &mut state, &mut components);
-        }
-    }
+            // Find index of minimum element in the component.
+            //
+            // The cycle path is not computed deterministically because the
+            // graph is stored in a hash map, so random state will cause the
+            // traversal algorithm to start at different nodes each time.
+            //
+            // Therefore, to avoid reporting errors to the user differently
+            // every time, we'll use a simple deterministic way to determine
+            // the start node of a cycle.
+            //
+            // Basically, the start node will always be the smallest type name in
+            // the cycle. That gets rid of the random state.
+            let min_index = component
+                .iter()
+                .enumerate()
+                .min_by(|(_, a), (_, b)| a.cmp(b))
+                .map(|(i, _)| i);
 
-    // Filter to only cycles (SCCs with more than one node, or self-loops)
-    components
-        .into_iter()
-        .filter(|component| {
-            match component.len().cmp(&1) {
-                std::cmp::Ordering::Greater => true,
-                std::cmp::Ordering::Equal => {
-                    // Check for self-loop
-                    let node = &component[0];
-                    graph
-                        .get(node)
-                        .map(|deps| deps.contains(node))
-                        .unwrap_or(false)
+            // We have a cycle if the component contains more than one node or
+            // it contains a single node that points to itself. Otherwise it's
+            // just a normal node with no cycles whatsoever, so we'll skip it.
+            if component.len() > 1
+                || (component.len() == 1 && self.graph[node_id].contains(node_id))
+            {
+                if let Some(index) = min_index {
+                    component.rotate_left(index);
+                    self.components.push(component);
                 }
-                std::cmp::Ordering::Less => false,
             }
-        })
-        .map(|mut cycle| {
-            // Sort to get deterministic output starting with min element
-            cycle.sort();
-            cycle
-        })
-        .collect()
+        }
+    }
 }
 
+// ============================================================================
+// TYPE ALIAS CYCLE DETECTION
+// ============================================================================
+
 /// Extract all type alias dependencies from a resolved type.
-/// Returns (non-structural deps, structural deps) where structural means through maps/lists.
+///
+/// Returns `(non-structural deps, structural deps)` where structural means
+/// through maps/lists (which are allowed to be recursive).
 fn extract_type_alias_deps(ty: &Ty) -> (HashSet<Name>, HashSet<Name>) {
     fn visit(
         ty: &Ty,
@@ -136,7 +243,8 @@ fn extract_type_alias_deps(ty: &Ty) -> (HashSet<Name>, HashSet<Name>) {
     ) {
         match ty {
             Ty::TypeAlias(fqn) => {
-                // Type aliases in Ty are kept unexpanded - this is what we want to track
+                // Type aliases in Ty are kept unexpanded - this is what we want to track.
+                // They stay as names and never expand, preventing infinite recursion.
                 let name = fqn.name.clone();
                 if in_structural_context {
                     structural_deps.insert(name);
@@ -154,11 +262,11 @@ fn extract_type_alias_deps(ty: &Ty) -> (HashSet<Name>, HashSet<Name>) {
                 );
             }
             Ty::List(inner) => {
-                // List makes it structural
+                // List makes it structural - provides termination via []
                 visit(inner, non_structural_deps, structural_deps, true);
             }
             Ty::Map { key, value } => {
-                // Map makes it structural
+                // Map makes it structural - provides termination via {}
                 visit(key, non_structural_deps, structural_deps, true);
                 visit(value, non_structural_deps, structural_deps, true);
             }
@@ -184,8 +292,12 @@ fn extract_type_alias_deps(ty: &Ty) -> (HashSet<Name>, HashSet<Name>) {
     (non_structural_deps, structural_deps)
 }
 
+/// Result of building a type alias dependency graph.
 struct GraphResult {
-    graph: HashMap<Name, HashSet<Name>>,
+    /// The full dependency graph (all edges).
+    graph: Graph<Name>,
+    /// Edges that go through structural types (List/Map).
+    /// These edges indicate cycles that are allowed.
     structural_edges: HashSet<(Name, Name)>,
 }
 
@@ -193,7 +305,7 @@ struct GraphResult {
 ///
 /// This is position-independent - works only with the resolved types, no file access.
 fn build_type_alias_graph(type_aliases: &HashMap<Name, Ty>) -> GraphResult {
-    let mut graph: HashMap<Name, HashSet<Name>> = HashMap::new();
+    let mut graph: Graph<Name> = HashMap::new();
     let mut structural_edges: HashSet<(Name, Name)> = HashSet::new();
 
     for (alias_name, ty) in type_aliases {
@@ -217,9 +329,78 @@ fn build_type_alias_graph(type_aliases: &HashMap<Name, Ty>) -> GraphResult {
     }
 }
 
+/// Validate type alias cycles.
+///
+/// Returns type errors with position-independent locations (`ErrorLocation::TypeItem`).
+///
+/// # Algorithm
+///
+/// 1. Build dependency graph from type aliases
+/// 2. Find all cycles using Tarjan's algorithm
+/// 3. Filter out cycles that have at least one "structural" edge (through List/Map)
+/// 4. Report remaining cycles as errors
+///
+/// # Example
+///
+/// ```text
+/// type A = B       // Error: A -> B -> A (no structural edge)
+/// type B = A
+///
+/// type C = D[]     // OK: C -> D -> C but goes through List
+/// type D = C
+/// ```
+pub fn validate_type_alias_cycles(type_aliases: &HashMap<Name, Ty>) -> Vec<TirTypeError> {
+    let GraphResult {
+        graph,
+        structural_edges,
+    } = build_type_alias_graph(type_aliases);
+
+    // Find all cycles using Tarjan's algorithm
+    let cycles = Tarjan::components(&graph);
+
+    let mut errors = Vec::new();
+
+    for cycle in cycles {
+        // Check if this cycle has at least one structural edge (goes through map/list).
+        // If so, the cycle is allowed because the structural type provides a base case
+        // for termination (empty list or empty map).
+        let mut has_structural_edge = false;
+        for i in 0..cycle.len() {
+            let from = &cycle[i];
+            let to = &cycle[(i + 1) % cycle.len()];
+            if structural_edges.contains(&(from.clone(), to.clone())) {
+                has_structural_edge = true;
+                break;
+            }
+        }
+
+        // Only report cycles without any structural edges as errors
+        if !has_structural_edge {
+            let cycle_path = format_cycle_path(&cycle);
+            let first_in_cycle = cycle[0].clone();
+
+            errors.push(TypeError::AliasCycle {
+                cycle_path,
+                location: ErrorLocation::TypeItem(first_in_cycle),
+            });
+        }
+    }
+
+    errors
+}
+
+// ============================================================================
+// CLASS CYCLE DETECTION
+// ============================================================================
+
 /// Extract class dependencies from a resolved type for class cycle detection.
-/// Only considers required (non-optional) dependencies.
-/// Type aliases in Ty are kept unexpanded, so we need to resolve them.
+///
+/// Only considers **required** (non-optional) dependencies. Optional fields
+/// and fields inside lists/maps don't create hard dependencies because they
+/// can be absent or empty.
+///
+/// Type aliases in Ty are kept unexpanded, so we need to resolve them
+/// recursively to find the actual class dependencies.
 fn extract_class_deps(ty: &Ty, type_aliases: &HashMap<Name, Ty>) -> HashSet<Name> {
     fn visit(
         ty: &Ty,
@@ -231,16 +412,18 @@ fn extract_class_deps(ty: &Ty, type_aliases: &HashMap<Name, Ty>) -> HashSet<Name
     ) {
         match ty {
             Ty::Class(fqn) => {
-                // Only add if not optional and not in list/map
+                // Only add if not optional and not in list/map.
+                // Optional and structural contexts break the hard dependency.
                 if !optional && !in_list_or_map {
                     deps.insert(fqn.name.clone());
                 }
             }
             Ty::TypeAlias(fqn) => {
-                // Type aliases are kept unexpanded in Ty - resolve them
+                // Type aliases are kept unexpanded in Ty - resolve them.
+                // But only if this is a required field (not optional, not in list/map).
                 if !optional && !in_list_or_map {
                     let name = &fqn.name;
-                    // Prevent infinite recursion on cyclic type aliases
+                    // Prevent infinite recursion on cyclic type aliases using a visiting set
                     if !visiting.contains(name) {
                         if let Some(alias_ty) = type_aliases.get(name) {
                             visiting.insert(name.clone());
@@ -258,20 +441,22 @@ fn extract_class_deps(ty: &Ty, type_aliases: &HashMap<Name, Ty>) -> HashSet<Name
                 }
             }
             Ty::Optional(inner) => {
-                // Optional breaks cycles
+                // Optional breaks cycles - field can be absent
                 visit(inner, deps, true, in_list_or_map, type_aliases, visiting);
             }
             Ty::List(inner) => {
-                // Lists break cycles - mark as in structural context
+                // Lists break cycles - can be empty
                 visit(inner, deps, optional, true, type_aliases, visiting);
             }
             Ty::Map { key, value } => {
-                // Maps break cycles - mark as in structural context
+                // Maps break cycles - can be empty
                 visit(key, deps, optional, true, type_aliases, visiting);
                 visit(value, deps, optional, true, type_aliases, visiting);
             }
             Ty::Union(variants) => {
-                // For unions, we need to check if ALL variants lead to the same class
+                // For unions, we need to check if ALL variants lead to the same class.
+                // If they do, then that class is a hard dependency. Otherwise, the
+                // union can be satisfied by choosing a variant without that class.
                 let mut union_deps = Vec::new();
                 for variant in variants {
                     let mut variant_deps = HashSet::new();
@@ -312,8 +497,8 @@ fn extract_class_deps(ty: &Ty, type_aliases: &HashMap<Name, Ty>) -> HashSet<Name
 fn build_class_graph(
     class_field_types: &HashMap<Name, HashMap<Name, Ty>>,
     type_aliases: &HashMap<Name, Ty>,
-) -> HashMap<Name, HashSet<Name>> {
-    let mut graph: HashMap<Name, HashSet<Name>> = HashMap::new();
+) -> Graph<Name> {
+    let mut graph: Graph<Name> = HashMap::new();
 
     for (class_name, fields) in class_field_types {
         let mut deps = HashSet::new();
@@ -330,81 +515,38 @@ fn build_class_graph(
     graph
 }
 
-/// Format a cycle path for error messages.
-///
-/// For cycles with more than one element, shows the complete cycle by adding
-/// the first element at the end: "A -> B -> C -> A"
-fn format_cycle_path(cycle: &[Name]) -> String {
-    if cycle.len() == 1 {
-        // Self-referential cycle: "A"
-        cycle[0].to_string()
-    } else {
-        // Multi-element cycle: show complete path back to start
-        let mut path: Vec<String> = cycle.iter().map(std::string::ToString::to_string).collect();
-        path.push(cycle[0].to_string()); // Add first element at end to close the cycle
-        path.join(" -> ")
-    }
-}
-
-/// Validate type alias cycles.
-///
-/// Returns type errors with position-independent locations (`ErrorLocation::TypeItem`).
-pub fn validate_type_alias_cycles(type_aliases: &HashMap<Name, Ty>) -> Vec<TirTypeError> {
-    let GraphResult {
-        graph,
-        structural_edges,
-    } = build_type_alias_graph(type_aliases);
-
-    // Find all cycles
-    let mut cycles = find_cycles(&graph);
-
-    // Sort cycles for deterministic output
-    cycles.sort();
-
-    let mut errors = Vec::new();
-
-    for cycle in cycles {
-        // Check if this cycle has at least one structural edge (goes through map/list)
-        // If so, the cycle is allowed because the structural type provides a base case
-        let mut has_structural_edge = false;
-        for i in 0..cycle.len() {
-            let from = &cycle[i];
-            let to = &cycle[(i + 1) % cycle.len()];
-            if structural_edges.contains(&(from.clone(), to.clone())) {
-                has_structural_edge = true;
-                break;
-            }
-        }
-
-        // Only report cycles without any structural edges as errors
-        if !has_structural_edge {
-            let cycle_path = format_cycle_path(&cycle);
-            let first_in_cycle = cycle[0].clone();
-
-            errors.push(TypeError::AliasCycle {
-                cycle_path,
-                location: ErrorLocation::TypeItem(first_in_cycle),
-            });
-        }
-    }
-
-    errors
-}
-
 /// Validate class cycles.
 ///
 /// Returns type errors with position-independent locations (`ErrorLocation::TypeItem`).
+///
+/// # Algorithm
+///
+/// 1. Build dependency graph from class field types
+/// 2. Find all cycles using Tarjan's algorithm
+/// 3. Report all cycles as errors (classes can't be recursive at all)
+///
+/// # Example
+///
+/// ```text
+/// class User {
+///     post Post     // Error: User -> Post -> User
+/// }
+///
+/// class Post {
+///     author User
+/// }
+/// ```
+///
+/// Unlike type aliases, classes **cannot** be recursive even through lists/maps,
+/// because classes represent data structures that must be finitely constructed.
 pub fn validate_class_cycles(
     class_field_types: &HashMap<Name, HashMap<Name, Ty>>,
     type_aliases: &HashMap<Name, Ty>,
 ) -> Vec<TirTypeError> {
     let graph = build_class_graph(class_field_types, type_aliases);
 
-    // Find all cycles
-    let mut cycles = find_cycles(&graph);
-
-    // Sort cycles for deterministic output
-    cycles.sort();
+    // Find all cycles using Tarjan's algorithm
+    let cycles = Tarjan::components(&graph);
 
     let mut errors = Vec::new();
 
@@ -419,4 +561,26 @@ pub fn validate_class_cycles(
     }
 
     errors
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+/// Format a cycle path for error messages.
+///
+/// For cycles with more than one element, shows the complete cycle by adding
+/// the first element at the end: "A -> B -> C -> A"
+///
+/// For single-element cycles (self-loops), just shows: "A"
+fn format_cycle_path(cycle: &[Name]) -> String {
+    if cycle.len() == 1 {
+        // Self-referential cycle: "A"
+        cycle[0].to_string()
+    } else {
+        // Multi-element cycle: show complete path back to start
+        let mut path: Vec<String> = cycle.iter().map(std::string::ToString::to_string).collect();
+        path.push(cycle[0].to_string()); // Add first element at end to close the cycle
+        path.join(" -> ")
+    }
 }

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -34,6 +34,7 @@ use baml_workspace::Project;
 pub type TirTypeError = TypeError<TirContext<Ty>>;
 
 pub mod builtins;
+mod cycles;
 mod exhaustiveness;
 mod lower;
 mod normalize;
@@ -45,6 +46,7 @@ pub use builtins::{
     Bindings, lookup_function, lookup_method, match_pattern, method_param_types,
     method_return_type, substitute,
 };
+pub use cycles::{validate_class_cycles, validate_type_alias_cycles};
 pub use exhaustiveness::{ExhaustivenessChecker, ExhaustivenessResult, ValueSet};
 pub use lower::lower_type_ref;
 pub use normalize::find_invalid_map_keys;
@@ -1216,7 +1218,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                             },
                         );
                     }
-                    ty = infer_field_access(ctx, &ty, field, location);
+                    ty = infer_field_access(ctx, &ty, field, location.clone());
                     segment_types.push(ty.clone());
                 }
 
@@ -1360,7 +1362,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                             let first = &receiver_segments[0];
                             let mut ty = ctx.lookup(first).cloned().unwrap_or(Ty::Unknown);
                             for field in &receiver_segments[1..] {
-                                ty = infer_field_access(ctx, &ty, field, location);
+                                ty = infer_field_access(ctx, &ty, field, location.clone());
                             }
                             ty
                         };
@@ -1400,7 +1402,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         ctx.push_error(TypeError::ArgumentCountMismatch {
                             expected: params.len(),
                             found: effective_args.len(),
-                            location,
+                            location: location.clone(),
                         });
                     }
 
@@ -1410,7 +1412,8 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                     {
                         if !ctx.is_subtype_of(arg_ty, param_ty) {
                             // Use the argument's location if available, otherwise fall back to call location
-                            let error_location = arg_location.unwrap_or(location);
+                            let error_location =
+                                arg_location.clone().unwrap_or_else(|| location.clone());
                             ctx.push_error(TypeError::TypeMismatch {
                                 expected: param_ty.clone(),
                                 found: generalize_for_error(param_ty, arg_ty),
@@ -1446,13 +1449,15 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         if !ctx.is_watched(var_name) {
                             ctx.push_error(TypeError::WatchOnUnwatchedVariable {
                                 name: var_name.to_string(),
-                                location,
+                                location: location.clone(),
                             });
                         }
                     }
                     _ => {
                         // Not a simple variable (e.g., arr[0].$watch, obj.field.$watch)
-                        ctx.push_error(TypeError::WatchOnNonVariable { location });
+                        ctx.push_error(TypeError::WatchOnNonVariable {
+                            location: location.clone(),
+                        });
                     }
                 }
             }
@@ -1483,7 +1488,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         ctx.push_error(TypeError::TypeMismatch {
                             expected: elem_ty.clone(),
                             found: other_ty,
-                            location,
+                            location: location.clone(),
                             info_location: None,
                         });
                     }
@@ -1528,7 +1533,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                     ctx.push_error(TypeError::TypeMismatch {
                         expected: obj_ty.clone(),
                         found: spread_ty,
-                        location,
+                        location: location.clone(),
                         info_location: None,
                     });
                 }
@@ -1559,7 +1564,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         ctx.push_error(TypeError::TypeMismatch {
                             expected: key_ty.clone(),
                             found: generalize_for_error(&key_ty, &other_key_ty),
-                            location,
+                            location: location.clone(),
                             info_location: None,
                         });
                     }
@@ -1567,7 +1572,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                         ctx.push_error(TypeError::TypeMismatch {
                             expected: value_ty.clone(),
                             found: generalize_for_error(&value_ty, &other_value_ty),
-                            location,
+                            location: location.clone(),
                             info_location: None,
                         });
                     }
@@ -1698,7 +1703,7 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
                                 ctx.push_error(TypeError::TypeMismatch {
                                     expected: Ty::Bool,
                                     found: guard_ty,
-                                    location,
+                                    location: location.clone(),
                                     info_location: None,
                                 });
                             }
@@ -1818,7 +1823,7 @@ fn check_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody, expec
                             ctx.push_error(TypeError::TypeMismatch {
                                 expected: (**expected_elem).clone(),
                                 found: generalize_for_error(expected_elem, &elem_ty),
-                                location,
+                                location: location.clone(),
                                 info_location: None,
                             });
                         }
@@ -1943,7 +1948,7 @@ fn check_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody, expec
                             ctx.push_error(TypeError::TypeMismatch {
                                 expected: (**expected_key).clone(),
                                 found: generalize_for_error(expected_key, &key_ty),
-                                location,
+                                location: location.clone(),
                                 info_location: None,
                             });
                         }
@@ -1952,7 +1957,7 @@ fn check_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody, expec
                             ctx.push_error(TypeError::TypeMismatch {
                                 expected: (**expected_value).clone(),
                                 found: generalize_for_error(expected_value, &value_ty),
-                                location,
+                                location: location.clone(),
                                 info_location: None,
                             });
                         }

--- a/baml_language/crates/baml_compiler_tir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler_tir/src/pretty.rs
@@ -670,5 +670,11 @@ pub fn short_display(error: &TirTypeError) -> String {
         TypeError::InvalidMapKeyType { ty, .. } => {
             format!("Invalid key type for map: {ty}.")
         }
+        TypeError::AliasCycle { cycle_path, .. } => {
+            format!("Alias cycle detected: {cycle_path}")
+        }
+        TypeError::ClassCycle { cycle_path, .. } => {
+            format!("Class cycle detected: {cycle_path}")
+        }
     }
 }

--- a/baml_language/crates/baml_ide_tests/test_files/syntax/class/dependency_cycle.baml
+++ b/baml_language/crates/baml_ide_tests/test_files/syntax/class/dependency_cycle.baml
@@ -98,4 +98,48 @@ class Union {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// Error: These classes form a dependency cycle: A -> B -> C -> D -> A
+//     ╭─[ class_dependency_cycle.baml:37:7 ]
+//     │
+//  37 │ class A {
+//     │       ┬  
+//     │       ╰── These classes form a dependency cycle: A -> B -> C -> D -> A
+//     │ 
+//     │ Note: Error code: E0069
+// ────╯
+// Error: These classes form a dependency cycle: Five -> Four -> One -> Three -> Two -> Five
+//     ╭─[ class_dependency_cycle.baml:32:7 ]
+//     │
+//  32 │ class Five {
+//     │       ──┬─  
+//     │         ╰─── These classes form a dependency cycle: Five -> Four -> One -> Three -> Two -> Five
+//     │ 
+//     │ Note: Error code: E0069
+// ────╯
+// Error: These classes form a dependency cycle: InterfaceOne -> InterfaceTwo -> InterfaceOne
+//    ╭─[ class_dependency_cycle.baml:6:7 ]
+//    │
+//  6 │ class InterfaceOne {
+//    │       ──────┬─────  
+//    │             ╰─────── These classes form a dependency cycle: InterfaceOne -> InterfaceTwo -> InterfaceOne
+//    │ 
+//    │ Note: Error code: E0069
+// ───╯
+// Error: These classes form a dependency cycle: InterfaceThree
+//     ╭─[ class_dependency_cycle.baml:11:7 ]
+//     │
+//  11 │ class InterfaceThree {
+//     │       ───────┬──────  
+//     │              ╰──────── These classes form a dependency cycle: InterfaceThree
+//     │ 
+//     │ Note: Error code: E0069
+// ────╯
+// Error: These classes form a dependency cycle: Union
+//     ╭─[ class_dependency_cycle.baml:54:7 ]
+//     │
+//  54 │ class Union {
+//     │       ──┬──  
+//     │         ╰──── These classes form a dependency cycle: Union
+//     │ 
+//     │ Note: Error code: E0069
+// ────╯

--- a/baml_language/crates/baml_ide_tests/test_files/syntax/class/dependency_cycle.baml
+++ b/baml_language/crates/baml_ide_tests/test_files/syntax/class/dependency_cycle.baml
@@ -107,12 +107,12 @@ class Union {
 //     │ 
 //     │ Note: Error code: E0069
 // ────╯
-// Error: These classes form a dependency cycle: Five -> Four -> One -> Three -> Two -> Five
+// Error: These classes form a dependency cycle: Five -> One -> Two -> Three -> Four -> Five
 //     ╭─[ class_dependency_cycle.baml:32:7 ]
 //     │
 //  32 │ class Five {
 //     │       ──┬─  
-//     │         ╰─── These classes form a dependency cycle: Five -> Four -> One -> Three -> Two -> Five
+//     │         ╰─── These classes form a dependency cycle: Five -> One -> Two -> Three -> Four -> Five
 //     │ 
 //     │ Note: Error code: E0069
 // ────╯

--- a/baml_language/crates/baml_ide_tests/test_files/syntax/class/recursive_type_aliases.baml
+++ b/baml_language/crates/baml_ide_tests/test_files/syntax/class/recursive_type_aliases.baml
@@ -85,4 +85,39 @@ type Map = map<string, Map>
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// Error: These aliases form a dependency cycle: A -> B -> C -> A
+//     ╭─[ class_recursive_type_aliases.baml:15:6 ]
+//     │
+//  15 │ type A = B
+//     │      ┬  
+//     │      ╰── These aliases form a dependency cycle: A -> B -> C -> A
+//     │ 
+//     │ Note: Error code: E0068
+// ────╯
+// Error: These aliases form a dependency cycle: EnterCycle -> NoStop -> EnterCycle
+//     ╭─[ class_recursive_type_aliases.baml:51:6 ]
+//     │
+//  51 │ type EnterCycle = NoStop
+//     │      ─────┬────  
+//     │           ╰────── These aliases form a dependency cycle: EnterCycle -> NoStop -> EnterCycle
+//     │ 
+//     │ Note: Error code: E0068
+// ────╯
+// Error: These aliases form a dependency cycle: One -> Two -> One
+//     ╭─[ class_recursive_type_aliases.baml:10:6 ]
+//     │
+//  10 │ type One = Two
+//     │      ─┬─  
+//     │       ╰─── These aliases form a dependency cycle: One -> Two -> One
+//     │ 
+//     │ Note: Error code: E0068
+// ────╯
+// Error: These classes form a dependency cycle: Recursive
+//     ╭─[ class_recursive_type_aliases.baml:22:7 ]
+//     │
+//  22 │ class Recursive {
+//     │       ────┬────  
+//     │           ╰────── These classes form a dependency cycle: Recursive
+//     │ 
+//     │ Note: Error code: E0069
+// ────╯

--- a/baml_language/crates/baml_ide_tests/test_files/syntax/class/type_aliases_jinja.baml
+++ b/baml_language/crates/baml_ide_tests/test_files/syntax/class/type_aliases_jinja.baml
@@ -64,4 +64,12 @@ function InvalidAlias(i: I) -> string {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// Error: These aliases form a dependency cycle: I -> J -> I
+//     ╭─[ class_type_aliases_jinja.baml:26:6 ]
+//     │
+//  26 │ type I = J
+//     │      ┬  
+//     │      ╰── These aliases form a dependency cycle: I -> J -> I
+//     │ 
+//     │ Note: Error code: E0068
+// ────╯

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -16,12 +16,14 @@ use std::{collections::HashMap, path::PathBuf};
 
 use baml_compiler_diagnostics::{Diagnostic, ToDiagnostic};
 use baml_compiler_hir::{
-    self, FunctionBody, ItemId, file_items, file_lowering, function_body, function_signature,
-    function_signature_source_map,
+    self, Definition, ErrorLocation, FunctionBody, ItemId, file_items, file_lowering,
+    fqn::FullyQualifiedName, function_body, function_signature, function_signature_source_map,
+    get_item_name_span, symbol_table,
 };
 use baml_compiler_tir::{self, class_field_types, enum_variants, type_aliases, typing_context};
-use baml_db::{FileId, SourceFile, baml_compiler_parser};
+use baml_db::{FileId, SourceFile, Span, baml_compiler_parser};
 use baml_workspace::Project;
+use text_size::TextRange;
 
 use crate::ProjectDatabase;
 
@@ -34,6 +36,51 @@ pub struct CheckResult {
     pub sources: HashMap<FileId, String>,
     /// Maps `FileId` to file path (for URL generation).
     pub file_paths: HashMap<FileId, PathBuf>,
+}
+
+/// Resolve an `ErrorLocation` to a Span for type-level items.
+///
+/// For `ErrorLocation::TypeItem`, this looks up the type alias or class using the cached
+/// `SymbolTable` and returns its name span. For other `ErrorLocation` variants, this should
+/// not be called.
+fn resolve_type_item_location(db: &ProjectDatabase, project: Project, loc: &ErrorLocation) -> Span {
+    match loc {
+        ErrorLocation::TypeItem(name) => {
+            // Use the cached symbol table for efficient lookup
+            let symbols = symbol_table(db, project);
+            let fqn = FullyQualifiedName::local(name.clone());
+
+            if let Some(def) = symbols.lookup_type(db, &fqn) {
+                // Match on the definition type to get the appropriate location
+                match def {
+                    Definition::TypeAlias(alias_loc) => {
+                        let file = alias_loc.file(db);
+                        let local_id = alias_loc.id(db);
+                        get_item_name_span(db, file, "type alias", name.as_str(), local_id.index())
+                            .unwrap_or_else(|| {
+                                Span::new(file.file_id(db), TextRange::empty(0.into()))
+                            })
+                    }
+                    Definition::Class(class_loc) => {
+                        let file = class_loc.file(db);
+                        let local_id = class_loc.id(db);
+                        get_item_name_span(db, file, "class", name.as_str(), local_id.index())
+                            .unwrap_or_else(|| {
+                                Span::new(file.file_id(db), TextRange::empty(0.into()))
+                            })
+                    }
+                    _ => {
+                        // Should not happen - cycle errors are only for type aliases and classes
+                        Span::new(FileId::default(), TextRange::empty(0.into()))
+                    }
+                }
+            } else {
+                // Fallback if not found in symbol table
+                Span::new(FileId::default(), TextRange::empty(0.into()))
+            }
+        }
+        _ => panic!("resolve_type_item_location should only be called with TypeItem locations"),
+    }
 }
 
 /// Collect all diagnostics from a project.
@@ -81,10 +128,32 @@ pub fn collect_diagnostics(
         diagnostics.push(error.to_diagnostic());
     }
 
-    // 4. Collect type errors from function inference
-    let globals = typing_context(db, project).functions(db).clone();
+    // 3.5. Collect TIR validation errors (cycle detection)
+    // This requires resolved types, so it happens after HIR validation but uses TIR data
     let class_fields = class_field_types(db, project).classes(db).clone();
     let type_aliases_map = type_aliases(db, project).aliases(db).clone();
+
+    let alias_cycle_errors = baml_compiler_tir::validate_type_alias_cycles(&type_aliases_map);
+    for error in &alias_cycle_errors {
+        diagnostics.push(
+            error.to_diagnostic(std::string::ToString::to_string, |loc| {
+                resolve_type_item_location(db, project, loc)
+            }),
+        );
+    }
+
+    let class_cycle_errors =
+        baml_compiler_tir::validate_class_cycles(&class_fields, &type_aliases_map);
+    for error in &class_cycle_errors {
+        diagnostics.push(
+            error.to_diagnostic(std::string::ToString::to_string, |loc| {
+                resolve_type_item_location(db, project, loc)
+            }),
+        );
+    }
+
+    // 4. Collect type errors from function inference
+    let globals = typing_context(db, project).functions(db).clone();
     let enum_variants_struct = enum_variants(db, project);
     let enum_variants_map = enum_variants_struct.enums(db).clone();
 

--- a/baml_language/crates/baml_project/src/check.rs
+++ b/baml_language/crates/baml_project/src/check.rs
@@ -16,14 +16,12 @@ use std::{collections::HashMap, path::PathBuf};
 
 use baml_compiler_diagnostics::{Diagnostic, ToDiagnostic};
 use baml_compiler_hir::{
-    self, Definition, ErrorLocation, FunctionBody, ItemId, file_items, file_lowering,
-    fqn::FullyQualifiedName, function_body, function_signature, function_signature_source_map,
-    get_item_name_span, symbol_table,
+    self, FunctionBody, HirSourceMap, ItemId, file_items, file_lowering, function_body,
+    function_signature, function_signature_source_map, project_type_item_spans,
 };
 use baml_compiler_tir::{self, class_field_types, enum_variants, type_aliases, typing_context};
-use baml_db::{FileId, SourceFile, Span, baml_compiler_parser};
+use baml_db::{FileId, SourceFile, baml_compiler_parser};
 use baml_workspace::Project;
-use text_size::TextRange;
 
 use crate::ProjectDatabase;
 
@@ -36,51 +34,6 @@ pub struct CheckResult {
     pub sources: HashMap<FileId, String>,
     /// Maps `FileId` to file path (for URL generation).
     pub file_paths: HashMap<FileId, PathBuf>,
-}
-
-/// Resolve an `ErrorLocation` to a Span for type-level items.
-///
-/// For `ErrorLocation::TypeItem`, this looks up the type alias or class using the cached
-/// `SymbolTable` and returns its name span. For other `ErrorLocation` variants, this should
-/// not be called.
-fn resolve_type_item_location(db: &ProjectDatabase, project: Project, loc: &ErrorLocation) -> Span {
-    match loc {
-        ErrorLocation::TypeItem(name) => {
-            // Use the cached symbol table for efficient lookup
-            let symbols = symbol_table(db, project);
-            let fqn = FullyQualifiedName::local(name.clone());
-
-            if let Some(def) = symbols.lookup_type(db, &fqn) {
-                // Match on the definition type to get the appropriate location
-                match def {
-                    Definition::TypeAlias(alias_loc) => {
-                        let file = alias_loc.file(db);
-                        let local_id = alias_loc.id(db);
-                        get_item_name_span(db, file, "type alias", name.as_str(), local_id.index())
-                            .unwrap_or_else(|| {
-                                Span::new(file.file_id(db), TextRange::empty(0.into()))
-                            })
-                    }
-                    Definition::Class(class_loc) => {
-                        let file = class_loc.file(db);
-                        let local_id = class_loc.id(db);
-                        get_item_name_span(db, file, "class", name.as_str(), local_id.index())
-                            .unwrap_or_else(|| {
-                                Span::new(file.file_id(db), TextRange::empty(0.into()))
-                            })
-                    }
-                    _ => {
-                        // Should not happen - cycle errors are only for type aliases and classes
-                        Span::new(FileId::default(), TextRange::empty(0.into()))
-                    }
-                }
-            } else {
-                // Fallback if not found in symbol table
-                Span::new(FileId::default(), TextRange::empty(0.into()))
-            }
-        }
-        _ => panic!("resolve_type_item_location should only be called with TypeItem locations"),
-    }
 }
 
 /// Collect all diagnostics from a project.
@@ -102,6 +55,9 @@ pub fn collect_diagnostics(
     source_files: &[SourceFile],
 ) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
+
+    // Get cached type item spans for error location resolution
+    let type_spans = project_type_item_spans(db, project);
 
     // 1. Collect parse errors
     for source_file in source_files {
@@ -137,7 +93,8 @@ pub fn collect_diagnostics(
     for error in &alias_cycle_errors {
         diagnostics.push(
             error.to_diagnostic(std::string::ToString::to_string, |loc| {
-                resolve_type_item_location(db, project, loc)
+                // Cycle errors are type-level only, use empty source map
+                loc.to_span(&HirSourceMap::default(), &type_spans)
             }),
         );
     }
@@ -147,7 +104,8 @@ pub fn collect_diagnostics(
     for error in &class_cycle_errors {
         diagnostics.push(
             error.to_diagnostic(std::string::ToString::to_string, |loc| {
-                resolve_type_item_location(db, project, loc)
+                // Cycle errors are type-level only, use empty source map
+                loc.to_span(&HirSourceMap::default(), &type_spans)
             }),
         );
     }
@@ -188,11 +146,9 @@ pub fn collect_diagnostics(
 
                     // Convert TIR type errors (with ErrorLocation) to span-based diagnostics
                     for type_error in &inference_result.errors {
-                        diagnostics.push(
-                            type_error.to_diagnostic(ToString::to_string, |loc| {
-                                loc.to_span(hir_source_map)
-                            }),
-                        );
+                        diagnostics.push(type_error.to_diagnostic(ToString::to_string, |loc| {
+                            loc.to_span(hir_source_map, &type_spans)
+                        }));
                     }
                 }
             }


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds cycle detection for type aliases and classes in the new compiler, distinguishing between structural recursion (through maps/lists, allowed) and non-structural recursion (error). Implements Tarjan's algorithm for SCC detection and integrates validation into the TIR phase.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 6a0f0a34ac4f333b7c5548c3c3a979787d1fb141.</sup>
<!-- /MENDRAL_SUMMARY -->