### PR TITLE
baml-language: impl http.send

### DIFF
--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-b605630ce3acfe9e/out/generated_tests.rs
+source: target/debug/build/baml_tests-45411f112e4e4282/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -791,7 +791,7 @@ impl BexEngine {
             )),
             SysOp::LlmBuildRequest => SysOpResult::Ready(sys_llm::execute_build_request(args)),
             SysOp::LlmParseResponse => SysOpResult::Ready(sys_llm::execute_parse_response(args)),
-            SysOp::HttpSend => SysOpResult::Ready(sys_llm::execute_http_send(args)),
+            SysOp::HttpSend => (self.sys_ops.http_send)(heap, args),
         }
     }
 }

--- a/baml_language/crates/bex_external_types/src/builtins.rs
+++ b/baml_language/crates/bex_external_types/src/builtins.rs
@@ -52,6 +52,29 @@ pub fn new_file(handle: ResourceHandle) -> BexExternalValue {
     }
 }
 
+/// Create a new HTTP Request instance for a GET request.
+///
+/// Field order:
+/// 0. method
+/// 1. url
+/// 2. headers (empty)
+/// 3. body (empty)
+pub fn new_http_request_get(url: String) -> BexExternalValue {
+    BexExternalValue::Instance {
+        class_name: "baml.http.Request".to_string(),
+        fields: indexmap! {
+            "method".to_string() => BexExternalValue::String("GET".to_string()),
+            "url".to_string() => BexExternalValue::String(url),
+            "headers".to_string() => BexExternalValue::Map {
+                key_type: Ty::String,
+                value_type: Ty::String,
+                entries: indexmap::IndexMap::new(),
+            },
+            "body".to_string() => BexExternalValue::String(String::new()),
+        },
+    }
+}
+
 /// Create a new Socket instance.
 ///
 /// Field order:

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -235,13 +235,3 @@ pub fn execute_build_request(_args: &[BexValue]) -> Result<BexExternalValue, OpE
 pub fn execute_parse_response(_args: &[BexValue]) -> Result<BexExternalValue, OpError> {
     panic!("LlmParseResponse SysOp not yet implemented - TODO: port from legacy")
 }
-
-/// Execute the `http.send` operation.
-///
-/// Arguments: `[request: Request]`
-/// Returns: `Response`
-///
-/// TODO: Implement this by extending the HTTP client to support full requests.
-pub fn execute_http_send(_args: &[BexValue]) -> Result<BexExternalValue, OpError> {
-    panic!("HttpSend SysOp not yet implemented - TODO: implement HTTP POST support")
-}

--- a/baml_language/crates/sys_native/src/lib.rs
+++ b/baml_language/crates/sys_native/src/lib.rs
@@ -39,6 +39,7 @@ impl SysOpsExt for SysOps {
             http_fetch: ops::http::fetch,
             http_response_text: ops::http::text,
             http_response_ok: ops::http::ok,
+            http_send: ops::http::send,
         }
     }
 }

--- a/baml_language/crates/sys_native/src/ops/http.rs
+++ b/baml_language/crates/sys_native/src/ops/http.rs
@@ -122,6 +122,150 @@ impl ResponseRef {
     }
 }
 
