### PR TITLE
Improve test block validation

### DIFF
--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/mod.rs
@@ -1649,6 +1649,7 @@ mod tests {
         let arg_coercer = ArgCoercer {
             span_path: None,
             allow_implicit_cast_to_string: true,
+            skip_assert_eval: false,
         };
         let res = ir.check_function_params(function.inputs(), &params, arg_coercer);
         eprintln!("res: {res:?}");
@@ -1743,6 +1744,7 @@ mod tests {
         let arg_coercer = ArgCoercer {
             span_path: None,
             allow_implicit_cast_to_string: true,
+            skip_assert_eval: false,
         };
         let res = ir.check_function_params(function.inputs(), &params, arg_coercer);
         let err = res.expect_err("Should fail due to block constraint");

--- a/engine/baml-lib/baml-core/src/ir/ir_helpers/to_baml_arg.rs
+++ b/engine/baml-lib/baml-core/src/ir/ir_helpers/to_baml_arg.rs
@@ -126,6 +126,9 @@ impl ParameterError {
 pub struct ArgCoercer {
     pub span_path: Option<PathBuf>,
     pub allow_implicit_cast_to_string: bool,
+    /// If true, skip evaluating @assert/@check constraints during coercion.
+    /// Useful for type validation where we only care about structural type matching.
+    pub skip_assert_eval: bool,
 }
 
 /// Linter doesn't like `Result<T, ()>` so we'll use this as a placeholder.
@@ -606,6 +609,11 @@ impl ArgCoercer {
             }
         }?;
 
+        // Skip constraint evaluation if requested (e.g., for type-only validation)
+        if self.skip_assert_eval {
+            return Ok(value);
+        }
+
         let search_for_failures_result =
             first_failing_assert_nested(ir, &value.clone().value(), field_type).map_err(|e| {
                 scope.push_error(format!("Failed to evaluate assert: {e:?}"));
@@ -707,6 +715,7 @@ mod tests {
         let arg_coercer = ArgCoercer {
             span_path: None,
             allow_implicit_cast_to_string: true,
+            skip_assert_eval: false,
         };
         let res = arg_coercer.coerce_arg(&ir, &type_, &value, &mut ScopeStack::new());
         assert!(res.is_err());
@@ -726,6 +735,7 @@ type JsonArray = JsonValue[]
         let arg_coercer = ArgCoercer {
             span_path: None,
             allow_implicit_cast_to_string: true,
+            skip_assert_eval: false,
         };
 
         // let json = BamlValueWithMeta::Map(

--- a/engine/baml-lib/baml-core/src/ir/repr.rs
+++ b/engine/baml-lib/baml-core/src/ir/repr.rs
@@ -1105,6 +1105,104 @@ impl IntermediateRepr {
                 ));
             }
         }
+
+        // Check for unknown arguments
+        let unknown_args: Vec<&String> = test_args.difference(&function_inputs).copied().collect();
+
+        if !unknown_args.is_empty() {
+            let unknown_list: Vec<String> = unknown_args.iter().map(|s| s.to_string()).collect();
+            let expected_list: Vec<String> =
+                function_inputs.iter().map(|s| s.to_string()).collect();
+
+            diagnostics.push_warning(DatamodelWarning::new(
+                format!(
+                    "Test '{}' has unknown argument(s) for function '{}': {}. Expected: {}",
+                    test.name,
+                    function.name,
+                    unknown_list.join(", "),
+                    if expected_list.is_empty() {
+                        "(none)".to_string()
+                    } else {
+                        expected_list.join(", ")
+                    }
+                ),
+                test_span.clone(),
+            ));
+        }
+
+        // Type check each argument value against the expected type
+        self.validate_test_arg_types(function, test, test_span, diagnostics);
+    }
+
+    /// Validates that test argument values can be coerced to their expected types.
+    fn validate_test_arg_types(
+        &self,
+        function: &Function,
+        test: &TestCase,
+        test_span: &Span,
+        diagnostics: &mut Diagnostics,
+    ) {
+        use std::collections::HashMap;
+
+        use baml_types::{BamlValue, EvaluationContext};
+
+        use crate::ir::ir_helpers::{scope_diagnostics::ScopeStack, ArgCoercer};
+
+        // Create an evaluation context that allows missing env vars
+        // (we just want to check types, not resolve all values)
+        let empty_env: HashMap<String, String> = HashMap::new();
+        let ctx = EvaluationContext::new(&empty_env, true); // fill_missing_env_vars = true
+
+        let arg_coercer = ArgCoercer {
+            span_path: Some(test_span.file.path_buf().clone()),
+            allow_implicit_cast_to_string: true,
+            skip_assert_eval: true, // Only check types, don't evaluate constraints
+        };
+
+        // Check each test argument against its expected type
+        for (arg_name, arg_value) in &test.args {
+            // Find the expected type for this argument
+            let expected_type = function
+                .inputs
+                .iter()
+                .find(|(name, _)| name == arg_name)
+                .map(|(_, type_ir)| type_ir);
+
+            let Some(expected_type) = expected_type else {
+                // Unknown argument - already reported above
+                continue;
+            };
+
+            // Try to resolve the value to a BamlValue
+            let baml_value: Result<BamlValue, _> = arg_value.resolve_serde(&ctx);
+
+            match baml_value {
+                Ok(value) => {
+                    // Try to coerce the value to the expected type
+                    let mut scope = ScopeStack::new();
+                    let _result = arg_coercer.coerce_arg(self, expected_type, &value, &mut scope);
+
+                    if scope.has_errors() {
+                        diagnostics.push_warning(DatamodelWarning::new(
+                            format!(
+                                "Test '{}' argument '{}' has type error: {}",
+                                test.name, arg_name, scope
+                            ),
+                            test_span.clone(),
+                        ));
+                    }
+                }
+                Err(e) => {
+                    // Could not resolve the value (e.g., env var issues)
+                    // Skip type checking for this argument
+                    log::debug!(
+                        "Could not resolve test arg '{}' for type checking: {}",
+                        arg_name,
+                        e
+                    );
+                }
+            }
+        }
     }
 
     /// Some block_types like enums and classes may have attributes on them.

--- a/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/tests.rs
+++ b/engine/baml-lib/baml-core/src/validate/validation_pipeline/validations/tests.rs
@@ -25,6 +25,23 @@ pub(super) fn validate(ctx: &mut Context<'_>) {
             }
         }
 
