### PR TITLE
Fix Ctrl+C cancellation race in baml-cli test

### DIFF
--- a/engine/cli/src/commands.rs
+++ b/engine/cli/src/commands.rs
@@ -237,7 +237,7 @@ impl RuntimeCli {
                 let cancel_notify = Arc::new(tokio::sync::Notify::new());
                 let cancel_clone = cancel_notify.clone();
                 let cancel_token = if ctrlc::set_handler(move || {
-                    cancel_clone.notify_waiters();
+                    emit_cancel_signal(cancel_clone.as_ref());
                 })
                 .is_ok()
                 {
@@ -342,8 +342,42 @@ impl RuntimeCli {
     }
 }
 
+fn emit_cancel_signal(cancel_notify: &tokio::sync::Notify) {
+    // Persist one permit in case SIGINT arrives before the executor starts awaiting.
+    cancel_notify.notify_one();
+}
+
 fn baml_internal_env_is_truthy() -> bool {
     std::env::var("BAML_INTERNAL")
         .map(|value| matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true"))
         .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn notify_waiters_drops_signal_if_emitted_before_waiting() {
+        let notify = tokio::sync::Notify::new();
+        notify.notify_waiters();
+
+        let result = tokio::time::timeout(Duration::from_millis(20), notify.notified()).await;
+        assert!(
+            result.is_err(),
+            "notify_waiters should not persist signals for future waiters",
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_one_persists_signal_if_emitted_before_waiting() {
+        let notify = tokio::sync::Notify::new();
+        super::emit_cancel_signal(&notify);
+
+        let result = tokio::time::timeout(Duration::from_millis(20), notify.notified()).await;
+        assert!(
+            result.is_ok(),
+            "notify_one should persist one signal for a future waiter",
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- fix a Ctrl+C cancellation race in `baml-cli test` by using `Notify::notify_one()` instead of `notify_waiters()`
- add focused regression tests that document `Notify` behavior when the signal arrives before a waiter is registered
- keep the runtime executor path unchanged

## Issue
`notify_waiters()` only wakes tasks already waiting on `notified()` and does not persist a permit.

In `Commands::Test`, the SIGINT handler can run before the test executor reaches `notified().await`. When that timing happens, the cancellation signal is dropped. Result: Ctrl+C can be ignored and the test run can continue hanging.

## Why this fix
`notify_one()` stores a permit when there is no active waiter, so a later `notified().await` will complete immediately. That removes the race while preserving current cancellation flow.

## Concrete evidence
- buggy call site before fix: `engine/cli/src/commands.rs` used `cancel_clone.notify_waiters()` in the Ctrl+C handler
- runtime awaits cancellation via `notify.notified().await` in `engine/baml-runtime/src/test_executor/mod.rs`
- race exists when signal is emitted before waiter registration

## Validation
- `RUSTUP_TOOLCHAIN=stable-aarch64-apple-darwin cargo test -p baml-cli notify_ -- --nocapture`
- `RUSTUP_TOOLCHAIN=stable-aarch64-apple-darwin cargo test -p baml-runtime cancel_notify_returns_cancelled -- --nocapture`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests validating cancellation signal handling in CLI test execution.

* **Chores**
  * Improved internal implementation of signal cancellation handling to ensure proper signal persistence and reliability during operation interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->