### PR TITLE
baml-language: rename baml.http.Response to baml.http.HttpResponse

### DIFF
--- a/baml_language/crates/baml_builtins/src/lib.rs
+++ b/baml_language/crates/baml_builtins/src/lib.rs
@@ -204,27 +204,27 @@ macro_rules! with_builtins {
                 // =====================================================================
                 mod http {
                     #[builtin]
-                    struct Response {
+                    struct HttpResponse {
                         /// Get response body as text (consumes body).
                         #[sys_op]
-                        fn text(self: Response) -> String;
+                        fn text(self: HttpResponse) -> String;
                         /// Get HTTP status code.
                         #[sys_op]
-                        fn status(self: Response) -> i64;
+                        fn status(self: HttpResponse) -> i64;
                         /// Check if status is 2xx.
                         #[sys_op]
-                        fn ok(self: Response) -> bool;
+                        fn ok(self: HttpResponse) -> bool;
                         /// Get request URL (may differ if redirected).
                         #[sys_op]
-                        fn url(self: Response) -> String;
+                        fn url(self: HttpResponse) -> String;
                         /// Get response headers.
                         #[sys_op]
-                        fn headers(self: Response) -> Map<String, String>;
+                        fn headers(self: HttpResponse) -> Map<String, String>;
                     }
 
                     /// Fetch a URL via HTTP GET.
                     #[sys_op]
-                    fn fetch(url: String) -> Response;
+                    fn fetch(url: String) -> HttpResponse;
                 }
 
                 // =====================================================================
@@ -400,7 +400,7 @@ mod tests {
         assert!(find_builtin_by_path("baml.llm.PromptAst").is_none());
 
         // Other builtins in the same parent module are still visible
-        assert!(find_builtin_by_path("baml.http.Response.text").is_some());
+        assert!(find_builtin_by_path("baml.http.HttpResponse.text").is_some());
         assert!(find_builtin_by_path("baml.http.fetch").is_some());
     }
 

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -396,11 +396,11 @@ fn sys_op_for_builtin_path(path: &str) -> Option<SysOp> {
         "baml.net.Socket.read" => Some(SysOp::NetRead),
         "baml.net.Socket.close" => Some(SysOp::NetClose),
         "baml.http.fetch" => Some(SysOp::HttpFetch),
-        "baml.http.Response.text" => Some(SysOp::HttpResponseText),
-        "baml.http.Response.status" => Some(SysOp::HttpResponseStatus),
-        "baml.http.Response.ok" => Some(SysOp::HttpResponseOk),
-        "baml.http.Response.url" => Some(SysOp::HttpResponseUrl),
-        "baml.http.Response.headers" => Some(SysOp::HttpResponseHeaders),
+        "baml.http.HttpResponse.text" => Some(SysOp::HttpResponseText),
+        "baml.http.HttpResponse.status" => Some(SysOp::HttpResponseStatus),
+        "baml.http.HttpResponse.ok" => Some(SysOp::HttpResponseOk),
+        "baml.http.HttpResponse.url" => Some(SysOp::HttpResponseUrl),
+        "baml.http.HttpResponse.headers" => Some(SysOp::HttpResponseHeaders),
         _ => None,
     }
 }

--- a/baml_language/crates/bex_engine/tests/http.rs
+++ b/baml_language/crates/bex_engine/tests/http.rs
@@ -1,4 +1,4 @@
-//! Tests for HTTP operations (baml.http.fetch, Response methods).
+//! Tests for HTTP operations (baml.http.fetch, `HttpResponse` methods).
 
 mod common;
 

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -84,17 +84,17 @@ pub enum SysOp {
     NetRead,
     /// Close a socket: `Socket.close()`
     NetClose,
-    /// HTTP fetch: `baml.http.fetch(url: String) -> Response`
+    /// HTTP fetch: `baml.http.fetch(url: String) -> HttpResponse`
     HttpFetch,
-    /// Get response body as text: `Response.text() -> String`
+    /// Get response body as text: `HttpResponse.text() -> String`
     HttpResponseText,
-    /// Get response status code: `Response.status() -> i64`
+    /// Get response status code: `HttpResponse.status() -> i64`
     HttpResponseStatus,
-    /// Check if response is OK (2xx): `Response.ok() -> bool`
+    /// Check if response is OK (2xx): `HttpResponse.ok() -> bool`
     HttpResponseOk,
-    /// Get request URL: `Response.url() -> String`
+    /// Get request URL: `HttpResponse.url() -> String`
     HttpResponseUrl,
-    /// Get response headers: `Response.headers() -> Map<String, String>`
+    /// Get response headers: `HttpResponse.headers() -> Map<String, String>`
     HttpResponseHeaders,
     /// Render a Jinja template: `PrimitiveClient.render_prompt(template, args) -> PromptAst`
     RenderPrompt,
@@ -113,11 +113,11 @@ impl std::fmt::Display for SysOp {
             SysOp::NetRead => write!(f, "net.read"),
             SysOp::NetClose => write!(f, "net.close"),
             SysOp::HttpFetch => write!(f, "http.fetch"),
-            SysOp::HttpResponseText => write!(f, "http.Response.text"),
-            SysOp::HttpResponseStatus => write!(f, "http.Response.status"),
-            SysOp::HttpResponseOk => write!(f, "http.Response.ok"),
-            SysOp::HttpResponseUrl => write!(f, "http.Response.url"),
-            SysOp::HttpResponseHeaders => write!(f, "http.Response.headers"),
+            SysOp::HttpResponseText => write!(f, "http.HttpResponse.text"),
+            SysOp::HttpResponseStatus => write!(f, "http.HttpResponse.status"),
+            SysOp::HttpResponseOk => write!(f, "http.HttpResponse.ok"),
+            SysOp::HttpResponseUrl => write!(f, "http.HttpResponse.url"),
+            SysOp::HttpResponseHeaders => write!(f, "http.HttpResponse.headers"),
             SysOp::RenderPrompt => write!(f, "llm.render_prompt"),
             SysOp::SpecializePrompt => write!(f, "llm.specialize_prompt"),
         }

--- a/baml_language/crates/sys_native/src/ops/http.rs
+++ b/baml_language/crates/sys_native/src/ops/http.rs
@@ -11,9 +11,9 @@ use crate::registry::REGISTRY;
 /// Shared HTTP client with connection pooling.
 pub(crate) static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 
-/// Fetches a URL and returns a Response resource.
+/// Fetches a URL and returns an `HttpResponse` resource.
 ///
-/// Signature: `fn fetch(url: String) -> Response`
+/// Signature: `fn fetch(url: String) -> HttpResponse`
 pub(crate) fn fetch(args: Vec<BexExternalValue>) -> SysOpResult {
     SysOpResult::Async(Box::pin(fetch_async(args)))
 }
@@ -50,7 +50,7 @@ async fn fetch_async(args: Vec<BexExternalValue>) -> Result<BexExternalValue, Op
 
 /// Gets the response body as text (consumes the body).
 ///
-/// Signature: `fn text(self: Response) -> String`
+/// Signature: `fn text(self: HttpResponse) -> String`
 pub(crate) fn text(args: Vec<BexExternalValue>) -> SysOpResult {
     SysOpResult::Async(Box::pin(text_async(args)))
 }
@@ -60,7 +60,7 @@ async fn text_async(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpE
         Some(BexExternalValue::Resource(h)) => h,
         other => {
             return Err(OpError::TypeError {
-                expected: "Response resource",
+                expected: "HttpResponse resource",
                 actual: format!("{other:?}"),
             });
         }
@@ -68,12 +68,12 @@ async fn text_async(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpE
 
     let response_mutex = REGISTRY
         .get_http_response_body(handle.key())
-        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+        .ok_or_else(|| OpError::Other("HttpResponse handle is invalid".into()))?;
 
     let mut guard = response_mutex.lock().await;
     let response = guard
         .take()
-        .ok_or_else(|| OpError::Other("Response body has already been consumed".into()))?;
+        .ok_or_else(|| OpError::Other("HttpResponse body has already been consumed".into()))?;
 
     let text = response
         .text()
@@ -85,7 +85,7 @@ async fn text_async(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpE
 
 /// Gets the response status code.
 ///
-/// Signature: `fn status(self: Response) -> i64`
+/// Signature: `fn status(self: HttpResponse) -> i64`
 pub(crate) fn status(args: Vec<BexExternalValue>) -> SysOpResult {
     let result = status_sync(args);
     SysOpResult::Ready(result)
@@ -96,7 +96,7 @@ fn status_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError>
         Some(BexExternalValue::Resource(h)) => h,
         other => {
             return Err(OpError::TypeError {
-                expected: "Response resource",
+                expected: "HttpResponse resource",
                 actual: format!("{other:?}"),
             });
         }
@@ -104,14 +104,14 @@ fn status_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError>
 
     let (status, _, _) = REGISTRY
         .get_http_response_metadata(handle.key())
-        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+        .ok_or_else(|| OpError::Other("HttpResponse handle is invalid".into()))?;
 
     Ok(BexExternalValue::Int(i64::from(status)))
 }
 
 /// Checks if the response status is OK (2xx).
 ///
-/// Signature: `fn ok(self: Response) -> bool`
+/// Signature: `fn ok(self: HttpResponse) -> bool`
 pub(crate) fn ok(args: Vec<BexExternalValue>) -> SysOpResult {
     let result = ok_sync(args);
     SysOpResult::Ready(result)
@@ -122,7 +122,7 @@ fn ok_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
         Some(BexExternalValue::Resource(h)) => h,
         other => {
             return Err(OpError::TypeError {
-                expected: "Response resource",
+                expected: "HttpResponse resource",
                 actual: format!("{other:?}"),
             });
         }
@@ -130,14 +130,14 @@ fn ok_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
 
     let (status, _, _) = REGISTRY
         .get_http_response_metadata(handle.key())
-        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+        .ok_or_else(|| OpError::Other("HttpResponse handle is invalid".into()))?;
 
     Ok(BexExternalValue::Bool((200..300).contains(&status)))
 }
 
 /// Gets the request URL (may differ from original if redirected).
 ///
-/// Signature: `fn url(self: Response) -> String`
+/// Signature: `fn url(self: HttpResponse) -> String`
 pub(crate) fn url(args: Vec<BexExternalValue>) -> SysOpResult {
     let result = url_sync(args);
     SysOpResult::Ready(result)
@@ -148,7 +148,7 @@ fn url_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
         Some(BexExternalValue::Resource(h)) => h,
         other => {
             return Err(OpError::TypeError {
-                expected: "Response resource",
+                expected: "HttpResponse resource",
                 actual: format!("{other:?}"),
             });
         }
@@ -156,14 +156,14 @@ fn url_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
 
     let (_, _, url) = REGISTRY
         .get_http_response_metadata(handle.key())
-        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+        .ok_or_else(|| OpError::Other("HttpResponse handle is invalid".into()))?;
 
     Ok(BexExternalValue::String(url))
 }
 
 /// Gets the response headers as a map.
 ///
-/// Signature: `fn headers(self: Response) -> Map<String, String>`
+/// Signature: `fn headers(self: HttpResponse) -> Map<String, String>`
 pub(crate) fn headers(args: Vec<BexExternalValue>) -> SysOpResult {
     let result = headers_sync(args);
     SysOpResult::Ready(result)
@@ -174,7 +174,7 @@ fn headers_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError
         Some(BexExternalValue::Resource(h)) => h,
         other => {
             return Err(OpError::TypeError {
-                expected: "Response resource",
+                expected: "HttpResponse resource",
                 actual: format!("{other:?}"),
             });
         }
@@ -182,7 +182,7 @@ fn headers_sync(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError
 
     let (_, headers, _) = REGISTRY
         .get_http_response_metadata(handle.key())
-        .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
+        .ok_or_else(|| OpError::Other("HttpResponse handle is invalid".into()))?;
 
     let entries: IndexMap<String, BexExternalValue> = headers
         .into_iter()


### PR DESCRIPTION
Slack msg: https://gloo-global.slack.com/archives/C0A66240YFJ/p1769641041959379

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> This PR contains two refactorings: (1) Rename `baml.http.Response` to `baml.http.HttpResponse` for better clarity and consistency, and (2) Rename `ExternalOp` to `SysOp` and flatten the enum hierarchy by moving `LlmOp` variants to top-level `SysOp`.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4adbb69a43c49a9c0e797839d726a10a4ada4270.</sup>
<!-- /MENDRAL_SUMMARY -->