+        // Note: Test argument validation (missing/unknown args) is done post-IR
+        // in IntermediateRepr::validate_test_args() where we have access to resolved types.
+
+        let test_case = walker.test_case();
+
+        // Validate that referenced functions exist (warning only, so baml-cli generate still works)
+        for (function_name, function_span) in &test_case.functions {
+            if ctx.db.find_function_by_name(function_name).is_none()
+                && ctx.db.find_expr_fn_by_name(function_name).is_none()
+            {
+                ctx.push_warning(DatamodelWarning::new(
+                    format!("Function '{}' not found", function_name),
+                    function_span.clone(),
+                ));
+            }
+        }
+
         let constraints = &walker.test_case().constraints;
         let args = &walker.test_case().args;
         let mut check_names: Vec<String> = Vec::new();

--- a/engine/baml-lib/baml/tests/validation_files/constraints/block_level.baml
+++ b/engine/baml-lib/baml/tests/validation_files/constraints/block_level.baml
@@ -29,11 +29,16 @@ function FooFn(input: Foo2) -> Foo {
   client GPT35
   prompt #"
   "#
-} 
+}
 
 test TestFoo {
   functions [FooFn]
-  args {}
+  args {
+    input {
+      foo 42
+      bar "hello"
+    }
+  }
   @@check(foo_check_1, {{ this }})
   @@check(foo_check_2, {{ this }})
 }

