### PR TITLE
baml-language: implement specialize_prompt

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -782,6 +782,7 @@ dependencies = [
  "bex_vm",
  "bex_vm_types",
  "indexmap 2.13.0",
+ "sys_llm",
  "sys_native",
  "sys_resource_types",
  "sys_types",
@@ -4378,6 +4379,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
+]
+
+[[package]]
+name = "sys_llm"
+version = "0.0.0"
+dependencies = [
+ "bex_external_types",
+ "bex_program",
+ "indexmap 2.13.0",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -34,6 +34,7 @@ baml_compiler_tir = { path = "crates/baml_compiler_tir" }
 baml_compiler_vir = { path = "crates/baml_compiler_vir" }
 bex_program = { path = "crates/bex_program" }
 bex_engine = { path = "crates/bex_engine" }
+sys_llm = { path = "crates/sys_llm" }
 sys_types = { path = "crates/sys_types" }
 sys_native = { path = "crates/sys_native" }
 baml_db = { path = "crates/baml_db" }

--- a/baml_language/crates/baml_builtins/src/lib.rs
+++ b/baml_language/crates/baml_builtins/src/lib.rs
@@ -245,6 +245,12 @@ macro_rules! with_builtins {
                         /// Returns a structured PromptAst that can be sent to an LLM.
                         #[external]
                         fn render_prompt(self: PrimitiveClient, template: String, args: Map<String, Any>) -> PromptAst;
+
+                        /// Specialize a prompt for this client's provider.
+                        /// Applies provider-specific transformations (message merging, system prompt
+                        /// consolidation, metadata filtering).
+                        #[external]
+                        fn specialize_prompt(self: PrimitiveClient, prompt: PromptAst) -> PromptAst;
                     }
                 }
             }

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -389,6 +389,9 @@ fn external_op_for_builtin_path(path: &str) -> Option<ExternalOp> {
         "baml.llm.PrimitiveClient.render_prompt" => {
             Some(ExternalOp::Llm(bex_vm_types::LlmOp::RenderPrompt))
         }
+        "baml.llm.PrimitiveClient.specialize_prompt" => {
+            Some(ExternalOp::Llm(bex_vm_types::LlmOp::SpecializePrompt))
+        }
         // System operations
         "baml.fs.open" => Some(ExternalOp::Sys(SysOp::FsOpen)),
         "baml.fs.File.read" => Some(ExternalOp::Sys(SysOp::FsRead)),

--- a/baml_language/crates/bex_engine/Cargo.toml
+++ b/baml_language/crates/bex_engine/Cargo.toml
@@ -14,6 +14,7 @@ bex_llm_types = { workspace = true }
 bex_program = { workspace = true }
 bex_vm = { workspace = true }
 bex_vm_types = { workspace = true }
+sys_llm = { workspace = true }
 sys_resource_types = { workspace = true }
 sys_types = { workspace = true }
 indexmap = { workspace = true }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -1195,6 +1195,27 @@ impl BexEngine {
                                         }
                                     }
                                 }
