### PR TITLE
chore/baml-language: move cargo components into rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -235,14 +235,11 @@ jobs:
           workspaces: "baml_language -> target"
 
       - name: "Install Rust toolchain"
-        run: rustup show
+        run: rustup toolchain install
         working-directory: baml_language
 
-      - name: "Install clippy and wasm target"
+      - name: "Install cargo-binstall"
         run: |
-          rustup component add clippy
-          rustup target add wasm32-unknown-unknown
-          # install cargo binstall
           curl -L --proto '=https' --tlsv1.2 -sSf \
             https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh \
             | bash

--- a/baml_language/rust-toolchain.toml
+++ b/baml_language/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.89"
-components = ["rust-analyzer", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]
+components = ["clippy", "rust-analyzer", "rustfmt"]


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Refactors Rust toolchain management by moving clippy component and wasm32-unknown-unknown target into rust-toolchain.toml, and simplifies CI workflow steps accordingly.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit ee1ff15ee9f0b7ec5c56e52555f97eeab3a36129.</sup>
<!-- /MENDRAL_SUMMARY -->