--- a/engine/baml-lib/baml/tests/validation_files/functions_v2/tests/valid_tests.baml
+++ b/engine/baml-lib/baml/tests/validation_files/functions_v2/tests/valid_tests.baml
@@ -65,11 +65,13 @@ function InputImage(img: image) -> string {
 test Foo {
   functions [InputImage]
   args {
+    img { url "https://example.com/image.png" }
   }
 }
 
-test Foo {
+test Foo2 {
   functions [InputEnum]
   args {
+    color "RED"
   }
 }

--- a/engine/baml-lib/baml/tests/validation_files/tests/dynamic_types_external_cycle_errors.baml
+++ b/engine/baml-lib/baml/tests/validation_files/tests/dynamic_types_external_cycle_errors.baml
@@ -1,4 +1,4 @@
-function TypeBuilderFn() -> string { 
+function TypeBuilderFn() -> string {
   client "openai/gpt-4o-mini"
   prompt #"Hello"#
 }
@@ -26,9 +26,7 @@ test AttemptToIntroduceInfiniteCycle {
       cycle A
     }
   }
-  args {
-    from_text "Test"
-  }
+  args {}
 }
 
 test AttemptToMakeClassInfinitelyRecursive {
@@ -38,9 +36,7 @@ test AttemptToMakeClassInfinitelyRecursive {
       cycle DynamicClass
     }
   }
-  args {
-    from_text "Test"
-  }
+  args {}
 }
 
 // error: Error validating: These classes form a dependency cycle: A -> B -> C

--- a/engine/baml-lib/baml/tests/validation_files/tests/dynamic_types_internal_cycle_errors.baml
+++ b/engine/baml-lib/baml/tests/validation_files/tests/dynamic_types_internal_cycle_errors.baml
@@ -1,4 +1,4 @@
-function TypeBuilderFn() -> string { 
+function TypeBuilderFn() -> string {
   client "openai/gpt-4o-mini"
   prompt #"Hello"#
 }
@@ -16,9 +16,7 @@ test AttemptToMakeClassInfinitelyRecursive {
       cycle DynamicClass
     }
   }
-  args {
-    from_text "Test"
-  }
+  args {}
 }
 
 // error: Error validating: These classes form a dependency cycle: DynamicClass

--- a/engine/baml-lib/baml/tests/validation_files/tests/dynamic_types_validation_errors.baml
+++ b/engine/baml-lib/baml/tests/validation_files/tests/dynamic_types_validation_errors.baml
@@ -15,9 +15,7 @@ test AttemptToModifyNonDynamicClass {
       c string
     }
   }
-args {
-    from_text "Test"
-  }
+  args {}
 }
 
 type SomeAlias = NonDynamic
@@ -29,9 +27,7 @@ test AttemptToModifyTypeAlias {
       c string
     }
   }
-args {
-    from_text "Test"
-  }
+  args {}
 }
 
 class DynamicClass {
@@ -56,9 +52,7 @@ test AttemptToAddDynamicAttrInDyanmicDef {
       @@dynamic
     }
   }
-args {
-    from_text "Test"
-  }
+  args {}
 }
 
 test AttemptToModifySameDynamicMultipleTimes {
@@ -70,10 +64,8 @@ test AttemptToModifySameDynamicMultipleTimes {
     dynamic class DynamicClass {
       d string
     }
-}
-args {
-    from_text "Test"
   }
+  args {}
 }
 
 test NameAlreadyExists {
@@ -87,9 +79,7 @@ test NameAlreadyExists {
       non_dynamic NonDynamic
     }
   }
-args {
-    from_text "Test"
-  }
+  args {}
 }
 
 enum DynamicEnum {
@@ -107,10 +97,8 @@ test TypeMismatch {
     dynamic enum DynamicClass {
       c string
     }
-}
-args {
-    from_text "Test"
   }
+  args {}
 }
 
 // error: Error validating: Type 'NonDynamic' does not contain the `@@dynamic` attribute so it cannot be modified in a type builder block
