### PR TITLE
Port env from native function to sys_op, remove env_vars from pipeline

### DIFF
--- a/baml_language/crates/baml_builtins/src/lib.rs
+++ b/baml_language/crates/baml_builtins/src/lib.rs
@@ -364,8 +364,10 @@ macro_rules! with_builtins {
             }
 
             mod env {
-                #[uses(vm)]
-                fn get(key: String) -> Result<String>;
+                #[sys_op]
+                fn get(key: String) -> Option<String>;
+                #[sys_op]
+                fn get_or_panic(key: String) -> String;
             }
         }
     };
@@ -533,6 +535,12 @@ mod tests {
 
         let env_get = builtins().iter().find(|d| d.path == "env.get").unwrap();
         assert_eq!(env_get.method_name(), None);
+
+        let env_get_or_panic = builtins()
+            .iter()
+            .find(|d| d.path == "env.get_or_panic")
+            .unwrap();
+        assert_eq!(env_get_or_panic.method_name(), None);
     }
 
     #[test]
@@ -551,6 +559,12 @@ mod tests {
 
         let env_get = builtins().iter().find(|d| d.path == "env.get").unwrap();
         assert_eq!(env_get.arity(), 1); // key only
+
+        let env_get_or_panic = builtins()
+            .iter()
+            .find(|d| d.path == "env.get_or_panic")
+            .unwrap();
+        assert_eq!(env_get_or_panic.arity(), 1); // key only
     }
 
     #[test]
@@ -560,16 +574,40 @@ mod tests {
     }
 
     #[test]
+    fn test_env_builtins() {
+        // env.get is a sys_op returning optional string
+        let env_get = find_function("env.get").unwrap();
+        assert!(env_get.is_sys_op, "env.get should be a sys_op");
+        assert!(
+            env_get.receiver.is_none(),
+            "env.get should be a free function"
+        );
+
+        // env.get_or_panic is a sys_op returning string
+        let env_gop = find_function("env.get_or_panic").unwrap();
+        assert!(env_gop.is_sys_op, "env.get_or_panic should be a sys_op");
+        assert!(
+            env_gop.receiver.is_none(),
+            "env.get_or_panic should be a free function"
+        );
+    }
+
+    #[test]
     fn test_find_function() {
         let env_get = find_function("env.get");
         assert!(env_get.is_some());
         assert_eq!(env_get.unwrap().path, "env.get");
+
+        let env_get_or_panic = find_function("env.get_or_panic");
+        assert!(env_get_or_panic.is_some());
+        assert_eq!(env_get_or_panic.unwrap().path, "env.get_or_panic");
     }
 
     #[test]
     fn test_find_builtin_by_path() {
         assert!(find_builtin_by_path("baml.Array.length").is_some());
         assert!(find_builtin_by_path("env.get").is_some());
+        assert!(find_builtin_by_path("env.get_or_panic").is_some());
         assert!(find_builtin_by_path("nonexistent").is_none());
     }
 
@@ -579,6 +617,7 @@ mod tests {
         assert_eq!(paths::BAML_ARRAY_LENGTH, "baml.Array.length");
         assert_eq!(paths::BAML_STRING_TO_LOWER_CASE, "baml.String.toLowerCase");
         assert_eq!(paths::ENV_GET, "env.get");
+        assert_eq!(paths::ENV_GET_OR_PANIC, "env.get_or_panic");
         assert_eq!(paths::BAML_DEEP_COPY, "baml.deep_copy");
         assert_eq!(paths::BAML_UNSTABLE_STRING, "baml.unstable.string");
     }

