### PR TITLE
baml-language: implement template strings

### DIFF
--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -49,7 +49,7 @@ use std::collections::{HashMap, HashSet};
 use baml_base::{Name, SourceFile, Span};
 use baml_compiler_hir::{
     self, ItemId, function_body, function_qualified_name, function_signature,
-    function_signature_source_map,
+    function_signature_source_map, template_string_body, template_string_signature,
 };
 use baml_compiler_tir::TypeResolutionContext;
 pub use baml_compiler_vir::LoweringError;
@@ -528,6 +528,30 @@ pub fn compile_files(
             }
         }
     }
+
+    // --- Pass: Format template_string macros ---
+    let mut template_macros = Vec::new();
+    for file in files {
+        let items_struct = baml_compiler_hir::file_items(db, *file);
+        for item in items_struct.items(db) {
+            if let ItemId::TemplateString(ts_loc) = item {
+                let signature = template_string_signature(db, *ts_loc);
+                let body = template_string_body(db, *ts_loc);
+                let args = signature
+                    .params
+                    .iter()
+                    .map(|p| p.name.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                template_macros.push(format!(
+                    "{{% macro {name}({args}) %}}{body}{{% endmacro %}}",
+                    name = signature.name,
+                    body = body.text,
+                ));
+            }
+        }
+    }
+    program.template_strings_macros = template_macros.join("\n");
 
     Ok(program)
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -328,6 +328,7 @@ impl BexEngine {
         let sys_op_ctx = sys_types::SysOpContext {
             llm_functions,
             function_global_indices: bytecode.function_global_indices,
+            template_strings_macros: bytecode.template_strings_macros,
         };
 
         Ok(Self {

--- a/baml_language/crates/bex_engine/tests/llm_render.rs
+++ b/baml_language/crates/bex_engine/tests/llm_render.rs
@@ -557,3 +557,185 @@ function test_call_llm() -> unknown {
         }
     }
 }
+
+// ============================================================================
+// Template String Tests
+// ============================================================================
+
+/// Build a `BexExternalValue` wrapping a simple string `PromptAst`.
+fn prompt_ast_string(s: &str) -> BexExternalValue {
+    BexExternalValue::Adt(BexExternalAdt::PromptAst(std::sync::Arc::new(
+        BuiltinPromptAst::Simple(std::sync::Arc::new(s.to_string().into())),
+    )))
+}
+
+/// Test that a `template_string` is expanded as a Jinja macro in `render_prompt`.
+#[tokio::test]
+async fn test_template_string_in_prompt() {
+    use std::collections::HashMap;
+
+    use bex_engine::BexEngine;
+    use sys_native::SysOpsExt;
+
+    let source = r##"
+client TestClient {
+    provider openai
+    options {
+        model "gpt-4"
+    }
+}
+
+template_string Greet(name: string) #"Hello, {{ name }}!"#
+
+function TestFunc(name: string) -> string {
+    client TestClient
+    prompt #"
+        {{ Greet(name) }}
+    "#
+}
+
+function get_prompt() -> PromptAst {
+    let args = { "name": "Alice" };
+    baml.llm.render_prompt("TestFunc", args)
+}
+"##;
+
+    let snapshot = common::compile_for_engine(source);
+    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
+        .expect("Failed to create engine");
+
+    let result = engine
+        .call_function("get_prompt", vec![])
+        .await
+        .expect("failed to render prompt that calls template_string Greet(name)");
+    assert_eq!(result, prompt_ast_string("Hello, Alice!"));
+}
+
+/// Test that nested `template_strings` expand correctly.
+#[tokio::test]
+async fn test_nested_template_strings() {
+    use std::collections::HashMap;
+
+    use bex_engine::BexEngine;
+    use sys_native::SysOpsExt;
+
+    let source = r##"
+client TestClient {
+    provider openai
+    options {
+        model "gpt-4"
+    }
+}
+
+template_string Inner() #"INNER"#
+template_string Outer() #"before {{ Inner() }} after"#
+
+function TestFunc() -> string {
+    client TestClient
+    prompt #"{{ Outer() }}"#
+}
+
+function get_prompt() -> PromptAst {
+    let args = {};
+    baml.llm.render_prompt("TestFunc", args)
+}
+"##;
+
+    let snapshot = common::compile_for_engine(source);
+    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
+        .expect("Failed to create engine");
+
+    let result = engine
+        .call_function("get_prompt", vec![])
+        .await
+        .expect("failed to render prompt with nested template_strings Outer() -> Inner()");
+    assert_eq!(result, prompt_ast_string("before INNER after"));
+}
+
+/// Test a `template_string` with two args, one of which is a class (struct).
+#[tokio::test]
+async fn test_template_string_with_struct_arg() {
+    use std::collections::HashMap;
+
+    use bex_engine::BexEngine;
+    use sys_native::SysOpsExt;
+
+    let source = r##"
+client TestClient {
+    provider openai
+    options {
+        model "gpt-4"
+    }
+}
+
+class Person {
+    name string
+    age int
+}
+
+template_string Describe(label: string, person: Person) #"{{ label }}: {{ person.name }} (age {{ person.age }})"#
+
+function TestFunc(label: string, person: Person) -> string {
+    client TestClient
+    prompt #"
+        {{ Describe(label, person) }}
+    "#
+}
+
+function get_prompt() -> PromptAst {
+    let args = { "label": "User", "person": { "name": "Bob", "age": 42 } };
+    baml.llm.render_prompt("TestFunc", args)
+}
+"##;
+
+    let snapshot = common::compile_for_engine(source);
+    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
+        .expect("Failed to create engine");
+
+    let result = engine
+        .call_function("get_prompt", vec![])
+        .await
+        .expect("failed to render prompt with 2-arg template_string Describe(label, person)");
+    assert_eq!(result, prompt_ast_string("User: Bob (age 42)"));
+}
+
+/// Test that parameterless `template_strings` work.
+#[tokio::test]
+async fn test_parameterless_template_string() {
+    use std::collections::HashMap;
+
+    use bex_engine::BexEngine;
+    use sys_native::SysOpsExt;
+
+    let source = r##"
+client TestClient {
+    provider openai
+    options {
+        model "gpt-4"
+    }
+}
+
+template_string Header() #"=== HEADER ==="#
+
+function TestFunc() -> string {
+    client TestClient
+    prompt #"{{ Header() }}
+Content here"#
+}
+
+function get_prompt() -> PromptAst {
+    let args = {};
+    baml.llm.render_prompt("TestFunc", args)
+}
+"##;
+
+    let snapshot = common::compile_for_engine(source);
+    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
+        .expect("Failed to create engine");
+
+    let result = engine
+        .call_function("get_prompt", vec![])
+        .await
+        .expect("failed to render prompt that calls parameterless template_string Header()");
+    assert_eq!(result, prompt_ast_string("=== HEADER ===\nContent here"));
+}

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -281,6 +281,8 @@ pub struct BytecodeProgram {
     /// Maps function names to their global indices.
     /// Used for dynamic function lookup at runtime.
     pub function_global_indices: HashMap<String, usize>,
+    /// Pre-formatted Jinja `{% macro %}` definitions for all `template_strings`.
+    pub template_strings_macros: String,
 }
 
 /// Convert a compiled `Program` to a `BytecodeProgram` with native functions attached.
@@ -324,6 +326,7 @@ pub fn convert_program(program: bex_vm_types::Program) -> Result<BytecodeProgram
         resolved_class_names,
         resolved_enums_names,
         function_global_indices: program.function_global_indices,
+        template_strings_macros: program.template_strings_macros,
     })
 }
 

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -40,6 +40,10 @@ pub struct Program {
     /// Maps function names to their global indices.
     /// Used for dynamic function lookup at runtime.
     pub function_global_indices: HashMap<String, usize>,
+
+    /// Pre-formatted Jinja `{% macro %}` definitions for all `template_strings`.
+    /// Prepended to function prompt templates by `get_jinja_template`.
+    pub template_strings_macros: String,
 }
 
 impl Program {

--- a/baml_language/crates/sys_llm/src/jinja/mod.rs
+++ b/baml_language/crates/sys_llm/src/jinja/mod.rs
@@ -14,7 +14,8 @@ mod value_conversion;
 
 pub use error::RenderPromptError;
 pub use render::{
-    RenderContext, RenderContextClient, RenderEnum, RenderEnumVariant, render_prompt,
+    RenderContext, RenderContextClient, RenderEnum, RenderEnumVariant, preprocess_template,
+    render_prompt,
 };
 
 pub use crate::types::OutputFormatContent;

--- a/baml_language/crates/sys_llm/src/jinja/render.rs
+++ b/baml_language/crates/sys_llm/src/jinja/render.rs
@@ -60,9 +60,7 @@ pub fn render_prompt(
 ) -> Result<PromptAst, super::RenderPromptError> {
     let mut env = create_environment();
 
-    // Preprocess template
-    let processed_template = preprocess_template(template);
-    env.add_template("prompt", &processed_template)?;
+    env.add_template("prompt", template)?;
 
     let mut media_handles = HashMap::new();
     // Add globals (tags may contain media; share media_handles so parse_rendered_output can resolve them)
@@ -113,7 +111,7 @@ fn create_environment() -> Environment<'static> {
 /// Preprocess template: dedent and trim.
 ///
 /// Dedenting logic ported from engine/baml-lib/jinja-runtime/src/lib.rs:266-277
-fn preprocess_template(template: &str) -> String {
+pub fn preprocess_template(template: &str) -> String {
     // Dedent: find minimum whitespace and remove from all lines
     let lines: Vec<&str> = template.lines().collect();
 
@@ -448,10 +446,8 @@ mod tests {
             Hello,
             World!
         "#;
-        let args = IndexMap::new();
-        let result = render_prompt(template, &args, &test_ctx()).unwrap();
-
-        assert_eq!(result, "Hello,\nWorld!".to_string().into());
+        let result = preprocess_template(template);
+        assert_eq!(result, "Hello,\nWorld!");
     }
 
     #[test]

--- a/baml_language/crates/sys_llm/src/lib.rs
+++ b/baml_language/crates/sys_llm/src/lib.rs
@@ -22,7 +22,7 @@ use bex_heap::builtin_types;
 // Used by bex_engine tests
 pub use jinja::{
     OutputFormatContent, RenderContext, RenderContextClient, RenderEnum, RenderEnumVariant,
-    RenderPromptError, render_prompt,
+    RenderPromptError, preprocess_template, render_prompt,
 };
 // --- Crate-internal re-exports (used by submodules via `crate::`) ---
 pub(crate) use model_features::{AllowedMetadata, ModelFeatures};

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -242,6 +242,10 @@ pub struct SysOpContext {
     /// Maps function names to their global indices in the VM.
     /// Used by `get_client_function` to return `FunctionRef` values.
     pub function_global_indices: std::collections::HashMap<String, usize>,
+
+    /// Pre-formatted Jinja `{% macro %}` definitions for all `template_strings`.
+    /// Prepended to templates by `get_jinja_template`.
+    pub template_strings_macros: String,
 }
 
 /// Pre-extracted metadata for an LLM function.
@@ -263,6 +267,7 @@ impl SysOpContext {
         Self {
             llm_functions: std::collections::HashMap::new(),
             function_global_indices: std::collections::HashMap::new(),
+            template_strings_macros: String::new(),
         }
     }
 }
@@ -439,7 +444,13 @@ impl<T> SysOpLlm for T {
                 "LLM function not found: {function_name}"
             )));
         };
-        SysOpOutput::ok(info.prompt_template.clone())
+        let dedented = sys_llm::preprocess_template(&info.prompt_template);
+        let template = if ctx.template_strings_macros.is_empty() {
+            dedented
+        } else {
+            format!("{}\n{}", ctx.template_strings_macros, dedented)
+        };
+        SysOpOutput::ok(template)
     }
 
     fn baml_llm_build_primitive_client(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template-string macros are now included in assembled programs and prepended to prompt templates for rendering.
  * Template preprocessing exposed as a public API for dedenting/normalizing templates.

* **Behavior**
  * Prompt rendering now incorporates preformatted template macros so template strings expand correctly, including nested and struct-argument cases.

* **Tests**
  * Added tests covering template-string expansion in prompts (nested, parameterless, and struct-argument scenarios).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->