+                                LlmOp::SpecializePrompt => {
+                                    // specialize_prompt(self: PrimitiveClient, prompt: PromptAst) -> PromptAst
+                                    let result = Self::execute_specialize_prompt(&args)
+                                        .map_err(EngineError::from);
+                                    match result {
+                                        Ok(prompt_ast) => {
+                                            let vm_ast = Self::external_prompt_ast_to_vm_owned(
+                                                vm, prompt_ast,
+                                            );
+                                            let value = vm.alloc_prompt_ast(vm_ast);
+                                            vm.set_future_ready(id, value)?;
+                                        }
+                                        Err(e) => {
+                                            let pending_futures = pending_futures.clone();
+                                            tokio::spawn(async move {
+                                                let _ = pending_futures
+                                                    .send(FutureResult { id, result: Err(e) });
+                                            });
+                                        }
+                                    }
+                                }
                             }
                         }
                         ExternalOp::Sys(sys_op) => {
@@ -1381,6 +1402,35 @@ impl BexEngine {
 
         // Convert VM PromptAst to external PromptAst
         Ok(Self::vm_prompt_ast_to_external(&vm_prompt_ast))
+    }
+
+    /// Execute the `specialize_prompt` LLM operation.
+    ///
+    /// Arguments: [`PrimitiveClient`, prompt: `PromptAst`]
+    fn execute_specialize_prompt(
+        args: &[BexExternalValue],
+    ) -> Result<bex_external_types::PromptAst, OpError> {
+        let client = match &args[0] {
+            BexExternalValue::PrimitiveClient(c) => c,
+            other => {
+                return Err(OpError::TypeError {
+                    expected: "PrimitiveClient",
+                    actual: other.type_name().to_string(),
+                });
+            }
+        };
+
+        let prompt = match &args[1] {
+            BexExternalValue::PromptAst(p) => p.clone(),
+            other => {
+                return Err(OpError::TypeError {
+                    expected: "PromptAst",
+                    actual: other.type_name().to_string(),
+                });
+            }
+        };
+
+        Ok(sys_llm::specialize_prompt(client, prompt))
     }
 
     /// Convert VM `bex_vm_types::PromptAst` to external `bex_external_types::PromptAst`.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -83,6 +83,8 @@ pub enum ExternalOp {
 pub enum LlmOp {
     /// Render a Jinja template: `PrimitiveClient.render_prompt(template, args) -> PromptAst`
     RenderPrompt,
+    /// Specialize a prompt for a specific provider: `PrimitiveClient.specialize_prompt(prompt) -> PromptAst`
+    SpecializePrompt,
 }
 
 /// System operations that run outside the VM.
@@ -132,6 +134,7 @@ impl std::fmt::Display for LlmOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             LlmOp::RenderPrompt => write!(f, "llm.render_prompt"),
+            LlmOp::SpecializePrompt => write!(f, "llm.specialize_prompt"),
         }
     }
 }

--- a/baml_language/crates/sys_llm/Cargo.toml
+++ b/baml_language/crates/sys_llm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "sys_llm"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+bex_external_types = { workspace = true }
+indexmap = { workspace = true }
+
+[dev-dependencies]
+bex_program = { workspace = true }
+
+[lints]
+workspace = true

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -1,0 +1,25 @@
+//! LLM prompt specialization.
+//!
+//! This crate provides `specialize_prompt()`, which transforms a generic
+//! `PromptAst` into one tailored for a specific LLM provider. It applies
+//! provider-specific transformations based on `ModelFeatures`.
+
+mod model_features;
+mod transformations;
+
+use bex_external_types::{PrimitiveClientValue, PromptAst};
+pub use model_features::{AllowedMetadata, ModelFeatures};
+
+/// Specialize a prompt for a specific provider.
+///
+/// Applies three transformations in order:
+/// 1. Merge adjacent same-role messages
+/// 2. Consolidate system prompts (when `max_one_system_prompt` is true)
+/// 3. Filter role metadata (strip disallowed metadata keys)
+pub fn specialize_prompt(client: &PrimitiveClientValue, prompt: PromptAst) -> PromptAst {
+    let features = ModelFeatures::for_provider(&client.provider, &client.options);
+
+    let prompt = transformations::merge_adjacent_messages(prompt);
+    let prompt = transformations::consolidate_system_prompts(prompt, &features);
+    transformations::filter_metadata(prompt, &features)
+}

