### PR TITLE
Fix bug with type_builder in streaming contexts

### DIFF
--- a/engine/language_client_cffi/README.md
+++ b/engine/language_client_cffi/README.md
@@ -35,6 +35,51 @@ Internal FFI for the language client.
     ./integ-tests
     ```
 
+## Local Development with Go Tests
+
+When developing changes to the CFFI layer, Go tests will by default download and use a cached version of the library from GitHub releases. To test your local changes:
+
+1. **Build the CFFI library** (debug mode is faster for iteration):
+
+    ```bash
+    cd engine/language_client_cffi
+    cargo build  # or cargo build --release for optimized build
+    ```
+
+    This creates: `engine/target/debug/libbaml_cffi.dylib` (macOS) or `libbaml_cffi.so` (Linux)
+
+2. **Run Go tests with your local library**:
+
+    ```bash
+    cd engine/generators/languages/go/generated_tests/dynamic_types  # or any test directory
+    BAML_LIBRARY_PATH=/path/to/baml/engine/target/debug/libbaml_cffi.dylib go test -v
+    ```
+
+    The `BAML_LIBRARY_PATH` environment variable tells the Go SDK to use your locally built library instead of the cached version.
+
+3. **Regenerate Go test code** (if you've changed code generation):
+
+    ```bash
+    cd engine/generators/languages/go
+    cargo test --lib  # Regenerates all Go test projects
+    ```
+
+### Quick Development Loop
+
+```bash
+# 1. Make changes to Rust code
+vim engine/language_client_cffi/src/ffi/functions.rs
+
+# 2. Rebuild CFFI
+cd engine/language_client_cffi && cargo build
+
+# 3. Test with your changes
+cd ../generators/languages/go/generated_tests/dynamic_types
+BAML_LIBRARY_PATH=$PWD/../../../target/debug/libbaml_cffi.dylib go test -v
+```
+
+> **Note:** Without setting `BAML_LIBRARY_PATH`, Go tests will use the cached library at `~/.cache/baml/libs/{VERSION}/` or download from GitHub releases, which won't reflect your local changes.
+
 > **Note:** The actual go-sdk lives in [../language_client_go](../language_client_go/pkg/lib.go). The CFFI layer is a thin wrapper around the go-sdk.
 
 ## Additional Information

--- a/engine/language_client_cffi/src/ffi/functions.rs
+++ b/engine/language_client_cffi/src/ffi/functions.rs
@@ -272,6 +272,8 @@ fn call_function_stream_from_c_inner(
     let ctx = runtime.create_ctx_manager(BamlValue::String("cffi".to_string()), None);
     // TODO: There's a race condition bug here. Technically we should COPY the type builder, not just clone it.
     let type_builder = type_builder.map(|t| t.type_builder.as_ref().clone());
+    let client_registry_clone = client_registry.clone();
+    let env_vars_clone = env_vars.clone();
     let mut stream = match runtime.stream_function(
         func_name,
         &kwargs,
@@ -298,9 +300,9 @@ fn call_function_stream_from_c_inner(
                 Some(|| on_tick(id)),
                 Some(|r| on_event(id, r, runtime)),
                 &ctx,
-                None,
-                None,
-                HashMap::new(),
+                type_builder.as_ref(),
+                client_registry_clone.as_ref(),
+                env_vars_clone,
             )
             .await;
 

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
     flake-utils.lib.eachDefaultSystem (
       system:
 
-
       let
         pkgs = nixpkgs.legacyPackages.${system};
         pkgs-unstable = nixpkgs-unstable.legacyPackages.${system};
@@ -869,9 +868,18 @@
             else
               "-isystem ${pkgs.llvmPackages_17.libclang.lib}/lib/clang/17/include -isystem ${pkgs.llvmPackages_17.libclang.lib}/include -isystem ${pkgs.glibc.dev}/include";
 
-          # Prevent SDK conflicts on macOS
+          # Prevent SDK conflicts on macOS and configure CGO for Go
           shellHook = pkgs.lib.optionalString pkgs.stdenv.isDarwin ''
             unset DEVELOPER_DIR_FOR_TARGET
+            # Use native macOS SDK for Go instead of Nix SDK to avoid version mismatch
+            # The Nix SDK (11.3) is too old for some Go packages that require macOS 12+ APIs
+            if [ -d "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk" ]; then
+              export SDKROOT="/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk"
+            elif [ -d "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk" ]; then
+              export SDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
+            fi
+            export CGO_ENABLED=1
+            export CGO_LDFLAGS="-isysroot $SDKROOT"
           '';
         };
       }

--- a/integ-tests/go/test_type_builder_test.go
+++ b/integ-tests/go/test_type_builder_test.go
@@ -17,13 +17,13 @@ import (
 // Reference: test_typebuilder.py:18-43
 func TestDynamicClassCreation(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	personClass, err := tb.Person()
 	require.NoError(t, err)
-	
+
 	// Add property to Person class
 	stringType, err := tb.String()
 	require.NoError(t, err)
@@ -31,20 +31,20 @@ func TestDynamicClassCreation(t *testing.T) {
 	require.NoError(t, err)
 	_, err = personClass.AddProperty("last_name", listType)
 	require.NoError(t, err)
-	
+
 	floatType, err := tb.Float()
 	require.NoError(t, err)
-	
+
 	heightProperty, err := personClass.AddProperty("height", floatType)
 	require.NoError(t, err)
 	err = heightProperty.SetDescription("Height in meters")
 	require.NoError(t, err)
-	
+
 	// Test the modified class
 	result, err := b.ExtractPeople(ctx, "My name is Harrison. My hair is black and I'm 6 feet tall. I'm pretty good around the hoop.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
 	assert.NotEmpty(t, result, "Expected non-empty result")
-	
+
 	for _, person := range result {
 		t.Logf("Person: %+v", person)
 		// Verify basic properties still work
@@ -58,21 +58,21 @@ func TestDynamicClassCreation(t *testing.T) {
 // Reference: test_typebuilder.py:226-235
 func TestDynamicEnumCreation(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	hobbyEnum, err := tb.Hobby()
 	require.NoError(t, err)
-	
+
 	// Add value to existing enum
 	_, err = hobbyEnum.AddValue("SOFTWARE")
 	require.NoError(t, err)
-	
+
 	result, err := b.ExtractHobby(ctx, "My name is Harrison. My hair is black and I'm 6 feet tall. I love coding and music.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
 	assert.NotEmpty(t, result, "Expected non-empty result")
-	
+
 	// Should contain the new "Golfing" value
 	assert.Contains(t, result, types.Hobby("SOFTWARE"))
 	assert.Contains(t, result, types.HobbyMUSIC)
@@ -83,27 +83,27 @@ func TestDynamicEnumCreation(t *testing.T) {
 func TestTypeBuilderPrint(t *testing.T) {
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	personClass, err := tb.Person()
 	require.NoError(t, err)
-	
+
 	stringType, err := tb.String()
 	require.NoError(t, err)
 	listType, err := stringType.List()
 	require.NoError(t, err)
 	_, err = personClass.AddProperty("candy", listType)
 	require.NoError(t, err)
-	
+
 	tbStr := fmt.Sprintf("%v", tb)
 	t.Logf("TypeBuilder string representation: %s", tbStr)
-	
+
 	expectedContent := []string{
 		"TypeBuilder",
 		"Person",
 		"candy",
 		"string[]",
 	}
-	
+
 	for _, content := range expectedContent {
 		assert.Contains(t, tbStr, content, "Expected TypeBuilder string to contain '%s'", content)
 	}
@@ -113,22 +113,22 @@ func TestTypeBuilderPrint(t *testing.T) {
 // Reference: test_typebuilder.py:61-78
 func TestDynamicClassOutput(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	dynamicOutputClass, err := tb.DynamicOutput()
 	require.NoError(t, err)
-	
+
 	stringType, err := tb.String()
 	require.NoError(t, err)
 	_, err = dynamicOutputClass.AddProperty("hair_color", stringType)
 	require.NoError(t, err)
-	
+
 	// List properties to verify
 	properties, err := dynamicOutputClass.ListProperties()
 	require.NoError(t, err)
-	
+
 	var foundHairColor bool
 	for _, prop := range properties {
 		name, err := prop.Name()
@@ -139,11 +139,11 @@ func TestDynamicClassOutput(t *testing.T) {
 		}
 	}
 	assert.True(t, foundHairColor, "Expected to find hair_color property")
-	
+
 	// Test the function with dynamic output
 	output, err := b.MyFunc(ctx, "My name is Harrison. My hair is black and I'm 6 feet tall.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
-	
+
 	t.Logf("Dynamic output: %+v", output)
 	// The exact assertion depends on how dynamic properties are accessed in Go
 	// This is a structural test to ensure the call succeeds
@@ -153,76 +153,76 @@ func TestDynamicClassOutput(t *testing.T) {
 // Reference: test_typebuilder.py:81-109
 func TestDynamicClassNestedOutput(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	// Create nested class
 	nameClass, err := tb.AddClass("Name")
 	require.NoError(t, err)
-	
+
 	stringType, err := tb.String()
 	require.NoError(t, err)
 	_, err = nameClass.AddProperty("first_name", stringType)
 	require.NoError(t, err)
-	
+
 	optionalStringType, err := stringType.Optional()
 	require.NoError(t, err)
 	_, err = nameClass.AddProperty("last_name", optionalStringType)
 	require.NoError(t, err)
-	
+
 	_, err = nameClass.AddProperty("middle_name", optionalStringType)
 	require.NoError(t, err)
-	
+
 	// Create another nested class
 	addressClass, err := tb.AddClass("Address")
 	require.NoError(t, err)
-	
+
 	_, err = addressClass.AddProperty("street", stringType)
 	require.NoError(t, err)
-	
+
 	_, err = addressClass.AddProperty("city", stringType)
 	require.NoError(t, err)
-	
+
 	_, err = addressClass.AddProperty("state", stringType)
 	require.NoError(t, err)
-	
+
 	_, err = addressClass.AddProperty("zip", stringType)
 	require.NoError(t, err)
-	
+
 	// Add nested properties to DynamicOutput
 	dynamicOutputClass, err := tb.DynamicOutput()
 	require.NoError(t, err)
-	
+
 	nameType, err := nameClass.Type()
 	require.NoError(t, err)
 	optionalNameType, err := nameType.Optional()
 	require.NoError(t, err)
 	_, err = dynamicOutputClass.AddProperty("name", optionalNameType)
 	require.NoError(t, err)
-	
+
 	addressType, err := addressClass.Type()
 	require.NoError(t, err)
 	optionalAddressType, err := addressType.Optional()
 	require.NoError(t, err)
 	_, err = dynamicOutputClass.AddProperty("address", optionalAddressType)
 	require.NoError(t, err)
-	
+
 	hairColorProp, err := dynamicOutputClass.AddProperty("hair_color", optionalStringType)
 	require.NoError(t, err)
 	err = hairColorProp.SetAlias("hairColor")
 	require.NoError(t, err)
-	
+
 	floatType, err := tb.Float()
 	require.NoError(t, err)
 	optionalFloatType, err := floatType.Optional()
 	require.NoError(t, err)
 	_, err = dynamicOutputClass.AddProperty("height", optionalFloatType)
 	require.NoError(t, err)
-	
+
 	output, err := b.MyFunc(ctx, "My name is Mark Gonzalez. My hair is black and I'm 6 feet tall.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
-	
+
 	t.Logf("Nested dynamic output: %+v", output)
 }
 
@@ -230,32 +230,32 @@ func TestDynamicClassNestedOutput(t *testing.T) {
 // Reference: test_typebuilder.py:210-222
 func TestDynamicNewEnum(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	// Create new enum
 	animalEnum, err := tb.AddEnum("Animal")
 	require.NoError(t, err)
-	
+
 	animals := []string{"giraffe", "elephant", "lion"}
 	for _, animal := range animals {
 		_, err = animalEnum.AddValue(strings.ToUpper(animal))
 		require.NoError(t, err)
 	}
-	
+
 	// Add the new enum to Person class
 	personClass, err := tb.Person()
 	require.NoError(t, err)
-	
+
 	animalType, err := animalEnum.Type()
 	require.NoError(t, err)
 	_, err = personClass.AddProperty("animalLiked", animalType)
 	require.NoError(t, err)
-	
+
 	result, err := b.ExtractPeople(ctx, "My name is Harrison. My hair is black and I'm 6 feet tall. I'm pretty good around the hoop. I like giraffes.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
-	
+
 	assert.NotEmpty(t, result, "Expected non-empty result")
 	// The exact assertion for dynamic properties depends on Go client implementation
 }
@@ -264,10 +264,10 @@ func TestDynamicNewEnum(t *testing.T) {
 // Reference: test_typebuilder.py:239-253
 func TestDynamicLiterals(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	literalStringType, err := tb.LiteralString("GIRAFFE")
 	require.NoError(t, err)
 	literalStringType2, err := tb.LiteralString("ELEPHANT")
@@ -281,16 +281,16 @@ func TestDynamicLiterals(t *testing.T) {
 		literalStringType3,
 	})
 	require.NoError(t, err)
-	
+
 	personClass, err := tb.Person()
 	require.NoError(t, err)
-	
+
 	_, err = personClass.AddProperty("animalLiked", literals)
 	require.NoError(t, err)
-	
+
 	result, err := b.ExtractPeople(ctx, "My name is Harrison. My hair is black and I'm 6 feet tall. I'm pretty good around the hoop. I like giraffes.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
-	
+
 	assert.NotEmpty(t, result, "Expected non-empty result")
 }
 
@@ -298,10 +298,10 @@ func TestDynamicLiterals(t *testing.T) {
 // Reference: test_typebuilder.py:376-402
 func TestAddBAMLExistingClass(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	bamlCode := `
         class ExtraPersonInfo {
             height int
@@ -313,13 +313,13 @@ func TestAddBAMLExistingClass(t *testing.T) {
             extra ExtraPersonInfo?
         }
     `
-	
+
 	err = tb.AddBaml(bamlCode)
 	require.NoError(t, err)
-	
+
 	result, err := b.ExtractPeople(ctx, "My name is John Doe. I'm 30 years old. I'm 6 feet tall and weigh 180 pounds. My hair is yellow.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
-	
+
 	assert.NotEmpty(t, result, "Expected non-empty result")
 	person := result[0]
 	assert.NotNil(t, person.Name)
@@ -331,23 +331,23 @@ func TestAddBAMLExistingClass(t *testing.T) {
 // Reference: test_typebuilder.py:406-417
 func TestAddBAMLExistingEnum(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	bamlCode := `
         dynamic enum Hobby {
             VideoGames
             BikeRiding
         }
     `
-	
+
 	err = tb.AddBaml(bamlCode)
 	require.NoError(t, err)
-	
+
 	result, err := b.ExtractHobby(ctx, "I play video games", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
-	
+
 	assert.Contains(t, result, types.Hobby("VideoGames"))
 }
 
@@ -355,10 +355,10 @@ func TestAddBAMLExistingEnum(t *testing.T) {
 // Reference: test_typebuilder.py:421-466
 func TestAddBAMLBothClassesAndEnums(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	bamlCode := `
         class ExtraPersonInfo {
             height int @alias("height_inches")
@@ -387,13 +387,13 @@ func TestAddBAMLBothClassesAndEnums(t *testing.T) {
             hobbies Hobby[]
         }
     `
-	
+
 	err = tb.AddBaml(bamlCode)
 	require.NoError(t, err)
-	
+
 	result, err := b.ExtractPeople(ctx, "My name is John Doe. I'm 30 years old. My height is 6 feet and I weigh 180 pounds. My hair is brown. I work as a programmer and enjoy bike riding.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
-	
+
 	assert.NotEmpty(t, result, "Expected non-empty result")
 	person := result[0]
 	assert.NotNil(t, person.Name)
@@ -404,10 +404,10 @@ func TestAddBAMLBothClassesAndEnums(t *testing.T) {
 // Reference: test_typebuilder.py:470-494
 func TestAddBAMLWithAttrs(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	bamlCode := `
         class ExtraPersonInfo {
             height int @description("In centimeters and rounded to the nearest whole number")
@@ -418,13 +418,13 @@ func TestAddBAMLWithAttrs(t *testing.T) {
             extra ExtraPersonInfo?
         }
     `
-	
+
 	err = tb.AddBaml(bamlCode)
 	require.NoError(t, err)
-	
+
 	result, err := b.ExtractPeople(ctx, "My name is John Doe. I'm 30 years old. I'm 6 feet tall and weigh 180 pounds. My hair is yellow.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
-	
+
 	assert.NotEmpty(t, result, "Expected non-empty result")
 	person := result[0]
 	assert.NotNil(t, person.Name)
@@ -437,7 +437,7 @@ func TestAddBAMLWithAttrs(t *testing.T) {
 func TestAddBAMLError(t *testing.T) {
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	t.Run("InvalidBAMLSyntax", func(t *testing.T) {
 		invalidBAML := `
             dynamic Hobby {
@@ -445,16 +445,16 @@ func TestAddBAMLError(t *testing.T) {
                 BikeRiding
             }
         `
-		
+
 		err = tb.AddBaml(invalidBAML)
 		assert.Error(t, err, "Expected error for invalid BAML syntax")
 	})
-	
+
 	t.Run("ParserError", func(t *testing.T) {
 		syntaxErrorBAML := `
             syntaxerror
         `
-		
+
 		err = tb.AddBaml(syntaxErrorBAML)
 		assert.Error(t, err, "Expected parser error for syntax error")
 	})
@@ -465,24 +465,24 @@ func TestAddBAMLError(t *testing.T) {
 func TestReferencingExistingClassTypes(t *testing.T) {
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	personClass, err := tb.Person()
 	require.NoError(t, err)
-	
+
 	// Create union of existing types
 	resumeType, err := tb.Resume()
 	require.NoError(t, err)
 	resumeFieldType, err := resumeType.Type()
 	require.NoError(t, err)
-	
+
 	hobbyEnum, err := tb.Hobby()
 	require.NoError(t, err)
 	hobbyFieldType, err := hobbyEnum.Type()
 	require.NoError(t, err)
-	
+
 	propsUnion, err := tb.Union([]baml.Type{resumeFieldType, hobbyFieldType})
 	require.NoError(t, err)
-	
+
 	_, err = personClass.AddProperty("props", propsUnion)
 	require.NoError(t, err)
 }
@@ -494,12 +494,12 @@ func TestTypeBuilderAndFieldTypeImports(t *testing.T) {
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
 	assert.NotNil(t, tb, "Expected non-nil TypeBuilder")
-	
+
 	// Test that TypeBuilder methods return FieldType instances
 	stringType, err := tb.String()
 	require.NoError(t, err)
 	assert.NotNil(t, stringType, "Expected non-nil FieldType from String()")
-	
+
 	// Test method chaining
 	optionalStringList, err := stringType.List()
 	require.NoError(t, err)
@@ -512,39 +512,39 @@ func TestTypeBuilderAndFieldTypeImports(t *testing.T) {
 // Reference: test_typebuilder.py:296-316
 func TestDynamicOutputWithMap(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	dynamicOutputClass, err := tb.DynamicOutput()
 	require.NoError(t, err)
-	
+
 	stringType, err := tb.String()
 	require.NoError(t, err)
 	_, err = dynamicOutputClass.AddProperty("hair_color", stringType)
 	require.NoError(t, err)
-	
+
 	// Add map property
 	mapType, err := tb.Map(stringType, stringType)
 	require.NoError(t, err)
-	
+
 	attrs, err := dynamicOutputClass.AddProperty("attributes", mapType)
 	require.NoError(t, err)
 	err = attrs.SetDescription("Things like 'eye_color' or 'facial_hair'")
 	require.NoError(t, err)
-	
+
 	properties, err := dynamicOutputClass.ListProperties()
 	require.NoError(t, err)
-	
+
 	for _, prop := range properties {
 		name, err := prop.Name()
 		require.NoError(t, err)
 		t.Logf("Property: %s", name)
 	}
-	
+
 	result, err := b.MyFunc(ctx, "My name is Harrison. My hair is black and I'm 6 feet tall. I have blue eyes and a beard.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
-	
+
 	t.Logf("Dynamic output with map: %+v", result)
 }
 
@@ -552,18 +552,18 @@ func TestDynamicOutputWithMap(t *testing.T) {
 // Reference: test_typebuilder.py:320-364
 func TestDynamicOutputWithUnion(t *testing.T) {
 	ctx := context.Background()
-	
+
 	tb, err := b.NewTypeBuilder()
 	require.NoError(t, err)
-	
+
 	dynamicOutputClass, err := tb.DynamicOutput()
 	require.NoError(t, err)
-	
+
 	stringType, err := tb.String()
 	require.NoError(t, err)
 	_, err = dynamicOutputClass.AddProperty("hair_color", stringType)
 	require.NoError(t, err)
-	
+
 	// Add map property
 	mapType, err := tb.Map(stringType, stringType)
 	require.NoError(t, err)
@@ -571,7 +571,7 @@ func TestDynamicOutputWithUnion(t *testing.T) {
 	require.NoError(t, err)
 	err = attrs.SetDescription("Things like 'eye_color' or 'facial_hair'")
 	require.NoError(t, err)
-	
+
 	// Define two classes for union
 	class1, err := tb.AddClass("Class1")
 	require.NoError(t, err)
@@ -579,7 +579,7 @@ func TestDynamicOutputWithUnion(t *testing.T) {
 	require.NoError(t, err)
 	_, err = class1.AddProperty("meters", floatType)
 	require.NoError(t, err)
-	
+
 	class2, err := tb.AddClass("Class2")
 	require.NoError(t, err)
 	_, err = class2.AddProperty("feet", floatType)
@@ -588,35 +588,118 @@ func TestDynamicOutputWithUnion(t *testing.T) {
 	require.NoError(t, err)
 	_, err = class2.AddProperty("inches", optionalFloatType)
 	require.NoError(t, err)
-	
+
 	// Create union type
 	class1Type, err := class1.Type()
 	require.NoError(t, err)
 	class2Type, err := class2.Type()
 	require.NoError(t, err)
-	
+
 	heightUnion, err := tb.Union([]baml.Type{class1Type, class2Type})
 	require.NoError(t, err)
-	
+
 	_, err = dynamicOutputClass.AddProperty("height", heightUnion)
 	require.NoError(t, err)
-	
+
 	properties, err := dynamicOutputClass.ListProperties()
 	require.NoError(t, err)
-	
+
 	for _, prop := range properties {
 		name, err := prop.Name()
 		require.NoError(t, err)
 		t.Logf("Property: %s", name)
 	}
-	
+
 	// Test with feet measurement
 	result1, err := b.MyFunc(ctx, "My name is Harrison. My hair is black and I'm 6 feet tall. I have blue eyes and a beard. I am 30 years old.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
 	t.Logf("Result with feet: %+v", result1)
-	
+
 	// Test with meters measurement
 	result2, err := b.MyFunc(ctx, "My name is Harrison. My hair is black and I'm 1.8 meters tall. I have blue eyes and a beard. I am 30 years old.", b.WithTypeBuilder(tb))
 	require.NoError(t, err)
 	t.Logf("Result with meters: %+v", result2)
+}
+
+// TestDynamicClassNestedOutputStreaming tests streaming with dynamic nested classes
+// This is a regression test for a bug where dynamic classes worked in non-streaming
+// but failed in streaming with "Class X not found" error.
+func TestDynamicClassNestedOutputStreaming(t *testing.T) {
+	ctx := context.Background()
+
+	tb, err := b.NewTypeBuilder()
+	require.NoError(t, err)
+
+	// Create a new dynamic class "Location" - this is the key test case
+	// because it's a class that only exists in the TypeBuilder
+	locationClass, err := tb.AddClass("Location")
+	require.NoError(t, err)
+
+	stringType, err := tb.String()
+	require.NoError(t, err)
+	_, err = locationClass.AddProperty("city", stringType)
+	require.NoError(t, err)
+
+	_, err = locationClass.AddProperty("country", stringType)
+	require.NoError(t, err)
+
+	// Add Location as a property to DynamicOutput
+	dynamicOutputClass, err := tb.DynamicOutput()
+	require.NoError(t, err)
+
+	locationType, err := locationClass.Type()
+	require.NoError(t, err)
+	optionalLocationType, err := locationType.Optional()
+	require.NoError(t, err)
+	_, err = dynamicOutputClass.AddProperty("location", optionalLocationType)
+	require.NoError(t, err)
+
+	// Also add a simple property
+	optionalStringType, err := stringType.Optional()
+	require.NoError(t, err)
+	_, err = dynamicOutputClass.AddProperty("name", optionalStringType)
+	require.NoError(t, err)
+
+	inputText := "My name is Alice and I live in Paris, France."
+
+	// Test non-streaming first (this should work)
+	t.Run("NonStreaming", func(t *testing.T) {
+		result, err := b.MyFunc(ctx, inputText, b.WithTypeBuilder(tb))
+		require.NoError(t, err)
+		t.Logf("Non-streaming result: %+v", result)
+		// Verify we got a result with the dynamic properties
+		assert.NotNil(t, result)
+	})
+
+	// Test streaming - this was the bug case
+	t.Run("Streaming", func(t *testing.T) {
+		stream, err := b.Stream.MyFunc(ctx, inputText, b.WithTypeBuilder(tb))
+		require.NoError(t, err)
+
+		// Collect partial results
+		var partialCount int
+		var finalResult *types.DynamicOutput
+
+		for value := range stream {
+			if value.IsError {
+				t.Fatalf("Stream error: %v", value.Error)
+			}
+
+			if !value.IsFinal && value.Stream() != nil {
+				partialCount++
+				t.Logf("Partial result %d: %+v", partialCount, value.Stream())
+			}
+
+			// Get final result - this is where the bug would manifest
+			// as "Class Location not found" error
+			if value.IsFinal && value.Final() != nil {
+				finalResult = value.Final()
+				t.Logf("Final streaming result: %+v", finalResult)
+			}
+		}
+
+		// Verify we got partials and a final result
+		assert.Greater(t, partialCount, 0, "Expected at least one partial result")
+		assert.NotNil(t, finalResult, "Streaming should succeed with dynamic nested classes")
+	})
 }


### PR DESCRIPTION
 - Fixed a CFFI callsite where `None` placeholders were used for client_registry, type_builder and env_vars
 - Added an integ test in go for this case

<!-- MENDRAL_SUMMARY -->
---

> [!NOTE]
> Adds comprehensive regression test for the streaming type_builder bug fix, validating that dynamic classes work correctly in both streaming and non-streaming contexts
> 
> <sup>Written by [Mendral](https://mendral.com) for commit 8ed8324617df0a981e8ff91cf52a333e0c6a2d91.</sup>
<!-- /MENDRAL_SUMMARY -->