### PR TITLE
Unify VIR schema and BexProgram types into   baml_type::defs

### DIFF
--- a/baml_language/crates/baml_compiler_vir/src/schema.rs
+++ b/baml_language/crates/baml_compiler_vir/src/schema.rs
@@ -1,95 +1,11 @@
 //! Schema items for VIR.
 //!
-//! VIR schema captures classes, enums, and functions with resolved types
-//! and propagated HIR attributes. Emit maps these to `bex_program` types.
+//! VIR schema captures classes, enums, functions, and type aliases with resolved
+//! types and propagated HIR attributes. Types are re-exported from `baml_type::defs`
+//! — the canonical definitions shared with `bex_program`.
 
-use baml_base::Name;
-use baml_type::Ty;
-
-/// Top-level schema container produced by `project_schema`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VirSchema {
-    pub classes: Vec<VirClass>,
-    pub enums: Vec<VirEnum>,
-    pub functions: Vec<VirFunction>,
-}
-
-/// A class definition with resolved field types and propagated attributes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VirClass {
-    pub name: Name,
-    pub fields: Vec<VirField>,
-    /// @@dynamic — marks class as dynamically extensible
-    pub is_dynamic: bool,
-    /// @@description("text")
-    pub description: Option<String>,
-    /// @@alias("name")
-    pub alias: Option<String>,
-}
-
-/// A field within a class.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VirField {
-    pub name: Name,
-    /// Resolved type (`baml_type::Ty`, aliases expanded, literals preserved)
-    pub ty: Ty,
-    /// @description("text")
-    pub description: Option<String>,
-    /// @alias("name")
-    pub alias: Option<String>,
-    /// @skip — exclude field from serialization
-    pub skip: bool,
-}
-
-/// An enum definition with propagated attributes.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VirEnum {
-    pub name: Name,
-    pub variants: Vec<VirEnumVariant>,
-    /// @@description("text")
-    pub description: Option<String>,
-    /// @@alias("name")
-    pub alias: Option<String>,
-}
-
-/// A variant within an enum.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VirEnumVariant {
-    pub name: Name,
-    /// @description("text")
-    pub description: Option<String>,
-    /// @alias("name")
-    pub alias: Option<String>,
-    /// @skip — exclude variant from serialization
-    pub skip: bool,
-}
-
-/// A function definition with resolved parameter/return types.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VirFunction {
-    pub name: Name,
-    pub params: Vec<VirParam>,
-    pub return_type: Ty,
-    pub body_kind: VirFunctionBodyKind,
-}
-
-/// A function parameter.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VirParam {
-    pub name: Name,
-    pub ty: Ty,
-}
-
-/// The kind of function body — determines how the runtime dispatches it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum VirFunctionBodyKind {
-    /// Declarative LLM function with prompt template and client reference.
-    Llm {
-        prompt_template: String,
-        client: String,
-    },
-    /// Imperative expression function — compiled to bytecode.
-    Expr,
-    /// Function body is missing (error recovery in HIR).
-    Missing,
-}
+pub use baml_type::{
+    ClassDef as VirClass, EnumDef as VirEnum, EnumVariantDef as VirEnumVariant,
+    FieldDef as VirField, FunctionBodyKind as VirFunctionBodyKind, FunctionDef as VirFunction,
+    ParamDef as VirParam, SchemaDefs as VirSchema, TypeAliasDef as VirTypeAlias,
+};

--- a/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
+++ b/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
@@ -68,13 +68,14 @@ pub(crate) fn lower_schema(
         }
     }
 
-    let type_alias_defs: Vec<VirTypeAlias> = type_aliases
+    let mut type_alias_defs: Vec<VirTypeAlias> = type_aliases
         .iter()
         .map(|(name, tir_ty)| VirTypeAlias {
             name: name.clone(),
             resolves_to: convert_ty(tir_ty, type_aliases, recursive_aliases),
         })
         .collect();
+    type_alias_defs.sort_by_key(|alias| alias.name.clone());
 
     VirSchema {
         classes,

--- a/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
+++ b/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
@@ -75,7 +75,7 @@ pub(crate) fn lower_schema(
             resolves_to: convert_ty(tir_ty, type_aliases, recursive_aliases),
         })
         .collect();
-    type_alias_defs.sort_by_key(|alias| alias.name.clone());
+    type_alias_defs.sort_by(|a, b| a.name.cmp(&b.name));
 
     VirSchema {
         classes,

--- a/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
+++ b/baml_language/crates/baml_compiler_vir/src/schema_lower.rs
@@ -12,7 +12,7 @@ use baml_type::Ty;
 
 use crate::schema::{
     VirClass, VirEnum, VirEnumVariant, VirField, VirFunction, VirFunctionBodyKind, VirParam,
-    VirSchema,
+    VirSchema, VirTypeAlias,
 };
 
 /// Lower all HIR items in the given project to VIR schema.
@@ -68,10 +68,19 @@ pub(crate) fn lower_schema(
         }
     }
 