--- a/baml_language/crates/baml_builtins_macros/src/codegen_sys_ops.rs
+++ b/baml_language/crates/baml_builtins_macros/src/codegen_sys_ops.rs
@@ -150,11 +150,27 @@ pub(crate) fn generate(collected: &CollectedBuiltins) -> TokenStream2 {
 // Helpers
 // ============================================================================
 
-/// Extract the module name (second path segment) from a `sys_op` path.
+/// Extract the module name from a `sys_op` path.
+///
+/// For 2-segment paths like `"env.get"`, the module is the first segment (`"env"`).
+/// For 3+ segment paths like `"baml.fs.open"`, the module is the second segment (`"fs"`).
 fn module_from_path(path: &str) -> &str {
-    path.split('.').nth(1).unwrap_or_else(|| {
-        panic!("sys_op path '{path}' should have at least 2 segments (e.g., baml.fs.open)")
-    })
+    let mut segments = path.split('.');
+    let first = segments
+        .next()
+        .unwrap_or_else(|| panic!("sys_op path '{path}' should have at least 2 segments"));
+    match segments.next() {
+        None => panic!("sys_op path '{path}' should have at least 2 segments"),
+        Some(second) => {
+            if segments.next().is_none() {
+                // 2-segment path: "env.get" → module is "env"
+                first
+            } else {
+                // 3+ segment path: "baml.fs.open" → module is "fs"
+                second
+            }
+        }
+    }
 }
 
 /// Map a DSL type name to the Rust type used in clean `sys_op` trait signatures.
@@ -170,6 +186,11 @@ fn sys_op_rust_type(
         "()" => Ok(quote!(())),
         "Media" => Ok(quote!(bex_vm_types::MediaValue)),
         "PromptAst" => Ok(quote!(bex_vm_types::PromptAst)),
+        t if t.starts_with("Option<") && t.ends_with('>') => {
+            let inner = &t[7..t.len() - 1];
+            let inner_type = sys_op_rust_type(inner.trim(), builtin_types)?;
+            Ok(quote!(Option<#inner_type>))
+        }
         _ if builtin_types.contains_key(type_name) => {
             let full_path = builtin_types
                 .get(type_name)

--- a/baml_language/crates/baml_compiler_hir/src/body.rs
+++ b/baml_language/crates/baml_compiler_hir/src/body.rs
@@ -1066,6 +1066,7 @@ impl LoweringContext {
             }
             SyntaxKind::PATH_EXPR => self.lower_path_expr(node),
             SyntaxKind::FIELD_ACCESS_EXPR => self.lower_field_access_expr(node),
+            SyntaxKind::ENV_ACCESS_EXPR => self.lower_env_access_expr(node),
             SyntaxKind::INDEX_EXPR => self.lower_index_expr(node),
             SyntaxKind::PAREN_EXPR => {
                 // Unwrap parentheses - just lower the inner expression
@@ -1933,7 +1934,23 @@ impl LoweringContext {
             .find(|n| !matches!(n.kind(), SyntaxKind::CALL_ARGS));
 
         let callee = if let Some(n) = callee_node {
-            self.lower_expr(&n)
+            if n.kind() == SyntaxKind::ENV_ACCESS_EXPR {
+                // env.method(...) → Path(["env", method])
+                // Don't use lower_expr which would desugar to get_or_panic
+                use baml_compiler_syntax::ast::EnvAccessExpr;
+                use rowan::ast::AstNode;
+                let env_access = EnvAccessExpr::cast(n.clone());
+                let field = env_access
+                    .and_then(|e| e.field())
+                    .map(|t| t.text().to_string())
+                    .unwrap_or_default();
+                self.alloc_expr(
+                    Expr::Path(vec![Name::new("env"), Name::new(&field)]),
+                    n.text_range(),
+                )
+            } else {
+                self.lower_expr(&n)
+            }
         } else {
             // No callee node - check for a WORD token (simple function name)
             let word_token = node
@@ -1970,6 +1987,7 @@ impl LoweringContext {
                                     | SyntaxKind::CALL_EXPR
                                     | SyntaxKind::PATH_EXPR
                                     | SyntaxKind::FIELD_ACCESS_EXPR
+                                    | SyntaxKind::ENV_ACCESS_EXPR
                                     | SyntaxKind::INDEX_EXPR
                                     | SyntaxKind::IF_EXPR
                                     | SyntaxKind::BLOCK_EXPR
@@ -2092,6 +2110,42 @@ impl LoweringContext {
             .unwrap_or_else(|| Name::new(""));
 
         self.alloc_expr(Expr::FieldAccess { base, field }, node.text_range())
+    }
+
+    /// Lower an `ENV_ACCESS_EXPR` to a desugared call.
+    ///
+    /// In non-call position (standalone `env.FOO`), desugars to:
+    ///   `env.get_or_panic("FOO")`
+    ///
+    /// When used as a callee in a `CALL_EXPR` (e.g. `env.get(...)`), the
+    /// `lower_call_expr` method handles it specially — converting the
+    /// `ENV_ACCESS_EXPR` callee into a path into the env module.
+    fn lower_env_access_expr(&mut self, node: &baml_compiler_syntax::SyntaxNode) -> ExprId {
+        use baml_compiler_syntax::ast::EnvAccessExpr;
+        use rowan::ast::AstNode;
+
+        let env_access = EnvAccessExpr::cast(node.clone());
+        let field_name = env_access
+            .and_then(|e| e.field())
+            .map(|t| t.text().to_string())
+            .unwrap_or_default();
+
+        // Synthesize: env.get_or_panic("FIELD_NAME")
+        let callee = self.alloc_expr(
+            Expr::Path(vec![Name::new("env"), Name::new("get_or_panic")]),
+            node.text_range(),
+        );
+        let arg = self.alloc_expr(
+            Expr::Literal(Literal::String(field_name)),
+            node.text_range(),
+        );
+        self.alloc_expr(
+            Expr::Call {
+                callee,
+                args: vec![arg],
+            },
+            node.text_range(),
+        )
     }
 
     fn lower_index_expr(&mut self, node: &baml_compiler_syntax::SyntaxNode) -> ExprId {
@@ -2409,6 +2463,7 @@ impl LoweringContext {
                                     | SyntaxKind::MAP_LITERAL
                                     | SyntaxKind::INDEX_EXPR
                                     | SyntaxKind::FIELD_ACCESS_EXPR
+                                    | SyntaxKind::ENV_ACCESS_EXPR
                             )
                         })
                         .map(|n| self.lower_expr(&n))
@@ -2632,6 +2687,7 @@ impl LoweringContext {
                     | SyntaxKind::CALL_EXPR
                     | SyntaxKind::PATH_EXPR
                     | SyntaxKind::FIELD_ACCESS_EXPR
+                    | SyntaxKind::ENV_ACCESS_EXPR
                     | SyntaxKind::INDEX_EXPR
                     | SyntaxKind::IF_EXPR
                     | SyntaxKind::BLOCK_EXPR
@@ -2706,6 +2762,7 @@ impl LoweringContext {
                         | SyntaxKind::CALL_EXPR
                         | SyntaxKind::PATH_EXPR
                         | SyntaxKind::FIELD_ACCESS_EXPR
+                        | SyntaxKind::ENV_ACCESS_EXPR
                         | SyntaxKind::INDEX_EXPR
                         | SyntaxKind::IF_EXPR
                         | SyntaxKind::BLOCK_EXPR
@@ -3238,6 +3295,7 @@ impl LoweringContext {
                 | SyntaxKind::RAW_STRING_LITERAL
                 | SyntaxKind::BINARY_EXPR
                 | SyntaxKind::PATH_EXPR
+                | SyntaxKind::ENV_ACCESS_EXPR
                 | SyntaxKind::CALL_EXPR
                 | SyntaxKind::MAP_LITERAL => {
                     return self.lower_expr(&child);

--- a/baml_language/crates/baml_compiler_hir/src/body.rs
+++ b/baml_language/crates/baml_compiler_hir/src/body.rs
@@ -1939,15 +1939,14 @@ impl LoweringContext {
                 // Don't use lower_expr which would desugar to get_or_panic
                 use baml_compiler_syntax::ast::EnvAccessExpr;
                 use rowan::ast::AstNode;
-                let env_access = EnvAccessExpr::cast(n.clone());
-                let field = env_access
-                    .and_then(|e| e.field())
-                    .map(|t| t.text().to_string())
-                    .unwrap_or_default();
-                self.alloc_expr(
-                    Expr::Path(vec![Name::new("env"), Name::new(&field)]),
-                    n.text_range(),
-                )
+                if let Some(field_token) = EnvAccessExpr::cast(n.clone()).and_then(|e| e.field()) {
+                    self.alloc_expr(
+                        Expr::Path(vec![Name::new("env"), Name::new(field_token.text())]),
+                        n.text_range(),
+                    )
+                } else {
+                    self.alloc_expr(Expr::Missing, n.text_range())
+                }
             } else {
                 self.lower_expr(&n)
             }
@@ -2124,11 +2123,10 @@ impl LoweringContext {
         use baml_compiler_syntax::ast::EnvAccessExpr;
         use rowan::ast::AstNode;
 
-        let env_access = EnvAccessExpr::cast(node.clone());
-        let field_name = env_access
-            .and_then(|e| e.field())
-            .map(|t| t.text().to_string())
-            .unwrap_or_default();
+        let Some(field_token) = EnvAccessExpr::cast(node.clone()).and_then(|e| e.field()) else {
+            return self.alloc_expr(Expr::Missing, node.text_range());
+        };
+        let field_name = field_token.text().to_string();
 
         // Synthesize: env.get_or_panic("FIELD_NAME")
         let callee = self.alloc_expr(

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -2930,6 +2930,9 @@ impl<'a> Parser<'a> {
         } else if self.at(TokenKind::Match) {
             // Match expression
             self.parse_match_expr();
+        } else if self.at(TokenKind::Env) {
+            // env.FIELD or env.method(...)
+            self.parse_env_access();
         } else {
             self.error_unexpected_token("expression".to_string());
             // Consume the unexpected token to avoid infinite loops
@@ -2937,6 +2940,25 @@ impl<'a> Parser<'a> {
                 self.bump();
             }
         }
+    }
+
+    /// Parse `env.FIELD` expressions.
+    ///
+    /// Produces an `ENV_ACCESS_EXPR` node: `KW_ENV DOT WORD`.
+    /// HIR lowering decides how to desugar based on context.
+    fn parse_env_access(&mut self) {
+        self.with_node(SyntaxKind::ENV_ACCESS_EXPR, |p| {
+            p.bump(); // consume `env` (TokenKind::Env)
+            if p.eat(TokenKind::Dot) {
+                if p.at(TokenKind::Word) {
+                    p.bump(); // consume field name
+                } else {
+                    p.error_unexpected_token("identifier after 'env.'".to_string());
+                }
+            } else {
+                p.error_unexpected_token("'.' after 'env'".to_string());
+            }
+        });
     }
 
     fn parse_call_args(&mut self) {
@@ -3640,18 +3662,18 @@ impl<'a> Parser<'a> {
         }
 
         // Check for `env.` prefix - environment variable access
+        if self.at(TokenKind::Env) {
+            if let Some(next) = self.peek(1) {
+                if next.kind == TokenKind::Dot {
+                    return true;
+                }
+            }
+        }
+
+        // Boolean literals
         if self.at(TokenKind::Word) {
             if let Some(token) = self.current() {
                 let text = token.text.as_str();
-                if text == "env" {
-                    // Check if next token is a dot
-                    if let Some(next) = self.peek(1) {
-                        if next.kind == TokenKind::Dot {
-                            return true;
-                        }
-                    }
-                }
-                // Boolean literals
                 if text == "true" || text == "false" {
                     return true;
                 }

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -688,6 +688,7 @@ ast_node!(BreakStmt, BREAK_STMT);
 ast_node!(ContinueStmt, CONTINUE_STMT);
 ast_node!(PathExpr, PATH_EXPR);
 ast_node!(FieldAccessExpr, FIELD_ACCESS_EXPR);
+ast_node!(EnvAccessExpr, ENV_ACCESS_EXPR);
 ast_node!(MatchExpr, MATCH_EXPR);
 ast_node!(MatchArm, MATCH_ARM);
 ast_node!(MatchPattern, MATCH_PATTERN);
@@ -2316,6 +2317,7 @@ impl BlockExpr {
                         | SyntaxKind::BLOCK_EXPR
                         | SyntaxKind::PATH_EXPR
                         | SyntaxKind::FIELD_ACCESS_EXPR
+                        | SyntaxKind::ENV_ACCESS_EXPR
                         | SyntaxKind::INDEX_EXPR
                         | SyntaxKind::PAREN_EXPR
                         | SyntaxKind::ARRAY_LITERAL
@@ -2375,6 +2377,16 @@ impl FieldAccessExpr {
             .filter_map(rowan::NodeOrToken::into_token)
             .filter(|token| token.kind() == SyntaxKind::WORD)
             .last() // The field name is the last WORD token
+    }
+}
+
+impl EnvAccessExpr {
+    /// Get the field name (the env var name or method name after `env.`).
+    pub fn field(&self) -> Option<SyntaxToken> {
+        self.syntax
+            .children_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .find(|t| t.kind() == SyntaxKind::WORD)
     }
 }
 

--- a/baml_language/crates/baml_compiler_syntax/src/syntax_kind.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/syntax_kind.rs
@@ -216,6 +216,14 @@ pub enum SyntaxKind {
     /// For field access on complex expressions (like `f().field` or `arr[0].field`),
     /// use `FIELD_ACCESS_EXPR` instead.
     PATH_EXPR,
+    /// `env.FIELD` expression (e.g., `env.API_KEY`).
+    ///
+    /// Structure: `KW_ENV DOT WORD`
+    ///
+    /// Desugared during HIR lowering:
+    /// - In non-call position: `env.FOO` → `env.get_or_panic("FOO")`
+    /// - In call position: `env.get(...)` → call to `env.get` module function
+    ENV_ACCESS_EXPR,
     PAREN_EXPR,
     BLOCK_EXPR,
     IF_EXPR,

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
@@ -1,29 +1,29 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 61
-Globals: 49
+Objects: 62
+Globals: 50
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -51,18 +51,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -103,18 +103,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -1,35 +1,35 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 7
-Objects: 68
-Globals: 53
+Objects: 69
+Globals: 54
 
 Function GetMixedList (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetMixedList")
      2   ALLOC_MAP 0      
      3   CALL 2           
      4   RETURN           
 
 Function GetMixedMap (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetMixedMap")
      2   ALLOC_MAP 0      
      3   CALL 2           
      4   RETURN           
 
 Function GetStatus (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetStatus")
      2   ALLOC_MAP 0      
      3   CALL 2           
      4   RETURN           
 
 Function GetUser (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetUser")
      2   LOAD_VAR 1       (id)
      3   LOAD_CONST 1     ("id")
@@ -42,18 +42,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -81,18 +81,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -133,18 +133,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 14
-Objects: 81
-Globals: 60
+Objects: 82
+Globals: 61
 
 Function ChainCommands (arity: 0, kind: Bytecode):
      0    LOAD_CONST 0        (null)
@@ -200,18 +200,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -239,18 +239,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -291,18 +291,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__02_parser__test.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__02_parser__test.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-0a6cb66c091c7c00/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === SYNTAX TREE ===
@@ -43,10 +43,11 @@ SOURCE_FILE
                 QUOTE """
           CONFIG_ITEM
             WORD "api_key"
-            CONFIG_VALUE "env.OPENROUTER_API_KEY"
-              KW_ENV "env"
-              DOT "."
-              WORD "OPENROUTER_API_KEY"
+            CONFIG_VALUE
+              ENV_ACCESS_EXPR "env.OPENROUTER_API_KEY"
+                KW_ENV "env"
+                DOT "."
+                WORD "OPENROUTER_API_KEY"
           CONFIG_ITEM
             WORD "model"
             CONFIG_VALUE

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__03_hir.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__03_hir.snap
@@ -1,10 +1,10 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === HIR ITEMS ===
 function OpenRouterMistralSmall3_1_24b.resolve() -> baml.llm.PrimitiveClient {
-    baml.llm.build_primitive_client("OpenRouterMistralSmall3_1_24b", "unknown", "user", ["user", "assistant", "system"], { "base_url": "https://openrouter.ai/api/v1", "api_key": "OPENROUTER_API_KEY", "model": "mistralai/mistral-small-3.1-24b-instruct", "temperature": 0.1, "headers": {  } })
+    baml.llm.build_primitive_client("OpenRouterMistralSmall3_1_24b", "unknown", "user", ["user", "assistant", "system"], { "base_url": "https://openrouter.ai/api/v1", "api_key": env.get_or_panic("OPENROUTER_API_KEY"), "model": "mistralai/mistral-small-3.1-24b-instruct", "temperature": 0.1, "headers": {  } })
 }
 
 client OpenRouterMistralSmall3_1_24b {

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__04_5_mir.snap
@@ -1,5 +1,5 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === MIR ===
@@ -18,14 +18,17 @@ fn OpenRouterMistralSmall3_1_24b.resolve() -> baml.llm.PrimitiveClient {
     let _10: "base_url"
     let _11: "https://openrouter.ai/api/v1"
     let _12: "api_key"
-    let _13: "OPENROUTER_API_KEY"
-    let _14: "model"
-    let _15: "mistralai/mistral-small-3.1-24b-instruct"
-    let _16: "temperature"
-    let _17: 0.1
-    let _18: "headers"
-    let _19: map<null, null>
-    let _20: null
+    let _13: string
+    let _14: (string) -> string
+    let _15: "OPENROUTER_API_KEY"
+    let _16: null
+    let _17: "model"
+    let _18: "mistralai/mistral-small-3.1-24b-instruct"
+    let _19: "temperature"
+    let _20: 0.1
+    let _21: "headers"
+    let _22: map<null, null>
+    let _23: null
 
     bb0: {
         _1 = const fn baml.llm.build_primitive_client;
@@ -39,15 +42,9 @@ fn OpenRouterMistralSmall3_1_24b.resolve() -> baml.llm.PrimitiveClient {
         _10 = const "base_url";
         _11 = const "https://openrouter.ai/api/v1";
         _12 = const "api_key";
-        _13 = const "OPENROUTER_API_KEY";
-        _14 = const "model";
-        _15 = const "mistralai/mistral-small-3.1-24b-instruct";
-        _16 = const "temperature";
-        _17 = const 0.1_f64;
-        _18 = const "headers";
-        _19 = {  };
-        _9 = { copy _10: copy _11, copy _12: copy _13, copy _14: copy _15, copy _16: copy _17, copy _18: copy _19 };
-        _20 = dispatch_future copy _1(copy _2, copy _3, copy _4, copy _5, copy _9) -> bb2;
+        _14 = const fn env.get_or_panic;
+        _15 = const "OPENROUTER_API_KEY";
+        _16 = dispatch_future copy _14(copy _15) -> bb2;
     }
 
     bb1: {
@@ -55,10 +52,25 @@ fn OpenRouterMistralSmall3_1_24b.resolve() -> baml.llm.PrimitiveClient {
     }
 
     bb2: {
-        _0 = await _20 -> [bb3];
+        _13 = await _16 -> [bb3];
     }
 
     bb3: {
+        _17 = const "model";
+        _18 = const "mistralai/mistral-small-3.1-24b-instruct";
+        _19 = const "temperature";
+        _20 = const 0.1_f64;
+        _21 = const "headers";
+        _22 = {  };
+        _9 = { copy _10: copy _11, copy _12: copy _13, copy _17: copy _18, copy _19: copy _20, copy _21: copy _22 };
+        _23 = dispatch_future copy _1(copy _2, copy _3, copy _4, copy _5, copy _9) -> bb4;
+    }
+
+    bb4: {
+        _0 = await _23 -> [bb5];
+    }
+
+    bb5: {
         goto -> bb1;
     }
 

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
@@ -1,53 +1,59 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 70
-Globals: 50
+Objects: 71
+Globals: 51
 
 Function OpenRouterMistralSmall3_1_24b.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
-     1    LOAD_CONST 0        ("OpenRouterMistralSmall3_1_24b")
-     2    LOAD_CONST 1        ("unknown")
-     3    LOAD_CONST 2        ("user")
-     4    LOAD_CONST 3        ("user")
-     5    LOAD_CONST 4        ("assistant")
-     6    LOAD_CONST 5        ("system")
-     7    ALLOC_ARRAY 3       
-     8    LOAD_CONST 6        ("https://openrouter.ai/api/v1")
-     9    LOAD_CONST 7        ("OPENROUTER_API_KEY")
-     10   LOAD_CONST 8        ("mistralai/mistral-small-3.1-24b-instruct")
-     11   LOAD_CONST 9        (0.1)
-     12   ALLOC_MAP 0         
-     13   LOAD_CONST 10       ("base_url")
-     14   LOAD_CONST 11       ("api_key")
-     15   LOAD_CONST 12       ("model")
-     16   LOAD_CONST 13       ("temperature")
-     17   LOAD_CONST 14       ("headers")
-     18   ALLOC_MAP 5         
-     19   DISPATCH_FUTURE 5   
-     20   AWAIT               
-     21   RETURN              
+     0    LOAD_CONST 0        (null)
+     1    LOAD_GLOBAL 42      (<fn env.get_or_panic>)
+     2    LOAD_CONST 1        ("OPENROUTER_API_KEY")
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 1         (_13)
+     6    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
+     7    LOAD_CONST 2        ("OpenRouterMistralSmall3_1_24b")
+     8    LOAD_CONST 3        ("unknown")
+     9    LOAD_CONST 4        ("user")
+     10   LOAD_CONST 5        ("user")
+     11   LOAD_CONST 6        ("assistant")
+     12   LOAD_CONST 7        ("system")
+     13   ALLOC_ARRAY 3       
+     14   LOAD_CONST 8        ("https://openrouter.ai/api/v1")
+     15   LOAD_VAR 1          (_13)
+     16   LOAD_CONST 9        ("mistralai/mistral-small-3.1-24b-instruct")
+     17   LOAD_CONST 10       (0.1)
+     18   ALLOC_MAP 0         
+     19   LOAD_CONST 11       ("base_url")
+     20   LOAD_CONST 12       ("api_key")
+     21   LOAD_CONST 13       ("model")
+     22   LOAD_CONST 14       ("temperature")
+     23   LOAD_CONST 15       ("headers")
+     24   ALLOC_MAP 5         
+     25   DISPATCH_FUTURE 5   
+     26   AWAIT               
+     27   RETURN              
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -75,18 +81,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -127,18 +133,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -1,21 +1,21 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 6
-Objects: 68
-Globals: 52
+Objects: 69
+Globals: 53
 
 Function CommentAfterArrow (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("CommentAfterArrow")
      2   ALLOC_MAP 0      
      3   CALL 2           
      4   RETURN           
 
 Function FunctionWithComments (arity: 2, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("FunctionWithComments")
      2   LOAD_VAR 1       (a)
      3   LOAD_VAR 2       (b)
@@ -26,7 +26,7 @@ Function FunctionWithComments (arity: 2, kind: Bytecode):
      8   RETURN           
 
 Function TestClient.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("TestClient")
      2    LOAD_CONST 1        ("baml-openai-chat")
      3    LOAD_CONST 2        ("user")
@@ -44,18 +44,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -83,18 +83,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -135,18 +135,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 119
-Globals: 50
+Objects: 120
+Globals: 51
 
 Function MyClient.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("MyClient")
      2    LOAD_CONST 1        ("baml-openai-chat")
      3    LOAD_CONST 2        ("user")
@@ -104,18 +104,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -143,18 +143,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -195,18 +195,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
@@ -1,29 +1,29 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 57
-Globals: 49
+Objects: 58
+Globals: 50
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -51,18 +51,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -103,18 +103,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 9
-Objects: 64
-Globals: 55
+Objects: 65
+Globals: 56
 
 Function Bar (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 52   (<fn Foo>)
+     0   LOAD_GLOBAL 53   (<fn Foo>)
      1   LOAD_CONST 0     (1)
      2   CALL 1           
      3   RETURN           
@@ -29,7 +29,7 @@ Function Foo (arity: 1, kind: Bytecode):
      3   RETURN         
 
 Function GreetBaz (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 54     (<fn Baz.Greeting>)
+     0   LOAD_GLOBAL 55     (<fn Baz.Greeting>)
      1   ALLOC_INSTANCE 6   (<class Baz>)
      2   COPY 0             
      3   LOAD_VAR 1         (n)
@@ -51,18 +51,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -90,18 +90,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -142,18 +142,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 56
-Globals: 50
+Objects: 57
+Globals: 51
 
 Function GetTransform (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -16,18 +16,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -55,18 +55,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -107,18 +107,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 58
-Globals: 50
+Objects: 59
+Globals: 51
 
 Function GetUser (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetUser")
      2   ALLOC_MAP 0      
      3   CALL 2           
@@ -19,18 +19,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -58,18 +58,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -110,18 +110,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 5
-Objects: 68
-Globals: 51
+Objects: 69
+Globals: 52
 
 Function FetchDatax (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("FetchDatax")
      2   LOAD_VAR 1       (user_id)
      3   LOAD_CONST 1     ("user_id")
@@ -17,7 +17,7 @@ Function FetchDatax (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function VertexGCP.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("VertexGCP")
      2    LOAD_CONST 1        ("vertex-ai")
      3    LOAD_CONST 2        ("user")
@@ -37,18 +37,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -76,18 +76,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -128,18 +128,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 13
-Objects: 75
-Globals: 59
+Objects: 76
+Globals: 60
 
 Function ConsecutiveHeaders (arity: 0, kind: Bytecode):
      0   NOTIFY_BLOCK 0   (FirstHeader)
@@ -159,18 +159,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -198,18 +198,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -250,18 +250,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 89
-Objects: 312
-Globals: 135
+Objects: 313
+Globals: 136
 
 Function BoolLiteralAfterTypedBool (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1             (b)
@@ -787,7 +787,7 @@ Function MatchComplexScrutinee (arity: 1, kind: Bytecode):
      23   RETURN                 
 
 Function MatchFunctionCallScrutinee (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 90         (<fn GetStatus>)
+     0    LOAD_GLOBAL 91         (<fn GetStatus>)
      1    CALL 0                 
      2    DISCRIMINANT           
      3    COPY 0                 
@@ -1573,18 +1573,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -1612,18 +1612,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -1664,18 +1664,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
@@ -1,29 +1,29 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 56
-Globals: 49
+Objects: 57
+Globals: 50
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -51,18 +51,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -103,18 +103,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
@@ -1,29 +1,29 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 15
-Objects: 84
-Globals: 61
+Objects: 85
+Globals: 62
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -51,18 +51,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -103,18 +103,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
@@ -1,18 +1,18 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 7
-Objects: 72
-Globals: 53
+Objects: 73
+Globals: 54
 
 Function Foo (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (null)
      1   RETURN         
 
 Function GPT4.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("GPT4")
      2    LOAD_CONST 1        ("unknown")
      3    LOAD_CONST 2        ("user")
@@ -37,18 +37,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -76,18 +76,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -128,18 +128,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 7
-Objects: 63
-Globals: 53
+Objects: 64
+Globals: 54
 
 Function Calculate (arity: 0, kind: Bytecode):
      0    LOAD_CONST 0   (null)
@@ -118,18 +118,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -157,18 +157,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -209,18 +209,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 11
-Objects: 81
-Globals: 57
+Objects: 82
+Globals: 58
 
 Function Ambiguous (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Ambiguous")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -17,7 +17,7 @@ Function Ambiguous (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function AnotherLLM (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("AnotherLLM")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -26,7 +26,7 @@ Function AnotherLLM (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function ChainedProcess (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("ChainedProcess")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -35,7 +35,7 @@ Function ChainedProcess (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function ExtractData (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("ExtractData")
      2   LOAD_VAR 1       (text)
      3   LOAD_CONST 1     ("text")
@@ -44,7 +44,7 @@ Function ExtractData (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function LLMAnalyze (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("LLMAnalyze")
      2   LOAD_VAR 1       (text)
      3   LOAD_CONST 1     ("text")
@@ -121,18 +121,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -160,18 +160,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -212,18 +212,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 24
-Objects: 80
-Globals: 70
+Objects: 81
+Globals: 71
 
 Function ConditionalLogic (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (age)
@@ -65,18 +65,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -104,18 +104,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -156,18 +156,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 106
-Objects: 1465
-Globals: 152
+Objects: 1466
+Globals: 153
 
 Function BodyTorture (arity: 0, kind: Bytecode):
      0    LOAD_CONST 0           (null)
@@ -54,7 +54,7 @@ Function DeepExpression (arity: 0, kind: Bytecode):
      19   RETURN         
 
 Function Process1 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process1")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -63,7 +63,7 @@ Function Process1 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process10 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process10")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -72,7 +72,7 @@ Function Process10 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process100 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process100")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -81,7 +81,7 @@ Function Process100 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process11 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process11")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -90,7 +90,7 @@ Function Process11 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process12 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process12")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -99,7 +99,7 @@ Function Process12 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process13 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process13")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -108,7 +108,7 @@ Function Process13 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process14 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process14")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -117,7 +117,7 @@ Function Process14 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process15 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process15")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -126,7 +126,7 @@ Function Process15 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process16 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process16")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -135,7 +135,7 @@ Function Process16 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process17 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process17")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -144,7 +144,7 @@ Function Process17 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process18 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process18")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -153,7 +153,7 @@ Function Process18 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process19 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process19")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -162,7 +162,7 @@ Function Process19 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process2 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process2")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -171,7 +171,7 @@ Function Process2 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process20 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process20")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -180,7 +180,7 @@ Function Process20 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process21 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process21")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -189,7 +189,7 @@ Function Process21 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process22 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process22")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -198,7 +198,7 @@ Function Process22 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process23 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process23")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -207,7 +207,7 @@ Function Process23 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process24 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process24")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -216,7 +216,7 @@ Function Process24 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process25 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process25")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -225,7 +225,7 @@ Function Process25 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process26 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process26")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -234,7 +234,7 @@ Function Process26 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process27 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process27")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -243,7 +243,7 @@ Function Process27 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process28 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process28")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -252,7 +252,7 @@ Function Process28 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process29 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process29")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -261,7 +261,7 @@ Function Process29 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process3 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process3")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -270,7 +270,7 @@ Function Process3 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process30 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process30")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -279,7 +279,7 @@ Function Process30 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process31 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process31")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -288,7 +288,7 @@ Function Process31 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process32 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process32")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -297,7 +297,7 @@ Function Process32 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process33 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process33")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -306,7 +306,7 @@ Function Process33 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process34 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process34")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -315,7 +315,7 @@ Function Process34 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process35 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process35")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -324,7 +324,7 @@ Function Process35 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process36 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process36")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -333,7 +333,7 @@ Function Process36 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process37 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process37")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -342,7 +342,7 @@ Function Process37 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process38 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process38")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -351,7 +351,7 @@ Function Process38 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process39 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process39")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -360,7 +360,7 @@ Function Process39 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process4 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process4")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -369,7 +369,7 @@ Function Process4 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process40 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process40")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -378,7 +378,7 @@ Function Process40 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process41 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process41")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -387,7 +387,7 @@ Function Process41 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process42 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process42")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -396,7 +396,7 @@ Function Process42 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process43 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process43")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -405,7 +405,7 @@ Function Process43 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process44 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process44")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -414,7 +414,7 @@ Function Process44 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process45 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process45")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -423,7 +423,7 @@ Function Process45 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process46 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process46")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -432,7 +432,7 @@ Function Process46 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process47 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process47")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -441,7 +441,7 @@ Function Process47 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process48 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process48")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -450,7 +450,7 @@ Function Process48 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process49 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process49")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -459,7 +459,7 @@ Function Process49 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process5 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process5")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -468,7 +468,7 @@ Function Process5 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process50 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process50")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -477,7 +477,7 @@ Function Process50 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process51 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process51")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -486,7 +486,7 @@ Function Process51 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process52 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process52")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -495,7 +495,7 @@ Function Process52 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process53 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process53")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -504,7 +504,7 @@ Function Process53 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process54 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process54")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -513,7 +513,7 @@ Function Process54 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process55 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process55")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -522,7 +522,7 @@ Function Process55 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process56 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process56")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -531,7 +531,7 @@ Function Process56 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process57 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process57")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -540,7 +540,7 @@ Function Process57 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process58 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process58")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -549,7 +549,7 @@ Function Process58 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process59 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process59")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -558,7 +558,7 @@ Function Process59 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process6 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process6")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -567,7 +567,7 @@ Function Process6 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process60 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process60")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -576,7 +576,7 @@ Function Process60 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process61 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process61")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -585,7 +585,7 @@ Function Process61 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process62 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process62")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -594,7 +594,7 @@ Function Process62 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process63 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process63")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -603,7 +603,7 @@ Function Process63 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process64 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process64")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -612,7 +612,7 @@ Function Process64 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process65 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process65")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -621,7 +621,7 @@ Function Process65 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process66 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process66")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -630,7 +630,7 @@ Function Process66 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process67 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process67")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -639,7 +639,7 @@ Function Process67 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process68 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process68")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -648,7 +648,7 @@ Function Process68 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process69 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process69")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -657,7 +657,7 @@ Function Process69 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process7 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process7")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -666,7 +666,7 @@ Function Process7 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process70 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process70")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -675,7 +675,7 @@ Function Process70 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process71 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process71")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -684,7 +684,7 @@ Function Process71 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process72 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process72")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -693,7 +693,7 @@ Function Process72 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process73 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process73")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -702,7 +702,7 @@ Function Process73 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process74 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process74")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -711,7 +711,7 @@ Function Process74 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process75 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process75")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -720,7 +720,7 @@ Function Process75 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process76 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process76")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -729,7 +729,7 @@ Function Process76 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process77 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process77")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -738,7 +738,7 @@ Function Process77 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process78 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process78")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -747,7 +747,7 @@ Function Process78 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process79 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process79")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -756,7 +756,7 @@ Function Process79 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process8 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process8")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -765,7 +765,7 @@ Function Process8 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process80 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process80")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -774,7 +774,7 @@ Function Process80 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process81 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process81")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -783,7 +783,7 @@ Function Process81 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process82 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process82")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -792,7 +792,7 @@ Function Process82 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process83 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process83")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -801,7 +801,7 @@ Function Process83 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process84 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process84")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -810,7 +810,7 @@ Function Process84 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process85 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process85")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -819,7 +819,7 @@ Function Process85 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process86 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process86")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -828,7 +828,7 @@ Function Process86 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process87 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process87")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -837,7 +837,7 @@ Function Process87 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process88 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process88")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -846,7 +846,7 @@ Function Process88 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process89 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process89")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -855,7 +855,7 @@ Function Process89 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process9 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process9")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -864,7 +864,7 @@ Function Process9 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process90 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process90")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -873,7 +873,7 @@ Function Process90 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process91 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process91")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -882,7 +882,7 @@ Function Process91 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process92 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process92")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -891,7 +891,7 @@ Function Process92 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process93 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process93")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -900,7 +900,7 @@ Function Process93 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process94 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process94")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -909,7 +909,7 @@ Function Process94 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process95 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process95")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -918,7 +918,7 @@ Function Process95 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process96 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process96")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -927,7 +927,7 @@ Function Process96 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process97 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process97")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -936,7 +936,7 @@ Function Process97 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process98 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process98")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -945,7 +945,7 @@ Function Process98 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process99 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process99")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -958,18 +958,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -997,18 +997,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -1049,18 +1049,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 7
-Objects: 74
-Globals: 53
+Objects: 75
+Globals: 54
 
 Function FormatMessage (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("FormatMessage")
      2   LOAD_VAR 1       (name)
      3   LOAD_CONST 1     ("name")
@@ -17,7 +17,7 @@ Function FormatMessage (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function GPT4.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("GPT4")
      2    LOAD_CONST 1        ("unknown")
      3    LOAD_CONST 2        ("user")
@@ -35,7 +35,7 @@ Function GetRole (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function ProcessText (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("ProcessText")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -48,18 +48,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -87,18 +87,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -139,18 +139,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 5
-Objects: 62
-Globals: 51
+Objects: 63
+Globals: 52
 
 Function BadParam (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("BadParam")
      2   LOAD_VAR 1       (x)
      3   LOAD_CONST 1     ("x")
@@ -17,7 +17,7 @@ Function BadParam (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function BadReturnType (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("BadReturnType")
      2   ALLOC_MAP 0      
      3   CALL 2           
@@ -28,18 +28,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -67,18 +67,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -119,18 +119,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 64
-Globals: 50
+Objects: 65
+Globals: 51
 
 Function MyClient.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 43      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("MyClient")
      2    LOAD_CONST 1        ("openai")
      3    LOAD_CONST 2        ("user")
@@ -28,18 +28,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -67,18 +67,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -119,18 +119,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 59
-Globals: 50
+Objects: 60
+Globals: 51
 
 Function HelloWorld (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("HelloWorld")
      2   LOAD_VAR 1       (name)
      3   LOAD_CONST 1     ("name")
@@ -21,18 +21,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -60,18 +60,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -112,18 +112,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 57
-Globals: 50
+Objects: 58
+Globals: 51
 
 Function Foo (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -18,18 +18,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -57,18 +57,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -109,18 +109,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 56
-Globals: 50
+Objects: 57
+Globals: 51
 
 Function Foo (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -16,18 +16,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -55,18 +55,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -107,18 +107,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
@@ -1,29 +1,29 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 55
-Globals: 49
+Objects: 56
+Globals: 50
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -51,18 +51,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -103,18 +103,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 8
-Objects: 63
-Globals: 54
+Objects: 64
+Globals: 55
 
 Function Bar (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (true)
@@ -36,18 +36,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -75,18 +75,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -127,18 +127,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 59
-Globals: 50
+Objects: 60
+Globals: 51
 
 Function TypeBuilderFn (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("TypeBuilderFn")
      2   LOAD_VAR 1       (from_text)
      3   LOAD_CONST 1     ("from_text")
@@ -21,18 +21,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -60,18 +60,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -112,18 +112,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 59
-Globals: 50
+Objects: 60
+Globals: 51
 
 Function Fn (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 48   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Fn")
      2   ALLOC_MAP 0      
      3   CALL 2           
@@ -19,18 +19,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -58,18 +58,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -110,18 +110,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-d8c3d4c38f908488/out/generated_tests.rs
+source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 6
-Objects: 58
-Globals: 52
+Objects: 59
+Globals: 53
 
 Function Bar (arity: 1, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -24,18 +24,18 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
      3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      5    LOAD_VAR 1          (function_name)
      6    DISPATCH_FUTURE 1   
      7    AWAIT               
      8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      10   LOAD_VAR 1          (function_name)
      11   DISPATCH_FUTURE 1   
      12   AWAIT               
      13   CALL 0              
      14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      16   LOAD_VAR 4          (primitive_client)
      17   LOAD_VAR 3          (jinja_string)
      18   LOAD_VAR 2          (args)
@@ -63,18 +63,18 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      4    LOAD_CONST 0        (null)
      5    LOAD_CONST 0        (null)
      6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      8    LOAD_VAR 1          (function_name)
      9    DISPATCH_FUTURE 1   
      10   AWAIT               
      11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      13   LOAD_VAR 1          (function_name)
      14   DISPATCH_FUTURE 1   
      15   AWAIT               
      16   CALL 0              
      17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      19   LOAD_VAR 4          (primitive_client)
      20   LOAD_VAR 3          (jinja_string)
      21   LOAD_VAR 2          (args)
@@ -115,18 +115,18 @@ Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    LOAD_CONST 0        (null)
      1    LOAD_CONST 0        (null)
      2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 42      (<fn baml.llm.get_jinja_template>)
+     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
      4    LOAD_VAR 1          (function_name)
      5    DISPATCH_FUTURE 1   
      6    AWAIT               
      7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 45      (<fn baml.llm.get_client_function>)
+     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
      9    LOAD_VAR 1          (function_name)
      10   DISPATCH_FUTURE 1   
      11   AWAIT               
      12   CALL 0              
      13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 44      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
      15   LOAD_VAR 4          (primitive_client)
      16   LOAD_VAR 3          (jinja_string)
      17   LOAD_VAR 2          (args)

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -189,7 +189,7 @@ pub enum EngineError {
 /// ```ignore
 /// use std::sync::Arc;
 ///
-/// let engine = Arc::new(BexEngine::new(bytecode, env_vars, sys_ops)?);
+/// let engine = Arc::new(BexEngine::new(bytecode, sys_ops)?);
 ///
 /// // Concurrent calls are safe - each gets its own VM and TLAB
 /// let (result1, result2) = tokio::join!(
@@ -232,8 +232,6 @@ pub struct BexEngine {
     resolved_function_names: HashMap<String, (HeapPtr, bex_vm_types::FunctionKind)>,
     /// Resolved class names for instance allocation
     resolved_class_names: HashMap<String, HeapPtr>,
-    /// Environment variables passed to VM.
-    env_vars: HashMap<String, String>,
     /// System operations provider.
     sys_ops: sys_types::SysOps,
     /// Context passed to `sys_ops` that need engine-level information.
@@ -265,11 +263,9 @@ impl BexEngine {
     /// # Arguments
     ///
     /// * `bytecode_program` - The compiled BAML program bytecode
-    /// * `env_vars` - Environment variables accessible to the program
     /// * `sys_ops` - System operations provider (use `sys_types_native::SysOps::native()` for default)
     pub fn new(
         bytecode_program: bex_vm_types::Program,
-        env_vars: HashMap<String, String>,
         sys_ops: sys_types::SysOps,
     ) -> Result<Self, EngineError> {
         // Convert the pure bytecode to a VM-ready program with native functions attached
@@ -336,7 +332,6 @@ impl BexEngine {
             globals,
             resolved_function_names,
             resolved_class_names,
-            env_vars,
             sys_ops,
             sys_op_ctx,
             // Initialize epoch tracking
@@ -563,11 +558,7 @@ impl BexEngine {
         let guard = unsafe { EpochGuard::new() };
 
         // Create VM with shared heap (each VM gets its own TLAB)
-        let mut vm = BexVm::new(
-            Arc::clone(&self.heap),
-            self.globals.clone(),
-            self.env_vars.clone(),
-        );
+        let mut vm = BexVm::new(Arc::clone(&self.heap), self.globals.clone());
 
         // Convert ExternalValue args to Value, allocating BexExternalValue data on the heap
         let vm_args: Vec<Value> = args

--- a/baml_language/crates/bex_engine/tests/common/mod.rs
+++ b/baml_language/crates/bex_engine/tests/common/mod.rs
@@ -6,7 +6,7 @@
 // Allow dead code since not all test files use all utilities
 #![allow(dead_code)]
 
-use std::{collections::HashMap, io::Write};
+use std::io::Write;
 
 use baml_tests::bytecode::compile_source;
 use bex_engine::{BexEngine, BexExternalValue};
@@ -70,8 +70,8 @@ pub(crate) async fn assert_engine_executes(input: EngineProgram) -> anyhow::Resu
     let source = input.source.replace("{ROOT}", &root_path);
 
     let snapshot = compile_for_engine(&source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     let result = engine.call_function(input.entry, input.inputs).await;
 

--- a/baml_language/crates/bex_engine/tests/concurrent.rs
+++ b/baml_language/crates/bex_engine/tests/concurrent.rs
@@ -6,12 +6,9 @@
 
 mod common;
 
-use std::{
-    collections::HashMap,
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
 };
 
 use bex_engine::{BexEngine, BexExternalValue, Ty};
@@ -34,8 +31,7 @@ async fn test_concurrent_calls_no_race() {
 
     let snapshot = compile_for_engine(source);
     let engine = Arc::new(
-        BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-            .expect("Failed to create engine"),
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine"),
     );
 
     // Spawn 10 concurrent calls
@@ -71,8 +67,7 @@ async fn test_concurrent_allocations_no_overlap() {
 
     let snapshot = compile_for_engine(source);
     let engine = Arc::new(
-        BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-            .expect("Failed to create engine"),
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine"),
     );
 
     // Track allocations from each concurrent call
@@ -123,8 +118,7 @@ async fn test_heap_stats_during_concurrent_execution() {
 
     let snapshot = compile_for_engine(source);
     let engine = Arc::new(
-        BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-            .expect("Failed to create engine"),
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine"),
     );
 
     let initial_stats = engine.heap_stats();
@@ -174,8 +168,7 @@ async fn test_concurrent_string_allocations() {
 
     let snapshot = compile_for_engine(source);
     let engine = Arc::new(
-        BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-            .expect("Failed to create engine"),
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine"),
     );
 
     // Spawn many concurrent calls that allocate different strings
@@ -224,8 +217,7 @@ async fn test_concurrent_array_allocations() {
 
     let snapshot = compile_for_engine(source);
     let engine = Arc::new(
-        BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-            .expect("Failed to create engine"),
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine"),
     );
 
     // Spawn concurrent calls with different array sizes
@@ -279,8 +271,8 @@ async fn test_call_function_with_external_args() {
     "#;
 
     let snapshot = compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     // Test passing strings via BexExternalValue
     let result = engine

--- a/baml_language/crates/bex_engine/tests/env.rs
+++ b/baml_language/crates/bex_engine/tests/env.rs
@@ -1,0 +1,124 @@
+//! Tests for environment variable operations (`env.get`, `env.get_or_panic`).
+
+#![allow(unsafe_code)]
+
+mod common;
+
+use bex_engine::BexExternalValue;
+use common::{EngineProgram, assert_engine_executes};
+use indexmap::indexmap;
+
+#[tokio::test]
+async fn env_get_or_panic_existing_var() -> anyhow::Result<()> {
+    unsafe { std::env::set_var("BAML_TEST_ENV_PANIC", "panic_value") };
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function main() -> string {
+                env.get_or_panic("BAML_TEST_ENV_PANIC")
+            }
+        "#,
+        entry: "main",
+        inputs: vec![],
+        expected: Ok(BexExternalValue::String("panic_value".to_string())),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn env_get_or_panic_missing_var() -> anyhow::Result<()> {
+    unsafe { std::env::remove_var("BAML_TEST_MISSING_PANIC") };
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function main() -> string {
+                env.get_or_panic("BAML_TEST_MISSING_PANIC")
+            }
+        "#,
+        entry: "main",
+        inputs: vec![],
+        expected: Err("not found"),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn env_get_existing_var() -> anyhow::Result<()> {
+    unsafe { std::env::set_var("BAML_TEST_ENV_GET", "hello_env") };
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function main() -> string? {
+                env.get("BAML_TEST_ENV_GET")
+            }
+        "#,
+        entry: "main",
+        inputs: vec![],
+        // env.get returns string? — the engine wraps in Union metadata
+        expected: Ok(BexExternalValue::Union {
+            value: Box::new(BexExternalValue::String("hello_env".to_string())),
+            metadata: bex_engine::UnionMetadata::new(
+                bex_engine::Ty::Optional(Box::new(bex_engine::Ty::String)),
+                bex_engine::Ty::String,
+            ),
+        }),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn env_get_missing_var_returns_null() -> anyhow::Result<()> {
+    unsafe { std::env::remove_var("BAML_TEST_NONEXISTENT_VAR") };
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function main() -> string? {
+                env.get("BAML_TEST_NONEXISTENT_VAR")
+            }
+        "#,
+        entry: "main",
+        inputs: vec![],
+        expected: Ok(BexExternalValue::Union {
+            value: Box::new(BexExternalValue::Null),
+            metadata: bex_engine::UnionMetadata::new(
+                bex_engine::Ty::Optional(Box::new(bex_engine::Ty::String)),
+                bex_engine::Ty::Null,
+            ),
+        }),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn env_sugar_existing_var() -> anyhow::Result<()> {
+    unsafe { std::env::set_var("BAML_TEST_SUGAR_VAR", "sugar_value") };
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function main() -> string {
+                env.BAML_TEST_SUGAR_VAR
+            }
+        "#,
+        entry: "main",
+        inputs: vec![],
+        expected: Ok(BexExternalValue::String("sugar_value".to_string())),
+    })
+    .await
+}
+
+#[tokio::test]
+async fn env_sugar_missing_var() -> anyhow::Result<()> {
+    unsafe { std::env::remove_var("BAML_TEST_SUGAR_MISSING") };
+    assert_engine_executes(EngineProgram {
+        fs: indexmap! {},
+        source: r#"
+            function main() -> string {
+                env.BAML_TEST_SUGAR_MISSING
+            }
+        "#,
+        entry: "main",
+        inputs: vec![],
+        expected: Err("not found"),
+    })
+    .await
+}

--- a/baml_language/crates/bex_engine/tests/gc.rs
+++ b/baml_language/crates/bex_engine/tests/gc.rs
@@ -5,8 +5,6 @@
 
 mod common;
 
-use std::collections::HashMap;
-
 use bex_engine::{BexEngine, BexExternalValue};
 use common::compile_for_engine;
 use sys_native::SysOpsExt;
@@ -21,7 +19,7 @@ async fn test_handle_prevents_gc_collection() {
     "#;
 
     let snapshot = compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native()).unwrap();
+    let engine = BexEngine::new(snapshot, sys_types::SysOps::native()).unwrap();
 
     // Get a handle to a string object
     let result = engine.call_function("return_string", vec![]).await.unwrap();
@@ -48,7 +46,7 @@ async fn test_array_preserved_through_gc() {
     "#;
 
     let snapshot = compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native()).unwrap();
+    let engine = BexEngine::new(snapshot, sys_types::SysOps::native()).unwrap();
 
     // Get a handle to the array
     let result = engine.call_function("return_array", vec![]).await.unwrap();
@@ -90,7 +88,7 @@ async fn test_gc_updates_forwarding_pointers() {
     "#;
 
     let snapshot = compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native()).unwrap();
+    let engine = BexEngine::new(snapshot, sys_types::SysOps::native()).unwrap();
 
     // Create objects
     let result = engine
@@ -127,7 +125,7 @@ async fn test_multiple_handles_survive_gc() {
     "#;
 
     let snapshot = compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native()).unwrap();
+    let engine = BexEngine::new(snapshot, sys_types::SysOps::native()).unwrap();
 
     // Create multiple handles
     let h1 = engine
@@ -168,7 +166,7 @@ async fn test_primitive_returns_are_external_values() {
     "#;
 
     let snapshot = compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native()).unwrap();
+    let engine = BexEngine::new(snapshot, sys_types::SysOps::native()).unwrap();
 
     // Int should be BexExternalValue::Int
     let result = engine.call_function("return_int", vec![]).await.unwrap();

--- a/baml_language/crates/bex_engine/tests/llm_render.rs
+++ b/baml_language/crates/bex_engine/tests/llm_render.rs
@@ -202,8 +202,6 @@ mod common;
 /// 3. Verifies the call succeeds (`PromptAst` is an internal type, can't return it directly)
 #[tokio::test]
 async fn test_render_prompt_e2e() {
-    use std::collections::HashMap;
-
     use bex_engine::{BexEngine, BexExternalValue};
     use sys_native::SysOpsExt;
 
@@ -235,8 +233,8 @@ function test_render() -> int {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     let result = engine.call_function("test_render", vec![]).await;
 
@@ -256,8 +254,6 @@ function test_render() -> int {
 /// containing the expected rendered content.
 #[tokio::test]
 async fn test_render_prompt_returns_prompt_ast() {
-    use std::collections::HashMap;
-
     use bex_engine::{BexEngine, BexExternalValue};
     use sys_native::SysOpsExt;
 
@@ -285,8 +281,8 @@ function get_prompt() -> PromptAst {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     let result = engine.call_function("get_prompt", vec![]).await;
 
@@ -323,8 +319,6 @@ function get_prompt() -> PromptAst {
 /// and the underlying `LlmBuildRequest` `SysOp` is implemented.
 #[tokio::test]
 async fn test_build_request_returns() {
-    use std::collections::HashMap;
-
     use bex_engine::BexEngine;
     use sys_native::SysOpsExt;
 
@@ -351,8 +345,8 @@ function test_build_request() -> int {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     let result = engine.call_function("test_build_request", vec![]).await;
     assert!(result.is_ok(), "build_request should succeed: {result:?}");
@@ -360,8 +354,6 @@ function test_build_request() -> int {
 
 #[tokio::test]
 async fn test_call_llm_function_string() {
-    use std::collections::HashMap;
-
     use bex_engine::BexEngine;
     use sys_native::SysOpsExt;
 
@@ -387,8 +379,8 @@ function test_call_llm() -> unknown {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     // build_request now succeeds; this should panic at the next unimplemented
     // step: "LlmParseResponse SysOp not yet implemented"
@@ -427,8 +419,6 @@ function test_call_llm() -> unknown {
 
 #[tokio::test]
 async fn test_direct_llm_call() {
-    use std::collections::HashMap;
-
     use bex_engine::BexEngine;
     use sys_native::SysOpsExt;
 
@@ -453,8 +443,8 @@ function test_call_llm() -> string {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     // build_request now succeeds; this should panic at the next unimplemented
     // step: "LlmParseResponse SysOp not yet implemented"
@@ -493,8 +483,6 @@ function test_call_llm() -> string {
 
 #[tokio::test]
 async fn test_call_llm_function_non_string_returns_error() {
-    use std::collections::HashMap;
-
     use bex_engine::BexEngine;
     use sys_native::SysOpsExt;
 
@@ -520,8 +508,8 @@ function test_call_llm() -> unknown {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     // build_request now succeeds; this should panic at the next unimplemented
     // step: "LlmParseResponse SysOp not yet implemented"
@@ -572,8 +560,6 @@ fn prompt_ast_string(s: &str) -> BexExternalValue {
 /// Test that a `template_string` is expanded as a Jinja macro in `render_prompt`.
 #[tokio::test]
 async fn test_template_string_in_prompt() {
-    use std::collections::HashMap;
-
     use bex_engine::BexEngine;
     use sys_native::SysOpsExt;
 
@@ -601,8 +587,8 @@ function get_prompt() -> PromptAst {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     let result = engine
         .call_function("get_prompt", vec![])
@@ -614,8 +600,6 @@ function get_prompt() -> PromptAst {
 /// Test that nested `template_strings` expand correctly.
 #[tokio::test]
 async fn test_nested_template_strings() {
-    use std::collections::HashMap;
-
     use bex_engine::BexEngine;
     use sys_native::SysOpsExt;
 
@@ -642,8 +626,8 @@ function get_prompt() -> PromptAst {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     let result = engine
         .call_function("get_prompt", vec![])
@@ -655,8 +639,6 @@ function get_prompt() -> PromptAst {
 /// Test a `template_string` with two args, one of which is a class (struct).
 #[tokio::test]
 async fn test_template_string_with_struct_arg() {
-    use std::collections::HashMap;
-
     use bex_engine::BexEngine;
     use sys_native::SysOpsExt;
 
@@ -689,8 +671,8 @@ function get_prompt() -> PromptAst {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     let result = engine
         .call_function("get_prompt", vec![])
@@ -702,8 +684,6 @@ function get_prompt() -> PromptAst {
 /// Test that parameterless `template_strings` work.
 #[tokio::test]
 async fn test_parameterless_template_string() {
-    use std::collections::HashMap;
-
     use bex_engine::BexEngine;
     use sys_native::SysOpsExt;
 
@@ -730,8 +710,8 @@ function get_prompt() -> PromptAst {
 "##;
 
     let snapshot = common::compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())
-        .expect("Failed to create engine");
+    let engine =
+        BexEngine::new(snapshot, sys_types::SysOps::native()).expect("Failed to create engine");
 
     let result = engine
         .call_function("get_prompt", vec![])

--- a/baml_language/crates/bex_engine/tests/net.rs
+++ b/baml_language/crates/bex_engine/tests/net.rs
@@ -2,8 +2,6 @@
 
 mod common;
 
-use std::collections::HashMap;
-
 use bex_engine::{BexEngine, BexExternalValue};
 use common::compile_for_engine;
 use sys_native::SysOpsExt;
@@ -33,7 +31,7 @@ async fn net_connect_and_read() -> anyhow::Result<()> {
     );
 
     let snapshot = compile_for_engine(&source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())?;
+    let engine = BexEngine::new(snapshot, sys_types::SysOps::native())?;
     let result = engine.call_function("main", vec![]).await?;
 
     // Wait for server to finish
@@ -61,7 +59,7 @@ async fn net_connect_failure() -> anyhow::Result<()> {
     "#;
 
     let snapshot = compile_for_engine(source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())?;
+    let engine = BexEngine::new(snapshot, sys_types::SysOps::native())?;
     let result = engine.call_function("main", vec![]).await;
 
     assert!(result.is_err());
@@ -102,7 +100,7 @@ async fn net_multiple_reads() -> anyhow::Result<()> {
     );
 
     let snapshot = compile_for_engine(&source);
-    let engine = BexEngine::new(snapshot, HashMap::new(), sys_types::SysOps::native())?;
+    let engine = BexEngine::new(snapshot, sys_types::SysOps::native())?;
     let result = engine.call_function("main", vec![]).await?;
 
     server.await?;

--- a/baml_language/crates/bex_external_types/src/bex_external_value.rs
+++ b/baml_language/crates/bex_external_types/src/bex_external_value.rs
@@ -303,6 +303,15 @@ impl AsBexExternalValue for bex_vm_types::MediaValue {
     }
 }
 
+impl<T: AsBexExternalValue> AsBexExternalValue for Option<T> {
+    fn into_bex_external_value(self) -> BexExternalValue {
+        match self {
+            Some(v) => v.into_bex_external_value(),
+            None => BexExternalValue::Null,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/baml_language/crates/bex_factory/src/lib.rs
+++ b/baml_language/crates/bex_factory/src/lib.rs
@@ -35,12 +35,10 @@ impl BexFactory {
     /// # Arguments
     /// * `root_path` - Root path for BAML files
     /// * `src_files` - Map of filename to content
-    /// * `env_vars` - Environment variables
     /// * `sys_ops` - System operations provider
     pub fn new(
         root_path: &str,
         src_files: &HashMap<String, String>,
-        env_vars: HashMap<String, String>,
         sys_ops: SysOps,
     ) -> Result<Self, RuntimeError> {
         let mut db = ProjectDatabase::new();
@@ -53,7 +51,7 @@ impl BexFactory {
         let bytecode = baml_compiler_emit::generate_project_bytecode(&db)
             .map_err(|e| render_lowering_error(&db, &e))?;
 
-        let engine = BexEngine::new(bytecode, env_vars, sys_ops)?;
+        let engine = BexEngine::new(bytecode, sys_ops)?;
 
         Ok(Self {
             engine: Arc::new(engine),

--- a/baml_language/crates/bex_vm/src/native.rs
+++ b/baml_language/crates/bex_vm/src/native.rs
@@ -191,18 +191,6 @@ impl NativeFunctions for VmNatives {
     fn baml_media_mime_type(media: &MediaValue) -> Option<String> {
         media.mime_type.clone()
     }
-
-    // =========================================================================
-    // Env functions
-    // =========================================================================
-
-    fn env_get(vm: &mut BexVm, key: &str) -> Result<String, VmError> {
-        vm.env_vars.get(key).cloned().ok_or_else(|| {
-            VmError::RuntimeError(RuntimeError::Other(format!(
-                "Environment variable '{key}' not found",
-            )))
-        })
-    }
 }
 
 // =============================================================================

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -200,9 +200,6 @@ pub struct BexVm {
     /// Used by GC to know which objects are compile-time vs runtime.
     pub runtime_allocs_offset: ObjectIndex,
 
-    /// Environment variables available during execution.
-    pub env_vars: HashMap<String, String>,
-
     /// Emit dependency graph.
     pub watch: Watch,
 
@@ -377,7 +374,7 @@ impl BexVm {
     ///
     /// The heap is shared across all VMs. Each VM gets its own TLAB
     /// for contention-free allocation.
-    pub fn new(heap: Arc<BexHeap>, globals: GlobalPool, env_vars: HashMap<String, String>) -> Self {
+    pub fn new(heap: Arc<BexHeap>, globals: GlobalPool) -> Self {
         let runtime_allocs_offset = ObjectIndex::from_raw(heap.compile_time_boundary());
         let tlab = Tlab::new(Arc::clone(&heap));
 
@@ -388,7 +385,6 @@ impl BexVm {
             tlab,
             globals,
             runtime_allocs_offset,
-            env_vars,
             watch: Watch::new(),
             watched_vars: HashMap::new(),
             interrupt_frame: None,
@@ -600,7 +596,7 @@ impl BexVm {
             .collect();
         let globals = GlobalPool::from_vec(globals_vec);
 
-        Ok(Self::new(heap, globals, HashMap::new()))
+        Ok(Self::new(heap, globals))
     }
 
     /// Bootstraps the VM preparing the given function to run.

--- a/baml_language/crates/bridge_cffi/src/engine.rs
+++ b/baml_language/crates/bridge_cffi/src/engine.rs
@@ -38,18 +38,11 @@ pub fn get_runtime() -> Result<BexFactory, BridgeError> {
 /// # Arguments
 /// * `root_path` - Root path for BAML files
 /// * `src_files` - Map of filename to content
-/// * `env_vars` - Environment variables
 pub fn initialize_runtime(
     root_path: &str,
     src_files: HashMap<String, String>,
-    env_vars: HashMap<String, String>,
 ) -> Result<(), BridgeError> {
-    let rt = BexFactory::new(
-        root_path,
-        &src_files,
-        env_vars,
-        bex_factory::SysOps::native(),
-    )?;
+    let rt = BexFactory::new(root_path, &src_files, bex_factory::SysOps::native())?;
 
     let mut guard = RUNTIME_INSTANCE
         .write()

--- a/baml_language/crates/bridge_cffi/src/ffi/runtime.rs
+++ b/baml_language/crates/bridge_cffi/src/ffi/runtime.rs
@@ -18,7 +18,6 @@ pub extern "C" fn version() -> Buffer {
 /// # Arguments
 /// * `root_path` - Root path for BAML files (C string)
 /// * `src_files_json` - JSON-encoded HashMap<String, String> of file contents
-/// * `env_vars_json` - JSON-encoded HashMap<String, String> of env vars
 ///
 /// # Returns
 /// Non-null pointer on success (value is opaque, not used), null on failure.
@@ -27,7 +26,6 @@ pub extern "C" fn version() -> Buffer {
 pub extern "C" fn create_baml_runtime(
     root_path: *const libc::c_char,
     src_files_json: *const libc::c_char,
-    env_vars_json: *const libc::c_char,
 ) -> *const libc::c_void {
     ffi_safe_ptr(|| -> Result<*const libc::c_void, String> {
         // Parse root_path
@@ -46,17 +44,8 @@ pub extern "C" fn create_baml_runtime(
         let src_files: HashMap<String, String> = serde_json::from_str(src_files_str)
             .map_err(|e| format!("Failed to parse src_files JSON: {e}"))?;
 
-        // Parse env_vars JSON
-        let env_vars_str = unsafe {
-            CStr::from_ptr(env_vars_json)
-                .to_str()
-                .map_err(|e| format!("Invalid UTF-8 in env_vars_json: {e}"))?
-        };
-        let env_vars: HashMap<String, String> = serde_json::from_str(env_vars_str)
-            .map_err(|e| format!("Failed to parse env_vars JSON: {e}"))?;
-
         // Initialize global runtime
-        initialize_runtime(root_path_str, src_files, env_vars)
+        initialize_runtime(root_path_str, src_files)
             .map_err(|e| format!("Failed to initialize runtime: {e}"))?;
 
         // Return non-null pointer to indicate success

--- a/baml_language/crates/sys_native/src/lib.rs
+++ b/baml_language/crates/sys_native/src/lib.rs
@@ -35,15 +35,24 @@ pub struct NativeSysOps;
 
 impl SysOpEnv for NativeSysOps {
     fn env_get(key: String) -> SysOpOutput<Option<String>> {
-        SysOpOutput::ok(std::env::var(&key).ok())
+        match std::env::var(&key) {
+            Ok(val) => SysOpOutput::ok(Some(val)),
+            Err(std::env::VarError::NotPresent) => SysOpOutput::ok(None),
+            Err(std::env::VarError::NotUnicode(_)) => SysOpOutput::err(OpErrorKind::Other(
+                format!("Environment variable '{key}' is not valid UTF-8"),
+            )),
+        }
     }
 
     fn env_get_or_panic(key: String) -> SysOpOutput<String> {
         match std::env::var(&key) {
             Ok(val) => SysOpOutput::ok(val),
-            Err(_) => SysOpOutput::err(OpErrorKind::Other(format!(
+            Err(std::env::VarError::NotPresent) => SysOpOutput::err(OpErrorKind::Other(format!(
                 "Environment variable '{key}' not found",
             ))),
+            Err(std::env::VarError::NotUnicode(_)) => SysOpOutput::err(OpErrorKind::Other(
+                format!("Environment variable '{key}' is not valid UTF-8"),
+            )),
         }
     }
 }

--- a/baml_language/crates/sys_native/src/lib.rs
+++ b/baml_language/crates/sys_native/src/lib.rs
@@ -9,7 +9,7 @@
 //! use sys_native::SysOpsExt;
 //! use bex_engine::BexEngine;
 //!
-//! let engine = BexEngine::new(program, env_vars, SysOps::native())?;
+//! let engine = BexEngine::new(program, SysOps::native())?;
 //! ```
 
 mod ops;
@@ -18,8 +18,8 @@ pub mod registry;
 // Re-export types from sys_types for convenience
 use bex_heap::builtin_types;
 pub use sys_types::{
-    CompletionHandle, OpError, SysOp, SysOpContext, SysOpFn, SysOpFs, SysOpHttp, SysOpLlm,
-    SysOpNet, SysOpResult, SysOpSys, SysOps,
+    CompletionHandle, OpError, SysOp, SysOpContext, SysOpEnv, SysOpFn, SysOpFs, SysOpHttp,
+    SysOpLlm, SysOpNet, SysOpResult, SysOpSys, SysOps,
 };
 use sys_types::{OpErrorKind, SysOpOutput};
 
@@ -28,6 +28,25 @@ use sys_types::{OpErrorKind, SysOpOutput};
 /// Implements per-module traits (`SysOpFs`, `SysOpHttp`, etc.) with clean
 /// typed signatures. The generated glue handles arg extraction and error wrapping.
 pub struct NativeSysOps;
+
+// ============================================================================
+// Environment
+// ============================================================================
+
+impl SysOpEnv for NativeSysOps {
+    fn env_get(key: String) -> SysOpOutput<Option<String>> {
+        SysOpOutput::ok(std::env::var(&key).ok())
+    }
+
+    fn env_get_or_panic(key: String) -> SysOpOutput<String> {
+        match std::env::var(&key) {
+            Ok(val) => SysOpOutput::ok(val),
+            Err(_) => SysOpOutput::err(OpErrorKind::Other(format!(
+                "Environment variable '{key}' not found",
+            ))),
+        }
+    }
+}
 
 // ============================================================================
 // File System

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -326,7 +326,7 @@ impl<T> FunctionRef<T> {
 /// ```ignore
 /// // Using the native Tokio provider
 /// let sys_ops = sys_types_native::SysOps::native();
-/// let engine = BexEngine::new(program, env_vars, sys_ops)?;
+/// let engine = BexEngine::new(program, sys_ops)?;
 /// ```
 macro_rules! define_sys_ops_struct {
     ($({ $Variant:ident, $path:expr, $snake:ident, $uses_ctx:expr })*) => {


### PR DESCRIPTION
## Summary
- Convert `env.get` and `env.get_or_panic` from native VM functions to sys_ops that call `std::env::var()` directly
- Remove `env_vars: HashMap<String, String>` from BexVm, BexEngine, BexFactory, and CFFI bridge — env vars are now read at runtime instead of cloned through the entire pipeline
- Add `ENV_ACCESS_EXPR` syntax node so the parser properly handles `env.X` syntax (previously broken — lexer produced `TokenKind::Env` but parser only checked `TokenKind::Word`)
- Desugar `env.X` → `env.get_or_panic("X")` during HIR lowering; `env.get(...)` calls resolve normally through the env module
- Support `Option<T>` return types in sys_op codegen and `AsBexExternalValue`
- Fix `module_from_path` for 2-segment paths like `env.get` (was incorrectly extracting `"get"` as module name)

## Test plan
- [x] 6 new integration tests in `bex_engine/tests/env.rs` covering all forms:
  - `env.get_or_panic("V")` — existing and missing var
  - `env.get("V")` — existing var (returns `Union { String }`) and missing var (returns `Union { Null }`)
  - `env.SUGAR` — existing and missing var
- [x] All 375+ existing tests pass (34 snapshot updates for shifted global indices)
- [x] Clippy passes with no warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - env.get(key) returns an optional value; env.get_or_panic(key) returns a value or error
  - Shorthand env.FIELD syntax to access environment variables

* **Changes**
  - Runtime/engine initialization simplified: environment variables are no longer passed through the engine; environment access is provided via system operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->