### PR TITLE
fixed let annotations

### DIFF
--- a/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/to_diagnostic.rs
@@ -71,7 +71,7 @@ impl<C: ErrorContext> TypeError<C> {
                 )
                 .with_primary_span(loc_fn(location));
                 if let Some(info_location) = info_location {
-                    diag.with_related(loc_fn(info_location), "Type defined here")
+                    diag.with_secondary(loc_fn(info_location), "Type required here")
                 } else {
                     diag
                 }
@@ -1027,6 +1027,25 @@ mod tests {
         assert_eq!(diag.code(), "E0001");
         assert!(diag.message.contains("int"));
         assert!(diag.message.contains("string"));
+        assert_eq!(diag.phase, DiagnosticPhase::Type);
+    }
+
+    #[test]
+    fn test_type_error_with_info_location_to_diagnostic() {
+        let error: TypeError<SpanContext> = TypeError::TypeMismatch {
+            expected: "int".to_string(),
+            found: "string".to_string(),
+            location: Span {
+                file_id: baml_base::FileId::new(0),
+                range: TextRange::new(20.into(), 30.into()),
+            },
+            info_location: Some(test_span()),
+        };
+
+        let diag = error.to_diagnostic(Clone::clone, |s| *s);
+        assert_eq!(diag.code(), "E0001");
+        assert_eq!(diag.annotations.len(), 2); // primary + info span
+        assert!(diag.related_info.is_empty());
         assert_eq!(diag.phase, DiagnosticPhase::Type);
     }
 

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -2600,6 +2600,21 @@ fn infer_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody) -> Ty
 ///
 /// Returns the actual type of the expression (which should be a subtype of expected).
 fn check_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody, expected: &Ty) -> Ty {
+    check_expr_with_info_location(ctx, expr_id, body, expected, None)
+}
+
+/// Check an expression with an optional location for the type constraint source.
+///
+/// When `info_location` is provided, type mismatches include a secondary location
+/// that points to where the expected type requirement came from (for example,
+/// a `let` type annotation).
+fn check_expr_with_info_location(
+    ctx: &mut TypeContext<'_>,
+    expr_id: ExprId,
+    body: &ExprBody,
+    expected: &Ty,
+    info_location: Option<&ErrorLocation>,
+) -> Ty {
     use baml_compiler_hir::Expr;
 
     let expr = &body.exprs[expr_id];
@@ -2693,7 +2708,7 @@ fn check_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody, expec
                         expected: expected.clone(),
                         found: generalize_for_error(expected, &ty),
                         location,
-                        info_location: None,
+                        info_location: info_location.cloned(),
                     });
                 }
                 ty
@@ -2771,7 +2786,7 @@ fn check_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody, expec
                         expected: expected.clone(),
                         found: generalize_for_error(expected, &ty),
                         location,
-                        info_location: None,
+                        info_location: info_location.cloned(),
                     });
                 }
                 ty
@@ -2810,7 +2825,7 @@ fn check_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody, expec
                         expected: expected.clone(),
                         found: generalize_for_error(expected, &ty),
                         location,
-                        info_location: None,
+                        info_location: info_location.cloned(),
                     });
                 }
                 ty
@@ -2832,7 +2847,7 @@ fn check_expr(ctx: &mut TypeContext<'_>, expr_id: ExprId, body: &ExprBody, expec
                     expected: expected.clone(),
                     found: generalize_for_error(expected, &ty),
                     location,
-                    info_location: None,
+                    info_location: info_location.cloned(),
                 });
             }
             ty
@@ -3458,9 +3473,16 @@ fn check_stmt_with_return(
                     let type_ref = &body.types[*type_id];
                     let span = ctx.type_span(*type_id);
                     let annot_ty = ctx.lower_type(type_ref, span);
+                    let annotation_location = ErrorLocation::Span(span);
                     // Use check_expr when we have an expected type
                     // check_expr already reports any type mismatch errors
-                    check_expr(ctx, *init, body, &annot_ty);
+                    check_expr_with_info_location(
+                        ctx,
+                        *init,
+                        body,
+                        &annot_ty,
+                        Some(&annotation_location),
+                    );
                     annot_ty
                 } else {
                     // No type annotation - infer and generalize for mutable variables

--- a/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/expr/let_annotations.baml
+++ b/baml_language/crates/baml_lsp_actions_tests/test_files/syntax/expr/let_annotations.baml
@@ -28,7 +28,9 @@ function Ok() -> int {
 //    ╭─[ expr_let_annotations.baml:5:17 ]
 //    │
 //  5 │   let y : int = 10.0;
-//    │                 ──┬─  
+//    │          ──┬─   ──┬─  
+//    │            ╰────────── Type required here
+//    │                   │   
 //    │                   ╰─── Expected `int`, found `float`
 //    │ 
 //    │ Note: Error code: E0001
@@ -37,7 +39,9 @@ function Ok() -> int {
 //    ╭─[ expr_let_annotations.baml:6:15 ]
 //    │
 //  6 │   let c: int = "hello";
-//    │               ────┬───  
+//    │         ──┬─  ────┬───  
+//    │           ╰───────────── Type required here
+//    │                   │     
 //    │                   ╰───── Expected `int`, found `string`
 //    │ 
 //    │ Note: Error code: E0001


### PR DESCRIPTION
**Summary**
This PR fixes diagnostics for annotated `let` assignments so type mismatches include both:
- the existing primary span on the mismatched RHS expression, and
- a secondary info span pointing to the type annotation that introduced the requirement.

It keeps the existing diagnostic code/message/phase behavior (`E0001`, `Expected ..., found ...`, type phase), and only improves span context.

**Problem**
For `let` annotations like `let y: int = 10.0;`, the typechecker emitted only one span (on `10.0`).  
It should also show where the expected type came from (the `int` annotation).

**What Changed**
- **Type-checking flow (`baml_compiler_tir`)**
  - Added a scoped `check_expr_with_info_location(...)` path for passing optional constraint-source location.
  - Annotated `let` initializers now pass the annotation span as `info_location`.
  - Mismatch emission now carries that `info_location` through to diagnostics.
- **Diagnostic conversion (`baml_compiler_diagnostics`)**
  - `TypeMismatch.info_location` now maps to a **secondary annotation** (`with_secondary`) instead of related-info metadata.
  - Secondary label text: `Type required here`.
- **Tests**
  - Added unit coverage for `TypeMismatch` with `info_location` in `to_diagnostic`.
  - Updated `let_annotations.baml` expected diagnostics output to include secondary spans.
- **Lint/compliance cleanup**
  - Adjusted `info_location` passing to satisfy strict clippy (`Option<&ErrorLocation>` + `.cloned()`), no behavior change.

**Before / After**
- **Before**: one span per mismatch (RHS only).
- **After**: same primary RHS span + secondary span on annotation token.
  - `let y : int = 10.0;` -> secondary on `int` (line 5, cols 11–13)
  - `let c: int = "hello";` -> secondary on `int` (line 6, cols 10–12)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messages for type mismatches to display secondary annotations indicating where the expected type constraint originates, providing clearer guidance for resolving type-related issues in your code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->