### PR TITLE
baml-language: impl build_request for llm functions

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -4572,7 +4572,10 @@ dependencies = [
  "bex_program",
  "bex_vm_types",
  "indexmap 2.13.0",
+ "serde_json",
+ "strum",
  "sys_types",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -163,6 +163,7 @@ walkdir = { version = "2.4" }
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.3"
 webbrowser = "1.0.5"
+strum = { version = "0.26", features = [ "derive" ] }
 wee_alloc = "0.4"
 wiremock = "0.6"
 [workspace.lints.rust]

--- a/baml_language/crates/bex_engine/tests/llm_render.rs
+++ b/baml_language/crates/bex_engine/tests/llm_render.rs
@@ -437,13 +437,12 @@ function get_prompt() -> PromptAst {
     }
 }
 
-/// Test that `build_request` panics (not yet implemented).
+/// Test that `build_request` succeeds and returns an `int` result.
 ///
 /// This test verifies the `baml.llm.build_request` entry point is callable
-/// but panics because the underlying `LlmBuildRequest` `SysOp` is not implemented.
+/// and the underlying `LlmBuildRequest` `SysOp` is implemented.
 #[tokio::test]
-#[should_panic(expected = "LlmBuildRequest SysOp not yet implemented")]
-async fn test_build_request_panics() {
+async fn test_build_request_returns() {
     use std::collections::HashMap;
 
     use bex_engine::BexEngine;
@@ -475,16 +474,16 @@ function test_build_request() -> int {
     let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
         .expect("Failed to create engine");
 
-    // This should panic with "LlmBuildRequest SysOp not yet implemented"
-    let _ = engine.call_function("test_build_request", &[]).await;
+    let result = engine.call_function("test_build_request", &[]).await;
+    assert!(result.is_ok(), "build_request should succeed: {result:?}");
 }
 
-/// Test that `call_llm_function` panics (not yet implemented).
+/// Test that `call_llm_function` panics (parse response not yet implemented).
 ///
 /// This test verifies the `baml.llm.call_llm_function` entry point is callable
-/// but panics because the underlying `SysOps` are not implemented.
+/// but panics because the underlying `LlmParseResponse` `SysOp` is not implemented.
 #[tokio::test]
-#[should_panic(expected = "LlmBuildRequest SysOp not yet implemented")]
+#[should_panic(expected = "LlmParseResponse SysOp not yet implemented")]
 async fn test_call_llm_function_panics() {
     use std::collections::HashMap;
 
@@ -516,7 +515,7 @@ function test_call_llm() -> string {
     let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
         .expect("Failed to create engine");
 
-    // This should panic with "LlmBuildRequest SysOp not yet implemented"
-    // (build_request is called before http.send and parse)
+    // build_request now succeeds; this should panic at the next unimplemented
+    // step: "LlmParseResponse SysOp not yet implemented"
     let _ = engine.call_function("test_call_llm", &[]).await;
 }

--- a/baml_language/crates/sys_llm/Cargo.toml
+++ b/baml_language/crates/sys_llm/Cargo.toml
@@ -13,6 +13,9 @@ bex_llm_types = { workspace = true }
 bex_vm_types = { workspace = true }
 sys_types = { workspace = true }
 indexmap = { workspace = true }
+serde_json = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 bex_program = { workspace = true }

--- a/baml_language/crates/sys_llm/src/build_request/anthropic.rs
+++ b/baml_language/crates/sys_llm/src/build_request/anthropic.rs
@@ -1,0 +1,105 @@
+//! Anthropic-format HTTP request builder.
+
+use bex_external_types::{BexExternalValue, PrimitiveClientValue, PromptAst};
+use indexmap::IndexMap;
+
+use super::{BuildRequestError, LlmRequestBuilder, get_string_option, prompt_to_content_parts};
+
+/// Builder for the Anthropic provider.
+pub(crate) struct AnthropicBuilder;
+
+impl LlmRequestBuilder for AnthropicBuilder {
+    fn provider_skip_keys(&self) -> &'static [&'static str] {
+        &["anthropic_version"]
+    }
+
+    fn build_url(&self, client: &PrimitiveClientValue) -> Result<String, BuildRequestError> {
+        let base_url = get_string_option(client, "base_url")
+            .unwrap_or_else(|| "https://api.anthropic.com".to_string());
+        Ok(format!("{base_url}/v1/messages"))
+    }
+
+    fn build_auth_headers(&self, client: &PrimitiveClientValue) -> IndexMap<String, String> {
+        let mut headers = IndexMap::new();
+        // Anthropic uses x-api-key header
+        if let Some(api_key) = get_string_option(client, "api_key") {
+            headers.insert("x-api-key".to_string(), api_key);
+        }
+        // Anthropic version header
+        let version = get_string_option(client, "anthropic_version")
+            .unwrap_or_else(|| "2023-06-01".to_string());
+        headers.insert("anthropic-version".to_string(), version);
+        headers
+    }
+
+    fn build_prompt_body(&self, prompt: PromptAst) -> serde_json::Map<String, serde_json::Value> {
+        let mut map = serde_json::Map::new();
+        let (system_parts, messages) = extract_system_and_messages(prompt);
+        if !system_parts.is_empty() {
+            map.insert("system".to_string(), serde_json::Value::Array(system_parts));
+        }
+        map.insert("messages".to_string(), serde_json::Value::Array(messages));
+        map
+    }
+}
+
+/// Extract system messages to a separate array and return non-system messages.
+///
+/// Anthropic format:
+/// - System: top-level `"system": [{"type": "text", "text": "..."}]`
+/// - Messages: `[{"role": "user", "content": [{"type": "text", "text": "..."}]}]`
+fn extract_system_and_messages(
+    prompt: PromptAst,
+) -> (Vec<serde_json::Value>, Vec<serde_json::Value>) {
+    let mut system_parts = Vec::new();
+    let mut messages = Vec::new();
+
+    let items = match prompt {
+        PromptAst::Vec(items) => items,
+        single => vec![single],
+    };
+
+    for item in items {
+        match item {
+            PromptAst::Message {
+                role,
+                content,
+                metadata: _,
+            } if role == "system" => {
+                // System messages → top-level system field
+                let parts = prompt_to_content_parts(*content);
+                system_parts.extend(parts);
+            }
+            PromptAst::Message {
+                role,
+                content,
+                metadata,
+            } => {
+                // Non-system messages → messages array
+                let content_parts = prompt_to_content_parts(*content);
+                let mut msg = serde_json::Map::new();
+                msg.insert("role".to_string(), serde_json::Value::String(role));
+                msg.insert(
+                    "content".to_string(),
+                    serde_json::Value::Array(content_parts),
+                );
+
+                // Add metadata (e.g., cache_control)
+                if let BexExternalValue::Map { entries, .. } = *metadata {
+                    for (key, value) in entries {
+                        if let BexExternalValue::String(v) = value {
+                            msg.insert(key, serde_json::Value::String(v));
+                        } else if let BexExternalValue::Bool(v) = value {
+                            msg.insert(key, serde_json::Value::Bool(v));
+                        }
+                    }
+                }
+
+                messages.push(serde_json::Value::Object(msg));
+            }
+            _ => {} // Skip non-message nodes
+        }
+    }
+
+    (system_parts, messages)
+}

--- a/baml_language/crates/sys_llm/src/build_request/mod.rs
+++ b/baml_language/crates/sys_llm/src/build_request/mod.rs
@@ -1,0 +1,695 @@
+//! LlmProvider-specific HTTP request building.
+//!
+//! Converts a `PrimitiveClient` + `PromptAst` into a `baml.http.Request` instance.
+
+mod anthropic;
+mod openai;
+
+use std::str::FromStr;
+
+use bex_external_types::{BexExternalValue, PrimitiveClientValue, PromptAst, Ty};
+use indexmap::indexmap;
+
+use crate::LlmProvider;
+
+/// Option keys consumed by `specialize_prompt` — never forwarded to the request body.
+const SPECIALIZE_PROMPT_SKIP_KEYS: &[&str] = &[
+    "max_one_system_prompt",
+    "allowed_role_metadata",
+    "default_role",
+    "allowed_roles",
+];
+
+/// Option keys consumed by `build_request` itself (URL, auth, headers, model) —
+/// never forwarded to the request body.
+const BUILD_REQUEST_SKIP_KEYS: &[&str] = &["api_key", "base_url", "model", "headers"];
+
+/// Trait for building provider-specific HTTP requests.
+///
+/// Default methods handle shared logic (body assembly, option forwarding, header
+/// merging). Each provider implements only the parts that differ.
+pub(crate) trait LlmRequestBuilder {
+    /// LlmProvider-specific option keys to skip (in addition to the shared skip-key lists).
+    fn provider_skip_keys(&self) -> &'static [&'static str];
+
+    /// Build the request URL.
+    fn build_url(&self, client: &PrimitiveClientValue) -> Result<String, BuildRequestError>;
+
+    /// Build auth + provider-specific headers (without content-type or custom headers).
+    fn build_auth_headers(
+        &self,
+        client: &PrimitiveClientValue,
+    ) -> indexmap::IndexMap<String, String>;
+
+    /// Convert a specialized prompt into the JSON body fields specific to this provider.
+    fn build_prompt_body(&self, prompt: PromptAst) -> serde_json::Map<String, serde_json::Value>;
+
+    // --- Default methods (shared logic) ---
+
+    /// Build the full request. Default: POST with url/headers/body from trait methods.
+    fn build_request(
+        &self,
+        client: &PrimitiveClientValue,
+        prompt: PromptAst,
+    ) -> Result<RawHttpRequest, BuildRequestError> {
+        let url = self.build_url(client)?;
+        let headers = self.build_headers(client);
+        let body = self.build_body(client, prompt)?;
+        Ok(RawHttpRequest {
+            method: "POST".to_string(),
+            url,
+            headers,
+            body,
+        })
+    }
+
+    /// Build headers: auth headers + content-type + custom headers from options.
+    fn build_headers(&self, client: &PrimitiveClientValue) -> indexmap::IndexMap<String, String> {
+        let mut headers = indexmap::IndexMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        headers.extend(self.build_auth_headers(client));
+        // Forward custom headers from client.options["headers"]
+        if let Some(BexExternalValue::Map { entries, .. }) = client.options.get("headers") {
+            for (key, value) in entries {
+                if let BexExternalValue::String(v) = value {
+                    headers.insert(key.clone(), v.clone());
+                }
+            }
+        }
+        headers
+    }
+
+    /// Build JSON body: model + prompt fields + forwarded options.
+    fn build_body(
+        &self,
+        client: &PrimitiveClientValue,
+        prompt: PromptAst,
+    ) -> Result<String, BuildRequestError> {
+        let mut body = serde_json::Map::new();
+        if let Some(model) = get_string_option(client, "model") {
+            body.insert("model".to_string(), serde_json::Value::String(model));
+        }
+        body.extend(self.build_prompt_body(prompt));
+        self.forward_options(client, &mut body);
+        serde_json::to_string(&body).map_err(|e| BuildRequestError::InvalidOption {
+            key: "body".into(),
+            reason: e.to_string(),
+        })
+    }
+
+    /// Forward non-skipped options to body.
+    fn forward_options(
+        &self,
+        client: &PrimitiveClientValue,
+        body: &mut serde_json::Map<String, serde_json::Value>,
+    ) {
+        let provider_keys = self.provider_skip_keys();
+        for (key, value) in &client.options {
+            if SPECIALIZE_PROMPT_SKIP_KEYS.contains(&key.as_str())
+                || BUILD_REQUEST_SKIP_KEYS.contains(&key.as_str())
+                || provider_keys.contains(&key.as_str())
+            {
+                continue;
+            }
+            if let Some(json_val) = bex_value_to_json(value) {
+                body.insert(key.clone(), json_val);
+            }
+        }
+    }
+}
+
+/// Build a provider-specific HTTP request from a specialized prompt.
+///
+/// Returns a `BexExternalValue::Instance` matching the `baml.http.Request` class:
+/// `{ method: String, url: String, headers: Map<String, String>, body: String }`
+pub(crate) fn build_request(
+    client: &PrimitiveClientValue,
+    prompt: PromptAst,
+) -> Result<BexExternalValue, BuildRequestError> {
+    let provider = LlmProvider::from_str(&client.provider)
+        .map_err(|_| BuildRequestError::UnsupportedLlmProvider(client.provider.clone()))?;
+
+    let raw = match provider {
+        LlmProvider::OpenAi
+        | LlmProvider::OpenAiGeneric
+        | LlmProvider::AzureOpenAi
+        | LlmProvider::Ollama
+        | LlmProvider::OpenRouter
+        | LlmProvider::OpenAiResponses => {
+            openai::OpenAiBuilder::new(&provider).build_request(client, prompt)?
+        }
+        LlmProvider::Anthropic => anthropic::AnthropicBuilder.build_request(client, prompt)?,
+        LlmProvider::GoogleAi
+        | LlmProvider::VertexAi
+        | LlmProvider::AwsBedrock
+        | LlmProvider::BamlFallback
+        | LlmProvider::BamlRoundRobin => {
+            return Err(BuildRequestError::UnsupportedLlmProvider(
+                client.provider.clone(),
+            ));
+        }
+    };
+
+    // Convert RawHttpRequest to BexExternalValue::Instance matching baml.http.Request
+    Ok(raw.into_instance())
+}
+
+/// Intermediate struct before converting to `BexExternalValue::Instance`.
+pub(crate) struct RawHttpRequest {
+    pub method: String,
+    pub url: String,
+    pub headers: indexmap::IndexMap<String, String>,
+    pub body: String,
+}
+
+impl RawHttpRequest {
+    /// Convert to `BexExternalValue::Instance` matching `baml.http.Request`.
+    ///
+    /// Field order must match the builtin struct definition:
+    /// `method`, `url`, `headers`, `body`.
+    fn into_instance(self) -> BexExternalValue {
+        BexExternalValue::Instance {
+            class_name: "baml.http.Request".to_string(),
+            fields: indexmap! {
+                "method".to_string() => BexExternalValue::String(self.method),
+                "url".to_string() => BexExternalValue::String(self.url),
+                "headers".to_string() => BexExternalValue::Map {
+                    key_type: Ty::String,
+                    value_type: Ty::String,
+                    entries: self.headers.into_iter()
+                        .map(|(k, v)| (k, BexExternalValue::String(v)))
+                        .collect(),
+                },
+                "body".to_string() => BexExternalValue::String(self.body),
+            },
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BuildRequestError {
+    #[error("Unsupported provider: {0}")]
+    UnsupportedLlmProvider(String),
+    #[error("Missing required option: {0}")]
+    MissingOption(String),
+    #[error("Invalid option value for '{key}': {reason}")]
+    InvalidOption { key: String, reason: String },
+}
+
+/// Helper to extract a string option from client.options.
+pub(crate) fn get_string_option(client: &PrimitiveClientValue, key: &str) -> Option<String> {
+    match client.options.get(key) {
+        Some(BexExternalValue::String(s)) => Some(s.clone()),
+        _ => None,
+    }
+}
+
+/// Convert a `BexExternalValue` to a `serde_json::Value`.
+pub(crate) fn bex_value_to_json(value: &BexExternalValue) -> Option<serde_json::Value> {
+    match value {
+        BexExternalValue::Null => Some(serde_json::Value::Null),
+        BexExternalValue::Int(i) => Some(serde_json::json!(i)),
+        BexExternalValue::Float(f) => Some(serde_json::json!(f)),
+        BexExternalValue::Bool(b) => Some(serde_json::json!(b)),
+        BexExternalValue::String(s) => Some(serde_json::json!(s)),
+        BexExternalValue::Array { items, .. } => {
+            let arr: Vec<serde_json::Value> = items.iter().filter_map(bex_value_to_json).collect();
+            Some(serde_json::Value::Array(arr))
+        }
+        BexExternalValue::Map { entries, .. } => {
+            let map: serde_json::Map<String, serde_json::Value> = entries
+                .iter()
+                .filter_map(|(k, v)| bex_value_to_json(v).map(|jv| (k.clone(), jv)))
+                .collect();
+            Some(serde_json::Value::Object(map))
+        }
+        _ => None, // Skip non-serializable types (Resource, PromptAst, etc.)
+    }
+}
+
+/// Convert `PromptAst` content to JSON content parts.
+///
+/// Used by both `OpenAI` and Anthropic builders.
+pub(crate) fn prompt_to_content_parts(content: PromptAst) -> Vec<serde_json::Value> {
+    match content {
+        PromptAst::String(s) => {
+            vec![serde_json::json!({"type": "text", "text": s})]
+        }
+        PromptAst::Vec(items) => items
+            .into_iter()
+            .flat_map(prompt_to_content_parts)
+            .collect(),
+        PromptAst::Media(_handle) => {
+            // Media resolution deferred — emit placeholder
+            vec![
+                serde_json::json!({"type": "text", "text": "[media placeholder - resolution deferred]"}),
+            ]
+        }
+        PromptAst::Message { .. } => {
+            // Nested messages shouldn't appear in content parts
+            vec![]
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indexmap::IndexMap;
+
+    use super::*;
+
+    fn make_client(provider: &str, options: Vec<(&str, BexExternalValue)>) -> PrimitiveClientValue {
+        let mut opts = IndexMap::new();
+        for (k, v) in options {
+            opts.insert(k.to_string(), v);
+        }
+        PrimitiveClientValue {
+            name: "test-client".to_string(),
+            provider: provider.to_string(),
+            default_role: "user".to_string(),
+            allowed_roles: vec![
+                "system".to_string(),
+                "user".to_string(),
+                "assistant".to_string(),
+            ],
+            options: opts,
+        }
+    }
+
+    fn msg(role: &str, text: &str) -> PromptAst {
+        PromptAst::Message {
+            role: role.to_string(),
+            content: Box::new(PromptAst::String(text.to_string())),
+            metadata: Box::new(BexExternalValue::Null),
+        }
+    }
+
+    /// Parse the body field out of a Request instance.
+    fn parse_body(instance: &BexExternalValue) -> serde_json::Value {
+        let BexExternalValue::Instance { fields, .. } = instance else {
+            panic!("expected Instance");
+        };
+        let BexExternalValue::String(body) = &fields["body"] else {
+            panic!("expected String body");
+        };
+        serde_json::from_str(body).unwrap()
+    }
+
+    fn get_field_str<'a>(instance: &'a BexExternalValue, field: &str) -> &'a str {
+        let BexExternalValue::Instance { fields, .. } = instance else {
+            panic!("expected Instance");
+        };
+        let BexExternalValue::String(s) = &fields[field] else {
+            panic!("expected String for {field}");
+        };
+        s.as_str()
+    }
+
+    fn get_header<'a>(instance: &'a BexExternalValue, header: &str) -> Option<&'a str> {
+        let BexExternalValue::Instance { fields, .. } = instance else {
+            panic!("expected Instance");
+        };
+        let BexExternalValue::Map { entries, .. } = &fields["headers"] else {
+            panic!("expected Map for headers");
+        };
+        match entries.get(header) {
+            Some(BexExternalValue::String(s)) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    // ---- Result shape tests ----
+
+    #[test]
+    fn test_instance_class_name() {
+        let client = make_client(
+            "openai",
+            vec![("model", BexExternalValue::String("gpt-4o".into()))],
+        );
+        let prompt = msg("user", "hello");
+        let result = build_request(&client, prompt).unwrap();
+        let BexExternalValue::Instance { class_name, .. } = &result else {
+            panic!("expected Instance");
+        };
+        assert_eq!(class_name, "baml.http.Request");
+    }
+
+    #[test]
+    fn test_unsupported_provider() {
+        let client = make_client("unknown-provider", vec![]);
+        let prompt = msg("user", "hello");
+        let result = build_request(&client, prompt);
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Unsupported provider")
+        );
+    }
+
+    // ========================================================================
+    // OpenAI tests — modeled after integ-tests/python/tests/test_request.py
+    // ========================================================================
+
+    /// Matches `test_expose_request_gpt4` from `test_request.py`.
+    #[test]
+    fn test_openai_gpt4o_system_only() {
+        let client = make_client(
+            "openai",
+            vec![
+                ("model", BexExternalValue::String("gpt-4o".into())),
+                ("api_key", BexExternalValue::String("sk-test-key".into())),
+            ],
+        );
+
+        let system_text = "Given the receipt below:\n\n```\ntest@email.com\n```\n\nAnswer in JSON using this schema:\n{\n  items: [\n    {\n      name: string,\n      description: string or null,\n      quantity: int,\n      price: float,\n    }\n  ],\n  total_cost: float or null,\n  venue: \"barisa\" or \"ox_burger\",\n}";
+        let prompt = PromptAst::Vec(vec![msg("system", system_text)]);
+
+        let result = build_request(&client, prompt).unwrap();
+
+        // Verify envelope
+        assert_eq!(get_field_str(&result, "method"), "POST");
+        assert_eq!(
+            get_field_str(&result, "url"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+        assert_eq!(
+            get_header(&result, "authorization").unwrap(),
+            "Bearer sk-test-key"
+        );
+        assert_eq!(
+            get_header(&result, "content-type").unwrap(),
+            "application/json"
+        );
+
+        // Verify body
+        let body = parse_body(&result);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "model": "gpt-4o",
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": system_text,
+                            }
+                        ]
+                    }
+                ]
+            })
+        );
+    }
+
+    /// Matches `test_expose_request_fallback` from `test_request.py`.
+    #[test]
+    fn test_openai_gpt4_turbo_system_and_user() {
+        let client = make_client(
+            "openai",
+            vec![
+                ("model", BexExternalValue::String("gpt-4-turbo".into())),
+                ("api_key", BexExternalValue::String("sk-test-key".into())),
+            ],
+        );
+
+        let prompt = PromptAst::Vec(vec![
+            msg("system", "You are a helpful assistant."),
+            msg("user", "Write a nice short story about Dr. Pepper"),
+        ]);
+
+        let result = build_request(&client, prompt).unwrap();
+
+        assert_eq!(
+            get_field_str(&result, "url"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+
+        let body = parse_body(&result);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "model": "gpt-4-turbo",
+                "messages": [
+                    {
+                        "role": "system",
+                        "content": [{"type": "text", "text": "You are a helpful assistant."}],
+                    },
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Write a nice short story about Dr. Pepper",
+                            }
+                        ],
+                    },
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_openai_content_always_array() {
+        let client = make_client(
+            "openai",
+            vec![("model", BexExternalValue::String("gpt-4o".into()))],
+        );
+        let prompt = msg("user", "Hello world");
+        let result = build_request(&client, prompt).unwrap();
+        let body = parse_body(&result);
+        assert!(body["messages"][0]["content"].is_array());
+        assert_eq!(body["messages"][0]["content"][0]["type"], "text");
+        assert_eq!(body["messages"][0]["content"][0]["text"], "Hello world");
+    }
+
+    #[test]
+    fn test_openai_custom_base_url() {
+        let client = make_client(
+            "openai",
+            vec![(
+                "base_url",
+                BexExternalValue::String("https://custom.api.com".into()),
+            )],
+        );
+        let prompt = msg("user", "hello");
+        let result = build_request(&client, prompt).unwrap();
+        assert_eq!(
+            get_field_str(&result, "url"),
+            "https://custom.api.com/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn test_openai_forwards_options_to_body() {
+        let client = make_client(
+            "openai",
+            vec![
+                ("model", BexExternalValue::String("gpt-4o".into())),
+                ("temperature", BexExternalValue::Float(0.7)),
+            ],
+        );
+        let prompt = msg("user", "hello");
+        let result = build_request(&client, prompt).unwrap();
+        let body = parse_body(&result);
+        assert_eq!(body["temperature"], 0.7);
+    }
+
+    #[test]
+    fn test_openai_skips_internal_options_in_body() {
+        let client = make_client(
+            "openai",
+            vec![
+                ("api_key", BexExternalValue::String("sk-secret".into())),
+                (
+                    "base_url",
+                    BexExternalValue::String("https://api.openai.com".into()),
+                ),
+                ("model", BexExternalValue::String("gpt-4o".into())),
+            ],
+        );
+        let prompt = msg("user", "hello");
+        let result = build_request(&client, prompt).unwrap();
+        let body = parse_body(&result);
+        assert!(body.get("api_key").is_none());
+        assert!(body.get("base_url").is_none());
+        // model IS in the body
+        assert_eq!(body["model"], "gpt-4o");
+    }
+
+    // ========================================================================
+    // Anthropic tests — modeled after integ-tests/python/tests/test_request.py
+    // ========================================================================
+
+    /// Matches `test_expose_request_round_robin` from `test_request.py`.
+    #[test]
+    fn test_anthropic_claude_system_extracted() {
+        let client = make_client(
+            "anthropic",
+            vec![
+                (
+                    "model",
+                    BexExternalValue::String("claude-3-haiku-20240307".into()),
+                ),
+                ("api_key", BexExternalValue::String("sk-ant-test".into())),
+                ("max_tokens", BexExternalValue::Int(1000)),
+            ],
+        );
+
+        let prompt = PromptAst::Vec(vec![
+            msg("system", "You are a helpful assistant."),
+            msg("user", "Write a nice short story about Dr. Pepper"),
+        ]);
+
+        let result = build_request(&client, prompt).unwrap();
+
+        // Verify envelope
+        assert_eq!(get_field_str(&result, "method"), "POST");
+        assert_eq!(
+            get_field_str(&result, "url"),
+            "https://api.anthropic.com/v1/messages"
+        );
+        assert_eq!(get_header(&result, "x-api-key").unwrap(), "sk-ant-test");
+        assert_eq!(
+            get_header(&result, "content-type").unwrap(),
+            "application/json"
+        );
+        assert!(get_header(&result, "anthropic-version").is_some());
+
+        let body = parse_body(&result);
+        assert_eq!(
+            body,
+            serde_json::json!({
+                "model": "claude-3-haiku-20240307",
+                "max_tokens": 1000,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "Write a nice short story about Dr. Pepper",
+                            }
+                        ]
+                    }
+                ],
+                "system": [{"type": "text", "text": "You are a helpful assistant."}],
+            })
+        );
+    }
+
+    #[test]
+    fn test_anthropic_no_system_message() {
+        let client = make_client(
+            "anthropic",
+            vec![
+                (
+                    "model",
+                    BexExternalValue::String("claude-3-haiku-20240307".into()),
+                ),
+                ("max_tokens", BexExternalValue::Int(1000)),
+            ],
+        );
+        let prompt = msg("user", "Hello");
+        let result = build_request(&client, prompt).unwrap();
+        let body = parse_body(&result);
+        assert!(body.get("system").is_none());
+        assert_eq!(body["messages"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_anthropic_custom_headers() {
+        let mut header_entries = IndexMap::new();
+        header_entries.insert(
+            "anthropic-beta".to_string(),
+            BexExternalValue::String("prompt-caching-2024-07-31".into()),
+        );
+
+        let client = make_client(
+            "anthropic",
+            vec![
+                (
+                    "model",
+                    BexExternalValue::String("claude-3-haiku-20240307".into()),
+                ),
+                ("api_key", BexExternalValue::String("sk-ant-test".into())),
+                ("max_tokens", BexExternalValue::Int(500)),
+                (
+                    "allowed_role_metadata",
+                    BexExternalValue::Array {
+                        element_type: Ty::String,
+                        items: vec![BexExternalValue::String("cache_control".into())],
+                    },
+                ),
+                (
+                    "headers",
+                    BexExternalValue::Map {
+                        key_type: Ty::String,
+                        value_type: Ty::String,
+                        entries: header_entries,
+                    },
+                ),
+            ],
+        );
+
+        let prompt = msg("user", "hello");
+        let result = build_request(&client, prompt).unwrap();
+
+        assert_eq!(
+            get_header(&result, "anthropic-beta").unwrap(),
+            "prompt-caching-2024-07-31"
+        );
+
+        let body = parse_body(&result);
+        assert!(body.get("allowed_role_metadata").is_none());
+        assert!(body.get("headers").is_none());
+    }
+
+    #[test]
+    fn test_anthropic_custom_version() {
+        let client = make_client(
+            "anthropic",
+            vec![(
+                "anthropic_version",
+                BexExternalValue::String("2024-01-01".into()),
+            )],
+        );
+        let prompt = msg("user", "hello");
+        let result = build_request(&client, prompt).unwrap();
+        assert_eq!(
+            get_header(&result, "anthropic-version").unwrap(),
+            "2024-01-01"
+        );
+    }
+
+    #[test]
+    fn test_anthropic_default_version() {
+        let client = make_client("anthropic", vec![]);
+        let prompt = msg("user", "hello");
+        let result = build_request(&client, prompt).unwrap();
+        assert_eq!(
+            get_header(&result, "anthropic-version").unwrap(),
+            "2023-06-01"
+        );
+    }
+
+    #[test]
+    fn test_anthropic_forwards_max_tokens() {
+        let client = make_client(
+            "anthropic",
+            vec![
+                (
+                    "model",
+                    BexExternalValue::String("claude-3-haiku-20240307".into()),
+                ),
+                ("max_tokens", BexExternalValue::Int(1000)),
+            ],
+        );
+        let prompt = msg("user", "hello");
+        let result = build_request(&client, prompt).unwrap();
+        let body = parse_body(&result);
+        assert_eq!(body["max_tokens"], 1000);
+    }
+}

--- a/baml_language/crates/sys_llm/src/build_request/openai.rs
+++ b/baml_language/crates/sys_llm/src/build_request/openai.rs
@@ -1,0 +1,115 @@
+//! OpenAI-format HTTP request builder.
+//!
+//! Supports: `OpenAi`, `OpenAiGeneric`, `AzureOpenAi`, Ollama, `OpenRouter`.
+
+use bex_external_types::{BexExternalValue, PrimitiveClientValue, PromptAst};
+use indexmap::IndexMap;
+
+use super::{BuildRequestError, LlmRequestBuilder, get_string_option, prompt_to_content_parts};
+use crate::LlmProvider;
+
+/// Builder for OpenAI-compatible providers.
+pub(crate) struct OpenAiBuilder<'a> {
+    provider: &'a LlmProvider,
+}
+
+impl<'a> OpenAiBuilder<'a> {
+    pub(crate) fn new(provider: &'a LlmProvider) -> Self {
+        Self { provider }
+    }
+}
+
+impl LlmRequestBuilder for OpenAiBuilder<'_> {
+    fn provider_skip_keys(&self) -> &'static [&'static str] {
+        &["resource_name", "api_version"]
+    }
+
+    fn build_url(&self, client: &PrimitiveClientValue) -> Result<String, BuildRequestError> {
+        let base_url = get_string_option(client, "base_url")
+            .unwrap_or_else(|| "https://api.openai.com".to_string());
+
+        // Azure uses a different URL pattern
+        if *self.provider == LlmProvider::AzureOpenAi {
+            let deployment = get_string_option(client, "resource_name")
+                .ok_or_else(|| BuildRequestError::MissingOption("resource_name".into()))?;
+            let model = get_string_option(client, "model")
+                .ok_or_else(|| BuildRequestError::MissingOption("model".into()))?;
+            let api_version = get_string_option(client, "api_version")
+                .unwrap_or_else(|| "2024-02-15-preview".to_string());
+            return Ok(format!(
+                "https://{deployment}.openai.azure.com/openai/deployments/{model}/chat/completions?api-version={api_version}"
+            ));
+        }
+
+        Ok(format!("{base_url}/v1/chat/completions"))
+    }
+
+    fn build_auth_headers(&self, client: &PrimitiveClientValue) -> IndexMap<String, String> {
+        let mut headers = IndexMap::new();
+        if let Some(api_key) = get_string_option(client, "api_key") {
+            if *self.provider == LlmProvider::AzureOpenAi {
+                headers.insert("api-key".to_string(), api_key);
+            } else {
+                headers.insert("authorization".to_string(), format!("Bearer {api_key}"));
+            }
+        }
+        headers
+    }
+
+    fn build_prompt_body(&self, prompt: PromptAst) -> serde_json::Map<String, serde_json::Value> {
+        let mut map = serde_json::Map::new();
+        let messages = prompt_to_openai_messages(prompt);
+        map.insert("messages".to_string(), serde_json::Value::Array(messages));
+        map
+    }
+}
+
+/// Convert `PromptAst` to `OpenAI` message format.
+///
+/// `OpenAI` format:
+/// ```json
+/// [{"role": "system", "content": "..."}, {"role": "user", "content": [{"type": "text", "text": "..."}]}]
+/// ```
+fn prompt_to_openai_messages(prompt: PromptAst) -> Vec<serde_json::Value> {
+    match prompt {
+        PromptAst::Vec(items) => items
+            .into_iter()
+            .filter_map(prompt_node_to_message)
+            .collect(),
+        single => prompt_node_to_message(single).into_iter().collect(),
+    }
+}
+
+fn prompt_node_to_message(node: PromptAst) -> Option<serde_json::Value> {
+    match node {
+        PromptAst::Message {
+            role,
+            content,
+            metadata,
+        } => {
+            let content_parts = prompt_to_content_parts(*content);
+            let mut msg = serde_json::Map::new();
+            msg.insert("role".to_string(), serde_json::Value::String(role));
+
+            // Always use array format for content parts.
+            msg.insert(
+                "content".to_string(),
+                serde_json::Value::Array(content_parts),
+            );
+
+            // Add metadata (e.g., cache_control) if present
+            if let BexExternalValue::Map { entries, .. } = *metadata {
+                for (key, value) in entries {
+                    if let BexExternalValue::String(v) = value {
+                        msg.insert(key, serde_json::Value::String(v));
+                    } else if let BexExternalValue::Bool(v) = value {
+                        msg.insert(key, serde_json::Value::Bool(v));
+                    }
+                }
+            }
+
+            Some(serde_json::Value::Object(msg))
+        }
+        _ => None, // Skip non-message nodes at top level
+    }
+}

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -4,133 +4,22 @@
 //! - `specialize_prompt()` - Transform a generic `PromptAst` for a specific LLM provider
 //! - `SysOp` implementations for LLM operations (`render_prompt`, `build_primitive_client`, etc.)
 
