### PR TITLE
VM cleanup: remove dead code, refactor watch graph, fix GC tracing

### DIFF
--- a/baml_language/crates/baml_tests/src/codegen.rs
+++ b/baml_language/crates/baml_tests/src/codegen.rs
@@ -92,7 +92,6 @@ fn convert_instruction(
         bex_vm_types::Instruction::StoreField(idx) => Instruction::StoreField(*idx),
         bex_vm_types::Instruction::Pop(n) => Instruction::Pop(*n),
         bex_vm_types::Instruction::Copy(idx) => Instruction::Copy(*idx),
-        bex_vm_types::Instruction::PopReplace(n) => Instruction::PopReplace(*n),
         bex_vm_types::Instruction::Jump(offset) => Instruction::Jump(*offset),
         bex_vm_types::Instruction::PopJumpIfFalse(offset) => Instruction::PopJumpIfFalse(*offset),
         bex_vm_types::Instruction::BinOp(op) => Instruction::BinOp(*op),

--- a/baml_language/crates/baml_tests/src/vm.rs
+++ b/baml_language/crates/baml_tests/src/vm.rs
@@ -329,7 +329,6 @@ pub enum Instruction {
     StoreField(usize),
     Pop(usize),
     Copy(usize),
-    PopReplace(usize),
     Jump(isize),
     PopJumpIfFalse(isize),
     BinOp(BinOp),

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -468,6 +468,9 @@ impl BexEngine {
                 }
             }
 
+            // Update watch state (graph NodeIds, RootState values)
+            vm.watch.apply_forwarding(&forwarding);
+
             // Invalidate TLAB so next allocation gets chunk from new space
             vm.tlab.invalidate();
         }
@@ -643,6 +646,9 @@ impl BexEngine {
             }
         }
 
+        // Watch state (last_assigned/last_notified values that aren't on the stack)
+        vm.watch.collect_roots(&mut roots);
+
         // Note: Frame locals are stored in the stack at the locals_offset position,
         // so they're already included in the stack iteration above.
 
@@ -666,6 +672,9 @@ impl BexEngine {
                         }
                     }
                 }
+
+                // Update watch state (graph NodeIds, RootState values)
+                vm.watch.apply_forwarding(&forwarding);
 
                 // Invalidate TLAB so next allocation gets chunk from new space
                 vm.tlab.invalidate();

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -165,7 +165,6 @@ pub fn display_instruction(
         }
         Instruction::Pop(_)
         | Instruction::Copy(_)
-        | Instruction::PopReplace(_)
         | Instruction::BinOp(_)
         | Instruction::CmpOp(_)
         | Instruction::UnaryOp(_)
@@ -291,11 +290,9 @@ fn instruction_color(instruction: &Instruction) -> Color {
             Color::Yellow
         }
         Instruction::Call(_) => Color::Magenta,
-        Instruction::Assert
-        | Instruction::Return
-        | Instruction::Pop(_)
-        | Instruction::Copy(_)
-        | Instruction::PopReplace(_) => Color::Red,
+        Instruction::Assert | Instruction::Return | Instruction::Pop(_) | Instruction::Copy(_) => {
+            Color::Red
+        }
         Instruction::AllocMap(_)
         | Instruction::AllocInstance(_)
         | Instruction::AllocVariant(_)

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -51,16 +51,15 @@ use crate::indexable::EvalStack;
 ///
 /// If there's no relevant metadata to attach to the instruction, then this
 /// function returns an empty string.
