### PR TITLE
chore/baml-language: rename ExternalOp to SysOp

### DIFF
--- a/baml_language/crates/baml_builtins/src/lib.rs
+++ b/baml_language/crates/baml_builtins/src/lib.rs
@@ -64,9 +64,9 @@ pub struct BuiltinSignature {
     /// Return type.
     pub returns: TypePattern,
 
-    /// Whether this is an external function (runs async outside VM).
-    /// External functions use DispatchFuture/Await instead of Call.
-    pub is_external: bool,
+    /// Whether this is a `sys_op` function (runs async outside VM).
+    /// `Sys_op` functions use DispatchFuture/Await instead of Call.
+    pub is_sys_op: bool,
 }
 
 impl BuiltinSignature {
@@ -161,13 +161,13 @@ macro_rules! with_builtins {
                 mod fs {
                     #[builtin]
                     struct File {
-                        #[external]
+                        #[sys_op]
                         fn read(self: File) -> String;
-                        #[external]
+                        #[sys_op]
                         fn close(self: File);
                     }
 
-                    #[external]
+                    #[sys_op]
                     fn open(path: String) -> File;
                 }
 
@@ -176,7 +176,7 @@ macro_rules! with_builtins {
                 // =====================================================================
                 mod sys {
                     /// Execute a shell command and return stdout.
-                    #[external]
+                    #[sys_op]
                     fn shell(command: String) -> String;
                 }
 
@@ -187,15 +187,15 @@ macro_rules! with_builtins {
                     #[builtin]
                     struct Socket {
                         /// Read data from the socket as a string.
-                        #[external]
+                        #[sys_op]
                         fn read(self: Socket) -> String;
                         /// Close the socket.
-                        #[external]
+                        #[sys_op]
                         fn close(self: Socket);
                     }
 
                     /// Connect to a TCP address (host:port).
-                    #[external]
+                    #[sys_op]
                     fn connect(addr: String) -> Socket;
                 }
 
@@ -206,24 +206,24 @@ macro_rules! with_builtins {
                     #[builtin]
                     struct Response {
                         /// Get response body as text (consumes body).
-                        #[external]
+                        #[sys_op]
                         fn text(self: Response) -> String;
                         /// Get HTTP status code.
-                        #[external]
+                        #[sys_op]
                         fn status(self: Response) -> i64;
                         /// Check if status is 2xx.
-                        #[external]
+                        #[sys_op]
                         fn ok(self: Response) -> bool;
                         /// Get request URL (may differ if redirected).
-                        #[external]
+                        #[sys_op]
                         fn url(self: Response) -> String;
                         /// Get response headers.
-                        #[external]
+                        #[sys_op]
                         fn headers(self: Response) -> Map<String, String>;
                     }
 
                     /// Fetch a URL via HTTP GET.
-                    #[external]
+                    #[sys_op]
                     fn fetch(url: String) -> Response;
                 }
 
@@ -243,13 +243,13 @@ macro_rules! with_builtins {
                     struct PrimitiveClient {
                         /// Render a Jinja template with the given arguments.
                         /// Returns a structured PromptAst that can be sent to an LLM.
-                        #[external]
+                        #[sys_op]
                         fn render_prompt(self: PrimitiveClient, template: String, args: Map<String, Any>) -> PromptAst;
 
                         /// Specialize a prompt for this client's provider.
                         /// Applies provider-specific transformations (message merging, system prompt
                         /// consolidation, metadata filtering).
-                        #[external]
+                        #[sys_op]
                         fn specialize_prompt(self: PrimitiveClient, prompt: PromptAst) -> PromptAst;
                     }
                 }

--- a/baml_language/crates/baml_builtins_macros/src/lib.rs
+++ b/baml_language/crates/baml_builtins_macros/src/lib.rs
@@ -25,8 +25,8 @@ struct BuiltinDef {
     params: Vec<(String, TokenStream2)>,
     /// Return type pattern
     returns: TokenStream2,
-    /// Whether this is an external function (runs async outside VM)
-    is_external: bool,
+    /// Whether this is a `sys_op` function (runs async outside VM)
+    is_sys_op: bool,
 }
 
 /// Info for generating native function implementations.
@@ -47,8 +47,8 @@ struct NativeFnDef {
     returns: (String, bool, bool),
     /// Whether this function needs the VM (marked with #[uses(vm)])
     uses_vm: bool,
-    /// Whether this is an external function (runs async outside VM)
-    is_external: bool,
+    /// Whether this is a `sys_op` function (runs async outside VM)
+    is_sys_op: bool,
 }
 
 /// The root input to the macro: a list of modules.
@@ -109,9 +109,9 @@ struct FunctionItem {
     return_type: Type,
     /// Whether this function uses the VM (marked with #[uses(vm)])
     uses_vm: bool,
-    /// Whether this function is external (marked with #[external])
-    /// External functions run asynchronously outside the VM.
-    is_external: bool,
+    /// Whether this function is a `sys_op` (marked with #[`sys_op`])
+    /// `Sys_op` functions run asynchronously outside the VM.
+    is_sys_op: bool,
 }
 
 impl ModuleItem {
@@ -127,7 +127,7 @@ impl ModuleItem {
         let mut items = Vec::new();
         while !content.is_empty() {
             // Peek to determine what kind of item this is
-            // Handle attributes first (for #[opaque] struct, #[uses(vm)]/#[external] fn, or #[hide] mod)
+            // Handle attributes first (for #[opaque] struct, #[uses(vm)]/#[sys_op] fn, or #[hide] mod)
             let lookahead = content.lookahead1();
             if lookahead.peek(Token![mod]) {
                 items.push(ModuleContent::Module(ModuleItem::parse_with_attrs(
@@ -137,7 +137,7 @@ impl ModuleItem {
             } else if lookahead.peek(Token![struct]) {
                 items.push(ModuleContent::Struct(content.parse()?));
             } else if lookahead.peek(Token![#]) {
-                // Could be #[opaque] struct, #[uses(vm)]/#[external] fn, or #[hide] mod
+                // Could be #[opaque] struct, #[uses(vm)]/#[sys_op] fn, or #[hide] mod
                 // Parse attributes first, then peek again
                 let attrs = content.call(Attribute::parse_outer)?;
                 let lookahead2 = content.lookahead1();
@@ -220,7 +220,7 @@ impl FunctionItem {
             }
             false
         });
-        let is_external = attrs.iter().any(|attr| attr.path().is_ident("external"));
+        let is_sys_op = attrs.iter().any(|attr| attr.path().is_ident("sys_op"));
 
         // Parse: fn name<Generics>(params...) -> RetType;
         input.parse::<Token![fn]>()?;
@@ -286,14 +286,14 @@ impl FunctionItem {
             params,
             return_type,
             uses_vm,
-            is_external,
+            is_sys_op,
         })
     }
 }
 
 impl Parse for FunctionItem {
     fn parse(input: ParseStream) -> Result<Self> {
-        // Parse attributes like #[uses(vm)] or #[external]
+        // Parse attributes like #[uses(vm)] or #[sys_op]
         let attrs = input.call(Attribute::parse_outer)?;
         Self::parse_with_attrs(input, &attrs)
     }
@@ -660,7 +660,7 @@ fn collect_struct_builtins(s: &StructItem, ctx: &mut CollectContext) {
                 receiver,
                 params,
                 returns,
-                is_external: method.is_external,
+                is_sys_op: method.is_sys_op,
             });
         }
 
@@ -697,7 +697,7 @@ fn collect_struct_builtins(s: &StructItem, ctx: &mut CollectContext) {
             params: native_params,
             returns: native_returns,
             uses_vm: method.uses_vm,
-            is_external: method.is_external,
+            is_sys_op: method.is_sys_op,
         });
     }
 }
@@ -752,7 +752,7 @@ fn collect_function_builtins(f: &FunctionItem, ctx: &mut CollectContext) {
             receiver,
             params,
             returns,
-            is_external: f.is_external,
+            is_sys_op: f.is_sys_op,
         });
     }
 
@@ -788,7 +788,7 @@ fn collect_function_builtins(f: &FunctionItem, ctx: &mut CollectContext) {
         params: native_params,
         returns: native_returns,
         uses_vm: f.uses_vm,
-        is_external: f.is_external,
+        is_sys_op: f.is_sys_op,
     });
 }
 