+mod build_request;
 mod model_features;
-mod transformations;
+mod provider;
+mod render_prompt;
+mod specialize_prompt;
 
-use bex_external_types::{BexExternalValue, BexValue, PrimitiveClientValue, PromptAst};
+use bex_external_types::{BexExternalValue, BexValue, PrimitiveClientValue};
 pub use model_features::{AllowedMetadata, ModelFeatures};
+pub use provider::LlmProvider;
+pub use render_prompt::{execute_render_prompt, vm_prompt_ast_to_external};
+pub use specialize_prompt::{execute_specialize_prompt, specialize_prompt};
 use sys_types::OpError;
-
-/// Specialize a prompt for a specific provider.
-///
-/// Applies three transformations in order:
-/// 1. Merge adjacent same-role messages
-/// 2. Consolidate system prompts (when `max_one_system_prompt` is true)
-/// 3. Filter role metadata (strip disallowed metadata keys)
-pub fn specialize_prompt(client: &PrimitiveClientValue, prompt: PromptAst) -> PromptAst {
-    let features = ModelFeatures::for_provider(&client.provider, &client.options);
-
-    let prompt = transformations::merge_adjacent_messages(prompt);
-    let prompt = transformations::consolidate_system_prompts(prompt, &features);
-    transformations::filter_metadata(prompt, &features)
-}
 
 // ============================================================================
 // SysOp Implementations
 // ============================================================================