+/// Wrapper for Request instance that provides GC-safe access to fields.
+struct RequestRef {
+    method: String,
+    url: String,
+    headers: Vec<(String, String)>,
+    body: String,
+}
+
+impl RequestRef {
+    /// Extract a `RequestRef` from a `BexValue` that should be a Request instance.
+    fn from_value(heap: &Arc<BexHeap>, value: &BexValue) -> Result<Self, OpError> {
+        match value {
+            BexValue::Opaque(handle) => {
+                heap.with_gc_protection(|protected| {
+                    let ptr = protected
+                        .resolve_handle(handle.slab_key())
+                        .ok_or_else(|| OpError::Other("invalid handle".into()))?;
+
+                    // SAFETY: GC protection held, pointer is valid
+                    let obj = unsafe { ptr.get() };
+                    let Object::Instance(inst) = obj else {
+                        return Err(OpError::TypeError {
+                            expected: "Request instance",
+                            actual: format!("{obj:?}"),
+                        });
+                    };
+
+                    let Object::Class(class) = (unsafe { inst.class.get() }) else {
+                        return Err(OpError::Other("bad class ptr".into()));
+                    };
+
+                    if class.name != "baml.http.Request" {
+                        return Err(OpError::TypeError {
+                            expected: "Request instance",
+                            actual: format!("Instance of {}", class.name),
+                        });
+                    }
+
+                    // Extract fields by name
+                    let field_idx = |name: &str| -> Result<usize, OpError> {
+                        class
+                            .field_names
+                            .iter()
+                            .position(|n| n == name)
+                            .ok_or_else(|| OpError::Other(format!("missing field '{name}'")))
+                    };
+
+                    let extract_string = |idx: usize| -> Result<String, OpError> {
+                        match inst.fields.get(idx) {
+                            Some(Value::Object(h)) => match unsafe { h.get() } {
+                                Object::String(s) => Ok(s.clone()),
+                                other => Err(OpError::TypeError {
+                                    expected: "String",
+                                    actual: format!("{other:?}"),
+                                }),
+                            },
+                            other => Err(OpError::Other(format!("invalid field value: {other:?}"))),
+                        }
+                    };
+
+                    let method = extract_string(field_idx("method")?)?;
+                    let url = extract_string(field_idx("url")?)?;
+                    let body = extract_string(field_idx("body")?)?;
+
+                    // Extract headers map
+                    let headers_idx = field_idx("headers")?;
+                    let headers = match inst.fields.get(headers_idx) {
+                        Some(Value::Object(h)) => match unsafe { h.get() } {
+                            Object::Map(map) => map
+                                .iter()
+                                .map(|(k, v)| {
+                                    let val = match v {
+                                        Value::Object(ptr) => match unsafe { ptr.get() } {
+                                            Object::String(s) => s.clone(),
+                                            _ => String::new(),
+                                        },
+                                        _ => String::new(),
+                                    };
+                                    (k.clone(), val)
+                                })
+                                .collect(),
+                            _ => Vec::new(),
+                        },
+                        _ => Vec::new(),
+                    };
+
+                    Ok(Self {
+                        method,
+                        url,
+                        headers,
+                        body,
+                    })
+                })
+            }
+            BexValue::External(BexExternalValue::Instance { class_name, fields }) => {
+                if class_name != "baml.http.Request" {
+                    return Err(OpError::TypeError {
+                        expected: "Request instance",
+                        actual: format!("Instance of {class_name}"),
+                    });
+                }
+
+                let extract_string = |name: &str| -> Result<String, OpError> {
+                    match fields.get(name) {
+                        Some(BexExternalValue::String(s)) => Ok(s.clone()),
+                        other => Err(OpError::Other(format!(
+                            "expected String for '{name}', got {other:?}"
+                        ))),
+                    }
+                };
+
+                let method = extract_string("method")?;
+                let url = extract_string("url")?;
+                let body = extract_string("body")?;
+
+                let headers = match fields.get("headers") {
+                    Some(BexExternalValue::Map { entries, .. }) => entries
+                        .iter()
+                        .filter_map(|(k, v)| {
+                            if let BexExternalValue::String(s) = v {
+                                Some((k.clone(), s.clone()))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect(),
+                    _ => Vec::new(),
+                };
+
+                Ok(Self {
+                    method,
+                    url,
+                    headers,
+                    body,
+                })
+            }
+            other => Err(OpError::TypeError {
+                expected: "Request instance",
+                actual: format!("{other:?}"),
+            }),
+        }
+    }
+}
+
 // ============================================================================
 // HTTP Operations
 // ============================================================================
@@ -129,13 +273,26 @@ impl ResponseRef {
 /// Fetches a URL and returns a Response resource.
 ///
 /// Signature: `fn fetch(url: String) -> Response`
+///
+/// Implemented as a GET request via `send_async`.
 pub(crate) fn fetch(_heap: Arc<BexHeap>, args: &[BexValue]) -> SysOpResult {
-    // Clone the string argument for the async block
-    let url = match extract_string(&args.first().cloned().unwrap_or_default()) {
+    let Some(arg) = args.first() else {
+        return SysOpResult::Ready(Err(OpError::TypeError {
+            expected: "url argument",
+            actual: "no arguments".to_string(),
+        }));
+    };
+    let url = match extract_string(arg) {
         Ok(u) => u,
         Err(e) => return SysOpResult::Ready(Err(e)),
     };
-    SysOpResult::Async(Box::pin(fetch_async(url)))
+    let request_ref = RequestRef {
+        method: "GET".to_string(),
+        url,
+        headers: Vec::new(),
+        body: String::new(),
+    };
+    SysOpResult::Async(Box::pin(send_async(request_ref)))
 }
 
 fn extract_string(value: &BexValue) -> Result<String, OpError> {
@@ -146,29 +303,6 @@ fn extract_string(value: &BexValue) -> Result<String, OpError> {
             actual: format!("{other:?}"),
         }),
     }
-}
-
-async fn fetch_async(url: String) -> Result<BexExternalValue, OpError> {
-    let response = HTTP_CLIENT
-        .get(&url)
-        .send()
-        .await
-        .map_err(|e| OpError::Other(format!("HTTP request failed for '{url}': {e}")))?;
-
-    // Capture metadata before storing
-    let status = response.status().as_u16();
-    let headers: HashMap<String, String> = response
-        .headers()
-        .iter()
-        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
-        .collect();
-    let final_url = response.url().to_string();
-
-    let handle =
-        REGISTRY.register_http_response(response, status, headers.clone(), final_url.clone());
-    Ok(bex_external_types::builtins::new_http_response(
-        handle, status, headers, final_url,
-    ))
 }
 
 /// Gets the response body as text (consumes the body).
@@ -235,4 +369,59 @@ fn ok_sync(heap: &Arc<BexHeap>, args: &[BexValue]) -> Result<BexExternalValue, O
         .ok_or_else(|| OpError::Other("Response handle is invalid".into()))?;
 
     Ok(BexExternalValue::Bool((200..300).contains(&status)))
+}
+
+/// Sends an HTTP request and returns a Response.
+///
+/// Signature: `fn send(request: Request) -> Response`
+pub(crate) fn send(heap: Arc<BexHeap>, args: &[BexValue]) -> SysOpResult {
+    let request_ref = match args.first() {
+        Some(value) => match RequestRef::from_value(&heap, value) {
+            Ok(r) => r,
+            Err(e) => return SysOpResult::Ready(Err(e)),
+        },
+        None => {
+            return SysOpResult::Ready(Err(OpError::TypeError {
+                expected: "Request instance",
+                actual: "no arguments".to_string(),
+            }));
+        }
+    };
+
+    SysOpResult::Async(Box::pin(send_async(request_ref)))
+}
+
+async fn send_async(req: RequestRef) -> Result<BexExternalValue, OpError> {
+    let method = reqwest::Method::from_bytes(req.method.as_bytes())
+        .map_err(|e| OpError::Other(format!("Invalid HTTP method '{}': {e}", req.method)))?;
+
+    let mut builder = HTTP_CLIENT.request(method, &req.url);
+
+    for (key, value) in &req.headers {
+        builder = builder.header(key.as_str(), value.as_str());
+    }
+
+    if !req.body.is_empty() {
+        builder = builder.body(req.body);
+    }
+
+    let response = builder
+        .send()
+        .await
+        .map_err(|e| OpError::Other(format!("HTTP request failed for '{}': {e}", req.url)))?;
+
+    // Capture metadata before storing
+    let status = response.status().as_u16();
+    let headers: HashMap<String, String> = response
+        .headers()
+        .iter()
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+    let final_url = response.url().to_string();
+
+    let handle =
+        REGISTRY.register_http_response(response, status, headers.clone(), final_url.clone());
+    Ok(bex_external_types::builtins::new_http_response(
+        handle, status, headers, final_url,
+    ))
 }

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -104,6 +104,7 @@ pub struct SysOps {
     pub http_fetch: SysOpFn,
     pub http_response_text: SysOpFn,
     pub http_response_ok: SysOpFn,
+    pub http_send: SysOpFn,
 }
 
 impl SysOps {
@@ -234,6 +235,7 @@ impl SysOps {
             http_fetch: Self::unsupported(SysOp::HttpFetch),
             http_response_text: Self::unsupported(SysOp::ResponseText),
             http_response_ok: Self::unsupported(SysOp::ResponseOk),
+            http_send: Self::unsupported(SysOp::HttpSend),
         }
     }
 }


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Removes Request.get() constructor and associated tests, simplifying the HTTP API surface. The core http.send() implementation remains unchanged.
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4658ee1ff3bcbb13d2c17f186f9b219030065f59.</sup>
<!-- /MENDRAL_SUMMARY -->