@@ -122,69 +110,69 @@ args {
 // 16 |     }
 //    | 
 // error: Error validating: The `dynamic` keyword only works on classes and enums, but type 'SomeAlias' is a type alias
-//   -->  tests/dynamic_types_validation_errors.baml:28
+//   -->  tests/dynamic_types_validation_errors.baml:26
 //    | 
-// 27 |   type_builder {
-// 28 |     dynamic class SomeAlias {
-// 29 |       c string
-// 30 |     }
+// 25 |   type_builder {
+// 26 |     dynamic class SomeAlias {
+// 27 |       c string
+// 28 |     }
+//    | 
+// error: Error validating: The `@@dynamic` attribute is not allowed in type_builder blocks
+//   -->  tests/dynamic_types_validation_errors.baml:42
+//    | 
+// 41 |   type_builder {
+// 42 |     class NotAllowedHere {
+// 43 |       a string
+// 44 |       @@dynamic
+// 45 |     }
 //    | 
 // error: Error validating: The `@@dynamic` attribute is not allowed in type_builder blocks
 //   -->  tests/dynamic_types_validation_errors.baml:46
 //    | 
-// 45 |   type_builder {
-// 46 |     class NotAllowedHere {
-// 47 |       a string
+// 45 |     }
+// 46 |     enum StillNotAllowed {
+// 47 |       A
 // 48 |       @@dynamic
 // 49 |     }
 //    | 
-// error: Error validating: The `@@dynamic` attribute is not allowed in type_builder blocks
+// error: Error validating: Dynamic type definitions cannot contain the `@@dynamic` attribute
 //   -->  tests/dynamic_types_validation_errors.baml:50
 //    | 
 // 49 |     }
-// 50 |     enum StillNotAllowed {
-// 51 |       A
+// 50 |     dynamic class DynamicClass {
+// 51 |       c string
 // 52 |       @@dynamic
 // 53 |     }
 //    | 
-// error: Error validating: Dynamic type definitions cannot contain the `@@dynamic` attribute
-//   -->  tests/dynamic_types_validation_errors.baml:54
+// error: The class "DynamicClass" cannot be re-defined because a class with that name already exists.
+//   -->  tests/dynamic_types_validation_errors.baml:61
 //    | 
-// 53 |     }
-// 54 |     dynamic class DynamicClass {
-// 55 |       c string
-// 56 |       @@dynamic
-// 57 |     }
+// 60 |   type_builder {
+// 61 |     dynamic class DynamicClass {
+// 62 |       c string
+// 63 |     }
+//    | 
+//   -->  tests/dynamic_types_validation_errors.baml:64
+//    | 
+// 63 |     }
+// 64 |     dynamic class DynamicClass {
+// 65 |       d string
+// 66 |     }
 //    | 
 // error: The class "DynamicClass" cannot be re-defined because a class with that name already exists.
-//   -->  tests/dynamic_types_validation_errors.baml:67
+//   -->  tests/dynamic_types_validation_errors.baml:64
 //    | 
-// 66 |   type_builder {
-// 67 |     dynamic class DynamicClass {
-// 68 |       c string
-// 69 |     }
+// 63 |     }
+// 64 |     dynamic class DynamicClass {
+// 65 |       d string
+// 66 |     }
 //    | 
-//   -->  tests/dynamic_types_validation_errors.baml:70
+//   -->  tests/dynamic_types_validation_errors.baml:61
 //    | 
-// 69 |     }
-// 70 |     dynamic class DynamicClass {
-// 71 |       d string
-// 72 |     }
-//    | 
-// error: The class "DynamicClass" cannot be re-defined because a class with that name already exists.
-//   -->  tests/dynamic_types_validation_errors.baml:70
-//    | 
-// 69 |     }
-// 70 |     dynamic class DynamicClass {
-// 71 |       d string
-// 72 |     }
-//    | 
-//   -->  tests/dynamic_types_validation_errors.baml:67
-//    | 
-// 66 |   type_builder {
-// 67 |     dynamic class DynamicClass {
-// 68 |       c string
-// 69 |     }
+// 60 |   type_builder {
+// 61 |     dynamic class DynamicClass {
+// 62 |       c string
+// 63 |     }
 //    | 
 // error: The class "NonDynamic" cannot be re-defined because a class with that name already exists.
 //   -->  tests/dynamic_types_validation_errors.baml:6
@@ -192,16 +180,16 @@ args {
 //  5 | 
 //  6 | class NonDynamic {
 //    | 
-//   -->  tests/dynamic_types_validation_errors.baml:82
+//   -->  tests/dynamic_types_validation_errors.baml:74
 //    | 
-// 81 |   type_builder {
-// 82 |     class NonDynamic {
+// 73 |   type_builder {
+// 74 |     class NonDynamic {
 //    | 
 // error: The class "NonDynamic" cannot be re-defined because a class with that name already exists.
-//   -->  tests/dynamic_types_validation_errors.baml:82
+//   -->  tests/dynamic_types_validation_errors.baml:74
 //    | 
-// 81 |   type_builder {
-// 82 |     class NonDynamic {
+// 73 |   type_builder {
+// 74 |     class NonDynamic {
 //    | 
 //   -->  tests/dynamic_types_validation_errors.baml:6
 //    | 
@@ -209,18 +197,18 @@ args {
 //  6 | class NonDynamic {
 //    | 
 // error: Error validating: Type 'DynamicEnum' is an enum, but the dynamic block is defined as 'dynamic class'
-//   -->  tests/dynamic_types_validation_errors.baml:104
+//   -->  tests/dynamic_types_validation_errors.baml:94
 //    | 
-// 103 |   type_builder {
-// 104 |     dynamic class DynamicEnum {
-// 105 |       C
-// 106 |     }
+// 93 |   type_builder {
+// 94 |     dynamic class DynamicEnum {
+// 95 |       C
+// 96 |     }
 //    | 
 // error: Error validating: Type 'DynamicClass' is a class, but the dynamic block is defined as 'dynamic enum'
-//   -->  tests/dynamic_types_validation_errors.baml:107
+//   -->  tests/dynamic_types_validation_errors.baml:97
 //    | 
-// 106 |     }
-// 107 |     dynamic enum DynamicClass {
-// 108 |       c string
-// 109 |     }
+// 96 |     }
+// 97 |     dynamic enum DynamicClass {
+// 98 |       c string
+// 99 |     }
 //    | 

--- a/engine/baml-lib/baml/tests/validation_files/tests/missing_arg.baml
+++ b/engine/baml-lib/baml/tests/validation_files/tests/missing_arg.baml
@@ -16,3 +16,17 @@ test FooTest {
   functions [Foo]
   args {}
 }
+
+// warning: Test 'FooTest' is missing required arguments for function 'Foo'. Add an args block like:
+// 
+// args {
+//   bla 123
+// }
+//   -->  tests/missing_arg.baml:15
+//    | 
+// 14 | 
+// 15 | test FooTest {
+// 16 |   functions [Foo]
+// 17 |   args {}
+// 18 | }
+//    | 

--- a/engine/baml-lib/baml/tests/validation_tests.rs
+++ b/engine/baml-lib/baml/tests/validation_tests.rs
@@ -18,30 +18,56 @@ fn parse_schema_fail_on_diagnostics(file: impl Into<SourceFile>) -> Result<(), S
     let path = PathBuf::from("./unknown");
     let file = file.into();
     let feature_flags = FeatureFlags::from_vec(vec!["beta".to_string()]).unwrap();
-    let schema = baml_lib::validate(&path, vec![file], feature_flags);
+    let mut schema = baml_lib::validate(&path, vec![file], feature_flags);
 
-    match (schema.diagnostics.warnings(), schema.diagnostics.errors()) {
-        ([], []) => {
-            match IntermediateRepr::from_parser_database(&schema.db, schema.configuration) {
-                Ok(_ir) => Ok(()),
-                Err(e) => Err(format!("{:?}", e.context("Error while converting AST to IR (did you mean to add a step to AST validation?)")))
+    // If there are already errors, report them before trying to create IR
+    if !schema.diagnostics.errors().is_empty() {
+        let mut message: Vec<u8> = Vec::new();
+
+        for warn in schema.diagnostics.warnings() {
+            warn.pretty_print(&mut message)
+                .expect("printing datamodel warning");
+        }
+
+        for err in schema.diagnostics.errors() {
+            err.pretty_print(&mut message)
+                .expect("printing datamodel error");
+        }
+
+        return Err(String::from_utf8_lossy(&message).into_owned());
+    }
+
+    // Try to create IR and run post-IR validation
+    match IntermediateRepr::from_parser_database(&schema.db, schema.configuration) {
+        Ok(ir) => {
+            // Run post-IR validation (e.g., test argument validation)
+            ir.validate_test_args(&mut schema.diagnostics);
+
+            match (schema.diagnostics.warnings(), schema.diagnostics.errors()) {
+                ([], []) => Ok(()),
+                (warnings, errors) => {
+                    let mut message: Vec<u8> = Vec::new();
+
+                    for warn in warnings {
+                        warn.pretty_print(&mut message)
+                            .expect("printing datamodel warning");
+                    }
+
+                    for err in errors {
+                        err.pretty_print(&mut message)
+                            .expect("printing datamodel error");
+                    }
+
+                    Err(String::from_utf8_lossy(&message).into_owned())
+                }
             }
         }
-        (warnings, errors) => {
-            let mut message: Vec<u8> = Vec::new();
-
-            for warn in warnings {
-                warn.pretty_print(&mut message)
-                    .expect("printing datamodel warning");
-            }
-
-            for err in errors {
-                err.pretty_print(&mut message)
-                    .expect("printing datamodel error");
-            }
-
-            Err(String::from_utf8_lossy(&message).into_owned())
-        }
+        Err(e) => Err(format!(
+            "{:?}",
+            e.context(
+                "Error while converting AST to IR (did you mean to add a step to AST validation?)"
+            )
+        )),
     }
 }
 

--- a/engine/baml-runtime/src/cli/check.rs
+++ b/engine/baml-runtime/src/cli/check.rs
@@ -68,6 +68,7 @@ impl CheckArgs {
                 let diagnostics = &runtime.diagnostics;
                 if diagnostics.has_warnings() {
                     println!("{}", diagnostics.warnings_to_pretty_string());
+                    exit(1);
                 }
             }
         }

--- a/engine/baml-runtime/src/lib.rs
+++ b/engine/baml-runtime/src/lib.rs
@@ -595,6 +595,7 @@ impl BamlRuntime {
         schema.diagnostics.to_result()?;
 
         let ir = IntermediateRepr::from_parser_database(&schema.db, schema.configuration)?;
+        ir.validate_test_args(&mut schema.diagnostics);
 
         Self::new_runtime(Arc::new(ir), schema.db, schema.diagnostics, contents, &copy)
     }
@@ -700,6 +701,7 @@ impl BamlRuntime {
             internal_baml_core::ir::ArgCoercer {
                 span_path: None,
                 allow_implicit_cast_to_string: false,
+                skip_assert_eval: false,
             },
         )?;
 
@@ -811,6 +813,7 @@ impl BamlRuntime {
                         internal_baml_core::ir::ArgCoercer {
                             span_path: span.map(|s| s.file.path_buf().clone()),
                             allow_implicit_cast_to_string: true,
+                            skip_assert_eval: false,
                         },
                     )
                     .map(|bv| bv.into_iter().map(|(k, v)| (k, v.value())).collect())

--- a/engine/baml-runtime/src/runtime_methods/prepare_function.rs
+++ b/engine/baml-runtime/src/runtime_methods/prepare_function.rs
@@ -122,6 +122,7 @@ impl BamlRuntime {
                             ArgCoercer {
                                 span_path: None,
                                 allow_implicit_cast_to_string: false,
+                                skip_assert_eval: false,
                             },
                         ) {
                             Ok(baml_args) => baml_args,
@@ -163,6 +164,7 @@ impl BamlRuntime {
             ArgCoercer {
                 span_path: None,
                 allow_implicit_cast_to_string: false,
+                skip_assert_eval: false,
             },
         ) {
             Ok(baml_args) => baml_args,


### PR DESCRIPTION
 - Test block errors become warnings (to not block generation)
 - Test args must only have fields that match the params of the function under test
 - Test args must have fields for every non-empty param of the function under test
 - Test args must be parseable into the required types
 - Warnings in `baml-cli check` will return with non-0 exitcode

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Improves test block validation by adding checks for missing/unknown arguments and type validation, converting test errors to warnings to avoid blocking code generation
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 4eb8fab447fd3c91f6a49b7543fcb7315d70e434.</sup>
<!-- /MENDRAL_SUMMARY -->