-#[allow(clippy::cast_sign_loss)] // instruction_ptr is always non-negative in valid bytecode
 pub fn display_instruction(
-    instruction_ptr: isize,
+    instruction_ptr: usize,
     function: &Function,
     stack: &EvalStack,
     globals: &GlobalPool,
     objects: Option<&ObjectPool>,
     compile_time_globals: Option<&[bex_vm_types::ConstValue]>,
 ) -> (String, String) {
-    let instruction = &function.bytecode.instructions[instruction_ptr as usize];
+    let instruction = &function.bytecode.instructions[instruction_ptr];
 
     let metadata = match instruction {
         Instruction::NotifyBlock(block_index) => {
@@ -104,7 +103,7 @@ pub fn display_instruction(
                 "({})",
                 function
                     .locals_in_scope
-                    .get(function.bytecode.scopes[instruction_ptr as usize])
+                    .get(function.bytecode.scopes[instruction_ptr])
                     .and_then(|locals| locals.get(*index))
                     .unwrap_or(&"?".to_string())
             )
@@ -142,7 +141,7 @@ pub fn display_instruction(
             format!("({})", class.fields[*index].name)
         }
         Instruction::Jump(offset) | Instruction::PopJumpIfFalse(offset) => {
-            format!("(to {})", instruction_ptr + offset)
+            format!("(to {})", instruction_ptr.wrapping_add_signed(*offset))
         }
         Instruction::AllocInstance(index) | Instruction::AllocVariant(index) => {
             // Look up the class/enum from the compile-time ObjectPool if available
@@ -375,10 +374,9 @@ pub fn display_bytecode(
     let mut last_line: usize = 0;
 
     // Populate all the rows.
-    #[allow(clippy::cast_possible_wrap)] // instruction count is always small enough
     for instruction_ptr in 0..function.bytecode.instructions.len() {
         let (instruction, metadata) = display_instruction(
-            instruction_ptr as isize,
+            instruction_ptr,
             function,
             stack,
             globals,

--- a/baml_language/crates/bex_vm/src/errors.rs
+++ b/baml_language/crates/bex_vm/src/errors.rs
@@ -36,8 +36,8 @@ pub enum InternalError {
     #[error("array index is negative: {0}")]
     ArrayIndexIsNegative(i64),
 
-    #[error("negative instruction pointer: {0}")]
-    NegativeInstructionPtr(isize),
+    #[error("jump offset overflowed instruction pointer")]
+    InvalidJump,
 }
 
 /// Errors that can happen at runtime.

--- a/baml_language/crates/bex_vm/src/lib.rs
+++ b/baml_language/crates/bex_vm/src/lib.rs
@@ -21,4 +21,4 @@ pub mod watch;
 
 pub use errors::{InternalError, RuntimeError, StackTrace};
 pub use indexable::EvalStack;
-pub use vm::{BexVm, BytecodeProgram, Frame, VmExecState, convert_program};
+pub use vm::{BexVm, BytecodeProgram, VmExecState, convert_program};

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -52,13 +52,8 @@ pub struct Frame {
 
     /// Instruction pointer (IP) or program counter (PC).
     ///
-    /// Points to the next instruction that the VM will execute. It is of type
-    /// [`isize`] because some jumps can create negative offsets (for loops)
-    /// and it's easier to operate on an [`isize`] and cast it to [`usize`]
-    /// only once (when we index into [`bex_vm_types::Bytecode::instructions`]). However,
-    /// this number should never be negative, otherwise indexing into the
-    /// instruction vec will throw [`InternalError::NegativeInstructionPtr`].
-    pub instruction_ptr: isize,
+    /// Points to the next instruction that the VM will execute.
+    pub instruction_ptr: usize,
 
     /// Local variables offset in the eval stack.
     pub locals_offset: StackIndex,
@@ -769,11 +764,10 @@ impl BexVm {
                 // a bug somewhere.
                 let last_executed_instruction = frame.instruction_ptr.saturating_sub(1);
 
-                #[allow(clippy::cast_sign_loss)] // instruction_ptr is always non-negative
                 Ok(ErrorLocation {
                     function_name: function.name.clone(),
                     function_span: function.span,
-                    error_line: function.bytecode.source_lines[last_executed_instruction as usize],
+                    error_line: function.bytecode.source_lines[last_executed_instruction],
                 })
             })
             .collect::<Result<Vec<_>, VmError>>()
@@ -993,38 +987,30 @@ impl BexVm {
             // jump offsets later.
             self.frames[frame_idx].instruction_ptr += 1;
 
-            // NOTE: `core::intrinsics::unlikely` is only available on nightly.
-            // This branch is a big annoyance for small functions (like pushing the frame)
-            // and gets smaller the bigger the function due to branch (mis)prediction.
-            if instruction_ptr < 0 {
-                return Err(InternalError::NegativeInstructionPtr(instruction_ptr).into());
+            #[cfg(debug_assertions)]
+            #[allow(clippy::print_stderr)] // intentional debug output
+            if std::env::var("BEX_VM_DEBUG").is_ok() {
+                let stack = self
+                    .stack
+                    .iter()
+                    .map(crate::debug::display_value)
+                    .collect::<Vec<_>>()
+                    .join(", ");
+
+                let (instruction, metadata) = crate::debug::display_instruction(
+                    instruction_ptr,
+                    function,
+                    &self.stack,
+                    &self.globals,
+                    None,
+                    None,
+                );
+
+                eprintln!("[{stack}]");
+                eprintln!("{instruction} {metadata}");
             }
 
-            // Runtime debugging information.
-            // #[cfg(debug_assertions)]
-            // {
-            //     let stack = self
-            //         .stack
-            //         .iter()
-            //         .map(|v| crate::debug::display_value(v, &self.objects))
-            //         .collect::<Vec<_>>()
-            //         .join(", ");
-
-            //     eprintln!("[{stack}]");
-
-            //     let (instruction, metadata) = crate::debug::display_instruction(
-            //         instruction_ptr,
-            //         function,
-            //         &self.stack,
-            //         &self.objects,
-            //         &self.globals,
-            //     );
-
-            //     eprintln!("{instruction} {metadata}");
-            // }
-
-            #[allow(clippy::cast_sign_loss)] // instruction_ptr is validated non-negative above
-            match function.bytecode.instructions[instruction_ptr as usize] {
+            match function.bytecode.instructions[instruction_ptr] {
                 Instruction::NotifyBlock(block_index) => {
                     // Get the notification from the function's storage
                     let notification = &function.block_notifications[block_index];
@@ -1044,7 +1030,7 @@ impl BexVm {
                 }
 
                 Instruction::VizEnter(index) | Instruction::VizExit(index) => {
-                    let instruction = &function.bytecode.instructions[instruction_ptr as usize];
+                    let instruction = &function.bytecode.instructions[instruction_ptr];
                     let delta = match instruction {
                         Instruction::VizEnter(_) => bytecode::VizExecDelta::Enter,
                         Instruction::VizExit(_) => bytecode::VizExecDelta::Exit,
@@ -1228,10 +1214,14 @@ impl BexVm {
                 }
 
                 Instruction::Jump(offset) => {
-                    // Reassign the frame's IP to the new instruction.
-                    // Remember that offset can be negative here, so even though
-                    // we're adding it can still jump backwards.
-                    self.frames[frame_idx].instruction_ptr = instruction_ptr + offset;
+                    // Offset can be negative (backward jumps for loops).
+                    // NOTE: checked_add_signed has a branch on overflow. If this
+                    // becomes a bottleneck on hot loops, it can be replaced with
+                    // wrapping_add_signed — the array bounds check on the next
+                    // iteration will catch invalid pointers anyway.
+                    self.frames[frame_idx].instruction_ptr = instruction_ptr
+                        .checked_add_signed(offset)
+                        .ok_or(InternalError::InvalidJump)?;
                 }
 
                 Instruction::PopJumpIfFalse(offset) => {
@@ -1242,7 +1232,9 @@ impl BexVm {
                         // Reassign only if the condition is false.
                         Value::Bool(value) => {
                             if !value {
-                                self.frames[frame_idx].instruction_ptr = instruction_ptr + offset;
+                                self.frames[frame_idx].instruction_ptr = instruction_ptr
+                                    .checked_add_signed(offset)
+                                    .ok_or(InternalError::InvalidJump)?;
                             }
                         }
 
@@ -1922,9 +1914,8 @@ impl BexVm {
                         },
                     );
 
-                    #[allow(clippy::cast_sign_loss)] // instruction_ptr is validated non-negative
-                    let watched_var_name = &function.locals_in_scope
-                        [function.bytecode.scopes[instruction_ptr as usize]][index];
+                    let watched_var_name =
+                        &function.locals_in_scope[function.bytecode.scopes[instruction_ptr]][index];
                     // Track this so we can unregister on scope exit
                     self.watched_vars.insert(
                         local_var_index,
@@ -2199,7 +2190,9 @@ impl BexVm {
                     let offset = table.lookup(value).unwrap_or(default);
 
                     // Jump
-                    self.frames[frame_idx].instruction_ptr = instruction_ptr + offset;
+                    self.frames[frame_idx].instruction_ptr = instruction_ptr
+                        .checked_add_signed(offset)
+                        .ok_or(InternalError::InvalidJump)?;
                 }
 
                 Instruction::Discriminant => {

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -912,11 +912,7 @@ impl BexVm {
         }
 
         if let Value::Object(new) = new_value {
-            // Track dependencies first (using closure to avoid borrow conflicts)
-            watch::track_watch_dependencies(&mut self.watch, Value::Object(new));
-            // Then link the edge
-            self.watch
-                .link_edge(watched_node, path, NodeId::HeapObject(new));
+            watch::track_watch_dependencies(&mut self.watch, watched_node, path, new);
         }
 
         // Deep-copy previous root values so the notification filter can diff
@@ -1937,15 +1933,11 @@ impl BexVm {
 
                     // If it's an object, build the entire dependency graph
                     if let Value::Object(object_index) = value {
-                        // Build the graph.
-                        // Track dependencies first (using closure to avoid borrow conflicts)
-                        watch::track_watch_dependencies(&mut self.watch, value);
-
-                        // Link the root emittable variable to the object
-                        self.watch.link_edge(
+                        watch::track_watch_dependencies(
+                            &mut self.watch,
                             var_node,
                             watch::Path::Binding,
-                            NodeId::HeapObject(object_index),
+                            object_index,
                         );
                     }
                 }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -22,7 +22,7 @@ use bex_vm_types::{
     BinOp, CmpOp, FunctionKind, GlobalPool, HeapPtr, Instruction, Object, ObjectIndex, ObjectPool,
     ObjectType, StackIndex, UnaryOp, Value, Variant,
     bytecode::{self, BlockNotification},
-    types::{FunctionType, Future, FutureType, Instance, PendingFuture, Type},
+    types::{Function, FunctionType, Future, FutureType, Instance, PendingFuture, Type},
 };
 use indexmap::IndexMap;
 
@@ -919,29 +919,48 @@ impl BexVm {
                 .link_edge(watched_node, path, NodeId::HeapObject(new));
         }
 
-        // Copy previous values.
-        let mut old_roots_copies = vec![];
+        // Deep-copy previous root values so the notification filter can diff
+        // old vs new. Two-pass because `baml_deep_copy` needs `&mut self`,
+        // which conflicts with borrowing `self.watch` for root_state.
+        let roots = self.watch.copy_roots_reaching(watched_node);
+        let mut old_roots_copies = Vec::with_capacity(roots.len());
 
-        for root in self.watch.copy_roots_reaching(watched_node) {
+        for &root in &roots {
             if let Some(state) = self.watch.root_state(root) {
                 let deep_copy = crate::native::baml_deep_copy(self, &[state.value])?;
                 old_roots_copies.push(deep_copy);
             }
         }
 
-        for (root, old_value) in self
-            .watch
-            .copy_roots_reaching(watched_node)
-            .iter()
-            .zip(old_roots_copies)
-        {
-            if let Some(state) = self.watch.root_state_mut(*root) {
+        for (&root, old_value) in roots.iter().zip(old_roots_copies) {
+            if let Some(state) = self.watch.root_state_mut(root) {
                 state.last_assigned = Some(old_value);
-                // current value has not really changes, top level object is the same.
             }
         }
 
         Ok(())
+    }
+
+    /// Load the function object for the given frame.
+    ///
+    /// # Safety
+    ///
+    /// Function objects are compiled ahead of time and live in the compile-time
+    /// heap, which is never garbage collected. The returned `'static` reference
+    /// is valid for the lifetime of the program.
+    ///
+    /// TODO: When we add lambdas that capture variables, their function objects
+    /// will be allocated at runtime on the TLAB and *can* be garbage collected.
+    /// At that point `'static` becomes unsound. Options:
+    ///   1. Pin closures in a non-GC'd region so they remain `'static`.
+    ///   2. Drop `'static` and re-deref after each GC safepoint (cheap re-deref,
+    ///      still no clone).
+    #[inline]
+    unsafe fn load_function(&self, frame_idx: usize) -> Result<&'static Function, VmError> {
+        let ptr = self.frames[frame_idx].function;
+        // SAFETY: See doc comment above.
+        let obj: &'static Object = unsafe { ptr.get() };
+        obj.as_function()
     }
 
     /// Main VM execution loop.
@@ -967,12 +986,8 @@ impl BexVm {
         // pushing new frames during function calls.
         let mut frame_idx = self.frames.len() - 1;
 
-        // Clone the function object to avoid borrow checker issues with the new heap architecture.
-        // We clone because we need to access the function's bytecode throughout the loop
-        // while also mutating self (stack, frames, etc.). This is a trade-off for the
-        // unified heap architecture - the cost of cloning is acceptable for now.
-        let function_obj_idx = self.frames[frame_idx].function;
-        let mut function = self.get_object(function_obj_idx).as_function()?.clone();
+        // SAFETY: See `load_function` doc comment.
+        let mut function = unsafe { self.load_function(frame_idx)? };
 
         loop {
             // Current instruction pointer (read from frame).
@@ -1031,6 +1046,7 @@ impl BexVm {
                         full_notification,
                     )));
                 }
+
                 Instruction::VizEnter(index) | Instruction::VizExit(index) => {
                     let instruction = &function.bytecode.instructions[instruction_ptr as usize];
                     let delta = match instruction {
@@ -1059,6 +1075,7 @@ impl BexVm {
                         event,
                     }));
                 }
+
                 Instruction::LoadConst(index) => {
                     // Use pre-resolved constants (resolved at load time)
                     let value = function.bytecode.resolved_constants[index];
@@ -1080,48 +1097,41 @@ impl BexVm {
                     // Old value being replaced.
                     let old_value = std::mem::replace(&mut self.stack[local_var_index], value);
 
-                    // Check if this binding is emittable.
+                    // If this local is watched, update the watch graph.
+                    //
+                    // A watched local is a root in the watch graph. When
+                    // reassigned (e.g. `v = new_val`), three things happen:
+                    //
+                    // 1. `update_watched_node` handles edge topology: unlinks
+                    //    the old binding (so mutations to the old object no
+                    //    longer trigger notifications), links the new one, and
+                    //    deep-copies the previous root state into
+                    //    `last_assigned` so the notification filter can diff
+                    //    old vs new.
+                    //
+                    // 2. `state.value` is updated to the new value. This is
+                    //    specific to `StoreVar` — for field/array/map stores
+                    //    the root's top-level binding hasn't changed, but here
+                    //    the root itself is being rebound.
+                    //
+                    // 3. `process_notifications` walks all roots reaching this
+                    //    node (just itself, since it IS a root) and applies
+                    //    the watch filter to decide whether to notify.
                     if self.watched_vars.contains_key(&local_var_index) {
-                        // Node ID of the local variable in the emit graph.
                         let watched_node = NodeId::LocalVar(local_var_index);
 
-                        // If we had a previous binding to an object, unlink it
-                        // so it doesn't emit anymore.
-                        if let Value::Object(old_node) = old_value {
-                            self.watch.unlink_edge(
-                                watched_node,
-                                watch::Path::Binding,
-                                NodeId::HeapObject(old_node),
-                            );
-                        }
-
-                        // If we have a new binding, link it so it emits.
-                        if let Value::Object(new_node) = value {
-                            // Track dependencies first (using closure to avoid borrow conflicts)
-                            watch::track_watch_dependencies(&mut self.watch, value);
-                            // Then link the edge
-                            self.watch.link_edge(
-                                watched_node,
-                                watch::Path::Binding,
-                                NodeId::HeapObject(new_node),
-                            );
-                        }
-
-                        let old_value_deep_copy =
-                            crate::native::baml_deep_copy(self, &[old_value])?;
+                        self.update_watched_node(
+                            watched_node,
+                            watch::Path::Binding,
+                            old_value,
+                            value,
+                        )?;
 
                         if let Some(state) = self.watch.root_state_mut(watched_node) {
-                            state.last_assigned = Some(old_value_deep_copy);
                             state.value = value;
                         }
 
                         let notifications = self.process_notifications(watched_node)?;
-
-                        // borrow checker - update frame index and function.
-                        function = self
-                            .get_object(self.frames[frame_idx].function)
-                            .as_function()?
-                            .clone();
 
                         if !notifications.is_empty() {
                             return Ok(VmExecState::Notify(WatchNotification::Variables(
@@ -1202,12 +1212,6 @@ impl BexVm {
 
                     let notifications = self.process_notifications(watched_node)?;
 
-                    // Borrow checker - update function.
-                    function = self
-                        .get_object(self.frames[frame_idx].function)
-                        .as_function()?
-                        .clone();
-
                     if !notifications.is_empty() {
                         return Ok(VmExecState::Notify(WatchNotification::Variables(
                             notifications,
@@ -1218,69 +1222,12 @@ impl BexVm {
                 Instruction::Pop(n) => {
                     let drain_start = self.stack.len() - n;
                     let drain_range = StackIndex::from_raw(drain_start)..;
-
-                    // Check if any of the popped variables are emittable and
-                    // unregister them
-                    for i in drain_start..self.stack.len() {
-                        let index = StackIndex::from_raw(i);
-                        if self.watched_vars.remove(&index).is_some() {
-                            let var_node = NodeId::LocalVar(index);
-
-                            // Unregister the root since the variable is going
-                            // out of scope.
-                            self.watch.unregister_root(var_node);
-
-                            // Also unlink any edge from this variable.
-                            if let Value::Object(obj) = self.stack[index] {
-                                self.watch.unlink_edge(
-                                    var_node,
-                                    watch::Path::Binding,
-                                    NodeId::HeapObject(obj),
-                                );
-                            }
-                        }
-                    }
-
                     self.stack.drain(drain_range);
                 }
 
                 Instruction::Copy(offset) => {
                     let index = self.stack.ensure_slot_from_top(offset)?;
                     let value = self.stack[index];
-                    self.stack.push(value);
-                }
-
-                Instruction::PopReplace(n) => {
-                    let value = self.stack.ensure_pop()?;
-
-                    // Pop the last `n` locals from the stack.
-                    let drain_start = self.stack.len() - n;
-
-                    // Clean up any emittable variables in the range being
-                    // popped.
-                    for i in drain_start..self.stack.len() {
-                        let index = StackIndex::from_raw(i);
-                        if self.watched_vars.remove(&index).is_some() {
-                            let var_node = NodeId::LocalVar(index);
-
-                            // Unregister the root since the variable is going out of scope
-                            self.watch.unregister_root(var_node);
-
-                            // Also unlink any edge from this variable
-                            if let Value::Object(obj) = self.stack[index] {
-                                self.watch.unlink_edge(
-                                    var_node,
-                                    watch::Path::Binding,
-                                    NodeId::HeapObject(obj),
-                                );
-                            }
-                        }
-                    }
-
-                    let drain_range = StackIndex::from_raw(drain_start)..;
-                    self.stack.drain(drain_range);
-
-                    // Push the value back on top of the stack.
                     self.stack.push(value);
                 }
 
@@ -1379,15 +1326,7 @@ impl BexVm {
                             let mut concat = left.clone();
                             concat.push_str(right);
 
-                            let concat_str_object = self.alloc_string(concat);
-
-                            // Borrow check.
-                            function = self
-                                .get_object(self.frames[frame_idx].function)
-                                .as_function()?
-                                .clone();
-
-                            concat_str_object
+                            self.alloc_string(concat)
                         }
 
                         _ => {
@@ -1563,13 +1502,6 @@ impl BexVm {
 
                     // Push the array object on top of the stack.
                     self.stack.push(Value::Object(array_index));
-
-                    // objects.push() above might've reallocated the vector so
-                    // borrow checker complains. Restore the reference.
-                    function = self
-                        .get_object(self.frames[frame_idx].function)
-                        .as_function()?
-                        .clone();
                 }
 
                 Instruction::LoadArrayElement => {
@@ -1727,13 +1659,6 @@ impl BexVm {
 
                     let notifications = self.process_notifications(watched_node)?;
 
-                    // borrow checker.
-                    // No need to reassign frame since we're using frame_idx
-                    function = self
-                        .get_object(self.frames[frame_idx].function)
-                        .as_function()?
-                        .clone();
-
                     if !notifications.is_empty() {
                         return Ok(VmExecState::Notify(WatchNotification::Variables(
                             notifications,
@@ -1785,13 +1710,6 @@ impl BexVm {
 
                     let notifications = self.process_notifications(watched_node)?;
 
-                    // borrow checker.
-                    // No need to reassign frame since we're using frame_idx
-                    function = self
-                        .get_object(self.frames[frame_idx].function)
-                        .as_function()?
-                        .clone();
-
                     if !notifications.is_empty() {
                         return Ok(VmExecState::Notify(WatchNotification::Variables(
                             notifications,
@@ -1822,12 +1740,6 @@ impl BexVm {
 
                     // Push the instance object on top of the stack.
                     self.stack.push(Value::Object(instance_ptr));
-
-                    // borrow check.
-                    function = self
-                        .get_object(self.frames[frame_idx].function)
-                        .as_function()?
-                        .clone();
                 }
 
                 // TODO: Contains a lot of typechecking, we know at compile time
@@ -1880,12 +1792,6 @@ impl BexVm {
 
                     // Push the variant object on top of the stack.
                     self.stack.push(Value::Object(variant_ptr));
-
-                    // borrow check.
-                    function = self
-                        .get_object(self.frames[frame_idx].function)
-                        .as_function()?
-                        .clone();
                 }
 
                 Instruction::DispatchFuture(arg_count) => {
@@ -2149,13 +2055,6 @@ impl BexVm {
                             // Drop function call and place result on top.
                             self.stack.drain(locals_offset..);
                             self.stack.push(result);
-
-                            // No need to update frame_idx since we didn't push a new frame.
-                            // Just update the function reference.
-                            function = self
-                                .get_object(self.frames[frame_idx].function)
-                                .as_function()?
-                                .clone();
                         }
 
                         FunctionKind::Bytecode => {
@@ -2169,14 +2068,8 @@ impl BexVm {
                             // Update frame_idx to point to the new frame.
                             frame_idx = self.frames.len() - 1;
 
-                            // Grab function ref. We do this to avoid running this
-                            // code at the beginning of each iteration since it's
-                            // totally unnecessary. The function only changes when the
-                            // frame changes.
-                            function = self
-                                .get_object(self.frames[frame_idx].function)
-                                .as_function()?
-                                .clone();
+                            // SAFETY: See `load_function` doc comment.
+                            function = unsafe { self.load_function(frame_idx)? };
                         }
 
                         FunctionKind::SysOp(_) => {
@@ -2201,28 +2094,6 @@ impl BexVm {
                 Instruction::Return => {
                     // Pop the result from the eval stack.
                     let result = self.stack.ensure_pop()?;
-
-                    // Clean up any emittable variables in the function's scope
-                    for i in self.frames[frame_idx].locals_offset.into_raw()..self.stack.len() {
-                        let index = StackIndex::from_raw(i);
-                        if self.watched_vars.remove(&index).is_some() {
-                            let var_node = NodeId::LocalVar(index);
-
-                            // Unregister the root since the variable is going out of scope
-                            self.watch.unregister_root(var_node);
-
-                            // Also unlink any edge from this variable
-                            if i < self.stack.len() {
-                                if let Value::Object(obj) = self.stack[index] {
-                                    self.watch.unlink_edge(
-                                        var_node,
-                                        watch::Path::Binding,
-                                        NodeId::HeapObject(obj),
-                                    );
-                                }
-                            }
-                        }
-                    }
 
                     // Restore the eval stack to the state before the function
                     // was called and leave the result on top.
@@ -2254,13 +2125,8 @@ impl BexVm {
                     // Resume previous frame execution.
                     frame_idx = self.frames.len() - 1;
 
-                    // Point to the previous frame's function. Read the
-                    // implementation of `Instruction::Call` above this one for
-                    // more information about this piece.
-                    function = self
-                        .get_object(self.frames[frame_idx].function)
-                        .as_function()?
-                        .clone();
+                    // SAFETY: See `load_function` doc comment.
+                    function = unsafe { self.load_function(frame_idx)? };
                 }
 
                 Instruction::Assert => {
@@ -2318,12 +2184,6 @@ impl BexVm {
                     let obj_index = self.tlab.alloc(Object::Map(map));
 
                     self.stack.push(Value::Object(obj_index));
-
-                    // borrow check.
-                    function = self
-                        .get_object(self.frames[frame_idx].function)
-                        .as_function()?
-                        .clone();
                 }
 
                 // ============================================================

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -46,17 +46,17 @@ pub const MAX_FRAMES: usize = 256;
 /// functions) but instead use references to index into [`BexVm::heap`]. Should
 /// be [`Copy`].
 #[derive(Clone, Copy, Debug)]
-pub struct Frame {
+pub(crate) struct Frame {
     /// Pointer to the running function object.
-    pub function: HeapPtr,
+    pub(crate) function: HeapPtr,
 
     /// Instruction pointer (IP) or program counter (PC).
     ///
     /// Points to the next instruction that the VM will execute.
-    pub instruction_ptr: usize,
+    pub(crate) instruction_ptr: usize,
 
     /// Local variables offset in the eval stack.
-    pub locals_offset: StackIndex,
+    pub(crate) locals_offset: StackIndex,
 }
 
 /// The beast.
@@ -172,7 +172,7 @@ pub struct BexVm {
     /// On each function call we create a new [`Frame`] and push it on this
     /// stack. On each return, we destroy the frame and pop it from the stack
     /// to resume the execution of the previous frame.
-    pub frames: Vec<Frame>,
+    pub(crate) frames: Vec<Frame>,
 
     /// Evaluation stack.
     ///
@@ -190,18 +190,13 @@ pub struct BexVm {
     /// This stores the functions and globally declared variables.
     pub globals: GlobalPool,
 
-    /// Offset of the first runtime allocated object.
-    ///
-    /// Used by GC to know which objects are compile-time vs runtime.
-    pub runtime_allocs_offset: ObjectIndex,
-
     /// Emit dependency graph.
     pub watch: Watch,
 
     /// Tracks which local variables are watched (have @watch).
-    pub watched_vars: HashMap<StackIndex, (String, String)>,
+    pub(crate) watched_vars: HashMap<StackIndex, (String, String)>,
 
-    pub interrupt_frame: Option<usize>,
+    pub(crate) interrupt_frame: Option<usize>,
 }
 
 /// VM execution state.
@@ -370,7 +365,6 @@ impl BexVm {
     /// The heap is shared across all VMs. Each VM gets its own TLAB
     /// for contention-free allocation.
     pub fn new(heap: Arc<BexHeap>, globals: GlobalPool) -> Self {
-        let runtime_allocs_offset = ObjectIndex::from_raw(heap.compile_time_boundary());
         let tlab = Tlab::new(Arc::clone(&heap));
 
         Self {
@@ -379,7 +373,6 @@ impl BexVm {
             heap,
             tlab,
             globals,
-            runtime_allocs_offset,
             watch: Watch::new(),
             watched_vars: HashMap::new(),
             interrupt_frame: None,
@@ -756,7 +749,7 @@ impl BexVm {
             .frames
             .iter()
             .map(|frame| {
-                let function = self.get_object(frame.function).as_function()?.clone();
+                let function = self.get_object(frame.function).as_function()?;
 
                 // VM increments instruction pointer as soon as it reads the
                 // instruction. So in reality the error ocurred on the previous

--- a/baml_language/crates/bex_vm/src/watch.rs
+++ b/baml_language/crates/bex_vm/src/watch.rs
@@ -206,8 +206,7 @@ pub enum Path {
 ///
 /// - [`Watch::register_root`]
 /// - [`Watch::unregister_root`]
-/// - `Watch::add_edge`
-/// - [`Watch::link_edge`]
+/// - [`track_watch_dependencies`] (free function — tracks an object's dependencies)
 /// - [`Watch::unlink_edge`]
 /// - [`Watch::copy_roots_reaching`]
 ///
@@ -219,6 +218,12 @@ pub struct Watch {
     children: HashMap<NodeId, HashSet<(Path, NodeId)>>,
 
     /// Reverse edges: `child -> [(parent, path)]`
+    ///
+    /// Currently unused for any algorithmic purpose — all traversal uses
+    /// `children` (forward) and `roots_reaching_node` (inverse index).
+    /// Maintained for future use: reconstructing the full path from a
+    /// modified node back to its watch root, e.g. for debug logging like
+    /// "watch triggered from `obj` through `obj.inner.more_inner[5].x`".
     parents: HashMap<NodeId, HashSet<(NodeId, Path)>>,
 
     /// For each root, which nodes it can reach.
@@ -263,6 +268,22 @@ impl Watch {
             .entry(child)
             .or_default()
             .insert((parent, path));
+    }
+
+    /// Marks `node` as reachable from `root`. Returns `true` if newly reachable.
+    fn mark_reachable(&mut self, node: NodeId, root: NodeId) -> bool {
+        let reachable = self.reachable_from_root.entry(root).or_default();
+
+        if !reachable.insert(node) {
+            return false;
+        }
+
+        self.roots_reaching_node
+            .entry(node)
+            .or_default()
+            .insert(root);
+
+        true
     }
 
     /// Computes all nodes reachable from a starting node using BFS.
@@ -328,46 +349,6 @@ impl Watch {
         }
     }
 
-    /// Links parent.path -> child in the graph.
-    ///
-    /// Updates reachability incrementally for all affected roots.
-    ///
-    /// Note: Caller should call `track_dependencies` separately before this
-    /// if the child is a `HeapObject` that needs dependency tracking.
-    pub fn link_edge(&mut self, parent: NodeId, path: Path, child: NodeId) {
-        self.add_edge(parent, path, child);
-
-        // For each root that reaches parent, update reachability to include
-        // child and its descendants.
-        for root in self.copy_roots_reaching(parent) {
-            let mut queue = VecDeque::new();
-            queue.push_back(child);
-
-            // Set of nodes reachable from `root`. Also acts as a set of visited
-            // nodes. If a node is already reachable, that means we already indexed
-            // all its descendants, so no need to traverse that path again.
-            let reachable = self.reachable_from_root.entry(root).or_default();
-
-            while let Some(node) = queue.pop_front() {
-                // Skip already reachable nodes
-                if reachable.insert(node) {
-                    // Add to inverse index
-                    self.roots_reaching_node
-                        .entry(node)
-                        .or_default()
-                        .insert(root);
-
-                    // Queue children
-                    if let Some(edges) = self.children.get(&node) {
-                        for (_, child) in edges {
-                            queue.push_back(*child);
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     /// Unlinks parent.path -> child from the graph.
     ///
     /// Updates reachability incrementally for all affected roots.
@@ -393,28 +374,25 @@ impl Watch {
         for root in roots_reaching {
             let still_reachable = self.breadth_first_search_from(root);
 
-            // Get the old reachable set
+            // Swap in the new reachable set, taking ownership of the old one
+            // without cloning.
             let old_reachable = self
                 .reachable_from_root
-                .get(&root)
-                .cloned()
+                .insert(root, still_reachable)
                 .unwrap_or_default();
 
-            // Find nodes that are no longer reachable
-            let no_longer_reachable: Vec<NodeId> = old_reachable
-                .difference(&still_reachable)
-                .copied()
-                .collect();
+            let still_reachable = &self.reachable_from_root[&root];
 
-            // Update forward index
-            self.reachable_from_root.insert(root, still_reachable);
-
-            // Update inverse index: remove root from nodes no longer reachable
-            for node in no_longer_reachable {
-                if let Some(roots) = self.roots_reaching_node.get_mut(&node) {
+            // Update inverse index: remove root from nodes no longer reachable.
+            // If a node becomes unreachable from ALL roots, prune its graph
+            // edges to avoid stale entries (and dangling HeapPtrs after GC).
+            for node in old_reachable.difference(still_reachable) {
+                if let Some(roots) = self.roots_reaching_node.get_mut(node) {
                     roots.remove(&root);
                     if roots.is_empty() {
-                        self.roots_reaching_node.remove(&node);
+                        self.roots_reaching_node.remove(node);
+                        self.children.remove(node);
+                        self.parents.remove(node);
                     }
                 }
             }
@@ -452,76 +430,81 @@ impl Watch {
     }
 }
 
-/// Helper function to traverse an object graph and build emit edges.
+/// Tracks an object's watch dependencies by walking the heap and propagating
+/// root reachability in a single traversal.
 ///
-/// This is used when an object is marked as @watch to establish all the
-/// dependency edges. It does not declare any root, call `Watch::register_root` separately.
+/// Adds the edge `parent --path--> child_ptr`, then BFS-walks the object
+/// graph from `child_ptr`, building edges and marking all discovered nodes
+/// as reachable from the same roots that reach `parent`.
 ///
-/// This is a free function to avoid borrow checker issues when calling from `BexVm`.
-pub fn track_watch_dependencies(watch: &mut Watch, value: Value) {
-    let mut stack = vec![value];
+/// Free function to avoid borrow checker issues when calling from `BexVm`.
+pub fn track_watch_dependencies(watch: &mut Watch, parent: NodeId, path: Path, child_ptr: HeapPtr) {
+    let child = NodeId::HeapObject(child_ptr);
+
+    // Add the top-level edge (e.g. root --Binding--> object).
+    watch.add_edge(parent, path, child);
+
+    // Collect roots reaching parent so we can propagate reachability.
+    let roots = watch.copy_roots_reaching(parent);
+
+    // Walk the heap from child, building edges and propagating reachability.
+    let mut queue = VecDeque::new();
     let mut visited = HashSet::new();
+    queue.push_back(child_ptr);
+    visited.insert(child_ptr);
 
-    while let Some(v) = stack.pop() {
-        let Value::Object(ptr) = v else {
-            continue;
-        };
-
-        if !visited.insert(ptr) {
-            continue;
-        }
-
+    while let Some(ptr) = queue.pop_front() {
         let node = NodeId::HeapObject(ptr);
 
-        // Now traverse the object's contents
-        // SAFETY: We access the heap directly using unsafe code here to avoid
-        // borrow checker issues. This is safe because we're only reading immutably.
+        // Propagate reachability for this node.
+        for &root in &roots {
+            watch.mark_reachable(node, root);
+        }
+
+        // SAFETY: Read-only heap access during single-threaded VM execution.
         let obj = unsafe { ptr.get() };
-        match obj {
-            Object::Instance(instance) => {
-                // For each field in the instance, build edges
-                for (field_idx, field_value) in instance.fields.iter().enumerate() {
-                    if let Value::Object(child_ptr) = field_value {
-                        watch.add_edge(
-                            node,
-                            Path::InstanceField(field_idx),
-                            NodeId::HeapObject(*child_ptr),
-                        );
 
-                        stack.push(*field_value);
-                    }
-                }
-            }
+        // Discover child edges from this object.
+        let edges: Vec<(Path, HeapPtr)> = match obj {
+            Object::Instance(instance) => instance
+                .fields
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, v)| match v {
+                    Value::Object(p) => Some((Path::InstanceField(idx), *p)),
+                    _ => None,
+                })
+                .collect(),
 
-            Object::Array(array) => {
-                // For each element in the array, build edges
-                for (idx, elem_value) in array.iter().enumerate() {
-                    if let Value::Object(child_ptr) = elem_value {
-                        watch.add_edge(node, Path::ArrayIndex(idx), NodeId::HeapObject(*child_ptr));
+            Object::Array(array) => array
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, v)| match v {
+                    Value::Object(p) => Some((Path::ArrayIndex(idx), *p)),
+                    _ => None,
+                })
+                .collect(),
 
-                        stack.push(*elem_value);
-                    }
-                }
-            }
+            Object::Map(map) => map
+                .iter()
+                .filter_map(|(key, v)| match v {
+                    Value::Object(p) => Some((Path::MapKey(key.clone()), *p)),
+                    _ => None,
+                })
+                .collect(),
 
-            Object::Map(map) => {
-                // For each entry in the map, build edges
-                for (key, map_value) in map {
-                    if let Value::Object(child_ptr) = map_value {
-                        watch.add_edge(
-                            node,
-                            Path::MapKey(key.clone()),
-                            NodeId::HeapObject(*child_ptr),
-                        );
+            _ => vec![],
+        };
 
-                        stack.push(*map_value);
-                    }
-                }
-            }
+        for (edge_path, edge_child_ptr) in edges {
+            let edge_child = NodeId::HeapObject(edge_child_ptr);
 
-            _ => {
-                // Other object types (strings, functions, etc.) don't have
-                // nested structure
+            // Build graph structure.
+            watch.add_edge(node, edge_path, edge_child);
+
+            // Continue traversal into unvisited nodes.
+            if visited.insert(edge_child_ptr) {
+                queue.push_back(edge_child_ptr);
             }
         }
     }
@@ -529,6 +512,8 @@ pub fn track_watch_dependencies(watch: &mut Watch, value: Value) {
 
 #[cfg(test)]
 mod tests {
+    use bex_vm_types::types::Instance;
+
     use super::*;
 
     fn test_root_state() -> RootState {
@@ -541,149 +526,164 @@ mod tests {
         }
     }
 
-    /// Creates a fake `HeapPtr` for testing graph structure.
-    /// These pointers should never be dereferenced - they're just unique identifiers.
-    fn fake_heap_ptr(id: usize) -> HeapPtr {
-        // SAFETY: We're creating a fake pointer that will never be dereferenced.
-        // The tests only check graph connectivity, not object contents.
+    /// Allocates an `Object` on the heap via `Box` and returns a `HeapPtr`.
+    /// Leaked intentionally — tests are short-lived.
+    fn heap_alloc(obj: Object) -> HeapPtr {
+        let ptr = Box::into_raw(Box::new(obj));
         #[cfg(feature = "heap_debug")]
         unsafe {
-            HeapPtr::from_ptr(id as *mut Object, 0)
+            HeapPtr::from_ptr(ptr, 0)
         }
         #[cfg(not(feature = "heap_debug"))]
         unsafe {
-            HeapPtr::from_ptr(id as *mut Object)
+            HeapPtr::from_ptr(ptr)
         }
+    }
+
+    /// Allocates a leaf object (string) on the heap.
+    fn leaf() -> HeapPtr {
+        heap_alloc(Object::String(String::from("test leaf object")))
+    }
+
+    /// Allocates an instance whose fields point to the given objects.
+    fn instance(class: HeapPtr, fields: Vec<Value>) -> HeapPtr {
+        heap_alloc(Object::Instance(Instance { class, fields }))
     }
 
     #[test]
     fn test_basic_notify_registration() {
-        let mut emit = Watch::new();
+        let mut watch = Watch::new();
 
         let var = NodeId::LocalVar(StackIndex::from_raw(0));
-        emit.register_root(var, test_root_state());
+        watch.register_root(var, test_root_state());
 
-        // Root should be registered
-        assert!(emit.roots.contains_key(&var));
-
-        // Variable should be covered by the root
-        let covering: Vec<NodeId> = emit.copy_roots_reaching(var);
-        assert_eq!(covering.len(), 1);
+        assert!(watch.roots.contains_key(&var));
+        assert_eq!(watch.copy_roots_reaching(var).len(), 1);
     }
 
     #[test]
-    fn test_link_unlink_edge() {
-        let mut emit = Watch::new();
+    fn test_track_and_unlink() {
+        let mut watch = Watch::new();
 
         let var = NodeId::LocalVar(StackIndex::from_raw(0));
-        let obj = NodeId::HeapObject(fake_heap_ptr(0));
+        let obj_ptr = leaf();
 
-        // Register root at var
-        emit.register_root(var, test_root_state());
-
-        // Link var -> obj
-        emit.link_edge(var, Path::Binding, obj);
+        watch.register_root(var, test_root_state());
+        track_watch_dependencies(&mut watch, var, Path::Binding, obj_ptr);
 
         // Both should be covered
-        assert_eq!(emit.copy_roots_reaching(var).len(), 1);
-        assert_eq!(emit.copy_roots_reaching(obj).len(), 1);
+        assert_eq!(watch.copy_roots_reaching(var).len(), 1);
+        assert_eq!(
+            watch.copy_roots_reaching(NodeId::HeapObject(obj_ptr)).len(),
+            1
+        );
 
         // Unlink var -> obj
-        emit.unlink_edge(var, Path::Binding, obj);
+        watch.unlink_edge(var, Path::Binding, NodeId::HeapObject(obj_ptr));
 
-        // Only var should be covered now
-        assert_eq!(emit.copy_roots_reaching(var).len(), 1);
-        assert_eq!(emit.copy_roots_reaching(obj).len(), 0);
+        assert_eq!(watch.copy_roots_reaching(var).len(), 1);
+        assert_eq!(
+            watch.copy_roots_reaching(NodeId::HeapObject(obj_ptr)).len(),
+            0
+        );
     }
 
     #[test]
     fn test_cycle_handling() {
-        let mut emit = Watch::new();
+        let mut watch = Watch::new();
+        let root_var = NodeId::LocalVar(StackIndex::from_raw(0));
+        let class_ptr = leaf();
 
-        let a = NodeId::HeapObject(fake_heap_ptr(0));
-        let b = NodeId::HeapObject(fake_heap_ptr(1));
-        let root_node = NodeId::LocalVar(StackIndex::from_raw(0));
+        // Build cycle: A -> B -> A
+        let a = instance(class_ptr, vec![Value::Null]); // placeholder
+        let b = instance(class_ptr, vec![Value::Object(a)]);
+        // Close the cycle: mutate A's field to point to B.
+        unsafe {
+            if let Object::Instance(inst) = a.get_mut() {
+                inst.fields[0] = Value::Object(b);
+            }
+        }
 
-        // Create cycle: A -> B -> A
-        emit.link_edge(a, Path::InstanceField(0), b);
-        emit.link_edge(b, Path::InstanceField(0), a);
-
-        // Register root at root_node
-        emit.register_root(root_node, test_root_state());
-
-        // Link root -> A (brings cycle into reachability)
-        emit.link_edge(root_node, Path::Binding, a);
+        watch.register_root(root_var, test_root_state());
+        track_watch_dependencies(&mut watch, root_var, Path::Binding, a);
 
         // Both A and B should be covered
-        assert_eq!(emit.copy_roots_reaching(a).len(), 1);
-        assert_eq!(emit.copy_roots_reaching(b).len(), 1);
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(a)).len(), 1);
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(b)).len(), 1);
 
-        // Unlink root -> A (disconnects cycle)
-        emit.unlink_edge(root_node, Path::Binding, a);
+        // Disconnect root -> A
+        watch.unlink_edge(root_var, Path::Binding, NodeId::HeapObject(a));
 
-        // Neither A nor B should be covered
-        assert_eq!(emit.copy_roots_reaching(a).len(), 0);
-        assert_eq!(emit.copy_roots_reaching(b).len(), 0);
-    }
-
-    #[test]
-    fn test_multiple_roots() {
-        let mut emit = Watch::new();
-
-        let var1 = NodeId::LocalVar(StackIndex::from_raw(0));
-        let var2 = NodeId::LocalVar(StackIndex::from_raw(1));
-        let obj = NodeId::HeapObject(fake_heap_ptr(0));
-
-        // Register two roots
-        emit.register_root(var1, test_root_state());
-        emit.register_root(var2, test_root_state());
-
-        // Link both to the same object
-        emit.link_edge(var1, Path::Binding, obj);
-        emit.link_edge(var2, Path::Binding, obj);
-
-        // Object should be covered by both roots
-        assert_eq!(emit.copy_roots_reaching(obj).len(), 2);
-
-        // Unlink one
-        emit.unlink_edge(var1, Path::Binding, obj);
-
-        // Object should still be covered by root2
-        assert_eq!(emit.copy_roots_reaching(obj).len(), 1);
-
-        // Unregister root2
-        emit.unregister_root(var2);
-
-        // Object should not be covered anymore
-        assert_eq!(emit.copy_roots_reaching(obj).len(), 0);
+        // Neither should be covered
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(a)).len(), 0);
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(b)).len(), 0);
     }
 
     #[test]
     fn test_deep_object_graph() {
-        let mut emit = Watch::new();
-
+        let mut watch = Watch::new();
         let var = NodeId::LocalVar(StackIndex::from_raw(0));
-        let obj1 = NodeId::HeapObject(fake_heap_ptr(0));
-        let obj2 = NodeId::HeapObject(fake_heap_ptr(1));
-        let obj3 = NodeId::HeapObject(fake_heap_ptr(2));
 
-        // Create chain: var -> obj1 -> obj2 -> obj3
-        emit.register_root(var, test_root_state());
-        emit.link_edge(var, Path::Binding, obj1);
-        emit.link_edge(obj1, Path::InstanceField(0), obj2);
-        emit.link_edge(obj2, Path::InstanceField(0), obj3);
+        // Build chain: obj3 (leaf), obj2 -> obj3, obj1 -> obj2
+        // Class ptr is a dummy leaf — Instance only needs it for display.
+        let class_ptr = leaf();
+        let obj3 = leaf();
+        let obj2 = instance(class_ptr, vec![Value::Object(obj3)]);
+        let obj1 = instance(class_ptr, vec![Value::Object(obj2)]);
+
+        watch.register_root(var, test_root_state());
+        track_watch_dependencies(&mut watch, var, Path::Binding, obj1);
 
         // All should be covered
-        assert_eq!(emit.copy_roots_reaching(obj1).len(), 1);
-        assert_eq!(emit.copy_roots_reaching(obj2).len(), 1);
-        assert_eq!(emit.copy_roots_reaching(obj3).len(), 1);
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(obj1)).len(), 1);
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(obj2)).len(), 1);
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(obj3)).len(), 1);
 
         // Break the chain in the middle
-        emit.unlink_edge(obj1, Path::InstanceField(0), obj2);
+        watch.unlink_edge(
+            NodeId::HeapObject(obj1),
+            Path::InstanceField(0),
+            NodeId::HeapObject(obj2),
+        );
 
         // obj1 still covered, obj2 and obj3 not
-        assert_eq!(emit.copy_roots_reaching(obj1).len(), 1);
-        assert_eq!(emit.copy_roots_reaching(obj2).len(), 0);
-        assert_eq!(emit.copy_roots_reaching(obj3).len(), 0);
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(obj1)).len(), 1);
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(obj2)).len(), 0);
+        assert_eq!(watch.copy_roots_reaching(NodeId::HeapObject(obj3)).len(), 0);
+    }
+
+    #[test]
+    fn test_multiple_roots() {
+        let mut watch = Watch::new();
+
+        let var1 = NodeId::LocalVar(StackIndex::from_raw(0));
+        let var2 = NodeId::LocalVar(StackIndex::from_raw(1));
+        let obj_ptr = leaf();
+
+        watch.register_root(var1, test_root_state());
+        watch.register_root(var2, test_root_state());
+
+        track_watch_dependencies(&mut watch, var1, Path::Binding, obj_ptr);
+        track_watch_dependencies(&mut watch, var2, Path::Binding, obj_ptr);
+
+        // Object should be covered by both roots
+        assert_eq!(
+            watch.copy_roots_reaching(NodeId::HeapObject(obj_ptr)).len(),
+            2
+        );
+
+        // Unlink one
+        watch.unlink_edge(var1, Path::Binding, NodeId::HeapObject(obj_ptr));
+        assert_eq!(
+            watch.copy_roots_reaching(NodeId::HeapObject(obj_ptr)).len(),
+            1
+        );
+
+        // Unregister the other
+        watch.unregister_root(var2);
+        assert_eq!(
+            watch.copy_roots_reaching(NodeId::HeapObject(obj_ptr)).len(),
+            0
+        );
     }
 }

--- a/baml_language/crates/bex_vm/src/watch.rs
+++ b/baml_language/crates/bex_vm/src/watch.rs
@@ -510,6 +510,121 @@ pub fn track_watch_dependencies(watch: &mut Watch, parent: NodeId, path: Path, c
     }
 }
 
+// --- Garbage Collection ---
+
+/// Forward a `Value::Object` pointer if present in the forwarding map.
+fn forward_value(value: &mut Value, forwarding: &HashMap<HeapPtr, HeapPtr>) {
+    if let Value::Object(ptr) = value {
+        if let Some(&new_ptr) = forwarding.get(ptr) {
+            *ptr = new_ptr;
+        }
+    }
+}
+
+/// Remap a `NodeId` using the GC forwarding map.
+///
+/// Not all pointers are in the forwarding map — only objects that were actually
+/// relocated by the copying GC have entries. Compile-time objects (permanent
+/// space) and objects that weren't moved keep their original pointer.
+fn remap_node(node: NodeId, forwarding: &HashMap<HeapPtr, HeapPtr>) -> NodeId {
+    match node {
+        NodeId::HeapObject(ptr) => NodeId::HeapObject(*forwarding.get(&ptr).unwrap_or(&ptr)),
+        NodeId::LocalVar(_) => node,
+    }
+}
+
+/// Remap all keys and values in a `NodeId -> HashSet<NodeId>` map.
+fn remap_node_set(
+    map: &mut HashMap<NodeId, HashSet<NodeId>>,
+    forwarding: &HashMap<HeapPtr, HeapPtr>,
+) {
+    let old = std::mem::take(map);
+    for (key, values) in old {
+        let new_values: HashSet<_> = values
+            .into_iter()
+            .map(|v| remap_node(v, forwarding))
+            .collect();
+        map.insert(remap_node(key, forwarding), new_values);
+    }
+}
+
+impl Watch {
+    /// Collects GC roots from Watch state.
+    ///
+    /// Only `last_assigned` and `last_notified` need to be roots — `value`
+    /// is always a copy of the stack slot (already a root), and graph `NodeId`s
+    /// point to objects transitively reachable from stack values.
+    pub fn collect_roots(&self, roots: &mut Vec<HeapPtr>) {
+        for state in self.roots.values() {
+            if let Some(Value::Object(ptr)) = state.last_assigned {
+                roots.push(ptr);
+            }
+            if let Some(Value::Object(ptr)) = state.last_notified {
+                roots.push(ptr);
+            }
+        }
+    }
+
+    /// Applies GC forwarding pointers to all `HeapPtr`s in Watch state.
+    ///
+    /// After a copying GC, all heap objects may have moved. This updates
+    /// `RootState` values and rebuilds the graph maps with new pointers.
+    pub fn apply_forwarding(&mut self, forwarding: &HashMap<HeapPtr, HeapPtr>) {
+        if forwarding.is_empty() || self.roots.is_empty() {
+            return;
+        }
+
+        // Patch RootState values.
+        for state in self.roots.values_mut() {
+            forward_value(&mut state.value, forwarding);
+            if let Some(ref mut val) = state.last_assigned {
+                forward_value(val, forwarding);
+            }
+            if let Some(ref mut val) = state.last_notified {
+                forward_value(val, forwarding);
+            }
+            if let WatchFilter::Function(ref mut ptr) = state.filter {
+                if let Some(&new_ptr) = forwarding.get(ptr) {
+                    *ptr = new_ptr;
+                }
+            }
+        }
+
+        // Remap all HeapObject NodeIds in the graph maps.
+
+        // children: parent -> {(path, child)}
+        let old_children = std::mem::take(&mut self.children);
+        for (parent, edges) in old_children {
+            let new_edges: HashSet<_> = edges
+                .into_iter()
+                .map(|(path, child)| (path, remap_node(child, forwarding)))
+                .collect();
+            self.children
+                .insert(remap_node(parent, forwarding), new_edges);
+        }
+
+        // parents: child -> {(parent, path)}
+        let old_parents = std::mem::take(&mut self.parents);
+        for (child, edges) in old_parents {
+            let new_edges: HashSet<_> = edges
+                .into_iter()
+                .map(|(parent, path)| (remap_node(parent, forwarding), path))
+                .collect();
+            self.parents
+                .insert(remap_node(child, forwarding), new_edges);
+        }
+
+        remap_node_set(&mut self.reachable_from_root, forwarding);
+        remap_node_set(&mut self.roots_reaching_node, forwarding);
+
+        // roots: NodeId -> RootState
+        let old_roots = std::mem::take(&mut self.roots);
+        for (key, value) in old_roots {
+            self.roots.insert(remap_node(key, forwarding), value);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use bex_vm_types::types::Instance;

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -145,24 +145,6 @@ pub enum Instruction {
     /// `COPY 1` copies the second element from the top.
     Copy(usize),
 
-    /// End a nested block and put the result value on top of the stack.
-    ///
-    /// Format: `POP_REPLACE n` where `n` is the number of locals in the block's
-    /// scope.
-    ///
-    /// This is instruction is necessary to support "blocks as expressions".
-    /// Example:
-    ///
-    /// ```ignore
-    /// fn main() {
-    ///     let a = {
-    ///         let b = 1;
-    ///         b
-    ///     };
-    /// }
-    /// ```
-    PopReplace(usize),
-
     /// Jump to another instruction.
     ///
     /// Format: `JUMP o` where `o` is the offset from the current instruction
@@ -528,7 +510,6 @@ impl std::fmt::Display for Instruction {
             Instruction::StoreField(i) => write!(f, "STORE_FIELD {i}"),
             Instruction::Pop(n) => write!(f, "POP {n}"),
             Instruction::Copy(i) => write!(f, "COPY {i}"),
-            Instruction::PopReplace(n) => write!(f, "POP_REPLACE {n}"),
             Instruction::Jump(o) => write!(f, "JUMP {o:+}"),
             Instruction::PopJumpIfFalse(o) => write!(f, "POP_JUMP_IF_FALSE {o:+}"),
             Instruction::BinOp(op) => write!(f, "BIN_OP {op}"),


### PR DESCRIPTION
## Summary

- Remove `PopReplace` instruction from bytecode enum, VM handler, debug display, and test helpers. The MIR compiler never emits it — block expressions assign the trailing value directly into the destination `Place`, so there's no stack-based scope cleanup needed.

- Remove implicit watch cleanup from `Pop` and `Return` handlers. With the MIR's explicit `Unwatch` instruction, these were dead code. `Unwatch` is now the single canonical site for watch variable cleanup.

- Unify `StoreVar`'s watch edge logic with the existing `update_watched_node` helper, eliminating duplicated unlink/link/deep-copy code.

- Replace function cloning in the exec loop with unsafe `load_function()` returning `&'static Function`. Since all function objects live in the compile-time heap (never GC'd), `'static` is sound. This removes 11 redundant function re-clone sites, keeping reassignment only at `Call(Bytecode)` and `Return` where the frame actually changes. Includes a TODO documenting what needs to change when lambdas with captures are added.

- Refactor `watch.rs` graph internals: merge the two-pass pattern (`track_watch_dependencies` walking the heap to build edges, then `link_edge` walking the graph to propagate reachability) into a single BFS that does both simultaneously. Extract `mark_reachable` helper to deduplicate the reachability propagation logic that was inlined in both functions. Remove `link_edge` from `Watch`'s public API since it's no longer called from the VM. Fix stale graph edge accumulation by pruning `children`/`parents` entries when a node becomes unreachable from all roots. Replace `HashSet` clone with insert-swap in `unlink_edge`. Rewrite unit tests to use real `HeapPtr` from `Box` instead of fake pointers, testing `track_watch_dependencies` directly.

- Fix GC not tracing `Watch` state. `RootState`'s `last_assigned`/`last_notified` values are deep-copied off the stack, so GC could collect them. Graph `NodeId`s contain `HeapPtr`s that go stale after a copying GC. Added `collect_roots()` and `apply_forwarding()` to `Watch`, wired into both GC sites in `bex_engine`.

- Change `instruction_ptr` from `isize` to `usize`. The instruction pointer is a natural index into the instructions vec. Jump offsets (`isize`) are now applied via `checked_add_signed` at the 3 jump sites. This removes 6 clippy cast allows, the `NegativeInstructionPtr` error variant, and the per-instruction negativity check from the hot loop. Also re-enables the commented-out instruction tracing under a `BEX_VM_DEBUG` env var (debug builds only).

## Test plan
- [x] All 295 `bex_vm` tests pass (including 5 watch unit tests + 18 watch integration tests)
- [x] All 375 `baml_tests` pass
- [x] All 75 `bex_engine` tests pass (including 5 GC tests)
- [x] `cargo clippy` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Removed support for the POP_REPLACE instruction; it will no longer appear in bytecode or test output.

* **Bug Fixes**
  * Ensured watch state stays synchronized during garbage collection.
  * Improved error reporting for jump/offset overflow scenarios.

* **Internal Improvements**
  * Refactored VM internals for safer instruction pointer handling and streamlined function access (no behavioral change exposed).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->