--- a/baml_language/crates/sys_llm/src/model_features.rs
+++ b/baml_language/crates/sys_llm/src/model_features.rs
@@ -1,0 +1,120 @@
+use bex_external_types::BexExternalValue;
+use indexmap::IndexMap;
+
+/// Subset of engine's `ModelFeatures` relevant to prompt specialization.
+///
+/// Derived from provider name + client options at specialization time.
+/// Media resolution fields are deferred to a future phase.
+#[derive(Clone, Debug)]
+pub struct ModelFeatures {
+    /// If true, only one system message is allowed. Additional system messages
+    /// are converted to user messages.
+    pub max_one_system_prompt: bool,
+
+    /// Controls which metadata keys are allowed on messages.
+    pub allowed_metadata: AllowedMetadata,
+}
+
+/// Controls which metadata keys are allowed on messages.
+#[derive(Clone, Debug)]
+pub enum AllowedMetadata {
+    /// All metadata keys are allowed.
+    All,
+    /// No metadata keys are allowed.
+    None,
+    /// Only these specific keys are allowed.
+    Only(Vec<String>),
+}
+
+impl AllowedMetadata {
+    pub fn is_allowed(&self, key: &str) -> bool {
+        match self {
+            Self::All => true,
+            Self::None => false,
+            Self::Only(allowed) => allowed.iter().any(|a| a == key),
+        }
+    }
+}
+
+impl ModelFeatures {
+    /// Build model features from provider name and client options.
+    ///
+    /// Uses a hardcoded lookup table for provider defaults, then overrides
+    /// with any matching keys in the `options` map.
+    pub fn for_provider(provider: &str, options: &IndexMap<String, BexExternalValue>) -> Self {
+        let mut features = Self::defaults_for_provider(provider);
+        features.apply_overrides(options);
+        features
+    }
+
+    /// Hardcoded defaults per provider.
+    ///
+    /// Source: engine/baml-runtime/src/internal/llm_client/primitive/*/
+    fn defaults_for_provider(provider: &str) -> Self {
+        match provider {
+            // OpenAI variants: multiple system prompts allowed
+            "openai" | "openai-generic" | "azure" | "ollama" | "openrouter"
+            | "openai-responses" => Self {
+                max_one_system_prompt: false,
+                allowed_metadata: AllowedMetadata::All,
+            },
+            // Anthropic: single system prompt only
+            "anthropic" => Self {
+                max_one_system_prompt: true,
+                allowed_metadata: AllowedMetadata::All,
+            },
+            // AWS Bedrock: single system prompt only
+            "aws-bedrock" => Self {
+                max_one_system_prompt: true,
+                allowed_metadata: AllowedMetadata::All,
+            },
+            // Google AI: single system prompt only
+            "google-ai" => Self {
+                max_one_system_prompt: true,
+                allowed_metadata: AllowedMetadata::All,
+            },
+            // Vertex AI: single system prompt only
+            "vertex-ai" => Self {
+                max_one_system_prompt: true,
+                allowed_metadata: AllowedMetadata::All,
+            },
+            // Unknown provider: conservative defaults (single system prompt)
+            _ => Self {
+                max_one_system_prompt: true,
+                allowed_metadata: AllowedMetadata::All,
+            },
+        }
+    }
+
+    /// Override defaults with values from the client options map.
+    fn apply_overrides(&mut self, options: &IndexMap<String, BexExternalValue>) {
+        if let Some(BexExternalValue::Bool(v)) = options.get("max_one_system_prompt") {
+            self.max_one_system_prompt = *v;
+        }
+
+        if let Some(val) = options.get("allowed_role_metadata") {
+            match val {
+                BexExternalValue::String(s) if s == "all" => {
+                    self.allowed_metadata = AllowedMetadata::All;
+                }
+                BexExternalValue::String(s) if s == "none" => {
+                    self.allowed_metadata = AllowedMetadata::None;
+                }
+                BexExternalValue::Array { items, .. } => {
+                    let keys: Vec<String> = items
+                        .iter()
+                        .filter_map(|item| {
+                            if let BexExternalValue::String(s) = item {
+                                Some(s.clone())
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+                    self.allowed_metadata = AllowedMetadata::Only(keys);
+                }
+                _ => {}
+            }
+        }
+    }
+}

--- a/baml_language/crates/sys_llm/src/transformations.rs
+++ b/baml_language/crates/sys_llm/src/transformations.rs
@@ -1,0 +1,474 @@
+use bex_external_types::{BexExternalValue, PromptAst};
+use indexmap::IndexMap;
+
+use crate::{AllowedMetadata, ModelFeatures};
+
+/// Merge adjacent messages with the same role.
+///
+/// Walks the top-level `PromptAst::Vec` and merges consecutive `Message` nodes
+/// that share the same role by combining their contents into a `Vec` node.
+///
+/// Ported from: engine/baml-runtime/src/internal/llm_client/traits/mod.rs:89-102
+pub(crate) fn merge_adjacent_messages(prompt: PromptAst) -> PromptAst {
+    match prompt {
+        PromptAst::Vec(messages) => {
+            let mut merged: Vec<PromptAst> = Vec::with_capacity(messages.len());
+
+            for msg in messages {
+                let should_merge = match (&merged.last(), &msg) {
+                    (
+                        Some(PromptAst::Message {
+                            role: prev_role, ..
+                        }),
+                        PromptAst::Message {
+                            role: next_role, ..
+                        },
+                    ) => prev_role == next_role,
+                    _ => false,
+                };
+
+                if should_merge {
+                    let prev = merged.pop().unwrap();
+                    if let (
+                        PromptAst::Message {
+                            role,
+                            content: prev_content,
+                            metadata: prev_meta,
+                        },
+                        PromptAst::Message {
+                            content: next_content,
+                            ..
+                        },
+                    ) = (prev, msg)
+                    {
+                        let combined = match *prev_content {
+                            PromptAst::Vec(mut items) => {
+                                items.push(*next_content);
+                                PromptAst::Vec(items)
+                            }
+                            other => PromptAst::Vec(vec![other, *next_content]),
+                        };
+                        merged.push(PromptAst::Message {
+                            role,
+                            content: Box::new(combined),
+                            metadata: prev_meta,
+                        });
+                    }
+                } else {
+                    merged.push(msg);
+                }
+            }
+
+            if merged.len() == 1 {
+                merged.pop().unwrap()
+            } else {
+                PromptAst::Vec(merged)
+            }
+        }
+        other => other,
+    }
+}
+
+/// Consolidate system prompts based on provider capabilities.
+///
+/// When `max_one_system_prompt` is true:
+/// - If the entire prompt is a single system message, convert it to "user"
+/// - Otherwise, keep the first system message, convert all subsequent
+///   system messages to "user"
+///
+/// Ported from: engine/baml-runtime/src/internal/llm_client/traits/mod.rs:280-296
+pub(crate) fn consolidate_system_prompts(prompt: PromptAst, features: &ModelFeatures) -> PromptAst {
+    if !features.max_one_system_prompt {
+        return prompt;
+    }
+
+    match prompt {
+        PromptAst::Vec(messages) => {
+            let total = messages.len();
+            let mut seen_first_system = false;
+
+            let transformed: Vec<PromptAst> = messages
+                .into_iter()
+                .map(|msg| match msg {
+                    PromptAst::Message {
+                        role,
+                        content,
+                        metadata,
+                    } if role == "system" => {
+                        if total == 1 {
+                            return PromptAst::Message {
+                                role: "user".to_string(),
+                                content,
+                                metadata,
+                            };
+                        }
+
+                        if !seen_first_system {
+                            seen_first_system = true;
+                            PromptAst::Message {
+                                role,
+                                content,
+                                metadata,
+                            }
+                        } else {
+                            PromptAst::Message {
+                                role: "user".to_string(),
+                                content,
+                                metadata,
+                            }
+                        }
+                    }
+                    other => other,
+                })
+                .collect();
+
+            PromptAst::Vec(transformed)
+        }
+        PromptAst::Message {
+            role,
+            content,
+            metadata,
+        } if role == "system" => PromptAst::Message {
+            role: "user".to_string(),
+            content,
+            metadata,
+        },
+        other => other,
+    }
+}
+
+/// Filter metadata on messages based on allowed metadata configuration.
+///
+/// Walks all Message nodes and removes disallowed metadata keys.
+///
+/// Ported from: engine/baml-runtime/src/internal/llm_client/traits/mod.rs:110-128
+pub(crate) fn filter_metadata(prompt: PromptAst, features: &ModelFeatures) -> PromptAst {
+    if matches!(features.allowed_metadata, AllowedMetadata::All) {
+        return prompt;
+    }
+
+    filter_metadata_recursive(prompt, features)
+}
+
+fn filter_metadata_recursive(prompt: PromptAst, features: &ModelFeatures) -> PromptAst {
+    match prompt {
+        PromptAst::Message {
+            role,
+            content,
+            metadata,
+        } => {
+            let filtered_metadata = filter_metadata_value(*metadata, features);
+            PromptAst::Message {
+                role,
+                content: Box::new(filter_metadata_recursive(*content, features)),
+                metadata: Box::new(filtered_metadata),
+            }
+        }
+        PromptAst::Vec(items) => PromptAst::Vec(
+            items
+                .into_iter()
+                .map(|item| filter_metadata_recursive(item, features))
+                .collect(),
+        ),
+        other => other,
+    }
+}
+
+fn filter_metadata_value(metadata: BexExternalValue, features: &ModelFeatures) -> BexExternalValue {
+    match metadata {
+        BexExternalValue::Map {
+            key_type,
+            value_type,
+            entries,
+        } => {
+            let filtered: IndexMap<String, BexExternalValue> = entries
+                .into_iter()
+                .filter(|(key, _)| features.allowed_metadata.is_allowed(key))
+                .collect();
+            BexExternalValue::Map {
+                key_type,
+                value_type,
+                entries: filtered,
+            }
+        }
+        other => {
+            if matches!(features.allowed_metadata, AllowedMetadata::None) {
+                BexExternalValue::Null
+            } else {
+                other
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bex_external_types::{BexExternalValue, PromptAst};
+    use indexmap::IndexMap;
+
+    use super::*;
+    use crate::{AllowedMetadata, ModelFeatures};
+
+    fn msg(role: &str, text: &str) -> PromptAst {
+        PromptAst::Message {
+            role: role.to_string(),
+            content: Box::new(PromptAst::String(text.to_string())),
+            metadata: Box::new(BexExternalValue::Null),
+        }
+    }
+
+    fn msg_with_meta(role: &str, text: &str, meta: BexExternalValue) -> PromptAst {
+        PromptAst::Message {
+            role: role.to_string(),
+            content: Box::new(PromptAst::String(text.to_string())),
+            metadata: Box::new(meta),
+        }
+    }
+
+    // ---- ModelFeatures tests ----
+
+    #[test]
+    fn test_openai_defaults() {
+        let features = ModelFeatures::for_provider("openai", &IndexMap::new());
+        assert!(!features.max_one_system_prompt);
+    }
+
+    #[test]
+    fn test_anthropic_defaults() {
+        let features = ModelFeatures::for_provider("anthropic", &IndexMap::new());
+        assert!(features.max_one_system_prompt);
+    }
+
+    #[test]
+    fn test_unknown_provider_defaults() {
+        let features = ModelFeatures::for_provider("some-new-provider", &IndexMap::new());
+        assert!(features.max_one_system_prompt);
+    }
+
+    #[test]
+    fn test_override_max_one_system_prompt() {
+        let mut options = IndexMap::new();
+        options.insert(
+            "max_one_system_prompt".to_string(),
+            BexExternalValue::Bool(false),
+        );
+        let features = ModelFeatures::for_provider("anthropic", &options);
+        assert!(!features.max_one_system_prompt);
+    }
+
+    // ---- merge_adjacent_messages tests ----
+
+    #[test]
+    fn test_merge_adjacent_same_role() {
+        let prompt = PromptAst::Vec(vec![msg("user", "Hello"), msg("user", "World")]);
+        let result = merge_adjacent_messages(prompt);
+        let expected = PromptAst::Message {
+            role: "user".to_string(),
+            content: Box::new(PromptAst::Vec(vec![
+                PromptAst::String("Hello".to_string()),
+                PromptAst::String("World".to_string()),
+            ])),
+            metadata: Box::new(BexExternalValue::Null),
+        };
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_no_merge_different_roles() {
+        let prompt = PromptAst::Vec(vec![msg("system", "You are helpful"), msg("user", "Hello")]);
+        let result = merge_adjacent_messages(prompt);
+        let expected = PromptAst::Vec(vec![msg("system", "You are helpful"), msg("user", "Hello")]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_merge_three_same_role() {
+        let prompt = PromptAst::Vec(vec![msg("user", "A"), msg("user", "B"), msg("user", "C")]);
+        let result = merge_adjacent_messages(prompt);
+        let expected = PromptAst::Message {
+            role: "user".to_string(),
+            content: Box::new(PromptAst::Vec(vec![
+                PromptAst::String("A".to_string()),
+                PromptAst::String("B".to_string()),
+                PromptAst::String("C".to_string()),
+            ])),
+            metadata: Box::new(BexExternalValue::Null),
+        };
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_merge_passthrough_non_vec() {
+        let prompt = msg("user", "Hello");
+        let result = merge_adjacent_messages(prompt);
+        assert_eq!(result, msg("user", "Hello"));
+    }
+
+    // ---- consolidate_system_prompts tests ----
+
+    #[test]
+    fn test_consolidate_single_system_to_user() {
+        let features = ModelFeatures {
+            max_one_system_prompt: true,
+            allowed_metadata: AllowedMetadata::All,
+        };
+        let prompt = msg("system", "You are helpful");
+        let result = consolidate_system_prompts(prompt, &features);
+        assert_eq!(result, msg("user", "You are helpful"));
+    }
+
+    #[test]
+    fn test_consolidate_keeps_first_system() {
+        let features = ModelFeatures {
+            max_one_system_prompt: true,
+            allowed_metadata: AllowedMetadata::All,
+        };
+        let prompt = PromptAst::Vec(vec![
+            msg("system", "First system"),
+            msg("user", "Hello"),
+            msg("system", "Second system"),
+        ]);
+        let result = consolidate_system_prompts(prompt, &features);
+        let expected = PromptAst::Vec(vec![
+            msg("system", "First system"),
+            msg("user", "Hello"),
+            msg("user", "Second system"),
+        ]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_consolidate_noop_when_disabled() {
+        let features = ModelFeatures {
+            max_one_system_prompt: false,
+            allowed_metadata: AllowedMetadata::All,
+        };
+        let prompt = PromptAst::Vec(vec![msg("system", "First"), msg("system", "Second")]);
+        let result = consolidate_system_prompts(prompt, &features);
+        let expected = PromptAst::Vec(vec![msg("system", "First"), msg("system", "Second")]);
+        assert_eq!(result, expected);
+    }
+
+    // ---- filter_metadata tests ----
+
+    #[test]
+    fn test_filter_metadata_all_allowed() {
+        let features = ModelFeatures {
+            max_one_system_prompt: false,
+            allowed_metadata: AllowedMetadata::All,
+        };
+        let mut meta_entries = IndexMap::new();
+        meta_entries.insert("cache_control".to_string(), BexExternalValue::Bool(true));
+        let meta = BexExternalValue::Map {
+            key_type: bex_program::Ty::String,
+            value_type: bex_program::Ty::Bool,
+            entries: meta_entries.clone(),
+        };
+        let prompt = msg_with_meta("user", "Hello", meta);
+        let result = filter_metadata(prompt, &features);
+        let expected = msg_with_meta(
+            "user",
+            "Hello",
+            BexExternalValue::Map {
+                key_type: bex_program::Ty::String,
+                value_type: bex_program::Ty::Bool,
+                entries: meta_entries,
+            },
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_filter_metadata_none_allowed() {
+        let features = ModelFeatures {
+            max_one_system_prompt: false,
+            allowed_metadata: AllowedMetadata::None,
+        };
+        let mut meta_entries = IndexMap::new();
+        meta_entries.insert("cache_control".to_string(), BexExternalValue::Bool(true));
+        let meta = BexExternalValue::Map {
+            key_type: bex_program::Ty::String,
+            value_type: bex_program::Ty::Bool,
+            entries: meta_entries,
+        };
+        let prompt = msg_with_meta("user", "Hello", meta);
+        let result = filter_metadata(prompt, &features);
+        let expected = msg_with_meta(
+            "user",
+            "Hello",
+            BexExternalValue::Map {
+                key_type: bex_program::Ty::String,
+                value_type: bex_program::Ty::Bool,
+                entries: IndexMap::new(),
+            },
+        );
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_filter_metadata_only_specific() {
+        let features = ModelFeatures {
+            max_one_system_prompt: false,
+            allowed_metadata: AllowedMetadata::Only(vec!["cache_control".to_string()]),
+        };
+        let mut meta_entries = IndexMap::new();
+        meta_entries.insert("cache_control".to_string(), BexExternalValue::Bool(true));
+        meta_entries.insert(
+            "secret_field".to_string(),
+            BexExternalValue::String("x".to_string()),
+        );
+        let meta = BexExternalValue::Map {
+            key_type: bex_program::Ty::String,
+            value_type: bex_program::Ty::String,
+            entries: meta_entries,
+        };
+        let prompt = msg_with_meta("user", "Hello", meta);
+        let result = filter_metadata(prompt, &features);
+        let mut expected_entries = IndexMap::new();
+        expected_entries.insert("cache_control".to_string(), BexExternalValue::Bool(true));
+        let expected = msg_with_meta(
+            "user",
+            "Hello",
+            BexExternalValue::Map {
+                key_type: bex_program::Ty::String,
+                value_type: bex_program::Ty::String,
+                entries: expected_entries,
+            },
+        );
+        assert_eq!(result, expected);
+    }
+
+    // ---- Integration: full specialize_prompt pipeline ----
+
+    #[test]
+    fn test_specialize_anthropic_prompt() {
+        let prompt = PromptAst::Vec(vec![
+            msg("system", "You are helpful"),
+            msg("user", "Hello"),
+            msg("user", "How are you?"),
+            msg("system", "Also be concise"),
+            msg("assistant", "I'm fine"),
+        ]);
+
+        let features = ModelFeatures::for_provider("anthropic", &IndexMap::new());
+
+        let result = merge_adjacent_messages(prompt);
+        let result = consolidate_system_prompts(result, &features);
+        let result = filter_metadata(result, &features);
+
+        let expected = PromptAst::Vec(vec![
+            msg("system", "You are helpful"),
+            PromptAst::Message {
+                role: "user".to_string(),
+                content: Box::new(PromptAst::Vec(vec![
+                    PromptAst::String("Hello".to_string()),
+                    PromptAst::String("How are you?".to_string()),
+                ])),
+                metadata: Box::new(BexExternalValue::Null),
+            },
+            msg("user", "Also be concise"),
+            msg("assistant", "I'm fine"),
+        ]);
+        assert_eq!(result, expected);
+    }
+}


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Implements `specialize_prompt` operation for LLM clients, applying provider-specific transformations (message merging, system prompt consolidation, metadata filtering) based on model capabilities.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit b092e5c13a6baff3bfb94b2f1a25dad2153d86ae.</sup>
<!-- /MENDRAL_SUMMARY -->