### PR TITLE
Warn on use of nullable enums in templates

### DIFF
--- a/baml_language/crates/baml_compiler_tir/src/jinja/expr.rs
+++ b/baml_language/crates/baml_compiler_tir/src/jinja/expr.rs
@@ -278,7 +278,7 @@ fn extract_enum_from_nullable_union(types: &[JinjaType]) -> Option<&str> {
 
     for t in types {
         match t {
-            JinjaType::EnumValueRef(name) => {
+            JinjaType::EnumValueRef(name) | JinjaType::EnumRef(name) => {
                 if enum_name.is_some() {
                     // Multiple different enums - not a simple nullable enum
                     return None;
@@ -354,10 +354,13 @@ fn handle_enum_binary_op(
         }
     }
 
-    // Handle direct EnumValueRef operations
+    // Handle direct enum operations (both EnumValueRef and EnumRef)
     match (lhs, rhs) {
-        // Both are EnumValueRef - only allow comparison between same enum
-        (JinjaType::EnumValueRef(e1), JinjaType::EnumValueRef(e2)) => {
+        // Both are enum types - only allow comparison between same enum
+        (
+            JinjaType::EnumValueRef(e1) | JinjaType::EnumRef(e1),
+            JinjaType::EnumValueRef(e2) | JinjaType::EnumRef(e2),
+        ) => {
             if is_comparison_op(&bin_expr.op) {
                 if e1 == e2 {
                     Some(JinjaType::Bool)
@@ -380,9 +383,9 @@ fn handle_enum_binary_op(
             }
         }
 
-        // EnumValueRef with generic string
-        (JinjaType::EnumValueRef(enum_name), JinjaType::String)
-        | (JinjaType::String, JinjaType::EnumValueRef(enum_name)) => {
+        // Enum with generic string
+        (JinjaType::EnumValueRef(enum_name) | JinjaType::EnumRef(enum_name), JinjaType::String)
+        | (JinjaType::String, JinjaType::EnumValueRef(enum_name) | JinjaType::EnumRef(enum_name)) => {
             if is_comparison_op(&bin_expr.op) {
                 errors.push(TypeError::enum_string_comparison_deprecated(
                     expr,
@@ -400,8 +403,9 @@ fn handle_enum_binary_op(
             }
         }
 
-        // Any other combination with EnumValueRef is invalid
-        (JinjaType::EnumValueRef(enum_name), _) | (_, JinjaType::EnumValueRef(enum_name)) => {
+        // Any other combination with enum types is invalid
+        (JinjaType::EnumValueRef(enum_name) | JinjaType::EnumRef(enum_name), _)
+        | (_, JinjaType::EnumValueRef(enum_name) | JinjaType::EnumRef(enum_name)) => {
             errors.push(TypeError::enum_string_comparison_deprecated(
                 expr,
                 enum_name,

--- a/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/enum/enums_in_jinja.baml
+++ b/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/enum/enums_in_jinja.baml
@@ -388,4 +388,318 @@ function TestEnumJinjaSyntax(status: Status, priority: Priority, nullable_status
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:20:12 ]
+//     │
+//  20 │         {% if status == "Active" %}
+//     │            ──────────┬──────────  
+//     │                      ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:24:12 ]
+//     │
+//  24 │         {% if status == "Pending" %}
+//     │            ───────────┬──────────  
+//     │                       ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:29:12 ]
+//     │
+//  29 │         {% if "Inactive" == status %}
+//     │            ───────────┬───────────  
+//     │                       ╰───────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:34:12 ]
+//     │
+//  34 │         {% if status != "Active" %}
+//     │            ──────────┬──────────  
+//     │                      ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:41:12 ]
+//     │
+//  41 │         {% if status == "active" %}
+//     │            ──────────┬──────────  
+//     │                      ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:45:12 ]
+//     │
+//  45 │         {% if priority == "urgent" %}
+//     │            ───────────┬───────────  
+//     │                       ╰───────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:52:12 ]
+//     │
+//  52 │         {% if status == "ACTIVE" %}
+//     │            ──────────┬──────────  
+//     │                      ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:56:12 ]
+//     │
+//  56 │         {% if priority == "high" %}
+//     │            ──────────┬──────────  
+//     │                      ╰──────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:63:12 ]
+//     │
+//  63 │         {% if status == "Active" or status == "Pending" %}
+//     │            ──────────┬──────────  
+//     │                      ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:63:34 ]
+//     │
+//  63 │         {% if status == "Active" or status == "Pending" %}
+//     │                                  ───────────┬──────────  
+//     │                                             ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:68:15 ]
+//     │
+//  68 │         {% if (status == "Active" or priority == "High") and nullable_status != "Inactive" %}
+//     │               ─────────┬─────────  
+//     │                        ╰─────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:68:35 ]
+//     │
+//  68 │         {% if (status == "Active" or priority == "High") and nullable_status != "Inactive" %}
+//     │                                   ──────────┬──────────  
+//     │                                             ╰──────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:68:58 ]
+//     │
+//  68 │         {% if (status == "Active" or priority == "High") and nullable_status != "Inactive" %}
+//     │                                                          ────────────────┬────────────────  
+//     │                                                                          ╰────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:73:19 ]
+//     │
+//  73 │         {% if not (status == "Inactive") %}
+//     │                   ──────────┬──────────  
+//     │                             ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:80:12 ]
+//     │
+//  80 │         {% if status == "Active" %}
+//     │            ──────────┬──────────  
+//     │                      ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:82:12 ]
+//     │
+//  82 │         {% elif status == "Pending" %}
+//     │            ────────────┬───────────  
+//     │                        ╰───────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:84:12 ]
+//     │
+//  84 │         {% elif status == "Inactive" %}
+//     │            ────────────┬────────────  
+//     │                        ╰────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:91:36 ]
+//     │
+//  91 │         Result: {{ "High Priority" if priority == "High" else "Normal Priority" }}
+//     │                                    ──────────┬──────────  
+//     │                                              ╰──────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:92:29 ]
+//     │
+//  92 │         Status: {{ "Active" if status == "Active" else "Not Active" }}
+//     │                             ──────────┬──────────  
+//     │                                       ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_enums_in_jinja.baml:97:12 ]
+//     │
+//  97 │         {% if status < "ZZZ" %}
+//     │            ────────┬────────  
+//     │                    ╰────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:102:12 ]
+//      │
+//  102 │         {% if priority > "AAA" %}
+//      │            ─────────┬─────────  
+//      │                     ╰─────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:107:12 ]
+//      │
+//  107 │         {% if status >= "Active" and priority <= "Medium" %}
+//      │            ──────────┬──────────  
+//      │                      ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:107:34 ]
+//      │
+//  107 │         {% if status >= "Active" and priority <= "Medium" %}
+//      │                                  ────────────┬───────────  
+//      │                                              ╰───────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:115:16 ]
+//      │
+//  115 │             {% if status == s %}
+//      │                ───────┬──────  
+//      │                       ╰──────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:122:16 ]
+//      │
+//  122 │             {% if priority == p %}
+//      │                ────────┬───────  
+//      │                        ╰───────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:130:12 ]
+//      │
+//  130 │         {% if status == priority %}
+//      │            ──────────┬──────────  
+//      │                      ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:144:12 ]
+//      │
+//  144 │         {% if status == "Activ" %}
+//      │            ──────────┬─────────  
+//      │                      ╰─────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:148:12 ]
+//      │
+//  148 │         {% if priority == "Hgh" %}
+//      │            ──────────┬─────────  
+//      │                      ╰─────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:153:12 ]
+//      │
+//  153 │         {% if status == "Unknown" %}
+//      │            ───────────┬──────────  
+//      │                       ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:158:12 ]
+//      │
+//  158 │         {% if status == "" %}
+//      │            ───────┬───────  
+//      │                   ╰───────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:165:15 ]
+//      │
+//  165 │         {% if (status == "Active" and priority == "High") or (status == "Pending" and priority != "Low") %}
+//      │               ─────────┬─────────  
+//      │                        ╰─────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:165:35 ]
+//      │
+//  165 │         {% if (status == "Active" and priority == "High") or (status == "Pending" and priority != "Low") %}
+//      │                                   ───────────┬──────────  
+//      │                                              ╰──────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:165:62 ]
+//      │
+//  165 │         {% if (status == "Active" and priority == "High") or (status == "Pending" and priority != "Low") %}
+//      │                                                              ──────────┬─────────  
+//      │                                                                        ╰─────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:165:83 ]
+//      │
+//  165 │         {% if (status == "Active" and priority == "High") or (status == "Pending" and priority != "Low") %}
+//      │                                                                                   ──────────┬──────────  
+//      │                                                                                             ╰──────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_enums_in_jinja.baml:171:16 ]
+//      │
+//  171 │             {% if status == "Active" and item == "test" %}
+//      │                ──────────┬──────────  
+//      │                          ╰──────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯

--- a/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/enum/nullable_enums_in_jinja.baml
+++ b/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/enum/nullable_enums_in_jinja.baml
@@ -241,4 +241,138 @@ function TestUnionTypesNoWarnings(input: MyInput) -> string {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ enum_nullable_enums_in_jinja.baml:143:8 ]
+//      │
+//  143 │     {% if input.regular_status == "Active" %}
+//      │        ─────────────────┬─────────────────  
+//      │                         ╰─────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:89:8 ]
+//     │
+//  89 │     {% if input.nullable_status == input.nullable_priority %}
+//     │        ─────────────────────────┬─────────────────────────  
+//     │                                 ╰─────────────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:91:8 ]
+//     │
+//  91 │     {% elif input.nullable_status != input.nullable_priority %}
+//     │        ──────────────────────────┬──────────────────────────  
+//     │                                  ╰──────────────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:40:8 ]
+//     │
+//  40 │     {% if input.nullable_status == "Active" %}
+//     │        ──────────────────┬─────────────────  
+//     │                          ╰─────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:42:8 ]
+//     │
+//  42 │     {% elif input.nullable_status == "inactive" %}
+//     │        ────────────────────┬───────────────────  
+//     │                            ╰───────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:44:8 ]
+//     │
+//  44 │     {% elif "Pending" == input.nullable_status %}
+//     │        ───────────────────┬───────────────────  
+//     │                           ╰───────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:46:8 ]
+//     │
+//  46 │     {% elif input.nullable_status != "Inactive" %}
+//     │        ────────────────────┬───────────────────  
+//     │                            ╰───────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:51:8 ]
+//     │
+//  51 │     {% if input.nullable_status > "AAA" %}
+//     │        ────────────────┬───────────────  
+//     │                        ╰───────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:53:8 ]
+//     │
+//  53 │     {% elif input.nullable_status <= "Zzz" %}
+//     │        ─────────────────┬─────────────────  
+//     │                         ╰─────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:55:8 ]
+//     │
+//  55 │     {% elif input.nullable_status >= "Active" %}
+//     │        ───────────────────┬──────────────────  
+//     │                           ╰──────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:60:8 ]
+//     │
+//  60 │     {% if input.nullable_priority == "High" %}
+//     │        ──────────────────┬─────────────────  
+//     │                          ╰─────────────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:62:8 ]
+//     │
+//  62 │     {% elif input.nullable_priority != "Low" %}
+//     │        ──────────────────┬──────────────────  
+//     │                          ╰──────────────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:67:11 ]
+//     │
+//  67 │     {% if (input.nullable_status == "Active") and (input.nullable_priority != "Low") %}
+//     │           ─────────────────┬────────────────  
+//     │                            ╰────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:67:51 ]
+//     │
+//  67 │     {% if (input.nullable_status == "Active") and (input.nullable_priority != "Low") %}
+//     │                                                   ────────────────┬────────────────  
+//     │                                                                   ╰────────────────── Comparing enum Priority to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ enum_nullable_enums_in_jinja.baml:72:33 ]
+//     │
+//  72 │     {% if input.nullable_status and input.nullable_status == "Pending" %}
+//     │                                 ───────────────────┬──────────────────  
+//     │                                                    ╰──────────────────── Comparing enum Status to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯

--- a/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/functions_v2/valid.baml
+++ b/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/functions_v2/valid.baml
@@ -203,4 +203,120 @@ function TestEnumInExpressions(color: Color) -> string {
 
 //----
 //- diagnostics
-// <no-diagnostics-expected>
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ functions_v2_valid.baml:71:8 ]
+//     │
+//  71 │     {% if color == "RED" %}
+//     │        ────────┬────────  
+//     │                ╰────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ functions_v2_valid.baml:75:8 ]
+//     │
+//  75 │     {% if "BLUE" == color %}
+//     │        ─────────┬────────  
+//     │                 ╰────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ functions_v2_valid.baml:79:8 ]
+//     │
+//  79 │     {% if color != "GREEN" %}
+//     │        ─────────┬─────────  
+//     │                 ╰─────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ functions_v2_valid.baml:84:8 ]
+//     │
+//  84 │     {% if color < "YELLOW" %}
+//     │        ─────────┬─────────  
+//     │                 ╰─────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     ╭─[ functions_v2_valid.baml:88:8 ]
+//     │
+//  88 │     {% if color >= "BLUE" %}
+//     │        ─────────┬────────  
+//     │                 ╰────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//     │ 
+//     │ Note: Error code: E0076
+// ────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ functions_v2_valid.baml:101:23 ]
+//      │
+//  101 │     {% set is_primary = color == "RED" or color == "BLUE" %}
+//      │                       ────────┬───────  
+//      │                               ╰───────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ functions_v2_valid.baml:101:40 ]
+//      │
+//  101 │     {% set is_primary = color == "RED" or color == "BLUE" %}
+//      │                                        ─────────┬────────  
+//      │                                                 ╰────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ functions_v2_valid.baml:107:26 ]
+//      │
+//  107 │     Result: {{ "Primary" if color == "RED" or color == "BLUE" else "Secondary" }}
+//      │                          ────────┬────────  
+//      │                                  ╰────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ functions_v2_valid.baml:107:44 ]
+//      │
+//  107 │     Result: {{ "Primary" if color == "RED" or color == "BLUE" else "Secondary" }}
+//      │                                            ─────────┬────────  
+//      │                                                     ╰────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ functions_v2_valid.baml:110:8 ]
+//      │
+//  110 │     {% if color == "RED" and true %}
+//      │        ────────┬────────  
+//      │                ╰────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ functions_v2_valid.baml:115:8 ]
+//      │
+//  115 │     {% if color != "GREEN" %}
+//      │        ─────────┬─────────  
+//      │                 ╰─────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ functions_v2_valid.baml:116:10 ]
+//      │
+//  116 │       {% if color == "RED" %}
+//      │          ────────┬────────  
+//      │                  ╰────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯
+// Warning: Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      ╭─[ functions_v2_valid.baml:118:10 ]
+//      │
+//  118 │       {% elif color == "BLUE" %}
+//      │          ──────────┬─────────  
+//      │                    ╰─────────── Comparing enum Color to string - enum-string comparisons will soon be deprecated. Please see https://github.com/BoundaryML/baml/issues/2339.
+//      │ 
+//      │ Note: Error code: E0076
+// ─────╯


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Broader enum handling in template expressions so enum references are consistently recognized across comparisons and operations.

* **Deprecations**
  * Enum-to-string comparisons now emit deprecation warnings (E0076) with guidance to use enum-based comparisons.

* **Tests**
  * Updated test expectations to surface the new deprecation warnings in relevant template scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->