+    let type_alias_defs: Vec<VirTypeAlias> = type_aliases
+        .iter()
+        .map(|(name, tir_ty)| VirTypeAlias {
+            name: name.clone(),
+            resolves_to: convert_ty(tir_ty, type_aliases, recursive_aliases),
+        })
+        .collect();
+
     VirSchema {
         classes,
         enums,
         functions,
+        type_aliases: type_alias_defs,
     }
 }
 

--- a/baml_language/crates/baml_tests/src/bytecode.rs
+++ b/baml_language/crates/baml_tests/src/bytecode.rs
@@ -162,95 +162,21 @@ pub fn compile_source_with_schema(source: &str) -> BexProgram {
     let project = db.project();
     let schema = baml_compiler_vir::project_schema(&db, project);
 
-    // Map VIR schema to bex_program types (inline mapping since we can't depend on bridge)
+    // VIR schema and bex_program share the same types from baml_type — just clone.
     let classes = schema
         .classes
         .iter()
-        .map(|c| {
-            let fields = c
-                .fields
-                .iter()
-                .filter(|f| !f.skip) // Filter out @skip fields
-                .map(|f| bex_program::FieldDef {
-                    name: f.name.to_string(),
-                    field_type: f.ty.clone(),
-                    description: f.description.clone(),
-                    alias: f.alias.clone(),
-                })
-                .collect();
-            (
-                c.name.to_string(),
-                bex_program::ClassDef {
-                    name: c.name.to_string(),
-                    fields,
-                    description: c.description.clone(),
-                },
-            )
-        })
+        .map(|c| (c.name.to_string(), c.clone()))
         .collect();
-
     let enums = schema
         .enums
         .iter()
-        .map(|e| {
-            let variants = e
-                .variants
-                .iter()
-                .map(|v| bex_program::EnumVariantDef {
-                    name: v.name.to_string(),
-                    description: v.description.clone(),
-                    alias: v.alias.clone(),
-                    skip: v.skip,
-                })
-                .collect();
-            (
-                e.name.to_string(),
-                bex_program::EnumDef {
-                    name: e.name.to_string(),
-                    variants,
-                    description: e.description.clone(),
-                },
-            )
-        })
+        .map(|e| (e.name.to_string(), e.clone()))
         .collect();
-
     let functions = schema
         .functions
         .iter()
-        .map(|f| {
-            let params = f
-                .params
-                .iter()
-                .map(|p| bex_program::ParamDef {
-                    name: p.name.to_string(),
-                    param_type: p.ty.clone(),
-                })
-                .collect();
-
-            let body = match &f.body_kind {
-                baml_compiler_vir::VirFunctionBodyKind::Llm {
-                    prompt_template,
-                    client,
-                } => bex_program::FunctionBody::Llm {
-                    prompt_template: prompt_template.clone(),
-                    client: client.clone(),
-                },
-                baml_compiler_vir::VirFunctionBodyKind::Expr
-                | baml_compiler_vir::VirFunctionBodyKind::Missing => {
-                    bex_program::FunctionBody::Expr
-                }
-            };
-
-            (
-                f.name.to_string(),
-                bex_program::FunctionDef {
-                    name: f.name.to_string(),
-                    params,
-                    return_type: f.return_type.clone(),
-                    body,
-                },
-            )
-        })
+        .map(|f| (f.name.to_string(), f.clone()))
         .collect();
 
     BexProgram {

--- a/baml_language/crates/baml_type/src/defs.rs
+++ b/baml_language/crates/baml_type/src/defs.rs
@@ -1,0 +1,93 @@
+//! Canonical schema-level type definitions shared by VIR and BexProgram.
+//!
+//! These types represent classes, enums, functions, and type aliases as they
+//! appear in the compiled schema. Both `baml_compiler_vir` (which produces them)
+//! and `bex_program` (which consumes them at runtime) re-export these types.
+
+use baml_base::Name;
+
+use crate::Ty;
+
+/// Top-level container for all schema definitions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaDefs {
+    pub classes: Vec<ClassDef>,
+    pub enums: Vec<EnumDef>,
+    pub functions: Vec<FunctionDef>,
+    pub type_aliases: Vec<TypeAliasDef>,
+}
+
+/// A class definition with resolved field types and propagated attributes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClassDef {
+    pub name: Name,
+    pub fields: Vec<FieldDef>,
+    pub is_dynamic: bool,
+    pub description: Option<String>,
+    pub alias: Option<String>,
+}
+
+/// A field within a class.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldDef {
+    pub name: Name,
+    pub ty: Ty,
+    pub description: Option<String>,
+    pub alias: Option<String>,
+    pub skip: bool,
+}
+
+/// An enum definition with propagated attributes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumDef {
+    pub name: Name,
+    pub variants: Vec<EnumVariantDef>,
+    pub description: Option<String>,
+    pub alias: Option<String>,
+}
+
+/// A variant within an enum.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnumVariantDef {
+    pub name: Name,
+    pub description: Option<String>,
+    pub alias: Option<String>,
+    pub skip: bool,
+}
+
+/// A function definition with resolved parameter/return types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FunctionDef {
+    pub name: Name,
+    pub params: Vec<ParamDef>,
+    pub return_type: Ty,
+    pub body_kind: FunctionBodyKind,
+}
+
+/// A function parameter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParamDef {
+    pub name: Name,
+    pub ty: Ty,
+}
+
+/// The kind of function body — determines how the runtime dispatches it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FunctionBodyKind {
+    /// Declarative LLM function with prompt template and client reference.
+    Llm {
+        prompt_template: String,
+        client: String,
+    },
+    /// Imperative expression function — compiled to bytecode.
+    Expr,
+    /// Function body is missing (error recovery in HIR).
+    Missing,
+}
+
+/// A type alias definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeAliasDef {
+    pub name: Name,
+    pub resolves_to: Ty,
+}

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -14,8 +14,10 @@ use std::{
 pub use baml_base::{Literal, MediaKind, Name, Span};
 
 mod convert;
+mod defs;
 pub mod typetag;
 pub use convert::{convert_tir_ty, fqn_to_type_name, sanitize_for_runtime};
+pub use defs::*;
 
 /// A lightweight name type for class/enum/type-alias references.
 ///

--- a/baml_language/crates/bex_program/src/lib.rs
+++ b/baml_language/crates/bex_program/src/lib.rs
@@ -16,78 +16,14 @@ pub use baml_base::{Literal as LiteralValue, MediaKind};
 /// The unified type representation from `baml_type`.
 pub use baml_type::Ty;
 pub use baml_type::TypeName;
+// ============================================================================
+// Type Definitions (re-exported from baml_type)
+// ============================================================================
+pub use baml_type::{
+    ClassDef, EnumDef, EnumVariantDef, FieldDef, FunctionBodyKind as FunctionBody, FunctionDef,
+    ParamDef, TypeAliasDef,
+};
 pub use bex_vm_types::Program;
-
-// ============================================================================
-// Type Definitions
-// ============================================================================
-
-/// A class definition.
-#[derive(Clone, Debug)]
-pub struct ClassDef {
-    pub name: String,
-    pub fields: Vec<FieldDef>,
-    pub description: Option<String>,
-}
-
-/// A field within a class.
-#[derive(Clone, Debug)]
-pub struct FieldDef {
-    pub name: String,
-    pub field_type: Ty,
-    pub description: Option<String>,
-    pub alias: Option<String>,
-}
-
-/// An enum definition.
-#[derive(Clone, Debug)]
-pub struct EnumDef {
-    pub name: String,
-    pub variants: Vec<EnumVariantDef>,
-    pub description: Option<String>,
-}
-
-/// A variant within an enum.
-#[derive(Clone, Debug)]
-pub struct EnumVariantDef {
-    pub name: String,
-    pub description: Option<String>,
-    pub alias: Option<String>,
-    /// @skip — whether this variant should be excluded from serialization
-    pub skip: bool,
-}
-
-// ============================================================================
-// Function Definitions
-// ============================================================================
-
-/// A function definition.
-#[derive(Clone, Debug)]
-pub struct FunctionDef {
-    pub name: String,
-    pub params: Vec<ParamDef>,
-    pub return_type: Ty,
-    pub body: FunctionBody,
-}
-
-/// A function parameter.
-#[derive(Clone, Debug)]
-pub struct ParamDef {
-    pub name: String,
-    pub param_type: Ty,
-}
-
-/// The body of a function - either LLM or expression.
-#[derive(Clone, Debug)]
-pub enum FunctionBody {
-    /// Declarative LLM function - prompt template + client config.
-    Llm {
-        prompt_template: String,
-        client: String,
-    },
-    /// Imperative expression function - compiled to bytecode.
-    Expr,
-}
 
 // ============================================================================
 // Infrastructure Definitions
@@ -174,7 +110,7 @@ impl BexProgram {
         for (class_name, class_def) in &self.classes {
             for field in &class_def.fields {
                 field
-                    .field_type
+                    .ty
                     .validate_runtime()
                     .map_err(|e| format!("Class '{class_name}' field '{}': {e}", field.name))?;
             }
@@ -186,7 +122,7 @@ impl BexProgram {
                 .map_err(|e| format!("Function '{fn_name}' return type: {e}"))?;
             for param in &fn_def.params {
                 param
-                    .param_type
+                    .ty
                     .validate_runtime()
                     .map_err(|e| format!("Function '{fn_name}' param '{}': {e}", param.name))?;
             }


### PR DESCRIPTION
  Move canonical type definitions (ClassDef, EnumDef, FunctionDef, etc.)
  into baml_type::defs so VIR and BexProgram share the same structs,
  eliminating near-duplicate definitions and field name mismatches
  (field_type→ty, param_type→ty, body→body_kind). Also adds TypeAliasDef
  and type alias lowering in VIR schema.

  Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for type aliases in schema definitions.
  * Emitted programs now preserve and carry schema items directly (schema-driven output).

* **Refactor**
  * Introduced a single canonical set of schema definitions and exposed them across components for a consistent public API.
  * Consumer components now reuse shared schema types, simplifying schema handling and reducing duplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->