### PR TITLE
baml-language: implement baml.http.HttpRequest and fetch_http()

### DIFF
--- a/baml_language/crates/baml_bridge_cffi/src/ctypes/value_encode.rs
+++ b/baml_language/crates/baml_bridge_cffi/src/ctypes/value_encode.rs
@@ -114,7 +114,9 @@ pub fn external_to_cffi_value(value: &BexExternalValue) -> Result<CffiValueHolde
             // Resources cannot be serialized across FFI - return null
             None
         }
-        BexExternalValue::PromptAst(_) | BexExternalValue::PrimitiveClient(_) => {
+        BexExternalValue::PromptAst(_)
+        | BexExternalValue::PrimitiveClient(_)
+        | BexExternalValue::HttpRequest(_) => {
             // Internal types cannot be serialized across FFI - return null
             None
         }

--- a/baml_language/crates/baml_builtins/src/lib.rs
+++ b/baml_language/crates/baml_builtins/src/lib.rs
@@ -52,7 +52,7 @@ pub struct BuiltinField {
 /// A builtin type definition (struct with fields).
 #[derive(Debug, Clone)]
 pub struct BuiltinTypeDefinition {
-    /// Full path (e.g., "baml.http.Response").
+    /// Full path (e.g., "baml.http.HttpResponse").
     pub path: &'static str,
     /// All fields (public and private) in runtime order.
     pub fields: Vec<BuiltinField>,
@@ -228,22 +228,22 @@ macro_rules! with_builtins {
                 // =====================================================================
                 mod http {
                     #[builtin]
-                    struct Response {
+                    struct HttpResponse {
                         private _handle: ResourceHandle,
                         status_code: i64,
                         headers: Map<String, String>,
                         url: String,
                         /// Get response body as text (consumes body).
                         #[sys_op]
-                        fn text(self: Response) -> String;
+                        fn text(self: HttpResponse) -> String;
                         /// Check if status is 2xx.
                         #[sys_op]
-                        fn ok(self: Response) -> bool;
+                        fn ok(self: HttpResponse) -> bool;
                     }
 
                     /// Fetch a URL via HTTP GET.
                     #[sys_op]
-                    fn fetch(url: String) -> Response;
+                    fn fetch(url: String) -> HttpResponse;
                 }
 
                 // =====================================================================
@@ -435,7 +435,7 @@ mod tests {
         assert!(find_builtin_by_path("baml.llm.PromptAst").is_none());
 
         // Other builtins in the same parent module are still visible
-        assert!(find_builtin_by_path("baml.http.Response.text").is_some());
+        assert!(find_builtin_by_path("baml.http.HttpResponse.text").is_some());
         assert!(find_builtin_by_path("baml.http.fetch").is_some());
     }
 
@@ -493,7 +493,7 @@ mod tests {
         );
 
         // Find Response type
-        let response = find_builtin_type("baml.http.Response");
+        let response = find_builtin_type("baml.http.HttpResponse");
         assert!(response.is_some(), "Response type should exist");
         let response = response.unwrap();
 
@@ -516,14 +516,14 @@ mod tests {
         );
 
         // Check status_code is public
-        let status_field = find_field("baml.http.Response", "status_code");
+        let status_field = find_field("baml.http.HttpResponse", "status_code");
         assert!(status_field.is_some(), "status_code field should exist");
         let status_field = status_field.unwrap();
         assert!(!status_field.is_private, "status_code should be public");
         assert!(matches!(status_field.ty, Some(TypePattern::Int)));
 
         // Check headers field type is Map<String, String>
-        let headers_field = find_field("baml.http.Response", "headers");
+        let headers_field = find_field("baml.http.HttpResponse", "headers");
         assert!(headers_field.is_some(), "headers field should exist");
         let headers_field = headers_field.unwrap();
         assert!(matches!(headers_field.ty, Some(TypePattern::Map { .. })));

--- a/baml_language/crates/baml_builtins/src/lib.rs
+++ b/baml_language/crates/baml_builtins/src/lib.rs
@@ -227,6 +227,10 @@ macro_rules! with_builtins {
                 // HTTP operations
                 // =====================================================================
                 mod http {
+                    /// An HTTP request with method, URL, headers, and body.
+                    #[builtin]
+                    struct HttpRequest {}
+
                     #[builtin]
                     struct HttpResponse {
                         private _handle: ResourceHandle,
@@ -244,6 +248,10 @@ macro_rules! with_builtins {
                     /// Fetch a URL via HTTP GET.
                     #[sys_op]
                     fn fetch(url: String) -> HttpResponse;
+
+                    /// Execute a full HTTP request and return the response.
+                    #[sys_op]
+                    fn fetch_http(request: HttpRequest) -> HttpResponse;
                 }
 
                 // =====================================================================

--- a/baml_language/crates/baml_builtins_macros/src/lib.rs
+++ b/baml_language/crates/baml_builtins_macros/src/lib.rs
@@ -1367,6 +1367,13 @@ fn rust_type_for_input(type_name: &str, is_generic: bool, is_mut: bool) -> Token
                 quote!(&PrimitiveClient)
             }
         }
+        "HttpRequest" => {
+            if is_mut {
+                quote!(&mut HttpRequest)
+            } else {
+                quote!(&HttpRequest)
+            }
+        }
         t if t.starts_with("Array") => {
             if is_mut {
                 quote!(&mut Vec<Value>)
@@ -1412,6 +1419,7 @@ fn rust_type_for_output(type_name: &str, is_generic: bool) -> TokenStream2 {
         "Media" => quote!(MediaValue),
         "PromptAst" => quote!(PromptAst),
         "PrimitiveClient" => quote!(PrimitiveClient),
+        "HttpRequest" => quote!(HttpRequest),
         t if t.starts_with("Array") => quote!(Vec<Value>),
         t if t.starts_with("Map") => quote!(IndexMap<String, Value>),
         t if t.starts_with("Option<") => {
@@ -1574,6 +1582,17 @@ fn generate_single_extraction(
                 }
             }
         }
+        "HttpRequest" => {
+            if is_mut {
+                quote! {
+                    compile_error!("Mutable HttpRequest parameters not yet supported");
+                }
+            } else {
+                quote! {
+                    let #var_name = vm.as_http_request(&args[#idx])?.clone();
+                }
+            }
+        }
         t if t.starts_with("Array") => {
             if is_mut {
                 quote! {
@@ -1653,7 +1672,7 @@ fn needs_reference(type_name: &str, is_generic: bool) -> bool {
 
     matches!(
         type_name,
-        "String" | "Media" | "PromptAst" | "PrimitiveClient"
+        "String" | "Media" | "PromptAst" | "PrimitiveClient" | "HttpRequest"
     ) || type_name.starts_with("Array")
         || type_name.starts_with("Map")
 }
@@ -1688,6 +1707,7 @@ fn generate_result_conversion(d: &NativeFnDef) -> TokenStream2 {
         t if t.starts_with("Map") => quote!(Ok(vm.alloc_map(result))),
         "PromptAst" => quote!(Ok(vm.alloc_prompt_ast(result))),
         "PrimitiveClient" => quote!(Ok(vm.alloc_primitive_client(result))),
+        "HttpRequest" => quote!(Ok(vm.alloc_http_request(result))),
         _ => quote!(Ok(result)),
     }
 }

--- a/baml_language/crates/baml_builtins_macros/src/lib.rs
+++ b/baml_language/crates/baml_builtins_macros/src/lib.rs
@@ -31,7 +31,7 @@ struct BuiltinDef {
 
 /// A collected builtin type definition (struct marked with #[builtin]).
 struct BuiltinTypeDef {
-    /// Full path like "baml.http.Response"
+    /// Full path like "baml.http.HttpResponse"
     path: String,
     /// Field definitions
     fields: Vec<BuiltinFieldDef>,

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -440,6 +440,7 @@ fn sys_op_for_builtin_path(path: &str) -> Option<SysOp> {
         "baml.http.fetch" => Some(SysOp::HttpFetch),
         "baml.http.HttpResponse.text" => Some(SysOp::ResponseText),
         "baml.http.HttpResponse.ok" => Some(SysOp::ResponseOk),
+        "baml.http.fetch_http" => Some(SysOp::HttpFetchHttp),
         _ => None,
     }
 }

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -438,8 +438,8 @@ fn sys_op_for_builtin_path(path: &str) -> Option<SysOp> {
         "baml.net.Socket.read" => Some(SysOp::NetRead),
         "baml.net.Socket.close" => Some(SysOp::NetClose),
         "baml.http.fetch" => Some(SysOp::HttpFetch),
-        "baml.http.Response.text" => Some(SysOp::ResponseText),
-        "baml.http.Response.ok" => Some(SysOp::ResponseOk),
+        "baml.http.HttpResponse.text" => Some(SysOp::ResponseText),
+        "baml.http.HttpResponse.ok" => Some(SysOp::ResponseOk),
         _ => None,
     }
 }

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -1954,7 +1954,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
 
     /// Extract class name from a Ty.
     ///
-    /// For builtin classes, returns the full path (e.g., "baml.http.Response").
+    /// For builtin classes, returns the full path (e.g., "baml.http.HttpResponse").
     /// For user classes, returns just the name (e.g., "`MyClass`").
     fn class_name_from_ty(ty: &Ty) -> Option<String> {
         match ty {

--- a/baml_language/crates/baml_compiler_tir/src/builtins.rs
+++ b/baml_language/crates/baml_compiler_tir/src/builtins.rs
@@ -11,7 +11,7 @@ use baml_compiler_hir::FullyQualifiedName;
 
 use crate::Ty;
 
-/// Parse a builtin path string like "baml.http.Response" into an FQN.
+/// Parse a builtin path string like "baml.http.HttpResponse" into an FQN.
 ///
 /// The path is expected to start with "baml." and have at least one segment after.
 pub fn parse_builtin_path(path: &str) -> FullyQualifiedName {

--- a/baml_language/crates/baml_tests/src/vm.rs
+++ b/baml_language/crates/baml_tests/src/vm.rs
@@ -152,6 +152,9 @@ impl Object {
             VmObject::PrimitiveClient(_) => {
                 anyhow::bail!("Unsupported object type for testing: {obj:?}")
             }
+            VmObject::HttpRequest(_) => {
+                anyhow::bail!("Unsupported object type for testing: {obj:?}")
+            }
             #[cfg(feature = "heap_debug")]
             VmObject::Sentinel(_) => anyhow::bail!("Unsupported object type for testing: {obj:?}"),
         }

--- a/baml_language/crates/baml_typetags/src/lib.rs
+++ b/baml_language/crates/baml_typetags/src/lib.rs
@@ -56,6 +56,9 @@ pub const PROMPT_AST: i64 = 12;
 /// `PrimitiveClient` type tag.
 pub const PRIMITIVE_CLIENT: i64 = 13;
 
+/// `HttpRequest` type tag.
+pub const HTTP_REQUEST: i64 = 14;
+
 /// Base value for class type tags (classes start at 100).
 pub const CLASS_BASE: i64 = 100;
 

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -677,6 +677,38 @@ impl BexEngine {
             Object::PrimitiveClient(_) => Err(EngineError::CannotConvert {
                 type_name: "primitive_client".to_string(),
             }),
+            Object::HttpRequest(req) => {
+                // Convert headers from heap map to owned IndexMap
+                let headers_obj = unsafe { req.headers.get() };
+                let headers = if let Object::Map(map) = headers_obj {
+                    map.iter()
+                        .map(|(k, v)| {
+                            let val = match v {
+                                Value::Object(ptr) => {
+                                    let obj = unsafe { ptr.get() };
+                                    if let Object::String(s) = obj {
+                                        s.clone()
+                                    } else {
+                                        String::new()
+                                    }
+                                }
+                                _ => String::new(),
+                            };
+                            (k.clone(), val)
+                        })
+                        .collect()
+                } else {
+                    indexmap::IndexMap::new()
+                };
+                Ok(BexExternalValue::HttpRequest(
+                    bex_external_types::HttpRequestValue {
+                        method: req.method.clone(),
+                        url: req.url.clone(),
+                        headers,
+                        body: req.body.clone(),
+                    },
+                ))
+            }
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => Err(EngineError::CannotSnapshot {
                 type_name: "sentinel".to_string(),
@@ -1073,6 +1105,24 @@ impl BexEngine {
                     options: options_heap_ptr,
                 })
             }
+            BexExternalValue::HttpRequest(req) => {
+                // Allocate headers map to heap
+                let headers: indexmap::IndexMap<String, Value> = req
+                    .headers
+                    .iter()
+                    .map(|(k, v)| (k.clone(), vm.alloc_string(v.clone())))
+                    .collect();
+                let headers_ptr = vm.alloc_map(headers);
+                let Value::Object(headers_heap_ptr) = headers_ptr else {
+                    panic!("alloc_map should return an Object");
+                };
+                vm.alloc_http_request(bex_vm_types::HttpRequest {
+                    method: req.method.clone(),
+                    url: req.url.clone(),
+                    headers: headers_heap_ptr,
+                    body: req.body.clone(),
+                })
+            }
         }
     }
 
@@ -1311,6 +1361,7 @@ impl BexEngine {
             SysOp::SpecializePrompt => SysOpResult::Ready(
                 Self::execute_specialize_prompt(args).map(BexExternalValue::PromptAst),
             ),
+            SysOp::HttpFetchHttp => (self.sys_ops.http_fetch_http)(args),
         }
     }
 
@@ -1672,6 +1723,24 @@ impl BexEngine {
                     default_role: client.default_role,
                     allowed_roles: client.allowed_roles,
                     options: options_heap_ptr,
+                })
+            }
+            BexExternalValue::HttpRequest(req) => {
+                // Allocate headers map to heap
+                let headers: indexmap::IndexMap<String, Value> = req
+                    .headers
+                    .into_iter()
+                    .map(|(k, v)| (k, vm.alloc_string(v)))
+                    .collect();
+                let headers_ptr = vm.alloc_map(headers);
+                let Value::Object(headers_heap_ptr) = headers_ptr else {
+                    panic!("alloc_map should return an Object");
+                };
+                vm.alloc_http_request(bex_vm_types::HttpRequest {
+                    method: req.method,
+                    url: req.url,
+                    headers: headers_heap_ptr,
+                    body: req.body,
                 })
             }
         }

--- a/baml_language/crates/bex_external_types/src/bex_external_value.rs
+++ b/baml_language/crates/bex_external_types/src/bex_external_value.rs
@@ -165,6 +165,22 @@ pub enum BexExternalValue {
 
     /// Primitive LLM client.
     PrimitiveClient(PrimitiveClientValue),
+
+    /// HTTP request.
+    HttpRequest(HttpRequestValue),
+}
+
+/// A fully-owned HTTP request value.
+#[derive(Clone, Debug, PartialEq)]
+pub struct HttpRequestValue {
+    /// HTTP method (e.g., "GET", "POST").
+    pub method: String,
+    /// Request URL.
+    pub url: String,
+    /// Request headers.
+    pub headers: indexmap::IndexMap<String, String>,
+    /// Request body (None for GET requests, JSON string for POST).
+    pub body: Option<String>,
 }
 
 /// Extracted PrimitiveClient data (no HeapPtr, fully owned).
@@ -232,6 +248,7 @@ impl BexExternalValue {
             },
             BexExternalValue::PromptAst(_) => "prompt_ast",
             BexExternalValue::PrimitiveClient(_) => "primitive_client",
+            BexExternalValue::HttpRequest(_) => "http_request",
         }
     }
 }

--- a/baml_language/crates/bex_external_types/src/builtins.rs
+++ b/baml_language/crates/bex_external_types/src/builtins.rs
@@ -25,7 +25,7 @@ pub fn new_http_response(
     url: String,
 ) -> BexExternalValue {
     BexExternalValue::Instance {
-        class_name: "baml.http.Response".to_string(),
+        class_name: "baml.http.HttpResponse".to_string(),
         fields: indexmap! {
             "_handle".to_string() => BexExternalValue::Resource(handle),
             "status_code".to_string() => BexExternalValue::Int(i64::from(status_code)),

--- a/baml_language/crates/bex_external_types/src/lib.rs
+++ b/baml_language/crates/bex_external_types/src/lib.rs
@@ -28,7 +28,7 @@ mod epoch_guard;
 mod handle;
 
 pub use bex_external_value::{
-    BexExternalValue, PrimitiveClientValue, PromptAst, Ty, UnionMetadata,
+    BexExternalValue, HttpRequestValue, PrimitiveClientValue, PromptAst, Ty, UnionMetadata,
 };
 pub use bex_value::BexValue;
 pub use epoch_guard::EpochGuard;

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -317,6 +317,10 @@ impl BexHeap {
                 // PrimitiveClient.options is a heap pointer to a map
                 worklist.push(client.options);
             }
+            Object::HttpRequest(req) => {
+                // HttpRequest.headers is a heap pointer to a map
+                worklist.push(req.headers);
+            }
             // Primitives have no references
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => {}
@@ -414,6 +418,12 @@ impl BexHeap {
                 // Update options pointer
                 if let Some(&new_ptr) = forwarding.get(&client.options) {
                     client.options = new_ptr;
+                }
+            }
+            Object::HttpRequest(req) => {
+                // Update headers pointer
+                if let Some(&new_ptr) = forwarding.get(&req.headers) {
+                    req.headers = new_ptr;
                 }
             }
             // Primitives have no references

--- a/baml_language/crates/bex_heap/src/heap_debugger/real.rs
+++ b/baml_language/crates/bex_heap/src/heap_debugger/real.rs
@@ -352,6 +352,9 @@ impl BexHeap {
                 // Validate the options map reference
                 self.debug_assert_valid_index(client.options);
             }
+            Object::HttpRequest(req) => {
+                self.debug_assert_valid_index(req.headers);
+            }
             Object::Function(_)
             | Object::Class(_)
             | Object::Enum(_)

--- a/baml_language/crates/bex_jinja_runtime/src/value_conversion.rs
+++ b/baml_language/crates/bex_jinja_runtime/src/value_conversion.rs
@@ -75,5 +75,10 @@ pub(crate) fn external_value_to_jinja(value: &BexExternalValue) -> JinjaValue {
             // PrimitiveClient shouldn't appear in template arguments
             JinjaValue::from("[PrimitiveClient]")
         }
+
+        BexExternalValue::HttpRequest(_) => {
+            // HttpRequest shouldn't appear in template arguments
+            JinjaValue::from("[HttpRequest]")
+        }
     }
 }

--- a/baml_language/crates/bex_vm/src/native.rs
+++ b/baml_language/crates/bex_vm/src/native.rs
@@ -292,6 +292,7 @@ fn deep_copy_value_recursive(
                 Object::Future(f) => vm.tlab.alloc(Object::Future(f)),
                 Object::PromptAst(ast) => vm.tlab.alloc(Object::PromptAst(ast)),
                 Object::PrimitiveClient(c) => vm.tlab.alloc(Object::PrimitiveClient(c)),
+                Object::HttpRequest(r) => vm.tlab.alloc(Object::HttpRequest(r)),
                 #[cfg(feature = "heap_debug")]
                 Object::Sentinel(kind) => vm.tlab.alloc(Object::Sentinel(kind)),
             };
@@ -519,6 +520,7 @@ fn format_value_recursive(vm: &mut BexVm, value: &Value, depth: usize) -> Result
             Object::Future(_) => Ok("<future>".to_string()),
             Object::PromptAst(_) => Ok("<prompt_ast>".to_string()),
             Object::PrimitiveClient(c) => Ok(format!("<client {}:{}>", c.provider, c.name)),
+            Object::HttpRequest(r) => Ok(format!("<http_request {} {}>", r.method, r.url)),
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => Ok("<sentinel>".to_string()),
         },

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -350,6 +350,7 @@ fn value_type_tag(value: &Value) -> i64 {
                 Object::Resource(_) => type_tags::RESOURCE,
                 Object::PromptAst(_) => type_tags::PROMPT_AST,
                 Object::PrimitiveClient(_) => type_tags::PRIMITIVE_CLIENT,
+                Object::HttpRequest(_) => type_tags::HTTP_REQUEST,
                 Object::Class(_) => type_tags::UNKNOWN,
                 #[cfg(feature = "heap_debug")]
                 Object::Sentinel(_) => type_tags::UNKNOWN,
@@ -763,6 +764,27 @@ impl BexVm {
             Object::PrimitiveClient(client) => Ok(client),
             _ => Err(InternalError::TypeError {
                 expected: ObjectType::PrimitiveClient.into(),
+                got: ObjectType::of(obj).into(),
+            }),
+        }
+    }
+
+    /// Allocate an HTTP request object on the heap.
+    pub fn alloc_http_request(&mut self, req: bex_vm_types::HttpRequest) -> Value {
+        Value::Object(self.tlab.alloc(Object::HttpRequest(req)))
+    }
+
+    /// Get HTTP request from a Value.
+    pub fn as_http_request(
+        &self,
+        value: &Value,
+    ) -> Result<&bex_vm_types::HttpRequest, InternalError> {
+        let index = self.as_object_ptr(value, ObjectType::HttpRequest)?;
+        let obj = self.get_object(index);
+        match obj {
+            Object::HttpRequest(req) => Ok(req),
+            _ => Err(InternalError::TypeError {
+                expected: ObjectType::HttpRequest.into(),
                 got: ObjectType::of(obj).into(),
             }),
         }

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -22,6 +22,7 @@ pub use bytecode::{
 pub use heap_ptr::HeapPtr;
 pub use indexable::{GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, StackIndex};
 pub use types::{
-    Class, ConstValue, Enum, Function, FunctionKind, Future, Instance, Object, ObjectType,
-    PendingFuture, PrimitiveClient, Program, PromptAst, SysOp, Value, Variant, type_tags,
+    Class, ConstValue, Enum, Function, FunctionKind, Future, HttpRequest, Instance, Object,
+    ObjectType, PendingFuture, PrimitiveClient, Program, PromptAst, SysOp, Value, Variant,
+    type_tags,
 };

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -94,6 +94,8 @@ pub enum SysOp {
     RenderPrompt,
     /// Specialize a prompt for a specific provider: `PrimitiveClient.specialize_prompt(prompt) -> PromptAst`
     SpecializePrompt,
+    /// HTTP fetch with full request: `baml.http.fetch_http(request: HttpRequest) -> HttpResponse`
+    HttpFetchHttp,
 }
 
 impl std::fmt::Display for SysOp {
@@ -111,6 +113,7 @@ impl std::fmt::Display for SysOp {
             SysOp::ResponseOk => write!(f, "http.HttpResponse.ok"),
             SysOp::RenderPrompt => write!(f, "llm.render_prompt"),
             SysOp::SpecializePrompt => write!(f, "llm.specialize_prompt"),
+            SysOp::HttpFetchHttp => write!(f, "http.fetch_http"),
         }
     }
 }
@@ -423,6 +426,9 @@ pub enum Object {
     /// LLM primitive client.
     PrimitiveClient(PrimitiveClient),
 
+    /// HTTP request.
+    HttpRequest(HttpRequest),
+
     #[cfg(feature = "heap_debug")]
     Sentinel(SentinelKind),
     // TODO: Figure out how to handle this here.
@@ -446,6 +452,9 @@ impl std::fmt::Display for Object {
             Object::PromptAst(prompt) => write!(f, "<prompt_ast {prompt:?}>"),
             Object::PrimitiveClient(client) => {
                 write!(f, "<client {}:{}>", client.provider, client.name)
+            }
+            Object::HttpRequest(req) => {
+                write!(f, "<http_request {} {}>", req.method, req.url)
             }
             Object::Future(future) => match future {
                 Future::Pending(future) => {
@@ -551,6 +560,23 @@ pub struct PrimitiveClient {
 }
 
 // ============================================================================
+// HttpRequest - represents an HTTP request value
+// ============================================================================
+
+/// An HTTP request value.
+#[derive(Clone, Debug)]
+pub struct HttpRequest {
+    /// HTTP method (e.g., "GET", "POST").
+    pub method: String,
+    /// Request URL.
+    pub url: String,
+    /// Request headers (heap-allocated map).
+    pub headers: HeapPtr,
+    /// Request body (None for GET, JSON string for POST).
+    pub body: Option<String>,
+}
+
+// ============================================================================
 // PromptAst - represents a structured prompt (recursive tree)
 // ============================================================================
 
@@ -637,6 +663,7 @@ pub enum ObjectType {
     Resource,
     PromptAst,
     PrimitiveClient,
+    HttpRequest,
 }
 
 impl ObjectType {
@@ -654,6 +681,7 @@ impl ObjectType {
             Object::Resource(_) => Self::Resource,
             Object::PromptAst(_) => Self::PromptAst,
             Object::PrimitiveClient(_) => Self::PrimitiveClient,
+            Object::HttpRequest(_) => Self::HttpRequest,
             Object::Future(fut) => Self::Future(fut.into()),
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => Self::Any,
@@ -691,6 +719,7 @@ impl std::fmt::Display for ObjectType {
             ObjectType::Resource => write!(f, "resource"),
             ObjectType::PromptAst => write!(f, "prompt_ast"),
             ObjectType::PrimitiveClient => write!(f, "primitive_client"),
+            ObjectType::HttpRequest => write!(f, "http_request"),
         }
     }
 }

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -107,8 +107,8 @@ impl std::fmt::Display for SysOp {
             SysOp::NetRead => write!(f, "net.read"),
             SysOp::NetClose => write!(f, "net.close"),
             SysOp::HttpFetch => write!(f, "http.fetch"),
-            SysOp::ResponseText => write!(f, "http.Response.text"),
-            SysOp::ResponseOk => write!(f, "http.Response.ok"),
+            SysOp::ResponseText => write!(f, "http.HttpResponse.text"),
+            SysOp::ResponseOk => write!(f, "http.HttpResponse.ok"),
             SysOp::RenderPrompt => write!(f, "llm.render_prompt"),
             SysOp::SpecializePrompt => write!(f, "llm.specialize_prompt"),
         }

--- a/baml_language/crates/sys_native/src/lib.rs
+++ b/baml_language/crates/sys_native/src/lib.rs
@@ -37,6 +37,7 @@ impl SysOpsExt for SysOps {
             net_close: ops::net::close,
             shell: ops::sys::shell,
             http_fetch: ops::http::fetch,
+            http_fetch_http: ops::http::fetch_http,
             http_response_text: ops::http::text,
             http_response_ok: ops::http::ok,
         }

--- a/baml_language/crates/sys_native/src/ops/http.rs
+++ b/baml_language/crates/sys_native/src/ops/http.rs
@@ -171,6 +171,57 @@ async fn fetch_async(url: String) -> Result<BexExternalValue, OpError> {
     ))
 }
 
+/// Fetches using a full `HttpRequest` object and returns an `HttpResponse` resource.
+///
+/// Signature: `fn fetch_http(request: HttpRequest) -> HttpResponse`
+pub(crate) fn fetch_http(args: Vec<BexExternalValue>) -> SysOpResult {
+    SysOpResult::Async(Box::pin(fetch_http_async(args)))
+}
+
+async fn fetch_http_async(args: Vec<BexExternalValue>) -> Result<BexExternalValue, OpError> {
+    let req = match args.into_iter().next() {
+        Some(BexExternalValue::HttpRequest(r)) => r,
+        other => {
+            return Err(OpError::TypeError {
+                expected: "HttpRequest",
+                actual: format!("{other:?}"),
+            });
+        }
+    };
+
+    let method = req
+        .method
+        .parse::<reqwest::Method>()
+        .map_err(|e| OpError::Other(format!("Invalid HTTP method '{}': {e}", req.method)))?;
+
+    let mut builder = HTTP_CLIENT.request(method, &req.url);
+
+    for (key, value) in &req.headers {
+        builder = builder.header(key.as_str(), value.as_str());
+    }
+
+    if let Some(body) = req.body {
+        builder = builder.body(body);
+    }
+
+    let response = builder
+        .send()
+        .await
+        .map_err(|e| OpError::Other(format!("HTTP request failed for '{}': {e}", req.url)))?;
+
+    // Capture metadata before storing
+    let status = response.status().as_u16();
+    let headers: HashMap<String, String> = response
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let final_url = response.url().to_string();
+
+    let handle = REGISTRY.register_http_response(response, status, headers, final_url);
+    Ok(BexExternalValue::Resource(handle))
+}
+
 /// Gets the response body as text (consumes the body).
 ///
 /// Signature: `fn text(self: Response) -> String`

--- a/baml_language/crates/sys_native/src/ops/http.rs
+++ b/baml_language/crates/sys_native/src/ops/http.rs
@@ -62,7 +62,7 @@ impl ResponseRef {
                         return Err(OpError::Other("bad class ptr".into()));
                     };
 
-                    if class.name != "baml.http.Response" {
+                    if class.name != "baml.http.HttpResponse" {
                         return Err(OpError::TypeError {
                             expected: "Response instance",
                             actual: format!("Instance of {}", class.name),
@@ -93,7 +93,7 @@ impl ResponseRef {
             }
             BexValue::External(BexExternalValue::Instance { class_name, fields }) => {
                 // Already copied out - extract directly
-                if class_name != "baml.http.Response" {
+                if class_name != "baml.http.HttpResponse" {
                     return Err(OpError::TypeError {
                         expected: "Response instance",
                         actual: format!("Instance of {class_name}"),

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -102,6 +102,7 @@ pub struct SysOps {
 
     // HTTP operations
     pub http_fetch: SysOpFn,
+    pub http_fetch_http: SysOpFn,
     pub http_response_text: SysOpFn,
     pub http_response_ok: SysOpFn,
 }
@@ -185,6 +186,11 @@ impl SysOps {
                     operation: SysOp::SpecializePrompt,
                 }))
             },
+            SysOp::HttpFetchHttp => |_| {
+                SysOpResult::Ready(Err(OpError::Unsupported {
+                    operation: SysOp::HttpFetchHttp,
+                }))
+            },
         }
     }
 
@@ -201,6 +207,7 @@ impl SysOps {
             net_close: Self::unsupported(SysOp::NetClose),
             shell: Self::unsupported(SysOp::Shell),
             http_fetch: Self::unsupported(SysOp::HttpFetch),
+            http_fetch_http: Self::unsupported(SysOp::HttpFetchHttp),
             http_response_text: Self::unsupported(SysOp::ResponseText),
             http_response_ok: Self::unsupported(SysOp::ResponseOk),
         }

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -2463,6 +2463,7 @@ fn format_vm_value(value: &bex_vm_types::Value, vm: &bex_vm::BexVm) -> String {
                 Object::Resource(r) => format!("<resource: {}>", r),
                 Object::PromptAst(_) => "<prompt_ast>".to_string(),
                 Object::PrimitiveClient(c) => format!("<client {}:{}>", c.provider, c.name),
+                Object::HttpRequest(r) => format!("<http_request {} {}>", r.method, r.url),
                 #[cfg(feature = "heap_debug")]
                 Object::Sentinel(_) => "<sentinel>".to_string(),
             }


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Implements `baml.http.HttpRequest` type and `fetch_http()` function to enable full HTTP request control (method, headers, body). Renames `Response` to `HttpResponse` for clarity. Adds proper type handling across VM, GC, and serialization layers.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ebc6cc37e3cf73b5b08db010d5897198c870509f.</sup>
<!-- /MENDRAL_SUMMARY -->