### PR TITLE
baml-language: rename baml.http.Response to baml.http.HttpResponse

### DIFF
--- a/baml_language/crates/baml_builtins/src/lib.rs
+++ b/baml_language/crates/baml_builtins/src/lib.rs
@@ -52,7 +52,7 @@ pub struct BuiltinField {
 /// A builtin type definition (struct with fields).
 #[derive(Debug, Clone)]
 pub struct BuiltinTypeDefinition {
-    /// Full path (e.g., "baml.http.Response").
+    /// Full path (e.g., "baml.http.HttpResponse").
     pub path: &'static str,
     /// All fields (public and private) in runtime order.
     pub fields: Vec<BuiltinField>,
@@ -228,22 +228,22 @@ macro_rules! with_builtins {
                 // =====================================================================
                 mod http {
                     #[builtin]
-                    struct Response {
+                    struct HttpResponse {
                         private _handle: ResourceHandle,
                         status_code: i64,
                         headers: Map<String, String>,
                         url: String,
                         /// Get response body as text (consumes body).
                         #[sys_op]
-                        fn text(self: Response) -> String;
+                        fn text(self: HttpResponse) -> String;
                         /// Check if status is 2xx.
                         #[sys_op]
-                        fn ok(self: Response) -> bool;
+                        fn ok(self: HttpResponse) -> bool;
                     }
 
                     /// Fetch a URL via HTTP GET.
                     #[sys_op]
-                    fn fetch(url: String) -> Response;
+                    fn fetch(url: String) -> HttpResponse;
                 }
 
                 // =====================================================================
@@ -435,7 +435,7 @@ mod tests {
         assert!(find_builtin_by_path("baml.llm.PromptAst").is_none());
 
         // Other builtins in the same parent module are still visible
-        assert!(find_builtin_by_path("baml.http.Response.text").is_some());
+        assert!(find_builtin_by_path("baml.http.HttpResponse.text").is_some());
         assert!(find_builtin_by_path("baml.http.fetch").is_some());
     }
 
@@ -493,7 +493,7 @@ mod tests {
         );
 
         // Find Response type
-        let response = find_builtin_type("baml.http.Response");
+        let response = find_builtin_type("baml.http.HttpResponse");
         assert!(response.is_some(), "Response type should exist");
         let response = response.unwrap();
 
@@ -516,14 +516,14 @@ mod tests {
         );
 
         // Check status_code is public
-        let status_field = find_field("baml.http.Response", "status_code");
+        let status_field = find_field("baml.http.HttpResponse", "status_code");
         assert!(status_field.is_some(), "status_code field should exist");
         let status_field = status_field.unwrap();
         assert!(!status_field.is_private, "status_code should be public");
         assert!(matches!(status_field.ty, Some(TypePattern::Int)));
 
         // Check headers field type is Map<String, String>
-        let headers_field = find_field("baml.http.Response", "headers");
+        let headers_field = find_field("baml.http.HttpResponse", "headers");
         assert!(headers_field.is_some(), "headers field should exist");
         let headers_field = headers_field.unwrap();
         assert!(matches!(headers_field.ty, Some(TypePattern::Map { .. })));

--- a/baml_language/crates/baml_builtins_macros/src/lib.rs
+++ b/baml_language/crates/baml_builtins_macros/src/lib.rs
@@ -31,7 +31,7 @@ struct BuiltinDef {
 
 /// A collected builtin type definition (struct marked with #[builtin]).
 struct BuiltinTypeDef {
-    /// Full path like "baml.http.Response"
+    /// Full path like "baml.http.HttpResponse"
     path: String,
     /// Field definitions
     fields: Vec<BuiltinFieldDef>,

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -438,8 +438,8 @@ fn sys_op_for_builtin_path(path: &str) -> Option<SysOp> {
         "baml.net.Socket.read" => Some(SysOp::NetRead),
         "baml.net.Socket.close" => Some(SysOp::NetClose),
         "baml.http.fetch" => Some(SysOp::HttpFetch),
-        "baml.http.Response.text" => Some(SysOp::ResponseText),
-        "baml.http.Response.ok" => Some(SysOp::ResponseOk),
+        "baml.http.HttpResponse.text" => Some(SysOp::ResponseText),
+        "baml.http.HttpResponse.ok" => Some(SysOp::ResponseOk),
         _ => None,
     }
 }

--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -1954,7 +1954,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
 
     /// Extract class name from a Ty.
     ///
-    /// For builtin classes, returns the full path (e.g., "baml.http.Response").
+    /// For builtin classes, returns the full path (e.g., "baml.http.HttpResponse").
     /// For user classes, returns just the name (e.g., "`MyClass`").
     fn class_name_from_ty(ty: &Ty) -> Option<String> {
         match ty {

--- a/baml_language/crates/baml_compiler_tir/src/builtins.rs
+++ b/baml_language/crates/baml_compiler_tir/src/builtins.rs
@@ -11,7 +11,7 @@ use baml_compiler_hir::FullyQualifiedName;
 
 use crate::Ty;
 
-/// Parse a builtin path string like "baml.http.Response" into an FQN.
+/// Parse a builtin path string like "baml.http.HttpResponse" into an FQN.
 ///
 /// The path is expected to start with "baml." and have at least one segment after.
 pub fn parse_builtin_path(path: &str) -> FullyQualifiedName {

--- a/baml_language/crates/bex_external_types/src/builtins.rs
+++ b/baml_language/crates/bex_external_types/src/builtins.rs
@@ -25,7 +25,7 @@ pub fn new_http_response(
     url: String,
 ) -> BexExternalValue {
     BexExternalValue::Instance {
-        class_name: "baml.http.Response".to_string(),
+        class_name: "baml.http.HttpResponse".to_string(),
         fields: indexmap! {
             "_handle".to_string() => BexExternalValue::Resource(handle),
             "status_code".to_string() => BexExternalValue::Int(i64::from(status_code)),

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -107,8 +107,8 @@ impl std::fmt::Display for SysOp {
             SysOp::NetRead => write!(f, "net.read"),
             SysOp::NetClose => write!(f, "net.close"),
             SysOp::HttpFetch => write!(f, "http.fetch"),
-            SysOp::ResponseText => write!(f, "http.Response.text"),
-            SysOp::ResponseOk => write!(f, "http.Response.ok"),
+            SysOp::ResponseText => write!(f, "http.HttpResponse.text"),
+            SysOp::ResponseOk => write!(f, "http.HttpResponse.ok"),
             SysOp::RenderPrompt => write!(f, "llm.render_prompt"),
             SysOp::SpecializePrompt => write!(f, "llm.specialize_prompt"),
         }

--- a/baml_language/crates/sys_native/src/ops/http.rs
+++ b/baml_language/crates/sys_native/src/ops/http.rs
@@ -62,7 +62,7 @@ impl ResponseRef {
                         return Err(OpError::Other("bad class ptr".into()));
                     };
 
-                    if class.name != "baml.http.Response" {
+                    if class.name != "baml.http.HttpResponse" {
                         return Err(OpError::TypeError {
                             expected: "Response instance",
                             actual: format!("Instance of {}", class.name),
@@ -93,7 +93,7 @@ impl ResponseRef {
             }
             BexValue::External(BexExternalValue::Instance { class_name, fields }) => {
                 // Already copied out - extract directly
-                if class_name != "baml.http.Response" {
+                if class_name != "baml.http.HttpResponse" {
                     return Err(OpError::TypeError {
                         expected: "Response instance",
                         actual: format!("Instance of {class_name}"),


### PR DESCRIPTION
<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Renames the builtin type `baml.http.Response` to `baml.http.HttpResponse` across all internal references, including type definitions, system operations, runtime checks, and tests.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 14ce6c8ab4e6bdaf0cbbef49823308c3bf488fb9.</sup>
<!-- /MENDRAL_SUMMARY -->