@@ -834,7 +834,7 @@ pub fn define_builtins(input: TokenStream) -> TokenStream {
     // Generate const names for the for_native_builtins macro (exclude external functions)
     let native_const_names: Vec<_> = defs
         .iter()
-        .filter(|d| !d.is_external)
+        .filter(|d| !d.is_sys_op)
         .map(|d| &d.const_name)
         .collect();
 
@@ -853,7 +853,7 @@ pub fn define_builtins(input: TokenStream) -> TokenStream {
                 .map(|(name, ty)| quote!((#name, #ty)))
                 .collect();
             let returns = &d.returns;
-            let is_external = d.is_external;
+            let is_sys_op = d.is_sys_op;
 
             quote! {
                 BuiltinSignature {
@@ -861,7 +861,7 @@ pub fn define_builtins(input: TokenStream) -> TokenStream {
                     receiver: #receiver,
                     params: vec![#(#params),*],
                     returns: #returns,
-                    is_external: #is_external,
+                    is_sys_op: #is_sys_op,
                 }
             }
         })
@@ -1011,7 +1011,7 @@ pub fn generate_native_trait(input: TokenStream) -> TokenStream {
     // Note: External functions are skipped - they're handled by the embedder, not native Rust
     let required_methods: Vec<_> = native_defs
         .iter()
-        .filter(|d| !d.is_external) // Skip external functions
+        .filter(|d| !d.is_sys_op) // Skip external functions
         .map(|d| {
             let fn_name = &d.fn_name;
             let params = generate_clean_params(d);
@@ -1038,7 +1038,7 @@ pub fn generate_native_trait(input: TokenStream) -> TokenStream {
     // Note: External functions are skipped - they're handled by the embedder
     let glue_methods: Vec<_> = native_defs
         .iter()
-        .filter(|d| !d.is_external) // Skip external functions
+        .filter(|d| !d.is_sys_op) // Skip external functions
         .map(|d| {
             let fn_name = &d.fn_name;
             let glue_fn_name = format_ident!("__{}", fn_name);
@@ -1073,7 +1073,7 @@ pub fn generate_native_trait(input: TokenStream) -> TokenStream {
     // Note: External functions are skipped - they don't have native implementations
     let match_arms: Vec<_> = native_defs
         .iter()
-        .filter(|d| !d.is_external) // Skip external functions
+        .filter(|d| !d.is_sys_op) // Skip external functions
         .map(|d| {
             let path = &d.path;
             let glue_fn_name = format_ident!("__{}", d.fn_name);
@@ -1088,7 +1088,7 @@ pub fn generate_native_trait(input: TokenStream) -> TokenStream {
     // Note: External functions are skipped - they don't have native implementations
     let public_wrappers: Vec<_> = native_defs
         .iter()
-        .filter(|d| !d.is_external) // Skip external functions
+        .filter(|d| !d.is_sys_op) // Skip external functions
         .map(|d| {
             let fn_name = &d.fn_name;
             let glue_fn_name = format_ident!("__{}", d.fn_name);

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -53,8 +53,8 @@ use baml_compiler_hir::{
 use baml_compiler_tir::TypeResolutionContext;
 pub use baml_compiler_vir::LoweringError;
 pub use bex_vm_types::{
-    BinOp, Bytecode, Class, CmpOp, ConstValue, Enum, ExternalOp, Function, FunctionKind,
-    GlobalIndex, Instruction, Object, ObjectIndex, Program, SysOp, UnaryOp, Value, type_tags,
+    BinOp, Bytecode, Class, CmpOp, ConstValue, Enum, Function, FunctionKind, GlobalIndex,
+    Instruction, Object, ObjectIndex, Program, SysOp, UnaryOp, Value, type_tags,
 };
 
 /// Generate bytecode for all functions in a project.
@@ -197,12 +197,12 @@ pub fn compile_files(
 
     // Add builtin functions to globals FIRST (stable indices)
     for builtin in builtins {
-        // External builtins (like file I/O) use FunctionKind::External
+        // Sys_op builtins (like file I/O) use FunctionKind::SysOp
         // so the VM knows to dispatch them via DispatchFuture/Await
-        let kind = if builtin.is_external {
-            let external_op = external_op_for_builtin_path(builtin.path)
-                .expect("external builtin must have ExternalOp mapping");
-            FunctionKind::External(external_op)
+        let kind = if builtin.is_sys_op {
+            let sys_op = sys_op_for_builtin_path(builtin.path)
+                .expect("sys_op builtin must have SysOp mapping");
+            FunctionKind::SysOp(sys_op)
         } else {
             FunctionKind::NativeUnresolved
         };
@@ -240,9 +240,7 @@ pub fn compile_files(
                             name: signature.name.to_string(),
                             arity: params.len(),
                             bytecode: Bytecode::new(),
-                            kind: FunctionKind::External(ExternalOp::Llm(
-                                bex_vm_types::LlmOp::RenderPrompt,
-                            )),
+                            kind: FunctionKind::SysOp(SysOp::RenderPrompt),
                             locals_in_scope: vec![
                                 params
                                     .iter()
@@ -379,33 +377,29 @@ fn build_typing_context(
     context
 }
 
-/// Map a builtin path to its corresponding `ExternalOp`.
+/// Map a builtin path to its corresponding `SysOp`.
 ///
-/// This is used during code generation to set the correct `ExternalOp` variant
-/// for external builtin functions.
-fn external_op_for_builtin_path(path: &str) -> Option<ExternalOp> {
+/// This is used during code generation to set the correct `SysOp` variant
+/// for `sys_op` builtin functions.
+fn sys_op_for_builtin_path(path: &str) -> Option<SysOp> {
     match path {
         // LLM operations
-        "baml.llm.PrimitiveClient.render_prompt" => {
-            Some(ExternalOp::Llm(bex_vm_types::LlmOp::RenderPrompt))
-        }
-        "baml.llm.PrimitiveClient.specialize_prompt" => {
-            Some(ExternalOp::Llm(bex_vm_types::LlmOp::SpecializePrompt))
-        }
+        "baml.llm.PrimitiveClient.render_prompt" => Some(SysOp::RenderPrompt),
+        "baml.llm.PrimitiveClient.specialize_prompt" => Some(SysOp::SpecializePrompt),
         // System operations
-        "baml.fs.open" => Some(ExternalOp::Sys(SysOp::FsOpen)),
-        "baml.fs.File.read" => Some(ExternalOp::Sys(SysOp::FsRead)),
-        "baml.fs.File.close" => Some(ExternalOp::Sys(SysOp::FsClose)),
-        "baml.sys.shell" => Some(ExternalOp::Sys(SysOp::Shell)),
-        "baml.net.connect" => Some(ExternalOp::Sys(SysOp::NetConnect)),
-        "baml.net.Socket.read" => Some(ExternalOp::Sys(SysOp::NetRead)),
-        "baml.net.Socket.close" => Some(ExternalOp::Sys(SysOp::NetClose)),
-        "baml.http.fetch" => Some(ExternalOp::Sys(SysOp::HttpFetch)),
-        "baml.http.Response.text" => Some(ExternalOp::Sys(SysOp::HttpResponseText)),
-        "baml.http.Response.status" => Some(ExternalOp::Sys(SysOp::HttpResponseStatus)),
-        "baml.http.Response.ok" => Some(ExternalOp::Sys(SysOp::HttpResponseOk)),
-        "baml.http.Response.url" => Some(ExternalOp::Sys(SysOp::HttpResponseUrl)),
-        "baml.http.Response.headers" => Some(ExternalOp::Sys(SysOp::HttpResponseHeaders)),
+        "baml.fs.open" => Some(SysOp::FsOpen),
+        "baml.fs.File.read" => Some(SysOp::FsRead),
+        "baml.fs.File.close" => Some(SysOp::FsClose),
+        "baml.sys.shell" => Some(SysOp::Shell),
+        "baml.net.connect" => Some(SysOp::NetConnect),
+        "baml.net.Socket.read" => Some(SysOp::NetRead),
+        "baml.net.Socket.close" => Some(SysOp::NetClose),
+        "baml.http.fetch" => Some(SysOp::HttpFetch),
+        "baml.http.Response.text" => Some(SysOp::HttpResponseText),
+        "baml.http.Response.status" => Some(SysOp::HttpResponseStatus),
+        "baml.http.Response.ok" => Some(SysOp::HttpResponseOk),
+        "baml.http.Response.url" => Some(SysOp::HttpResponseUrl),
+        "baml.http.Response.headers" => Some(SysOp::HttpResponseHeaders),
         _ => None,
     }
 }

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -1769,8 +1769,8 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
                 all_args.extend(self.lower_args(args, body));
 
                 let callee = Operand::Constant(Constant::Function(Name::new(def.path)));
-                if def.is_external {
-                    self.emit_external_call(callee, all_args, dest);
+                if def.is_sys_op {
+                    self.emit_sys_op_call(callee, all_args, dest);
                 } else {
                     self.emit_call(callee, all_args, dest);
                 }
@@ -1799,19 +1799,19 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
 
         // Regular function call (not a method)
         // Check if this is an external builtin function (by path)
-        let is_external = Self::is_external_builtin_path(callee_expr, body);
+        let is_sys_op = Self::is_sys_op_builtin_path(callee_expr, body);
         let callee_operand = self.lower_to_operand(callee, body);
         let arg_operands = self.lower_args(args, body);
 
-        if is_external {
-            self.emit_external_call(callee_operand, arg_operands, dest);
+        if is_sys_op {
+            self.emit_sys_op_call(callee_operand, arg_operands, dest);
         } else {
             self.emit_call(callee_operand, arg_operands, dest);
         }
     }
 
-    /// Check if a callee expression refers to an external builtin function.
-    fn is_external_builtin_path(callee_expr: &Expr, body: &ExprBody) -> bool {
+    /// Check if a callee expression refers to a `sys_op` builtin function.
+    fn is_sys_op_builtin_path(callee_expr: &Expr, body: &ExprBody) -> bool {
         // Extract the path from the callee expression
         let path = match callee_expr {
             Expr::Var(name) => name.to_string(),
@@ -1847,9 +1847,9 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             _ => return false,
         };
 
-        // Look up the builtin by path and check if it's external
+        // Look up the builtin by path and check if it's a sys_op
         baml_compiler_tir::builtins::lookup_builtin_by_path(&path)
-            .map(|def| def.is_external)
+            .map(|def| def.is_sys_op)
             .unwrap_or(false)
     }
 
@@ -1993,7 +1993,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
     /// This emits:
     /// 1. `DispatchFuture`: Start the async operation, get a future handle
     /// 2. Await: Wait for the future and retrieve the result
-    fn emit_external_call(&mut self, callee: Operand, args: Vec<Operand>, dest: Place) {
+    fn emit_sys_op_call(&mut self, callee: Operand, args: Vec<Operand>, dest: Place) {
         // Create a temp to hold the future handle
         // Future handles are opaque to the VM - we use Unknown type
         let future_local = self.builder.temp(Ty::Unknown);

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -7,14 +7,14 @@ Functions: 4
 Objects: 45
 Globals: 41
 
-Function GetMixedList (arity: 0, kind: External(Llm(RenderPrompt))):
+Function GetMixedList (arity: 0, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function GetMixedMap (arity: 0, kind: External(Llm(RenderPrompt))):
+Function GetMixedMap (arity: 0, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function GetStatus (arity: 0, kind: External(Llm(RenderPrompt))):
+Function GetStatus (arity: 0, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function GetUser (arity: 1, kind: External(Llm(RenderPrompt))):
+Function GetUser (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -7,8 +7,8 @@ Functions: 2
 Objects: 39
 Globals: 39
 
-Function CommentAfterArrow (arity: 0, kind: External(Llm(RenderPrompt))):
+Function CommentAfterArrow (arity: 0, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function FunctionWithComments (arity: 2, kind: External(Llm(RenderPrompt))):
+Function FunctionWithComments (arity: 2, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -7,5 +7,5 @@ Functions: 1
 Objects: 39
 Globals: 38
 
-Function GetUser (arity: 0, kind: External(Llm(RenderPrompt))):
+Function GetUser (arity: 0, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -7,5 +7,5 @@ Functions: 1
 Objects: 39
 Globals: 38
 
-Function FetchDatax (arity: 1, kind: External(Llm(RenderPrompt))):
+Function FetchDatax (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
@@ -7,7 +7,7 @@ Functions: 3
 Objects: 47
 Globals: 40
 
-Function Foo (arity: 0, kind: External(Llm(RenderPrompt))):
+Function Foo (arity: 0, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
 Function Incomplete (arity: 1, kind: Bytecode):

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -7,19 +7,19 @@ Functions: 8
 Objects: 53
 Globals: 45
 
-Function Ambiguous (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Ambiguous (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function AnotherLLM (arity: 1, kind: External(Llm(RenderPrompt))):
+Function AnotherLLM (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function ChainedProcess (arity: 1, kind: External(Llm(RenderPrompt))):
+Function ChainedProcess (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function ExtractData (arity: 1, kind: External(Llm(RenderPrompt))):
+Function ExtractData (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function LLMAnalyze (arity: 1, kind: External(Llm(RenderPrompt))):
+Function LLMAnalyze (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
 Function ProcessAnalysis (arity: 1, kind: Bytecode):

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
@@ -53,302 +53,302 @@ Function DeepExpression (arity: 0, kind: Bytecode):
      18   BIN_OP +       
      19   RETURN         
 
-Function Process1 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process1 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process10 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process10 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process100 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process100 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process11 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process11 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process12 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process12 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process13 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process13 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process14 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process14 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process15 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process15 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process16 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process16 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process17 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process17 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process18 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process18 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process19 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process19 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process2 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process2 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process20 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process20 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process21 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process21 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process22 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process22 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process23 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process23 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process24 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process24 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process25 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process25 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process26 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process26 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process27 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process27 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process28 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process28 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process29 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process29 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process3 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process3 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process30 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process30 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process31 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process31 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process32 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process32 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process33 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process33 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process34 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process34 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process35 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process35 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process36 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process36 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process37 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process37 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process38 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process38 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process39 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process39 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process4 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process4 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process40 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process40 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process41 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process41 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process42 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process42 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process43 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process43 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process44 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process44 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process45 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process45 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process46 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process46 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process47 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process47 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process48 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process48 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process49 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process49 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process5 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process5 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process50 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process50 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process51 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process51 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process52 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process52 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process53 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process53 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process54 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process54 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process55 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process55 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process56 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process56 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process57 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process57 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process58 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process58 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process59 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process59 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process6 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process6 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process60 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process60 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process61 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process61 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process62 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process62 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process63 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process63 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process64 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process64 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process65 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process65 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process66 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process66 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process67 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process67 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process68 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process68 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process69 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process69 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process7 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process7 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process70 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process70 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process71 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process71 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process72 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process72 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process73 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process73 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process74 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process74 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process75 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process75 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process76 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process76 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process77 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process77 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process78 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process78 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process79 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process79 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process8 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process8 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process80 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process80 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process81 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process81 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process82 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process82 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process83 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process83 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process84 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process84 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process85 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process85 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process86 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process86 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process87 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process87 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process88 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process88 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process89 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process89 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process9 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process9 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process90 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process90 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process91 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process91 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process92 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process92 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process93 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process93 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process94 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process94 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process95 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process95 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process96 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process96 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process97 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process97 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process98 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process98 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function Process99 (arity: 1, kind: External(Llm(RenderPrompt))):
+Function Process99 (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -7,12 +7,12 @@ Functions: 3
 Objects: 45
 Globals: 40
 
-Function FormatMessage (arity: 1, kind: External(Llm(RenderPrompt))):
+Function FormatMessage (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
 Function GetRole (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   ("user")
      1   RETURN         
 
-Function ProcessText (arity: 1, kind: External(Llm(RenderPrompt))):
+Function ProcessText (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -7,8 +7,8 @@ Functions: 2
 Objects: 41
 Globals: 39
 
-Function BadParam (arity: 1, kind: External(Llm(RenderPrompt))):
+Function BadParam (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)
 
-Function BadReturnType (arity: 0, kind: External(Llm(RenderPrompt))):
+Function BadReturnType (arity: 0, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -7,5 +7,5 @@ Functions: 1
 Objects: 39
 Globals: 38
 
-Function HelloWorld (arity: 1, kind: External(Llm(RenderPrompt))):
+Function HelloWorld (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-5af6b621dd74eb70/out/generated_tests.rs
+source: target/debug/build/baml_tests-606b1b092e324f15/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
@@ -7,5 +7,5 @@ Functions: 1
 Objects: 39
 Globals: 38
 
-Function TypeBuilderFn (arity: 1, kind: External(Llm(RenderPrompt))):
+Function TypeBuilderFn (arity: 1, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -7,5 +7,5 @@ Functions: 1
 Objects: 40
 Globals: 38
 
-Function Fn (arity: 0, kind: External(Llm(RenderPrompt))):
+Function Fn (arity: 0, kind: SysOp(RenderPrompt)):
   (no bytecode)

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -12,7 +12,7 @@
 //! # External Operations
 //!
 //! External operations (LLM calls, HTTP requests, file I/O) are dispatched via
-//! the `ExternalOp` enum using static dispatch. This avoids dynamic dispatch
+//! the `SysOp` enum using static dispatch. This avoids dynamic dispatch
 //! overhead and makes the system more macro-friendly.
 //!
 //! # Resources
@@ -67,7 +67,7 @@ use bex_heap::BexHeap;
 pub use bex_heap::GcStats;
 use bex_program::BexProgram;
 use bex_vm::{BexVm, VmExecState};
-use bex_vm_types::{ExternalOp, GlobalPool, HeapPtr, LlmOp, Object, Value};
+use bex_vm_types::{GlobalPool, HeapPtr, Object, Value};
 // Re-export sys_types types for convenience
 pub use sys_types::{
     CompletionHandle, OpError, ResourceHandle, ResourceType, SysOp, SysOpFn, SysOpResult, SysOps,
@@ -1168,80 +1168,25 @@ impl BexEngine {
                     // Convert arguments to BexExternalValue
                     let args = Self::vm_args_to_external(vm, &pending.args);
 
-                    match pending.operation {
-                        ExternalOp::Llm(llm_op) => {
-                            match llm_op {
-                                LlmOp::RenderPrompt => {
-                                    // render_prompt(self: PrimitiveClient, template: String, args: Map<String, Any>) -> PromptAst
-                                    // args[0] = PrimitiveClient, args[1] = template, args[2] = args map
-                                    let result = Self::execute_render_prompt(&args)
-                                        .map_err(EngineError::from);
-                                    match result {
-                                        Ok(prompt_ast) => {
-                                            // Convert external PromptAst to VM PromptAst and set future ready
-                                            let vm_ast = Self::external_prompt_ast_to_vm_owned(
-                                                vm, prompt_ast,
-                                            );
-                                            let value = vm.alloc_prompt_ast(vm_ast);
-                                            vm.set_future_ready(id, value)?;
-                                        }
-                                        Err(e) => {
-                                            // Send error through the channel
-                                            let pending_futures = pending_futures.clone();
-                                            tokio::spawn(async move {
-                                                let _ = pending_futures
-                                                    .send(FutureResult { id, result: Err(e) });
-                                            });
-                                        }
-                                    }
-                                }
-                                LlmOp::SpecializePrompt => {
-                                    // specialize_prompt(self: PrimitiveClient, prompt: PromptAst) -> PromptAst
-                                    let result = Self::execute_specialize_prompt(&args)
-                                        .map_err(EngineError::from);
-                                    match result {
-                                        Ok(prompt_ast) => {
-                                            let vm_ast = Self::external_prompt_ast_to_vm_owned(
-                                                vm, prompt_ast,
-                                            );
-                                            let value = vm.alloc_prompt_ast(vm_ast);
-                                            vm.set_future_ready(id, value)?;
-                                        }
-                                        Err(e) => {
-                                            let pending_futures = pending_futures.clone();
-                                            tokio::spawn(async move {
-                                                let _ = pending_futures
-                                                    .send(FutureResult { id, result: Err(e) });
-                                            });
-                                        }
-                                    }
-                                }
-                            }
+                    match self.execute_sys_op(pending.operation, args) {
+                        SysOpResult::Ready(result) => {
+                            // Sync operation - set future to Ready without touching stack.
+                            // The VM will continue to the Await instruction which will
+                            // extract the value from the Ready future.
+                            let value =
+                                Self::external_to_vm_value(vm, result.map_err(EngineError::from)?);
+                            vm.set_future_ready(id, value)?;
                         }
-                        ExternalOp::Sys(sys_op) => {
-                            match self.execute_sys_op(sys_op, args) {
-                                SysOpResult::Ready(result) => {
-                                    // Sync operation - set future to Ready without touching stack.
-                                    // The VM will continue to the Await instruction which will
-                                    // extract the value from the Ready future.
-                                    let value = Self::external_to_vm_value(
-                                        vm,
-                                        result.map_err(EngineError::from)?,
-                                    );
-                                    vm.set_future_ready(id, value)?;
-                                }
-                                SysOpResult::Async(fut) => {
-                                    // Async operation - spawn task
-                                    let pending_futures = pending_futures.clone();
-                                    tokio::spawn(async move {
-                                        let result = fut.await;
-                                        let _ = pending_futures.send(FutureResult {
-                                            id,
-                                            result: result.map_err(EngineError::from),
-                                        });
-                                    });
-                                }
-                            }
+                        SysOpResult::Async(fut) => {
+                            // Async operation - spawn task
+                            let pending_futures = pending_futures.clone();
+                            tokio::spawn(async move {
+                                let result = fut.await;
+                                let _ = pending_futures.send(FutureResult {
+                                    id,
+                                    result: result.map_err(EngineError::from),
+                                });
+                            });
                         }
                     }
                 }
@@ -1323,7 +1268,7 @@ impl BexEngine {
         }
     }
 
-    /// Execute a system operation using the provider table.
+    /// Execute a system operation.
     fn execute_sys_op(&self, op: SysOp, args: Vec<BexExternalValue>) -> SysOpResult {
         match op {
             SysOp::FsOpen => (self.sys_ops.fs_open)(args),
@@ -1339,6 +1284,12 @@ impl BexEngine {
             SysOp::HttpResponseOk => (self.sys_ops.http_response_ok)(args),
             SysOp::HttpResponseUrl => (self.sys_ops.http_response_url)(args),
             SysOp::HttpResponseHeaders => (self.sys_ops.http_response_headers)(args),
+            SysOp::RenderPrompt => SysOpResult::Ready(
+                Self::execute_render_prompt(&args).map(BexExternalValue::PromptAst),
+            ),
+            SysOp::SpecializePrompt => SysOpResult::Ready(
+                Self::execute_specialize_prompt(&args).map(BexExternalValue::PromptAst),
+            ),
         }
     }
 

--- a/baml_language/crates/bex_vm/src/native.rs
+++ b/baml_language/crates/bex_vm/src/native.rs
@@ -536,9 +536,7 @@ pub fn attach_builtins(object: Object) -> Result<Object, VmError> {
         Object::Function(function) => {
             let kind = match function.kind {
                 bex_vm_types::FunctionKind::Bytecode => bex_vm_types::FunctionKind::Bytecode,
-                bex_vm_types::FunctionKind::External(op) => {
-                    bex_vm_types::FunctionKind::External(op)
-                }
+                bex_vm_types::FunctionKind::SysOp(op) => bex_vm_types::FunctionKind::SysOp(op),
                 bex_vm_types::FunctionKind::NativeUnresolved => {
                     let Some(native_function) = crate::get_native_fn(function.name.as_str()) else {
                         return Err(VmError::RuntimeError(RuntimeError::Other(format!(

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1915,7 +1915,7 @@ impl BexVm {
                 Instruction::DispatchFuture(arg_count) => {
                     let args_offset = self.stack.ensure_slot_from_top(arg_count)?;
 
-                    let expected_type = FunctionType::External;
+                    let expected_type = FunctionType::SysOp;
 
                     let index =
                         self.as_object_ptr(&self.stack[args_offset], expected_type.into())?;
@@ -1938,10 +1938,10 @@ impl BexVm {
                         }));
                     }
 
-                    // Must be an external operation - extract the ExternalOp.
-                    let FunctionKind::External(external_op) = callable_future.kind else {
+                    // Must be a sys_op - extract the SysOp.
+                    let FunctionKind::SysOp(sys_op) = callable_future.kind else {
                         return Err(VmError::from(InternalError::TypeError {
-                            expected: FunctionType::External.into(),
+                            expected: FunctionType::SysOp.into(),
                             got: FunctionType::from(&callable_future.kind).into(),
                         }));
                     };
@@ -1949,9 +1949,9 @@ impl BexVm {
                     // Collect the function call args and cleanup the call.
                     let future_args: Vec<Value> = self.stack.drain(args_offset..).skip(1).collect();
 
-                    // Create the pending future with the ExternalOp enum.
+                    // Create the pending future with the SysOp enum.
                     let pending_future = PendingFuture {
-                        operation: external_op,
+                        operation: sys_op,
                         args: future_args,
                     };
 
@@ -2203,7 +2203,7 @@ impl BexVm {
                                 .clone();
                         }
 
-                        FunctionKind::External(_) => {
+                        FunctionKind::SysOp(_) => {
                             return Err(InternalError::TypeError {
                                 expected: FunctionType::Callable.into(),
                                 got: FunctionType::from(&callee.kind).into(),

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -22,7 +22,6 @@ pub use bytecode::{
 pub use heap_ptr::HeapPtr;
 pub use indexable::{GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, StackIndex};
 pub use types::{
-    Class, ConstValue, Enum, ExternalOp, Function, FunctionKind, Future, Instance, LlmOp, Object,
-    ObjectType, PendingFuture, PrimitiveClient, Program, PromptAst, SysOp, Value, Variant,
-    type_tags,
+    Class, ConstValue, Enum, Function, FunctionKind, Future, Instance, Object, ObjectType,
+    PendingFuture, PrimitiveClient, Program, PromptAst, SysOp, Value, Variant, type_tags,
 };

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -64,29 +64,6 @@ impl Program {
 // External Operations
 // ============================================================================
 
-/// External operation to be executed by the engine.
-///
-/// This enum enables static dispatch instead of dynamic dispatch via traits.
-/// The engine matches on this enum to execute the appropriate async operation.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum ExternalOp {
-    /// LLM operation (render prompt, specialize, build request, etc.).
-    Llm(LlmOp),
-    /// System operation (file I/O, shell, HTTP, etc.).
-    Sys(SysOp),
-}
-
-/// LLM operations that run outside the VM.
-///
-/// These are built-in LLM-related operations provided by the engine.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum LlmOp {
-    /// Render a Jinja template: `PrimitiveClient.render_prompt(template, args) -> PromptAst`
-    RenderPrompt,
-    /// Specialize a prompt for a specific provider: `PrimitiveClient.specialize_prompt(prompt) -> PromptAst`
-    SpecializePrompt,
-}
-
 /// System operations that run outside the VM.
 ///
 /// These are built-in async operations provided by the engine.
@@ -119,24 +96,10 @@ pub enum SysOp {
     HttpResponseUrl,
     /// Get response headers: `Response.headers() -> Map<String, String>`
     HttpResponseHeaders,
-}
-
-impl std::fmt::Display for ExternalOp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ExternalOp::Llm(llm_op) => write!(f, "{llm_op}"),
-            ExternalOp::Sys(sys_op) => write!(f, "{sys_op}"),
-        }
-    }
-}
-
-impl std::fmt::Display for LlmOp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LlmOp::RenderPrompt => write!(f, "llm.render_prompt"),
-            LlmOp::SpecializePrompt => write!(f, "llm.specialize_prompt"),
-        }
-    }
+    /// Render a Jinja template: `PrimitiveClient.render_prompt(template, args) -> PromptAst`
+    RenderPrompt,
+    /// Specialize a prompt for a specific provider: `PrimitiveClient.specialize_prompt(prompt) -> PromptAst`
+    SpecializePrompt,
 }
 
 impl std::fmt::Display for SysOp {
@@ -155,6 +118,8 @@ impl std::fmt::Display for SysOp {
             SysOp::HttpResponseOk => write!(f, "http.Response.ok"),
             SysOp::HttpResponseUrl => write!(f, "http.Response.url"),
             SysOp::HttpResponseHeaders => write!(f, "http.Response.headers"),
+            SysOp::RenderPrompt => write!(f, "llm.render_prompt"),
+            SysOp::SpecializePrompt => write!(f, "llm.specialize_prompt"),
         }
     }
 }
@@ -188,11 +153,11 @@ pub enum FunctionKind {
     /// The VM pushes a call frame onto the call stack and runs the bytecode.
     Bytecode,
 
-    /// External operation (LLM calls, HTTP requests, file I/O, etc.).
+    /// System operation (LLM calls, HTTP requests, file I/O, etc.).
     ///
     /// The VM yields control to the engine which executes the operation
-    /// asynchronously via static dispatch on the `ExternalOp` enum.
-    External(ExternalOp),
+    /// asynchronously via static dispatch on the `SysOp` enum.
+    SysOp(SysOp),
 
     /// Unresolved native function (placeholder).
     ///
@@ -521,8 +486,8 @@ pub enum Future {
 /// LLM calls, HTTP requests, file I/O, or shell commands.
 #[derive(Clone, Debug)]
 pub struct PendingFuture {
-    /// The external operation to execute.
-    pub operation: ExternalOp,
+    /// The system operation to execute.
+    pub operation: SysOp,
     /// Arguments to the operation.
     pub args: Vec<Value>,
 }
@@ -744,7 +709,7 @@ pub enum FunctionType {
     /// Top of function type lattice: represents all function types.
     Any,
     Callable,
-    External,
+    SysOp,
 }
 
 impl std::fmt::Display for FunctionType {
@@ -752,15 +717,15 @@ impl std::fmt::Display for FunctionType {
         match self {
             FunctionType::Any => write!(f, "any"),
             FunctionType::Callable => write!(f, "callable"),
-            FunctionType::External => write!(f, "external"),
+            FunctionType::SysOp => write!(f, "sys_op"),
         }
     }
 }
 
 impl From<&FunctionKind> for FunctionType {
     fn from(value: &FunctionKind) -> Self {
-        if matches!(value, FunctionKind::External(_)) {
-            FunctionType::External
+        if matches!(value, FunctionKind::SysOp(_)) {
+            FunctionType::SysOp
         } else {
             FunctionType::Callable
         }

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -187,6 +187,16 @@ impl SysOps {
                     operation: SysOp::HttpResponseHeaders,
                 }))
             },
+            SysOp::RenderPrompt => |_| {
+                SysOpResult::Ready(Err(OpError::Unsupported {
+                    operation: SysOp::RenderPrompt,
+                }))
+            },
+            SysOp::SpecializePrompt => |_| {
+                SysOpResult::Ready(Err(OpError::Unsupported {
+                    operation: SysOp::SpecializePrompt,
+                }))
+            },
         }
     }
 


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Rename ExternalOp to SysOp and flatten LlmOp variants into SysOp enum
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4858b74e27be8e5a4103d9ef47b02c09a9455ef1.</sup>
<!-- /MENDRAL_SUMMARY -->