### PR TITLE
Rust CI cache problem

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -35,13 +35,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Linux jobs for better hit rates
+          shared-key: "linux-cargo"
 
       - name: "Install cargo insta"
         uses: taiki-e/install-action@v2
@@ -89,13 +92,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar macOS jobs for better hit rates
+          shared-key: "macos-cargo"
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -121,13 +127,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Windows jobs for better hit rates
+          shared-key: "windows-cargo"
 
       - name: "Install cargo nextest"
         uses: taiki-e/install-action@v2
@@ -154,15 +163,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: |
           rustup show
           rustup target add wasm32-unknown-unknown
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Linux WASM jobs for better hit rates
+          shared-key: "linux-wasm"
 
       - name: "Build for WASM"
         run: |
@@ -193,10 +205,7 @@ jobs:
           file: "baml_language/Cargo.toml"
           field: "workspace.package.rust-version"
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain (MSRV)"
         env:
           MSRV: ${{ steps.msrv.outputs.value }}
@@ -204,6 +213,12 @@ jobs:
           rustup toolchain install "${MSRV}"
           rustup default "${MSRV}"
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across Linux MSRV jobs
+          shared-key: "linux-msrv"
 
       - name: "Build with MSRV"
         env:
@@ -244,13 +259,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Linux jobs for better hit rates
+          shared-key: "linux-cargo"
 
       - name: "Install cargo insta"
         uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -230,13 +230,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup toolchain install
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Linux jobs for better hit rates
+          shared-key: "linux-cargo"
 
       - name: "Install cargo-binstall"
         run: |
@@ -367,13 +370,16 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: rustup show
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Linux jobs for better hit rates
+          shared-key: "linux-cargo"
 
       - name: "Install codspeed"
         uses: taiki-e/install-action@v2

--- a/.github/workflows/wasm-pack-tests.reusable.yaml
+++ b/.github/workflows/wasm-pack-tests.reusable.yaml
@@ -30,15 +30,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: |
           rustup show
           rustup target add wasm32-unknown-unknown
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Linux WASM jobs for better hit rates
+          shared-key: "linux-wasm"
 
       - name: "Install wasm-pack"
         uses: taiki-e/install-action@v2

--- a/.github/workflows/webview-tests.reusable.yaml
+++ b/.github/workflows/webview-tests.reusable.yaml
@@ -27,15 +27,18 @@ jobs:
       - name: "Setup Node.js for typescript2"
         uses: ./.github/actions/setup-node2
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: |
           rustup show
           rustup target add wasm32-unknown-unknown
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Linux WASM jobs for better hit rates
+          shared-key: "linux-wasm"
 
       - name: "Install wasm-pack"
         uses: taiki-e/install-action@v2
@@ -62,15 +65,18 @@ jobs:
       - name: "Setup Node.js for typescript2"
         uses: ./.github/actions/setup-node2
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: |
           rustup show
           rustup target add wasm32-unknown-unknown
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Linux WASM jobs for better hit rates
+          shared-key: "linux-wasm"
 
       - name: "Install wasm-pack"
         uses: taiki-e/install-action@v2
@@ -101,15 +107,18 @@ jobs:
       - name: "Setup Node.js for typescript2"
         uses: ./.github/actions/setup-node2
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-
+      # Install Rust toolchain BEFORE rust-cache so cache key uses correct Rust version
       - name: "Install Rust toolchain"
         run: |
           rustup show
           rustup target add wasm32-unknown-unknown
         working-directory: baml_language
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "baml_language -> target"
+          # Share cache across similar Linux WASM jobs for better hit rates
+          shared-key: "linux-wasm"
 
       - name: "Install wasm-pack"
         uses: taiki-e/install-action@v2


### PR DESCRIPTION
# Pull Request Template

Thanks for taking the time to fill out this pull request!

## Issue Reference
Please link to any related issues
- [ ] This PR fixes/closes # (This PR addresses the Rust cache miss issue discussed in the conversation, referencing a similar issue: https://github.com/Swatinem/rust-cache/issues/9)

## Changes
Please describe the changes proposed in this pull request

This PR fixes a persistent Rust cache miss issue in CI workflows by:
1.  **Reordering CI steps**: The `Swatinem/rust-cache@v2` action now runs *after* the Rust toolchain is installed via `rustup show`. This ensures the cache key is generated based on the project's `rust-toolchain.toml` version, not the GitHub runner's default Rust version.
2.  **Adding `shared-key`**: Configured `shared-key` for `rust-cache` in various jobs (e.g., `linux-cargo`, `macos-cargo`, `windows-cargo`, `linux-wasm`, `linux-msrv`) to improve cache hit rates across similar CI runs.

## Testing
Please describe how you tested these changes

- [ ] Unit tests added/updated
- [x] Manual testing performed (Internal diagnostics and verification of workflow file changes)
- [ ] Tested in [environment] (Validation will occur via subsequent CI runs)

## Screenshots
If applicable, add screenshots to help explain your changes

[Add screenshots here...]

## PR Checklist
Please ensure you've completed these items

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
Add any other context about the PR here

### Root Cause
The `Swatinem/rust-cache@v2` action was running **BEFORE** the Rust toolchain was installed via `rustup show`. This caused the cache key to be generated using the pre-installed Rust version on GitHub runners (e.g., `1.93.0`) instead of your project's `rust-toolchain.toml` version (`1.89`). When GitHub updates their runner images with new Rust versions, ALL previous caches were invalidated.

From the CI logs (before fix):
```
Rust Version: 1.93.0 x86_64-unknown-linux-gnu (254b59607d4417e9dffbc307138ae5c86280fe4c)
```
While `rust-toolchain.toml` specifies `channel = "1.89"`.

### Fix Applied
1.  **Reordered steps** in all affected workflows to install the Rust toolchain BEFORE `rust-cache` runs:
    -   `cargo-tests.reusable.yaml` (6 jobs fixed)
    -   `ci.yaml` (2 jobs fixed)
    -   `wasm-pack-tests.reusable.yaml` (1 job fixed)
    -   `webview-tests.reusable.yaml` (3 jobs fixed)

2.  **Added `shared-key`** configuration to improve cache sharing between similar jobs:
    -   `linux-cargo` for Linux cargo test jobs
    -   `macos-cargo` for macOS cargo test jobs
    -   `windows-cargo` for Windows cargo test jobs
    -   `linux-wasm` for WASM build jobs
    -   `linux-msrv` for MSRV build jobs

### Expected Result
After this fix, the cache key will use the correct Rust version from `rust-toolchain.toml`, resulting in stable cache keys that persist across CI runs until dependencies or the Rust version are actually changed.

---
[Slack Thread](https://gloo-global.slack.com/archives/C09F3QMJE9G/p1770256299798159?thread_ts=1770256299.798159&cid=C09F3QMJE9G)

<p><a href="https://cursor.com/background-agent?bcId=bc-de7ae1e2-7789-5122-9a5c-e6e81b24ffbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-de7ae1e2-7789-5122-9a5c-e6e81b24ffbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration build caching infrastructure by reorganizing workflow execution steps to ensure Rust toolchain versions are accurately reflected in cache keys. Implemented environment-specific shared cache configurations for Linux, macOS, Windows, and WebAssembly testing pipelines, improving cache hit rates and reducing overall build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->