-
-/// Execute the `render_prompt` LLM operation.
-///
-/// Arguments: `[PrimitiveClient, template: String, args: Map<String, Any>]`
-pub fn execute_render_prompt(args: &[BexValue]) -> Result<PromptAst, OpError> {
-    use bex_jinja_runtime::RenderPromptError;
-    let BexValue::External(BexExternalValue::PrimitiveClient(client)) = &args[0] else {
-        return Err(RenderPromptError::InvalidArgument {
-            message: "expected PrimitiveClient, got something else".to_string(),
-        }
-        .into());
-    };
-
-    // Extract template string
-    let BexValue::External(BexExternalValue::String(s)) = &args[1] else {
-        return Err(RenderPromptError::InvalidArgument {
-            message: "expected String for template, got something else".to_string(),
-        }
-        .into());
-    };
-    let template = s.as_str();
-
-    // Extract args map
-    let BexValue::External(BexExternalValue::Map { entries, .. }) = &args[2] else {
-        return Err(RenderPromptError::InvalidArgument {
-            message: "expected Map for args, got something else".to_string(),
-        }
-        .into());
-    };
-    let template_args = entries.clone();
-
-    // Build render context from PrimitiveClient
-    let render_ctx = bex_jinja_runtime::RenderContext {
-        client: bex_jinja_runtime::RenderContextClient {
-            name: client.name.clone(),
-            provider: client.provider.clone(),
-            default_role: client.default_role.clone(),
-            allowed_roles: client.allowed_roles.clone(),
-        },
-        // TODO: output_format should come from somewhere (function return type?)
-        output_format: bex_llm_types::OutputFormatContent::new(bex_external_types::Ty::String),
-        tags: indexmap::IndexMap::new(),
-        // TODO: enums should be passed from the orchestrator or looked up from snapshot
-        enums: std::collections::HashMap::new(),
-    };
-
-    // Call the Jinja runtime - RenderPromptError converts to OpError via From
-    let vm_prompt_ast = bex_jinja_runtime::render_prompt(template, &template_args, &render_ctx)?;
-
-    // Convert VM PromptAst to external PromptAst
-    Ok(vm_prompt_ast_to_external(&vm_prompt_ast))
-}
-
-/// Execute the `specialize_prompt` LLM `SysOp`.
-///
-/// Arguments: `[PrimitiveClient, prompt: PromptAst]`
-pub fn execute_specialize_prompt(args: &[BexValue]) -> Result<PromptAst, OpError> {
-    let BexValue::External(BexExternalValue::PrimitiveClient(client)) = &args[0] else {
-        return Err(bex_jinja_runtime::RenderPromptError::InvalidArgument {
-            message: "expected PrimitiveClient, got something else".to_string(),
-        }
-        .into());
-    };
-
-    let BexValue::External(BexExternalValue::PromptAst(prompt)) = &args[1] else {
-        return Err(bex_jinja_runtime::RenderPromptError::InvalidArgument {
-            message: "expected PromptAst, got something else".to_string(),
-        }
-        .into());
-    };
-
-    Ok(specialize_prompt(client, prompt.clone()))
-}
-
-/// Convert VM `bex_vm_types::PromptAst` to external `bex_external_types::PromptAst`.
-pub fn vm_prompt_ast_to_external(ast: &bex_vm_types::PromptAst) -> PromptAst {
-    match ast {
-        bex_vm_types::PromptAst::String(s) => PromptAst::String(s.clone()),
-        bex_vm_types::PromptAst::Media(handle) => PromptAst::Media(*handle),
-        bex_vm_types::PromptAst::Message {
-            role,
-            content,
-            metadata,
-        } => {
-            let ext_content = vm_prompt_ast_to_external(content);
-            // For now, just convert metadata to BexExternalValue::Null
-            // In a full implementation, we'd need to convert the Value properly
-            let ext_metadata = match metadata {
-                bex_vm_types::Value::Null => BexExternalValue::Null,
-                _ => BexExternalValue::Null, // TODO: proper conversion
-            };
-            PromptAst::Message {
-                role: role.clone(),
-                content: Box::new(ext_content),
-                metadata: Box::new(ext_metadata),
-            }
-        }
-        bex_vm_types::PromptAst::Vec(items) => {
-            let ext_items: Vec<_> = items.iter().map(vm_prompt_ast_to_external).collect();
-            PromptAst::Vec(ext_items)
-        }
-    }
-}
 
 /// Execute the `build_primitive_client` LLM operation.
 ///
@@ -219,11 +108,23 @@ pub fn execute_build_primitive_client(args: &[BexValue]) -> Result<BexExternalVa
 /// Execute the `build_request` LLM operation.
 ///
 /// Arguments: `[PrimitiveClient, prompt: PromptAst]`
-/// Returns: `HttpRequest` (to be sent via HTTP)
-///
-/// TODO: Implement this by porting logic from legacy `LLMPrimitiveProvider::build_request`.
-pub fn execute_build_request(_args: &[BexValue]) -> Result<BexExternalValue, OpError> {
-    panic!("LlmBuildRequest SysOp not yet implemented - TODO: port from legacy")
+/// Returns: `Instance { class_name: "baml.http.Request", fields: { method, url, headers, body } }`
+pub fn execute_build_request(args: &[BexValue]) -> Result<BexExternalValue, OpError> {
+    let BexValue::External(BexExternalValue::PrimitiveClient(client)) = &args[0] else {
+        return Err(OpError::TypeError {
+            expected: "PrimitiveClient",
+            actual: format!("{:?}", args[0]),
+        });
+    };
+
+    let BexValue::External(BexExternalValue::PromptAst(prompt)) = &args[1] else {
+        return Err(OpError::TypeError {
+            expected: "PromptAst",
+            actual: format!("{:?}", args[1]),
+        });
+    };
+
+    build_request::build_request(client, prompt.clone()).map_err(|e| OpError::Other(e.to_string()))
 }
 
 /// Execute the `parse` LLM operation.

--- a/baml_language/crates/sys_llm/src/model_features.rs
+++ b/baml_language/crates/sys_llm/src/model_features.rs
@@ -1,6 +1,8 @@
 use bex_external_types::BexExternalValue;
 use indexmap::IndexMap;
 
+use crate::LlmProvider;
+
 /// Subset of engine's `ModelFeatures` relevant to prompt specialization.
 ///
 /// Derived from provider name + client options at specialization time.
@@ -37,11 +39,14 @@ impl AllowedMetadata {
 }
 
 impl ModelFeatures {
-    /// Build model features from provider name and client options.
+    /// Build model features from provider and client options.
     ///
     /// Uses a hardcoded lookup table for provider defaults, then overrides
     /// with any matching keys in the `options` map.
-    pub fn for_provider(provider: &str, options: &IndexMap<String, BexExternalValue>) -> Self {
+    pub fn for_provider(
+        provider: LlmProvider,
+        options: &IndexMap<String, BexExternalValue>,
+    ) -> Self {
         let mut features = Self::defaults_for_provider(provider);
         features.apply_overrides(options);
         features
@@ -50,36 +55,30 @@ impl ModelFeatures {
     /// Hardcoded defaults per provider.
     ///
     /// Source: engine/baml-runtime/src/internal/llm_client/primitive/*/
-    fn defaults_for_provider(provider: &str) -> Self {
+    fn defaults_for_provider(provider: LlmProvider) -> Self {
         match provider {
             // OpenAI variants: multiple system prompts allowed
-            "openai" | "openai-generic" | "azure" | "ollama" | "openrouter"
-            | "openai-responses" => Self {
+            LlmProvider::OpenAi
+            | LlmProvider::OpenAiGeneric
+            | LlmProvider::AzureOpenAi
+            | LlmProvider::Ollama
+            | LlmProvider::OpenRouter
+            | LlmProvider::OpenAiResponses => Self {
                 max_one_system_prompt: false,
                 allowed_metadata: AllowedMetadata::All,
             },
             // Anthropic: single system prompt only
-            "anthropic" => Self {
+            LlmProvider::Anthropic => Self {
                 max_one_system_prompt: true,
                 allowed_metadata: AllowedMetadata::All,
             },
-            // AWS Bedrock: single system prompt only
-            "aws-bedrock" => Self {
+            // AWS Bedrock, Google AI, Vertex AI: single system prompt only
+            LlmProvider::AwsBedrock | LlmProvider::GoogleAi | LlmProvider::VertexAi => Self {
                 max_one_system_prompt: true,
                 allowed_metadata: AllowedMetadata::All,
             },
-            // Google AI: single system prompt only
-            "google-ai" => Self {
-                max_one_system_prompt: true,
-                allowed_metadata: AllowedMetadata::All,
-            },
-            // Vertex AI: single system prompt only
-            "vertex-ai" => Self {
-                max_one_system_prompt: true,
-                allowed_metadata: AllowedMetadata::All,
-            },
-            // Unknown provider: conservative defaults (single system prompt)
-            _ => Self {
+            // Strategy providers — shouldn't reach here, but conservative defaults
+            LlmProvider::BamlFallback | LlmProvider::BamlRoundRobin => Self {
                 max_one_system_prompt: true,
                 allowed_metadata: AllowedMetadata::All,
             },

--- a/baml_language/crates/sys_llm/src/provider.rs
+++ b/baml_language/crates/sys_llm/src/provider.rs
@@ -1,0 +1,54 @@
+/// Known LLM providers.
+///
+/// Parsed from `PrimitiveClientValue.provider` using strum's `EnumString`.
+/// Unknown provider strings fall through to parse errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString)]
+#[strum(serialize_all = "kebab-case")]
+pub enum LlmProvider {
+    /// `OpenAI` API (api.openai.com)
+    #[strum(serialize = "openai")]
+    OpenAi,
+
+    /// OpenAI-compatible generic endpoint (custom `base_url`)
+    #[strum(serialize = "openai-generic")]
+    OpenAiGeneric,
+
+    /// Azure `OpenAI` Service
+    #[strum(serialize = "azure-openai")]
+    AzureOpenAi,
+
+    /// Ollama (local OpenAI-compatible)
+    #[strum(serialize = "ollama")]
+    Ollama,
+
+    /// `OpenRouter` (OpenAI-compatible)
+    #[strum(serialize = "openrouter")]
+    OpenRouter,
+
+    /// `OpenAI` Responses API
+    #[strum(serialize = "openai-responses")]
+    OpenAiResponses,
+
+    /// Anthropic API (api.anthropic.com)
+    #[strum(serialize = "anthropic")]
+    Anthropic,
+
+    // --- Providers not yet supported by build_request ---
+    /// Google AI (Gemini) — deferred
+    #[strum(serialize = "google-ai")]
+    GoogleAi,
+
+    /// Vertex AI — deferred
+    #[strum(serialize = "vertex-ai")]
+    VertexAi,
+
+    /// AWS Bedrock — deferred (uses AWS SDK, not HTTP)
+    #[strum(serialize = "aws-bedrock")]
+    AwsBedrock,
+
+    // Strategy providers (not LLM providers — handled upstream)
+    #[strum(serialize = "baml-fallback")]
+    BamlFallback,
+    #[strum(serialize = "baml-round-robin")]
+    BamlRoundRobin,
+}

--- a/baml_language/crates/sys_llm/src/render_prompt.rs
+++ b/baml_language/crates/sys_llm/src/render_prompt.rs
@@ -1,0 +1,86 @@
+//! Jinja template rendering to `PromptAst`.
+
+use bex_external_types::{BexExternalValue, BexValue, PromptAst};
+use sys_types::OpError;
+
+/// Execute the `render_prompt` LLM operation.
+///
+/// Arguments: `[PrimitiveClient, template: String, args: Map<String, Any>]`
+pub fn execute_render_prompt(args: &[BexValue]) -> Result<PromptAst, OpError> {
+    use bex_jinja_runtime::RenderPromptError;
+    let BexValue::External(BexExternalValue::PrimitiveClient(client)) = &args[0] else {
+        return Err(RenderPromptError::InvalidArgument {
+            message: "expected PrimitiveClient, got something else".to_string(),
+        }
+        .into());
+    };
+
+    // Extract template string
+    let BexValue::External(BexExternalValue::String(s)) = &args[1] else {
+        return Err(RenderPromptError::InvalidArgument {
+            message: "expected String for template, got something else".to_string(),
+        }
+        .into());
+    };
+    let template = s.as_str();
+
+    // Extract args map
+    let BexValue::External(BexExternalValue::Map { entries, .. }) = &args[2] else {
+        return Err(RenderPromptError::InvalidArgument {
+            message: "expected Map for args, got something else".to_string(),
+        }
+        .into());
+    };
+    let template_args = entries.clone();
+
+    // Build render context from PrimitiveClient
+    let render_ctx = bex_jinja_runtime::RenderContext {
+        client: bex_jinja_runtime::RenderContextClient {
+            name: client.name.clone(),
+            provider: client.provider.clone(),
+            default_role: client.default_role.clone(),
+            allowed_roles: client.allowed_roles.clone(),
+        },
+        // TODO: output_format should come from somewhere (function return type?)
+        output_format: bex_llm_types::OutputFormatContent::new(bex_external_types::Ty::String),
+        tags: indexmap::IndexMap::new(),
+        // TODO: enums should be passed from the orchestrator or looked up from snapshot
+        enums: std::collections::HashMap::new(),
+    };
+
+    // Call the Jinja runtime - RenderPromptError converts to OpError via From
+    let vm_prompt_ast = bex_jinja_runtime::render_prompt(template, &template_args, &render_ctx)?;
+
+    // Convert VM PromptAst to external PromptAst
+    Ok(vm_prompt_ast_to_external(&vm_prompt_ast))
+}
+
+/// Convert VM `bex_vm_types::PromptAst` to external `bex_external_types::PromptAst`.
+pub fn vm_prompt_ast_to_external(ast: &bex_vm_types::PromptAst) -> PromptAst {
+    match ast {
+        bex_vm_types::PromptAst::String(s) => PromptAst::String(s.clone()),
+        bex_vm_types::PromptAst::Media(handle) => PromptAst::Media(*handle),
+        bex_vm_types::PromptAst::Message {
+            role,
+            content,
+            metadata,
+        } => {
+            let ext_content = vm_prompt_ast_to_external(content);
+            // For now, just convert metadata to BexExternalValue::Null
+            // In a full implementation, we'd need to convert the Value properly
+            let ext_metadata = match metadata {
+                bex_vm_types::Value::Null => BexExternalValue::Null,
+                _ => BexExternalValue::Null, // TODO: proper conversion
+            };
+            PromptAst::Message {
+                role: role.clone(),
+                content: Box::new(ext_content),
+                metadata: Box::new(ext_metadata),
+            }
+        }
+        bex_vm_types::PromptAst::Vec(items) => {
+            let ext_items: Vec<_> = items.iter().map(vm_prompt_ast_to_external).collect();
+            PromptAst::Vec(ext_items)
+        }
+    }
+}

--- a/baml_language/crates/sys_llm/src/specialize_prompt/mod.rs
+++ b/baml_language/crates/sys_llm/src/specialize_prompt/mod.rs
@@ -1,0 +1,51 @@
+//! Prompt specialization for specific LLM providers.
+//!
+//! Applies provider-specific transformations to a generic `PromptAst`:
+//! 1. Merge adjacent same-role messages
+//! 2. Consolidate system prompts
+//! 3. Filter metadata
+
+mod transformations;
+
+use std::str::FromStr;
+
+use bex_external_types::{BexExternalValue, BexValue, PrimitiveClientValue, PromptAst};
+use sys_types::OpError;
+
+use crate::{LlmProvider, ModelFeatures};
+
+/// Specialize a prompt for a specific provider.
+///
+/// Applies three transformations in order:
+/// 1. Merge adjacent same-role messages
+/// 2. Consolidate system prompts (when `max_one_system_prompt` is true)
+/// 3. Filter role metadata (strip disallowed metadata keys)
+pub fn specialize_prompt(client: &PrimitiveClientValue, prompt: PromptAst) -> PromptAst {
+    let provider = LlmProvider::from_str(&client.provider).unwrap_or(LlmProvider::OpenAiGeneric);
+    let features = ModelFeatures::for_provider(provider, &client.options);
+
+    let prompt = transformations::merge_adjacent_messages(prompt);
+    let prompt = transformations::consolidate_system_prompts(prompt, &features);
+    transformations::filter_metadata(prompt, &features)
+}
+
+/// Execute the `specialize_prompt` LLM `SysOp`.
+///
+/// Arguments: `[PrimitiveClient, prompt: PromptAst]`
+pub fn execute_specialize_prompt(args: &[BexValue]) -> Result<PromptAst, OpError> {
+    let BexValue::External(BexExternalValue::PrimitiveClient(client)) = &args[0] else {
+        return Err(bex_jinja_runtime::RenderPromptError::InvalidArgument {
+            message: "expected PrimitiveClient, got something else".to_string(),
+        }
+        .into());
+    };
+
+    let BexValue::External(BexExternalValue::PromptAst(prompt)) = &args[1] else {
+        return Err(bex_jinja_runtime::RenderPromptError::InvalidArgument {
+            message: "expected PromptAst, got something else".to_string(),
+        }
+        .into());
+    };
+
+    Ok(specialize_prompt(client, prompt.clone()))
+}

--- a/baml_language/crates/sys_llm/src/specialize_prompt/transformations.rs
+++ b/baml_language/crates/sys_llm/src/specialize_prompt/transformations.rs
@@ -9,7 +9,7 @@ use crate::{AllowedMetadata, ModelFeatures};
 /// that share the same role by combining their contents into a `Vec` node.
 ///
 /// Ported from: engine/baml-runtime/src/internal/llm_client/traits/mod.rs:89-102
-pub(crate) fn merge_adjacent_messages(prompt: PromptAst) -> PromptAst {
+pub(super) fn merge_adjacent_messages(prompt: PromptAst) -> PromptAst {
     match prompt {
         PromptAst::Vec(messages) => {
             let mut merged: Vec<PromptAst> = Vec::with_capacity(messages.len());
@@ -77,7 +77,7 @@ pub(crate) fn merge_adjacent_messages(prompt: PromptAst) -> PromptAst {
 ///   system messages to "user"
 ///
 /// Ported from: engine/baml-runtime/src/internal/llm_client/traits/mod.rs:280-296
-pub(crate) fn consolidate_system_prompts(prompt: PromptAst, features: &ModelFeatures) -> PromptAst {
+pub(super) fn consolidate_system_prompts(prompt: PromptAst, features: &ModelFeatures) -> PromptAst {
     if !features.max_one_system_prompt {
         return prompt;
     }
@@ -142,7 +142,7 @@ pub(crate) fn consolidate_system_prompts(prompt: PromptAst, features: &ModelFeat
 /// Walks all Message nodes and removes disallowed metadata keys.
 ///
 /// Ported from: engine/baml-runtime/src/internal/llm_client/traits/mod.rs:110-128
-pub(crate) fn filter_metadata(prompt: PromptAst, features: &ModelFeatures) -> PromptAst {
+pub(super) fn filter_metadata(prompt: PromptAst, features: &ModelFeatures) -> PromptAst {
     if matches!(features.allowed_metadata, AllowedMetadata::All) {
         return prompt;
     }
@@ -207,7 +207,7 @@ mod tests {
     use indexmap::IndexMap;
 
     use super::*;
-    use crate::{AllowedMetadata, ModelFeatures};
+    use crate::{AllowedMetadata, LlmProvider, ModelFeatures};
 
     fn msg(role: &str, text: &str) -> PromptAst {
         PromptAst::Message {
@@ -229,19 +229,19 @@ mod tests {
 
     #[test]
     fn test_openai_defaults() {
-        let features = ModelFeatures::for_provider("openai", &IndexMap::new());
+        let features = ModelFeatures::for_provider(LlmProvider::OpenAi, &IndexMap::new());
         assert!(!features.max_one_system_prompt);
     }
 
     #[test]
     fn test_anthropic_defaults() {
-        let features = ModelFeatures::for_provider("anthropic", &IndexMap::new());
+        let features = ModelFeatures::for_provider(LlmProvider::Anthropic, &IndexMap::new());
         assert!(features.max_one_system_prompt);
     }
 
     #[test]
-    fn test_unknown_provider_defaults() {
-        let features = ModelFeatures::for_provider("some-new-provider", &IndexMap::new());
+    fn test_strategy_provider_defaults() {
+        let features = ModelFeatures::for_provider(LlmProvider::BamlFallback, &IndexMap::new());
         assert!(features.max_one_system_prompt);
     }
 
@@ -252,7 +252,7 @@ mod tests {
             "max_one_system_prompt".to_string(),
             BexExternalValue::Bool(false),
         );
-        let features = ModelFeatures::for_provider("anthropic", &options);
+        let features = ModelFeatures::for_provider(LlmProvider::Anthropic, &options);
         assert!(!features.max_one_system_prompt);
     }
 
@@ -450,7 +450,7 @@ mod tests {
             msg("assistant", "I'm fine"),
         ]);
 
-        let features = ModelFeatures::for_provider("anthropic", &IndexMap::new());
+        let features = ModelFeatures::for_provider(LlmProvider::Anthropic, &IndexMap::new());
 
         let result = merge_adjacent_messages(prompt);
         let result = consolidate_system_prompts(result, &features);


### PR DESCRIPTION


<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Implements HTTP request building for OpenAI and Anthropic LLM providers, converting PrimitiveClient + PromptAst into baml.http.Request instances with a trait-based architecture
> 
> <sup>Written by [Mendral](https://mendral.com) for commit cfc82644a92a80c8b3635e134cfeab0d4d6a5b7a.</sup>
<!-- /MENDRAL_SUMMARY -->