### PR TITLE
Serde implementations on generated types for Rust

### DIFF
--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ArrayWithConstraints {
     pub nonEmptyStrings: Vec<String>,
 
@@ -22,14 +22,14 @@ pub struct ArrayWithConstraints {
     pub positiveFloats: Vec<f64>,
 }
 
-impl AsRef<ArrayWithConstraints> for ArrayWithConstraints {
+impl ::std::convert::AsRef<ArrayWithConstraints> for ArrayWithConstraints {
     fn as_ref(&self) -> &ArrayWithConstraints {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedArrays {
     pub primitiveArray: Vec<types::Union4BoolOrFloatOrIntOrString>,
 
@@ -42,14 +42,14 @@ pub struct MixedArrays {
     pub complexMixed: Vec<Union3ProductOrTagOrUser>,
 }
 
-impl AsRef<MixedArrays> for MixedArrays {
+impl ::std::convert::AsRef<MixedArrays> for MixedArrays {
     fn as_ref(&self) -> &MixedArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedArrays {
     pub matrix: Vec<Vec<i64>>,
 
@@ -58,14 +58,14 @@ pub struct NestedArrays {
     pub threeDimensional: Vec<Vec<Vec<f64>>>,
 }
 
-impl AsRef<NestedArrays> for NestedArrays {
+impl ::std::convert::AsRef<NestedArrays> for NestedArrays {
     fn as_ref(&self) -> &NestedArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ObjectArrays {
     pub users: Vec<User>,
 
@@ -74,14 +74,14 @@ pub struct ObjectArrays {
     pub tags: Vec<Tag>,
 }
 
-impl AsRef<ObjectArrays> for ObjectArrays {
+impl ::std::convert::AsRef<ObjectArrays> for ObjectArrays {
     fn as_ref(&self) -> &ObjectArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Product {
     pub id: Option<i64>,
 
@@ -94,14 +94,14 @@ pub struct Product {
     pub inStock: Option<bool>,
 }
 
-impl AsRef<Product> for Product {
+impl ::std::convert::AsRef<Product> for Product {
     fn as_ref(&self) -> &Product {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleArrays {
     pub strings: Vec<String>,
 
@@ -112,14 +112,14 @@ pub struct SimpleArrays {
     pub booleans: Vec<bool>,
 }
 
-impl AsRef<SimpleArrays> for SimpleArrays {
+impl ::std::convert::AsRef<SimpleArrays> for SimpleArrays {
     fn as_ref(&self) -> &SimpleArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Tag {
     pub id: Option<i64>,
 
@@ -128,14 +128,14 @@ pub struct Tag {
     pub color: Option<String>,
 }
 
-impl AsRef<Tag> for Tag {
+impl ::std::convert::AsRef<Tag> for Tag {
     fn as_ref(&self) -> &Tag {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: Option<i64>,
 
@@ -146,7 +146,7 @@ pub struct User {
     pub isActive: Option<bool>,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     ArrayWithConstraints(ArrayWithConstraints),
 
@@ -38,7 +41,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -62,5 +65,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::Union3ProductOrTagOrUser(_) => "Union3ProductOrTagOrUser",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/stream_types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/stream_types/unions.rs
@@ -7,11 +7,15 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{
+    BamlDecode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (Streaming.User | Streaming.Product | Streaming.Tag)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3ProductOrTagOrUser {
     #[baml(name = "User")]
     User(User),
@@ -23,14 +27,14 @@ pub enum Union3ProductOrTagOrUser {
     Tag(Tag),
 }
 
-impl AsRef<Union3ProductOrTagOrUser> for Union3ProductOrTagOrUser {
+impl ::std::convert::AsRef<Union3ProductOrTagOrUser> for Union3ProductOrTagOrUser {
     fn as_ref(&self) -> &Union3ProductOrTagOrUser {
         self
     }
 }
 
-impl Default for Union3ProductOrTagOrUser {
+impl ::std::default::Default for Union3ProductOrTagOrUser {
     fn default() -> Self {
-        Self::User(Default::default())
+        Self::User(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ArrayWithConstraintsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ArrayWithConstraintsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "ArrayWithConstraints is statically defined in .baml and should always have a type",
         )
@@ -37,19 +37,19 @@ impl ArrayWithConstraintsClassBuilder {
     // =========================================================================
 
     /// Access the `nonEmptyStrings` field builder.
-    pub fn property_nonEmptyStrings(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nonEmptyStrings(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nonEmptyStrings")
             .expect("ArrayWithConstraints.nonEmptyStrings is statically defined in .baml and should always be present")
     }
 
     /// Access the `limitedInts` field builder.
-    pub fn property_limitedInts(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_limitedInts(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("limitedInts")
             .expect("ArrayWithConstraints.limitedInts is statically defined in .baml and should always be present")
     }
 
     /// Access the `positiveFloats` field builder.
-    pub fn property_positiveFloats(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_positiveFloats(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("positiveFloats")
             .expect("ArrayWithConstraints.positiveFloats is statically defined in .baml and should always be present")
     }
@@ -61,22 +61,22 @@ impl ArrayWithConstraintsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MixedArraysClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MixedArraysClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("MixedArrays is statically defined in .baml and should always have a type")
@@ -87,34 +87,34 @@ impl MixedArraysClassBuilder {
     // =========================================================================
 
     /// Access the `primitiveArray` field builder.
-    pub fn property_primitiveArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_primitiveArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("primitiveArray")
             .expect("MixedArrays.primitiveArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `nullableArray` field builder.
-    pub fn property_nullableArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableArray").expect(
             "MixedArrays.nullableArray is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `optionalItems` field builder.
-    pub fn property_optionalItems(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optionalItems(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optionalItems").expect(
             "MixedArrays.optionalItems is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `arrayOfArrays` field builder.
-    pub fn property_arrayOfArrays(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_arrayOfArrays(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("arrayOfArrays").expect(
             "MixedArrays.arrayOfArrays is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `complexMixed` field builder.
-    pub fn property_complexMixed(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_complexMixed(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("complexMixed").expect(
             "MixedArrays.complexMixed is statically defined in .baml and should always be present",
         )
@@ -127,22 +127,22 @@ impl MixedArraysClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NestedArraysClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NestedArraysClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("NestedArrays is statically defined in .baml and should always have a type")
@@ -153,21 +153,21 @@ impl NestedArraysClassBuilder {
     // =========================================================================
 
     /// Access the `matrix` field builder.
-    pub fn property_matrix(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_matrix(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("matrix").expect(
             "NestedArrays.matrix is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `stringMatrix` field builder.
-    pub fn property_stringMatrix(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringMatrix(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringMatrix").expect(
             "NestedArrays.stringMatrix is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `threeDimensional` field builder.
-    pub fn property_threeDimensional(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_threeDimensional(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("threeDimensional")
             .expect("NestedArrays.threeDimensional is statically defined in .baml and should always be present")
     }
@@ -179,22 +179,22 @@ impl NestedArraysClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ObjectArraysClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ObjectArraysClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ObjectArrays is statically defined in .baml and should always have a type")
@@ -205,21 +205,21 @@ impl ObjectArraysClassBuilder {
     // =========================================================================
 
     /// Access the `users` field builder.
-    pub fn property_users(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_users(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("users").expect(
             "ObjectArrays.users is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `products` field builder.
-    pub fn property_products(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_products(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("products").expect(
             "ObjectArrays.products is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tags")
             .expect("ObjectArrays.tags is statically defined in .baml and should always be present")
@@ -232,22 +232,22 @@ impl ObjectArraysClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ProductClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ProductClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Product is statically defined in .baml and should always have a type")
@@ -258,35 +258,35 @@ impl ProductClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Product.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Product.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `price` field builder.
-    pub fn property_price(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_price(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("price")
             .expect("Product.price is statically defined in .baml and should always be present")
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tags")
             .expect("Product.tags is statically defined in .baml and should always be present")
     }
 
     /// Access the `inStock` field builder.
-    pub fn property_inStock(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_inStock(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("inStock")
             .expect("Product.inStock is statically defined in .baml and should always be present")
@@ -299,22 +299,22 @@ impl ProductClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SimpleArraysClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SimpleArraysClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SimpleArrays is statically defined in .baml and should always have a type")
@@ -325,28 +325,28 @@ impl SimpleArraysClassBuilder {
     // =========================================================================
 
     /// Access the `strings` field builder.
-    pub fn property_strings(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_strings(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("strings").expect(
             "SimpleArrays.strings is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `integers` field builder.
-    pub fn property_integers(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_integers(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("integers").expect(
             "SimpleArrays.integers is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `floats` field builder.
-    pub fn property_floats(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_floats(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("floats").expect(
             "SimpleArrays.floats is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `booleans` field builder.
-    pub fn property_booleans(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_booleans(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("booleans").expect(
             "SimpleArrays.booleans is statically defined in .baml and should always be present",
         )
@@ -359,22 +359,22 @@ impl SimpleArraysClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TagClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TagClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Tag is statically defined in .baml and should always have a type")
@@ -385,21 +385,21 @@ impl TagClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Tag.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Tag.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `color` field builder.
-    pub fn property_color(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_color(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("color")
             .expect("Tag.color is statically defined in .baml and should always be present")
@@ -412,22 +412,22 @@ impl TagClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("User is statically defined in .baml and should always have a type")
@@ -438,28 +438,28 @@ impl UserClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("User.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("User.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `email` field builder.
-    pub fn property_email(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_email(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("email")
             .expect("User.email is statically defined in .baml and should always be present")
     }
 
     /// Access the `isActive` field builder.
-    pub fn property_isActive(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_isActive(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("isActive")
             .expect("User.isActive is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -131,27 +129,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -160,17 +158,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -179,22 +177,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -203,12 +201,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -217,17 +215,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -236,29 +237,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/types/classes.rs
@@ -6,143 +6,124 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ArrayWithConstraints {
     pub nonEmptyStrings: Vec<String>,
-
     pub limitedInts: Vec<i64>,
-
     pub positiveFloats: Vec<f64>,
 }
 
-impl AsRef<ArrayWithConstraints> for ArrayWithConstraints {
+impl ::std::convert::AsRef<ArrayWithConstraints> for ArrayWithConstraints {
     fn as_ref(&self) -> &ArrayWithConstraints {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedArrays {
     pub primitiveArray: Vec<Union4BoolOrFloatOrIntOrString>,
-
     pub nullableArray: Vec<Option<String>>,
-
     pub optionalItems: Vec<Option<String>>,
-
     pub arrayOfArrays: Vec<Vec<String>>,
-
     pub complexMixed: Vec<Union3ProductOrTagOrUser>,
 }
 
-impl AsRef<MixedArrays> for MixedArrays {
+impl ::std::convert::AsRef<MixedArrays> for MixedArrays {
     fn as_ref(&self) -> &MixedArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedArrays {
     pub matrix: Vec<Vec<i64>>,
-
     pub stringMatrix: Vec<Vec<String>>,
-
     pub threeDimensional: Vec<Vec<Vec<f64>>>,
 }
 
-impl AsRef<NestedArrays> for NestedArrays {
+impl ::std::convert::AsRef<NestedArrays> for NestedArrays {
     fn as_ref(&self) -> &NestedArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ObjectArrays {
     pub users: Vec<User>,
-
     pub products: Vec<Product>,
-
     pub tags: Vec<Tag>,
 }
 
-impl AsRef<ObjectArrays> for ObjectArrays {
+impl ::std::convert::AsRef<ObjectArrays> for ObjectArrays {
     fn as_ref(&self) -> &ObjectArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Product {
     pub id: i64,
-
     pub name: String,
-
     pub price: f64,
-
     pub tags: Vec<String>,
-
     pub inStock: bool,
 }
 
-impl AsRef<Product> for Product {
+impl ::std::convert::AsRef<Product> for Product {
     fn as_ref(&self) -> &Product {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleArrays {
     pub strings: Vec<String>,
-
     pub integers: Vec<i64>,
-
     pub floats: Vec<f64>,
-
     pub booleans: Vec<bool>,
 }
 
-impl AsRef<SimpleArrays> for SimpleArrays {
+impl ::std::convert::AsRef<SimpleArrays> for SimpleArrays {
     fn as_ref(&self) -> &SimpleArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Tag {
     pub id: i64,
-
     pub name: String,
-
     pub color: String,
 }
 
-impl AsRef<Tag> for Tag {
+impl ::std::convert::AsRef<Tag> for Tag {
     fn as_ref(&self) -> &Tag {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: i64,
-
     pub name: String,
-
     pub email: String,
-
     pub isActive: bool,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/types/mod.rs
@@ -48,34 +48,34 @@ pub enum Types {
     Union4BoolOrFloatOrIntOrString(Union4BoolOrFloatOrIntOrString),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::ArrayWithConstraints(_) => "ArrayWithConstraints",
+            Self::ArrayWithConstraints(_) => "ArrayWithConstraints",
 
-            Types::MixedArrays(_) => "MixedArrays",
+            Self::MixedArrays(_) => "MixedArrays",
 
-            Types::NestedArrays(_) => "NestedArrays",
+            Self::NestedArrays(_) => "NestedArrays",
 
-            Types::ObjectArrays(_) => "ObjectArrays",
+            Self::ObjectArrays(_) => "ObjectArrays",
 
-            Types::Product(_) => "Product",
+            Self::Product(_) => "Product",
 
-            Types::SimpleArrays(_) => "SimpleArrays",
+            Self::SimpleArrays(_) => "SimpleArrays",
 
-            Types::Tag(_) => "Tag",
+            Self::Tag(_) => "Tag",
 
-            Types::User(_) => "User",
+            Self::User(_) => "User",
 
-            Types::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
+            Self::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
 
-            Types::Union3ProductOrTagOrUser(_) => "Union3ProductOrTagOrUser",
+            Self::Union3ProductOrTagOrUser(_) => "Union3ProductOrTagOrUser",
 
-            Types::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
+            Self::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     ArrayWithConstraints(ArrayWithConstraints),
 
@@ -47,7 +49,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -75,5 +77,15 @@ impl baml::KnownTypes for Types {
 
             Types::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/array_types/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/array_types/baml_client/types/unions.rs
@@ -6,11 +6,15 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (string | int | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BoolOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -22,21 +26,22 @@ pub enum Union3BoolOrIntOrString {
     Bool(bool),
 }
 
-impl AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
+impl ::std::convert::AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
     fn as_ref(&self) -> &Union3BoolOrIntOrString {
         self
     }
 }
 
-impl Default for Union3BoolOrIntOrString {
+impl ::std::default::Default for Union3BoolOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (User | Product | Tag)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3ProductOrTagOrUser {
     #[baml(name = "User")]
     User(User),
@@ -48,21 +53,22 @@ pub enum Union3ProductOrTagOrUser {
     Tag(Tag),
 }
 
-impl AsRef<Union3ProductOrTagOrUser> for Union3ProductOrTagOrUser {
+impl ::std::convert::AsRef<Union3ProductOrTagOrUser> for Union3ProductOrTagOrUser {
     fn as_ref(&self) -> &Union3ProductOrTagOrUser {
         self
     }
 }
 
-impl Default for Union3ProductOrTagOrUser {
+impl ::std::default::Default for Union3ProductOrTagOrUser {
     fn default() -> Self {
-        Self::User(Default::default())
+        Self::User(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int | float | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4BoolOrFloatOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -77,14 +83,14 @@ pub enum Union4BoolOrFloatOrIntOrString {
     Bool(bool),
 }
 
-impl AsRef<Union4BoolOrFloatOrIntOrString> for Union4BoolOrFloatOrIntOrString {
+impl ::std::convert::AsRef<Union4BoolOrFloatOrIntOrString> for Union4BoolOrFloatOrIntOrString {
     fn as_ref(&self) -> &Union4BoolOrFloatOrIntOrString {
         self
     }
 }
 
-impl Default for Union4BoolOrFloatOrIntOrString {
+impl ::std::default::Default for Union4BoolOrFloatOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/asserts/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/asserts/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/asserts/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/asserts/baml_client/stream_types/classes.rs
@@ -10,17 +10,17 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Person {
     pub name: Option<String>,
 
     pub age: Option<i64>,
 }
 
-impl AsRef<Person> for Person {
+impl ::std::convert::AsRef<Person> for Person {
     fn as_ref(&self) -> &Person {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/asserts/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/asserts/baml_client/stream_types/mod.rs
@@ -15,14 +15,17 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     Person(Person),
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -30,5 +33,15 @@ impl baml::KnownTypes for StreamTypes {
         match self {
             StreamTypes::Person(_) => "Person",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/asserts/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/asserts/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PersonClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PersonClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Person is statically defined in .baml and should always have a type")
@@ -37,14 +37,14 @@ impl PersonClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Person.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `age` field builder.
-    pub fn property_age(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_age(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("age")
             .expect("Person.age is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/asserts/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/asserts/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -68,27 +66,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -97,17 +95,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -116,22 +114,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -140,12 +138,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -154,17 +152,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -173,29 +174,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/asserts/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/asserts/baml_client/types/classes.rs
@@ -6,17 +6,19 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Person {
     pub name: String,
-
     pub age: i64,
 }
 
-impl AsRef<Person> for Person {
+impl ::std::convert::AsRef<Person> for Person {
     fn as_ref(&self) -> &Person {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/asserts/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/asserts/baml_client/types/mod.rs
@@ -16,18 +16,20 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     Person(Person),
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -35,5 +37,15 @@ impl baml::KnownTypes for Types {
         match self {
             Types::Person(_) => "Person",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/asserts/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/asserts/baml_client/types/mod.rs
@@ -28,14 +28,14 @@ pub enum Types {
     Person(Person),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::Person(_) => "Person",
+            Self::Person(_) => "Person",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/classes/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/classes/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/classes/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/classes/baml_client/stream_types/classes.rs
@@ -10,17 +10,17 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleClass {
     pub digits: Option<i64>,
 
     pub words: baml::StreamState<Option<String>>,
 }
 
-impl AsRef<SimpleClass> for SimpleClass {
+impl ::std::convert::AsRef<SimpleClass> for SimpleClass {
     fn as_ref(&self) -> &SimpleClass {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/classes/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/classes/baml_client/stream_types/mod.rs
@@ -15,14 +15,17 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     SimpleClass(SimpleClass),
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -30,5 +33,15 @@ impl baml::KnownTypes for StreamTypes {
         match self {
             StreamTypes::SimpleClass(_) => "SimpleClass",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/classes/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/classes/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SimpleClassClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SimpleClassClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SimpleClass is statically defined in .baml and should always have a type")
@@ -37,14 +37,14 @@ impl SimpleClassClassBuilder {
     // =========================================================================
 
     /// Access the `digits` field builder.
-    pub fn property_digits(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_digits(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("digits").expect(
             "SimpleClass.digits is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `words` field builder.
-    pub fn property_words(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_words(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("words")
             .expect("SimpleClass.words is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/classes/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/classes/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -68,27 +66,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -97,17 +95,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -116,22 +114,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -140,12 +138,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -154,17 +152,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -173,29 +174,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/classes/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/classes/baml_client/types/classes.rs
@@ -6,17 +6,19 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleClass {
     pub digits: i64,
-
     pub words: String,
 }
 
-impl AsRef<SimpleClass> for SimpleClass {
+impl ::std::convert::AsRef<SimpleClass> for SimpleClass {
     fn as_ref(&self) -> &SimpleClass {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/classes/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/classes/baml_client/types/mod.rs
@@ -28,14 +28,14 @@ pub enum Types {
     SimpleClass(SimpleClass),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::SimpleClass(_) => "SimpleClass",
+            Self::SimpleClass(_) => "SimpleClass",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/classes/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/classes/baml_client/types/mod.rs
@@ -16,18 +16,20 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     SimpleClass(SimpleClass),
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -35,5 +37,15 @@ impl baml::KnownTypes for Types {
         match self {
             Types::SimpleClass(_) => "SimpleClass",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Address {
     pub street: Option<String>,
 
@@ -22,15 +22,15 @@ pub struct Address {
     pub country: Option<String>,
 }
 
-impl AsRef<Address> for Address {
+impl ::std::convert::AsRef<Address> for Address {
     fn as_ref(&self) -> &Address {
         self
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Article {
     pub title: Option<String>,
 
@@ -42,23 +42,24 @@ pub struct Article {
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    #[serde(flatten)]
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl Article {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -67,7 +68,9 @@ impl Article {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -79,41 +82,41 @@ impl Article {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for Article {
+impl ::std::default::Default for Article {
     fn default() -> Self {
         Self {
-            title: Default::default(),
+            title: ::std::default::Default::default(),
 
-            category: Default::default(),
+            category: ::std::default::Default::default(),
 
-            author: Default::default(),
+            author: ::std::default::Default::default(),
 
-            status: Default::default(),
+            status: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<Article> for Article {
+impl ::std::convert::AsRef<Article> for Article {
     fn as_ref(&self) -> &Article {
         self
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Person {
     pub name: Option<String>,
 
@@ -121,23 +124,24 @@ pub struct Person {
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    #[serde(flatten)]
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl Person {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -146,7 +150,9 @@ impl Person {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -158,57 +164,58 @@ impl Person {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for Person {
+impl ::std::default::Default for Person {
     fn default() -> Self {
         Self {
-            name: Default::default(),
+            name: ::std::default::Default::default(),
 
-            age: Default::default(),
+            age: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<Person> for Person {
+impl ::std::convert::AsRef<Person> for Person {
     fn as_ref(&self) -> &Person {
         self
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PureDynamic {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    #[serde(flatten)]
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl PureDynamic {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -217,7 +224,9 @@ impl PureDynamic {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -229,25 +238,25 @@ impl PureDynamic {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for PureDynamic {
+impl ::std::default::Default for PureDynamic {
     fn default() -> Self {
         Self {
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<PureDynamic> for PureDynamic {
+impl ::std::convert::AsRef<PureDynamic> for PureDynamic {
     fn as_ref(&self) -> &PureDynamic {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/stream_types/classes.rs
@@ -45,7 +45,7 @@ pub struct Article {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -127,7 +127,7 @@ pub struct Person {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -201,7 +201,7 @@ pub struct PureDynamic {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     Address(Address),
 
@@ -28,7 +31,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -42,5 +45,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::PureDynamic(_) => "PureDynamic",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/type_builder/classes.rs
@@ -93,7 +93,7 @@ impl ArticleClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -165,7 +165,7 @@ impl PersonClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -223,7 +223,7 @@ impl PureDynamicClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct AddressClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl AddressClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Address is statically defined in .baml and should always have a type")
@@ -37,21 +37,21 @@ impl AddressClassBuilder {
     // =========================================================================
 
     /// Access the `street` field builder.
-    pub fn property_street(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_street(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("street")
             .expect("Address.street is statically defined in .baml and should always be present")
     }
 
     /// Access the `city` field builder.
-    pub fn property_city(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_city(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("city")
             .expect("Address.city is statically defined in .baml and should always be present")
     }
 
     /// Access the `country` field builder.
-    pub fn property_country(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_country(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("country")
             .expect("Address.country is statically defined in .baml and should always be present")
@@ -67,22 +67,22 @@ impl AddressClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct ArticleClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ArticleClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Article is statically defined in .baml and should always have a type")
@@ -92,8 +92,8 @@ impl ArticleClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -102,28 +102,28 @@ impl ArticleClassBuilder {
     // =========================================================================
 
     /// Access the `title` field builder.
-    pub fn property_title(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_title(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("title")
             .expect("Article.title is statically defined in .baml and should always be present")
     }
 
     /// Access the `category` field builder.
-    pub fn property_category(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_category(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("category")
             .expect("Article.category is statically defined in .baml and should always be present")
     }
 
     /// Access the `author` field builder.
-    pub fn property_author(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_author(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("author")
             .expect("Article.author is statically defined in .baml and should always be present")
     }
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("status")
             .expect("Article.status is statically defined in .baml and should always be present")
@@ -139,22 +139,22 @@ impl ArticleClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct PersonClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PersonClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Person is statically defined in .baml and should always have a type")
@@ -164,8 +164,8 @@ impl PersonClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -174,14 +174,14 @@ impl PersonClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Person.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `age` field builder.
-    pub fn property_age(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_age(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("age")
             .expect("Person.age is statically defined in .baml and should always be present")
@@ -197,22 +197,22 @@ impl PersonClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct PureDynamicClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PureDynamicClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("PureDynamic is statically defined in .baml and should always have a type")
@@ -222,8 +222,8 @@ impl PureDynamicClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/type_builder/enums.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/type_builder/enums.rs
@@ -14,29 +14,32 @@
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 
 pub struct CategoryEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl CategoryEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Category is statically defined in .baml and should always have a type")
     }
 
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(
+        &self,
+        value: &str,
+    ) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -45,21 +48,21 @@ impl CategoryEnumBuilder {
     // =========================================================================
 
     /// Access the `Technology` value builder.
-    pub fn value_Technology(&self) -> baml::EnumValueBuilder {
+    pub fn value_Technology(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("Technology").expect(
             "Category.Technology is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `Science` value builder.
-    pub fn value_Science(&self) -> baml::EnumValueBuilder {
+    pub fn value_Science(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Science")
             .expect("Category.Science is statically defined in .baml and should always be present")
     }
 
     /// Access the `Arts` value builder.
-    pub fn value_Arts(&self) -> baml::EnumValueBuilder {
+    pub fn value_Arts(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Arts")
             .expect("Category.Arts is statically defined in .baml and should always be present")
@@ -75,29 +78,32 @@ impl CategoryEnumBuilder {
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 
 pub struct PriorityEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl PriorityEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Priority is statically defined in .baml and should always have a type")
     }
 
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(
+        &self,
+        value: &str,
+    ) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -106,21 +112,21 @@ impl PriorityEnumBuilder {
     // =========================================================================
 
     /// Access the `High` value builder.
-    pub fn value_High(&self) -> baml::EnumValueBuilder {
+    pub fn value_High(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("High")
             .expect("Priority.High is statically defined in .baml and should always be present")
     }
 
     /// Access the `Medium` value builder.
-    pub fn value_Medium(&self) -> baml::EnumValueBuilder {
+    pub fn value_Medium(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Medium")
             .expect("Priority.Medium is statically defined in .baml and should always be present")
     }
 
     /// Access the `Low` value builder.
-    pub fn value_Low(&self) -> baml::EnumValueBuilder {
+    pub fn value_Low(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Low")
             .expect("Priority.Low is statically defined in .baml and should always be present")
@@ -133,22 +139,22 @@ impl PriorityEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct StatusEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl StatusEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Status is statically defined in .baml and should always have a type")
@@ -159,21 +165,21 @@ impl StatusEnumBuilder {
     // =========================================================================
 
     /// Access the `Active` value builder.
-    pub fn value_Active(&self) -> baml::EnumValueBuilder {
+    pub fn value_Active(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Active")
             .expect("Status.Active is statically defined in .baml and should always be present")
     }
 
     /// Access the `Inactive` value builder.
-    pub fn value_Inactive(&self) -> baml::EnumValueBuilder {
+    pub fn value_Inactive(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Inactive")
             .expect("Status.Inactive is statically defined in .baml and should always be present")
     }
 
     /// Access the `Pending` value builder.
-    pub fn value_Pending(&self) -> baml::EnumValueBuilder {
+    pub fn value_Pending(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Pending")
             .expect("Status.Pending is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -122,27 +120,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -151,17 +149,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -170,22 +168,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -194,12 +192,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -208,17 +206,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -227,29 +228,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/classes.rs
@@ -6,55 +6,53 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Address {
     pub street: String,
-
     pub city: String,
-
     pub country: String,
 }
 
-impl AsRef<Address> for Address {
+impl ::std::convert::AsRef<Address> for Address {
     fn as_ref(&self) -> &Address {
         self
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Article {
     pub title: String,
-
     pub category: Category,
-
     pub author: Person,
-
     pub status: Status,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    #[serde(flatten)]
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl Article {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -63,7 +61,9 @@ impl Article {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -75,7 +75,7 @@ impl Article {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -85,55 +85,50 @@ impl Article {
     }
 }
 
-impl Default for Article {
+impl ::std::default::Default for Article {
     fn default() -> Self {
         Self {
-            title: Default::default(),
-
-            category: Default::default(),
-
-            author: Default::default(),
-
-            status: Default::default(),
-
-            __dynamic: std::collections::HashMap::new(),
+            title: ::std::default::Default::default(),
+            category: ::std::default::Default::default(),
+            author: ::std::default::Default::default(),
+            status: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<Article> for Article {
+impl ::std::convert::AsRef<Article> for Article {
     fn as_ref(&self) -> &Article {
         self
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Person {
     pub name: String,
-
     pub age: i64,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    #[serde(flatten)]
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl Person {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -142,7 +137,9 @@ impl Person {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -154,7 +151,7 @@ impl Person {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -164,47 +161,46 @@ impl Person {
     }
 }
 
-impl Default for Person {
+impl ::std::default::Default for Person {
     fn default() -> Self {
         Self {
-            name: Default::default(),
-
-            age: Default::default(),
-
-            __dynamic: std::collections::HashMap::new(),
+            name: ::std::default::Default::default(),
+            age: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<Person> for Person {
+impl ::std::convert::AsRef<Person> for Person {
     fn as_ref(&self) -> &Person {
         self
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PureDynamic {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    #[serde(flatten)]
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl PureDynamic {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -213,7 +209,9 @@ impl PureDynamic {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -225,7 +223,7 @@ impl PureDynamic {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -235,15 +233,15 @@ impl PureDynamic {
     }
 }
 
-impl Default for PureDynamic {
+impl ::std::default::Default for PureDynamic {
     fn default() -> Self {
         Self {
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<PureDynamic> for PureDynamic {
+impl ::std::convert::AsRef<PureDynamic> for PureDynamic {
     fn as_ref(&self) -> &PureDynamic {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/enums.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/enums.rs
@@ -5,11 +5,14 @@
 
 //! Generated enum types.
 
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Category {
     Technology,
 
@@ -19,17 +22,18 @@ pub enum Category {
 
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
-    _Dynamic(String),
+    #[serde(untagged)]
+    _Dynamic(::std::string::String),
 }
 
-impl Default for Category {
+impl ::std::default::Default for Category {
     fn default() -> Self {
         Self::Technology
     }
 }
 
-impl std::fmt::Display for Category {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Category {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::Technology => write!(f, "Technology"),
 
@@ -42,31 +46,31 @@ impl std::fmt::Display for Category {
     }
 }
 
-impl std::str::FromStr for Category {
+impl ::std::str::FromStr for Category {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Technology" => Ok(Self::Technology),
+            "Technology" => ::std::result::Result::Ok(Self::TECHNOLOGY),
 
-            "Science" => Ok(Self::Science),
+            "Science" => ::std::result::Result::Ok(Self::SCIENCE),
 
-            "Arts" => Ok(Self::Arts),
+            "Arts" => ::std::result::Result::Ok(Self::ARTS),
 
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
     }
 }
 
-impl AsRef<Category> for Category {
+impl ::std::convert::AsRef<Category> for Category {
     fn as_ref(&self) -> &Category {
         self
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Priority {
     High,
 
@@ -76,17 +80,18 @@ pub enum Priority {
 
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
-    _Dynamic(String),
+    #[serde(untagged)]
+    _Dynamic(::std::string::String),
 }
 
-impl Default for Priority {
+impl ::std::default::Default for Priority {
     fn default() -> Self {
         Self::High
     }
 }
 
-impl std::fmt::Display for Priority {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Priority {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::High => write!(f, "High"),
 
@@ -99,30 +104,30 @@ impl std::fmt::Display for Priority {
     }
 }
 
-impl std::str::FromStr for Priority {
+impl ::std::str::FromStr for Priority {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "High" => Ok(Self::High),
+            "High" => ::std::result::Result::Ok(Self::HIGH),
 
-            "Medium" => Ok(Self::Medium),
+            "Medium" => ::std::result::Result::Ok(Self::MEDIUM),
 
-            "Low" => Ok(Self::Low),
+            "Low" => ::std::result::Result::Ok(Self::LOW),
 
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
     }
 }
 
-impl AsRef<Priority> for Priority {
+impl ::std::convert::AsRef<Priority> for Priority {
     fn as_ref(&self) -> &Priority {
         self
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Status {
     Active,
 
@@ -131,14 +136,14 @@ pub enum Status {
     Pending,
 }
 
-impl Default for Status {
+impl ::std::default::Default for Status {
     fn default() -> Self {
         Self::Active
     }
 }
 
-impl std::fmt::Display for Status {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Status {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::Active => write!(f, "Active"),
 
@@ -149,23 +154,23 @@ impl std::fmt::Display for Status {
     }
 }
 
-impl std::str::FromStr for Status {
+impl ::std::str::FromStr for Status {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Active" => Ok(Self::Active),
+            "Active" => ::std::result::Result::Ok(Self::ACTIVE),
 
-            "Inactive" => Ok(Self::Inactive),
+            "Inactive" => ::std::result::Result::Ok(Self::INACTIVE),
 
-            "Pending" => Ok(Self::Pending),
+            "Pending" => ::std::result::Result::Ok(Self::PENDING),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<Status> for Status {
+impl ::std::convert::AsRef<Status> for Status {
     fn as_ref(&self) -> &Status {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/enums.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/enums.rs
@@ -51,11 +51,11 @@ impl ::std::str::FromStr for Category {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Technology" => ::std::result::Result::Ok(Self::TECHNOLOGY),
+            "Technology" => ::std::result::Result::Ok(Self::Technology),
 
-            "Science" => ::std::result::Result::Ok(Self::SCIENCE),
+            "Science" => ::std::result::Result::Ok(Self::Science),
 
-            "Arts" => ::std::result::Result::Ok(Self::ARTS),
+            "Arts" => ::std::result::Result::Ok(Self::Arts),
 
             other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
@@ -109,11 +109,11 @@ impl ::std::str::FromStr for Priority {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "High" => ::std::result::Result::Ok(Self::HIGH),
+            "High" => ::std::result::Result::Ok(Self::High),
 
-            "Medium" => ::std::result::Result::Ok(Self::MEDIUM),
+            "Medium" => ::std::result::Result::Ok(Self::Medium),
 
-            "Low" => ::std::result::Result::Ok(Self::LOW),
+            "Low" => ::std::result::Result::Ok(Self::Low),
 
             other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
@@ -159,11 +159,11 @@ impl ::std::str::FromStr for Status {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Active" => ::std::result::Result::Ok(Self::ACTIVE),
+            "Active" => ::std::result::Result::Ok(Self::Active),
 
-            "Inactive" => ::std::result::Result::Ok(Self::INACTIVE),
+            "Inactive" => ::std::result::Result::Ok(Self::Inactive),
 
-            "Pending" => ::std::result::Result::Ok(Self::PENDING),
+            "Pending" => ::std::result::Result::Ok(Self::Pending),
 
             _ => ::std::result::Result::Err(()),
         }

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     Address(Address),
 
@@ -39,7 +41,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -59,5 +61,15 @@ impl baml::KnownTypes for Types {
 
             Types::Status(_) => "Status",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/dynamic_types/baml_client/types/mod.rs
@@ -40,26 +40,26 @@ pub enum Types {
     Status(Status),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::Address(_) => "Address",
+            Self::Address(_) => "Address",
 
-            Types::Article(_) => "Article",
+            Self::Article(_) => "Article",
 
-            Types::Person(_) => "Person",
+            Self::Person(_) => "Person",
 
-            Types::PureDynamic(_) => "PureDynamic",
+            Self::PureDynamic(_) => "PureDynamic",
 
-            Types::Category(_) => "Category",
+            Self::Category(_) => "Category",
 
-            Types::Priority(_) => "Priority",
+            Self::Priority(_) => "Priority",
 
-            Types::Status(_) => "Status",
+            Self::Status(_) => "Status",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AllNullable {
     pub nullString: Option<String>,
 
@@ -28,14 +28,14 @@ pub struct AllNullable {
     pub nullObject: Option<User>,
 }
 
-impl AsRef<AllNullable> for AllNullable {
+impl ::std::convert::AsRef<AllNullable> for AllNullable {
     fn as_ref(&self) -> &AllNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BooleanEdgeCases {
     pub explicitTrue: Option<bool>,
 
@@ -48,14 +48,14 @@ pub struct BooleanEdgeCases {
     pub mixedBoolArray: Vec<bool>,
 }
 
-impl AsRef<BooleanEdgeCases> for BooleanEdgeCases {
+impl ::std::convert::AsRef<BooleanEdgeCases> for BooleanEdgeCases {
     fn as_ref(&self) -> &BooleanEdgeCases {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CircularReference {
     pub id: Option<i64>,
 
@@ -68,28 +68,28 @@ pub struct CircularReference {
     pub relatedItems: Vec<Box<CircularReference>>,
 }
 
-impl AsRef<CircularReference> for CircularReference {
+impl ::std::convert::AsRef<CircularReference> for CircularReference {
     fn as_ref(&self) -> &CircularReference {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DeepRecursion {
     pub value: Option<String>,
 
     pub next: Option<Box<DeepRecursion>>,
 }
 
-impl AsRef<DeepRecursion> for DeepRecursion {
+impl ::std::convert::AsRef<DeepRecursion> for DeepRecursion {
     fn as_ref(&self) -> &DeepRecursion {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct EmptyCollections {
     pub emptyStringArray: Vec<String>,
 
@@ -102,26 +102,26 @@ pub struct EmptyCollections {
     pub emptyNestedArray: Vec<Vec<String>>,
 }
 
-impl AsRef<EmptyCollections> for EmptyCollections {
+impl ::std::convert::AsRef<EmptyCollections> for EmptyCollections {
     fn as_ref(&self) -> &EmptyCollections {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InnerNullable {
     pub value: Option<String>,
 }
 
-impl AsRef<InnerNullable> for InnerNullable {
+impl ::std::convert::AsRef<InnerNullable> for InnerNullable {
     fn as_ref(&self) -> &InnerNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LargeStructure {
     pub field1: Option<String>,
 
@@ -184,14 +184,14 @@ pub struct LargeStructure {
     pub map5: std::collections::HashMap<String, User>,
 }
 
-impl AsRef<LargeStructure> for LargeStructure {
+impl ::std::convert::AsRef<LargeStructure> for LargeStructure {
     fn as_ref(&self) -> &LargeStructure {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedEdgeCases {
     pub emptyString: Option<String>,
 
@@ -209,26 +209,26 @@ pub struct MixedEdgeCases {
     pub optionalEverything: Option<OptionalEverything>,
 }
 
-impl AsRef<MixedEdgeCases> for MixedEdgeCases {
+impl ::std::convert::AsRef<MixedEdgeCases> for MixedEdgeCases {
     fn as_ref(&self) -> &MixedEdgeCases {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedNullable {
     pub outer: Option<OuterNullable>,
 }
 
-impl AsRef<NestedNullable> for NestedNullable {
+impl ::std::convert::AsRef<NestedNullable> for NestedNullable {
     fn as_ref(&self) -> &NestedNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NullEdgeCases {
     pub allNull: Option<AllNullable>,
 
@@ -237,14 +237,14 @@ pub struct NullEdgeCases {
     pub nestedNull: Option<NestedNullable>,
 }
 
-impl AsRef<NullEdgeCases> for NullEdgeCases {
+impl ::std::convert::AsRef<NullEdgeCases> for NullEdgeCases {
     fn as_ref(&self) -> &NullEdgeCases {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NumberEdgeCases {
     pub zero: Option<i64>,
 
@@ -267,14 +267,14 @@ pub struct NumberEdgeCases {
     pub notANumber: Option<f64>,
 }
 
-impl AsRef<NumberEdgeCases> for NumberEdgeCases {
+impl ::std::convert::AsRef<NumberEdgeCases> for NumberEdgeCases {
     fn as_ref(&self) -> &NumberEdgeCases {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalEverything {
     pub optString: Option<String>,
 
@@ -291,26 +291,26 @@ pub struct OptionalEverything {
     pub optObject: Option<User>,
 }
 
-impl AsRef<OptionalEverything> for OptionalEverything {
+impl ::std::convert::AsRef<OptionalEverything> for OptionalEverything {
     fn as_ref(&self) -> &OptionalEverything {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OuterNullable {
     pub inner: Option<InnerNullable>,
 }
 
-impl AsRef<OuterNullable> for OuterNullable {
+impl ::std::convert::AsRef<OuterNullable> for OuterNullable {
     fn as_ref(&self) -> &OuterNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SomeNullable {
     pub presentString: Option<String>,
 
@@ -321,14 +321,14 @@ pub struct SomeNullable {
     pub nullInt: Option<i64>,
 }
 
-impl AsRef<SomeNullable> for SomeNullable {
+impl ::std::convert::AsRef<SomeNullable> for SomeNullable {
     fn as_ref(&self) -> &SomeNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SpecialCharacters {
     pub normalText: Option<String>,
 
@@ -347,28 +347,28 @@ pub struct SpecialCharacters {
     pub withMixedSpecial: Option<String>,
 }
 
-impl AsRef<SpecialCharacters> for SpecialCharacters {
+impl ::std::convert::AsRef<SpecialCharacters> for SpecialCharacters {
     fn as_ref(&self) -> &SpecialCharacters {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: Option<i64>,
 
     pub name: Option<String>,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct VeryLongStrings {
     pub shortString: Option<String>,
 
@@ -381,7 +381,7 @@ pub struct VeryLongStrings {
     pub extremelyLongString: Option<String>,
 }
 
-impl AsRef<VeryLongStrings> for VeryLongStrings {
+impl ::std::convert::AsRef<VeryLongStrings> for VeryLongStrings {
     fn as_ref(&self) -> &VeryLongStrings {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     AllNullable(AllNullable),
 
@@ -54,7 +57,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -94,5 +97,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::VeryLongStrings(_) => "VeryLongStrings",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct AllNullableClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl AllNullableClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("AllNullable is statically defined in .baml and should always have a type")
@@ -37,42 +37,42 @@ impl AllNullableClassBuilder {
     // =========================================================================
 
     /// Access the `nullString` field builder.
-    pub fn property_nullString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullString").expect(
             "AllNullable.nullString is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullInt` field builder.
-    pub fn property_nullInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullInt").expect(
             "AllNullable.nullInt is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullFloat` field builder.
-    pub fn property_nullFloat(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullFloat(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullFloat").expect(
             "AllNullable.nullFloat is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullBool` field builder.
-    pub fn property_nullBool(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullBool(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullBool").expect(
             "AllNullable.nullBool is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullArray` field builder.
-    pub fn property_nullArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullArray").expect(
             "AllNullable.nullArray is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullObject` field builder.
-    pub fn property_nullObject(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullObject(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullObject").expect(
             "AllNullable.nullObject is statically defined in .baml and should always be present",
         )
@@ -85,22 +85,22 @@ impl AllNullableClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BooleanEdgeCasesClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BooleanEdgeCasesClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("BooleanEdgeCases is statically defined in .baml and should always have a type")
@@ -111,31 +111,31 @@ impl BooleanEdgeCasesClassBuilder {
     // =========================================================================
 
     /// Access the `explicitTrue` field builder.
-    pub fn property_explicitTrue(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_explicitTrue(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("explicitTrue")
             .expect("BooleanEdgeCases.explicitTrue is statically defined in .baml and should always be present")
     }
 
     /// Access the `explicitFalse` field builder.
-    pub fn property_explicitFalse(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_explicitFalse(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("explicitFalse")
             .expect("BooleanEdgeCases.explicitFalse is statically defined in .baml and should always be present")
     }
 
     /// Access the `arrayOfTrue` field builder.
-    pub fn property_arrayOfTrue(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_arrayOfTrue(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("arrayOfTrue")
             .expect("BooleanEdgeCases.arrayOfTrue is statically defined in .baml and should always be present")
     }
 
     /// Access the `arrayOfFalse` field builder.
-    pub fn property_arrayOfFalse(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_arrayOfFalse(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("arrayOfFalse")
             .expect("BooleanEdgeCases.arrayOfFalse is statically defined in .baml and should always be present")
     }
 
     /// Access the `mixedBoolArray` field builder.
-    pub fn property_mixedBoolArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mixedBoolArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mixedBoolArray")
             .expect("BooleanEdgeCases.mixedBoolArray is statically defined in .baml and should always be present")
     }
@@ -147,22 +147,22 @@ impl BooleanEdgeCasesClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct CircularReferenceClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl CircularReferenceClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "CircularReference is statically defined in .baml and should always have a type",
         )
@@ -173,34 +173,34 @@ impl CircularReferenceClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("id").expect(
             "CircularReference.id is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("name").expect(
             "CircularReference.name is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `parent` field builder.
-    pub fn property_parent(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_parent(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("parent").expect(
             "CircularReference.parent is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `children` field builder.
-    pub fn property_children(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_children(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("children")
             .expect("CircularReference.children is statically defined in .baml and should always be present")
     }
 
     /// Access the `relatedItems` field builder.
-    pub fn property_relatedItems(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_relatedItems(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("relatedItems")
             .expect("CircularReference.relatedItems is statically defined in .baml and should always be present")
     }
@@ -212,22 +212,22 @@ impl CircularReferenceClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DeepRecursionClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DeepRecursionClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DeepRecursion is statically defined in .baml and should always have a type")
@@ -238,14 +238,14 @@ impl DeepRecursionClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value").expect(
             "DeepRecursion.value is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `next` field builder.
-    pub fn property_next(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_next(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("next").expect(
             "DeepRecursion.next is statically defined in .baml and should always be present",
         )
@@ -258,22 +258,22 @@ impl DeepRecursionClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct EmptyCollectionsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl EmptyCollectionsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("EmptyCollections is statically defined in .baml and should always have a type")
@@ -284,32 +284,32 @@ impl EmptyCollectionsClassBuilder {
     // =========================================================================
 
     /// Access the `emptyStringArray` field builder.
-    pub fn property_emptyStringArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_emptyStringArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("emptyStringArray")
             .expect("EmptyCollections.emptyStringArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `emptyIntArray` field builder.
-    pub fn property_emptyIntArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_emptyIntArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("emptyIntArray")
             .expect("EmptyCollections.emptyIntArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `emptyObjectArray` field builder.
-    pub fn property_emptyObjectArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_emptyObjectArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("emptyObjectArray")
             .expect("EmptyCollections.emptyObjectArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `emptyMap` field builder.
-    pub fn property_emptyMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_emptyMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("emptyMap").expect(
             "EmptyCollections.emptyMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `emptyNestedArray` field builder.
-    pub fn property_emptyNestedArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_emptyNestedArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("emptyNestedArray")
             .expect("EmptyCollections.emptyNestedArray is statically defined in .baml and should always be present")
     }
@@ -321,22 +321,22 @@ impl EmptyCollectionsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct InnerNullableClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl InnerNullableClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("InnerNullable is statically defined in .baml and should always have a type")
@@ -347,7 +347,7 @@ impl InnerNullableClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value").expect(
             "InnerNullable.value is statically defined in .baml and should always be present",
         )
@@ -360,22 +360,22 @@ impl InnerNullableClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct LargeStructureClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl LargeStructureClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("LargeStructure is statically defined in .baml and should always have a type")
@@ -386,210 +386,210 @@ impl LargeStructureClassBuilder {
     // =========================================================================
 
     /// Access the `field1` field builder.
-    pub fn property_field1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field1").expect(
             "LargeStructure.field1 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field2` field builder.
-    pub fn property_field2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field2").expect(
             "LargeStructure.field2 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field3` field builder.
-    pub fn property_field3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field3").expect(
             "LargeStructure.field3 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field4` field builder.
-    pub fn property_field4(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field4(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field4").expect(
             "LargeStructure.field4 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field5` field builder.
-    pub fn property_field5(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field5(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field5").expect(
             "LargeStructure.field5 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field6` field builder.
-    pub fn property_field6(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field6(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field6").expect(
             "LargeStructure.field6 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field7` field builder.
-    pub fn property_field7(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field7(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field7").expect(
             "LargeStructure.field7 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field8` field builder.
-    pub fn property_field8(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field8(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field8").expect(
             "LargeStructure.field8 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field9` field builder.
-    pub fn property_field9(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field9(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field9").expect(
             "LargeStructure.field9 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field10` field builder.
-    pub fn property_field10(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field10(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field10").expect(
             "LargeStructure.field10 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field11` field builder.
-    pub fn property_field11(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field11(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field11").expect(
             "LargeStructure.field11 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field12` field builder.
-    pub fn property_field12(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field12(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field12").expect(
             "LargeStructure.field12 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field13` field builder.
-    pub fn property_field13(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field13(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field13").expect(
             "LargeStructure.field13 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field14` field builder.
-    pub fn property_field14(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field14(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field14").expect(
             "LargeStructure.field14 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field15` field builder.
-    pub fn property_field15(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field15(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field15").expect(
             "LargeStructure.field15 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field16` field builder.
-    pub fn property_field16(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field16(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field16").expect(
             "LargeStructure.field16 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field17` field builder.
-    pub fn property_field17(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field17(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field17").expect(
             "LargeStructure.field17 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field18` field builder.
-    pub fn property_field18(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field18(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field18").expect(
             "LargeStructure.field18 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field19` field builder.
-    pub fn property_field19(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field19(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field19").expect(
             "LargeStructure.field19 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `field20` field builder.
-    pub fn property_field20(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field20(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field20").expect(
             "LargeStructure.field20 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `array1` field builder.
-    pub fn property_array1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_array1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("array1").expect(
             "LargeStructure.array1 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `array2` field builder.
-    pub fn property_array2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_array2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("array2").expect(
             "LargeStructure.array2 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `array3` field builder.
-    pub fn property_array3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_array3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("array3").expect(
             "LargeStructure.array3 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `array4` field builder.
-    pub fn property_array4(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_array4(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("array4").expect(
             "LargeStructure.array4 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `array5` field builder.
-    pub fn property_array5(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_array5(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("array5").expect(
             "LargeStructure.array5 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `map1` field builder.
-    pub fn property_map1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_map1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("map1").expect(
             "LargeStructure.map1 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `map2` field builder.
-    pub fn property_map2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_map2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("map2").expect(
             "LargeStructure.map2 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `map3` field builder.
-    pub fn property_map3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_map3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("map3").expect(
             "LargeStructure.map3 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `map4` field builder.
-    pub fn property_map4(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_map4(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("map4").expect(
             "LargeStructure.map4 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `map5` field builder.
-    pub fn property_map5(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_map5(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("map5").expect(
             "LargeStructure.map5 is statically defined in .baml and should always be present",
         )
@@ -602,22 +602,22 @@ impl LargeStructureClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MixedEdgeCasesClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MixedEdgeCasesClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("MixedEdgeCases is statically defined in .baml and should always have a type")
@@ -628,38 +628,38 @@ impl MixedEdgeCasesClassBuilder {
     // =========================================================================
 
     /// Access the `emptyString` field builder.
-    pub fn property_emptyString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_emptyString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("emptyString")
             .expect("MixedEdgeCases.emptyString is statically defined in .baml and should always be present")
     }
 
     /// Access the `singleChar` field builder.
-    pub fn property_singleChar(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_singleChar(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("singleChar").expect(
             "MixedEdgeCases.singleChar is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `veryLongArray` field builder.
-    pub fn property_veryLongArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_veryLongArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("veryLongArray")
             .expect("MixedEdgeCases.veryLongArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `deeplyNestedMap` field builder.
-    pub fn property_deeplyNestedMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_deeplyNestedMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("deeplyNestedMap")
             .expect("MixedEdgeCases.deeplyNestedMap is statically defined in .baml and should always be present")
     }
 
     /// Access the `mixedTypeArray` field builder.
-    pub fn property_mixedTypeArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mixedTypeArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mixedTypeArray")
             .expect("MixedEdgeCases.mixedTypeArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `optionalEverything` field builder.
-    pub fn property_optionalEverything(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optionalEverything(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optionalEverything")
             .expect("MixedEdgeCases.optionalEverything is statically defined in .baml and should always be present")
     }
@@ -671,22 +671,22 @@ impl MixedEdgeCasesClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NestedNullableClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NestedNullableClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("NestedNullable is statically defined in .baml and should always have a type")
@@ -697,7 +697,7 @@ impl NestedNullableClassBuilder {
     // =========================================================================
 
     /// Access the `outer` field builder.
-    pub fn property_outer(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_outer(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("outer").expect(
             "NestedNullable.outer is statically defined in .baml and should always be present",
         )
@@ -710,22 +710,22 @@ impl NestedNullableClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NullEdgeCasesClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NullEdgeCasesClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("NullEdgeCases is statically defined in .baml and should always have a type")
@@ -736,21 +736,21 @@ impl NullEdgeCasesClassBuilder {
     // =========================================================================
 
     /// Access the `allNull` field builder.
-    pub fn property_allNull(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_allNull(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("allNull").expect(
             "NullEdgeCases.allNull is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `someNull` field builder.
-    pub fn property_someNull(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_someNull(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("someNull").expect(
             "NullEdgeCases.someNull is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nestedNull` field builder.
-    pub fn property_nestedNull(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nestedNull(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nestedNull").expect(
             "NullEdgeCases.nestedNull is statically defined in .baml and should always be present",
         )
@@ -763,22 +763,22 @@ impl NullEdgeCasesClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NumberEdgeCasesClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NumberEdgeCasesClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("NumberEdgeCases is statically defined in .baml and should always have a type")
@@ -789,64 +789,64 @@ impl NumberEdgeCasesClassBuilder {
     // =========================================================================
 
     /// Access the `zero` field builder.
-    pub fn property_zero(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_zero(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("zero").expect(
             "NumberEdgeCases.zero is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `negativeInt` field builder.
-    pub fn property_negativeInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_negativeInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("negativeInt")
             .expect("NumberEdgeCases.negativeInt is statically defined in .baml and should always be present")
     }
 
     /// Access the `largeInt` field builder.
-    pub fn property_largeInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_largeInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("largeInt").expect(
             "NumberEdgeCases.largeInt is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `veryLargeInt` field builder.
-    pub fn property_veryLargeInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_veryLargeInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("veryLargeInt")
             .expect("NumberEdgeCases.veryLargeInt is statically defined in .baml and should always be present")
     }
 
     /// Access the `smallFloat` field builder.
-    pub fn property_smallFloat(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_smallFloat(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("smallFloat")
             .expect("NumberEdgeCases.smallFloat is statically defined in .baml and should always be present")
     }
 
     /// Access the `largeFloat` field builder.
-    pub fn property_largeFloat(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_largeFloat(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("largeFloat")
             .expect("NumberEdgeCases.largeFloat is statically defined in .baml and should always be present")
     }
 
     /// Access the `negativeFloat` field builder.
-    pub fn property_negativeFloat(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_negativeFloat(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("negativeFloat")
             .expect("NumberEdgeCases.negativeFloat is statically defined in .baml and should always be present")
     }
 
     /// Access the `scientificNotation` field builder.
-    pub fn property_scientificNotation(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_scientificNotation(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("scientificNotation")
             .expect("NumberEdgeCases.scientificNotation is statically defined in .baml and should always be present")
     }
 
     /// Access the `infinity` field builder.
-    pub fn property_infinity(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_infinity(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("infinity").expect(
             "NumberEdgeCases.infinity is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `notANumber` field builder.
-    pub fn property_notANumber(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_notANumber(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("notANumber")
             .expect("NumberEdgeCases.notANumber is statically defined in .baml and should always be present")
     }
@@ -858,22 +858,22 @@ impl NumberEdgeCasesClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OptionalEverythingClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OptionalEverythingClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "OptionalEverything is statically defined in .baml and should always have a type",
         )
@@ -884,45 +884,45 @@ impl OptionalEverythingClassBuilder {
     // =========================================================================
 
     /// Access the `optString` field builder.
-    pub fn property_optString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optString")
             .expect("OptionalEverything.optString is statically defined in .baml and should always be present")
     }
 
     /// Access the `optInt` field builder.
-    pub fn property_optInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optInt").expect(
             "OptionalEverything.optInt is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `optFloat` field builder.
-    pub fn property_optFloat(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optFloat(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optFloat")
             .expect("OptionalEverything.optFloat is statically defined in .baml and should always be present")
     }
 
     /// Access the `optBool` field builder.
-    pub fn property_optBool(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optBool(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optBool")
             .expect("OptionalEverything.optBool is statically defined in .baml and should always be present")
     }
 
     /// Access the `optArray` field builder.
-    pub fn property_optArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optArray")
             .expect("OptionalEverything.optArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `optMap` field builder.
-    pub fn property_optMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optMap").expect(
             "OptionalEverything.optMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `optObject` field builder.
-    pub fn property_optObject(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optObject(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optObject")
             .expect("OptionalEverything.optObject is statically defined in .baml and should always be present")
     }
@@ -934,22 +934,22 @@ impl OptionalEverythingClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OuterNullableClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OuterNullableClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("OuterNullable is statically defined in .baml and should always have a type")
@@ -960,7 +960,7 @@ impl OuterNullableClassBuilder {
     // =========================================================================
 
     /// Access the `inner` field builder.
-    pub fn property_inner(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_inner(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("inner").expect(
             "OuterNullable.inner is statically defined in .baml and should always be present",
         )
@@ -973,22 +973,22 @@ impl OuterNullableClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SomeNullableClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SomeNullableClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SomeNullable is statically defined in .baml and should always have a type")
@@ -999,27 +999,27 @@ impl SomeNullableClassBuilder {
     // =========================================================================
 
     /// Access the `presentString` field builder.
-    pub fn property_presentString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_presentString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("presentString")
             .expect("SomeNullable.presentString is statically defined in .baml and should always be present")
     }
 
     /// Access the `nullString` field builder.
-    pub fn property_nullString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullString").expect(
             "SomeNullable.nullString is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `presentInt` field builder.
-    pub fn property_presentInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_presentInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("presentInt").expect(
             "SomeNullable.presentInt is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullInt` field builder.
-    pub fn property_nullInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullInt").expect(
             "SomeNullable.nullInt is statically defined in .baml and should always be present",
         )
@@ -1032,22 +1032,22 @@ impl SomeNullableClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SpecialCharactersClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SpecialCharactersClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "SpecialCharacters is statically defined in .baml and should always have a type",
         )
@@ -1058,49 +1058,49 @@ impl SpecialCharactersClassBuilder {
     // =========================================================================
 
     /// Access the `normalText` field builder.
-    pub fn property_normalText(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_normalText(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("normalText")
             .expect("SpecialCharacters.normalText is statically defined in .baml and should always be present")
     }
 
     /// Access the `withNewlines` field builder.
-    pub fn property_withNewlines(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_withNewlines(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("withNewlines")
             .expect("SpecialCharacters.withNewlines is statically defined in .baml and should always be present")
     }
 
     /// Access the `withTabs` field builder.
-    pub fn property_withTabs(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_withTabs(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("withTabs")
             .expect("SpecialCharacters.withTabs is statically defined in .baml and should always be present")
     }
 
     /// Access the `withQuotes` field builder.
-    pub fn property_withQuotes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_withQuotes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("withQuotes")
             .expect("SpecialCharacters.withQuotes is statically defined in .baml and should always be present")
     }
 
     /// Access the `withBackslashes` field builder.
-    pub fn property_withBackslashes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_withBackslashes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("withBackslashes")
             .expect("SpecialCharacters.withBackslashes is statically defined in .baml and should always be present")
     }
 
     /// Access the `withUnicode` field builder.
-    pub fn property_withUnicode(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_withUnicode(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("withUnicode")
             .expect("SpecialCharacters.withUnicode is statically defined in .baml and should always be present")
     }
 
     /// Access the `withEmoji` field builder.
-    pub fn property_withEmoji(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_withEmoji(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("withEmoji")
             .expect("SpecialCharacters.withEmoji is statically defined in .baml and should always be present")
     }
 
     /// Access the `withMixedSpecial` field builder.
-    pub fn property_withMixedSpecial(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_withMixedSpecial(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("withMixedSpecial")
             .expect("SpecialCharacters.withMixedSpecial is statically defined in .baml and should always be present")
     }
@@ -1112,22 +1112,22 @@ impl SpecialCharactersClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("User is statically defined in .baml and should always have a type")
@@ -1138,14 +1138,14 @@ impl UserClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("User.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("User.name is statically defined in .baml and should always be present")
@@ -1158,22 +1158,22 @@ impl UserClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct VeryLongStringsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl VeryLongStringsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("VeryLongStrings is statically defined in .baml and should always have a type")
@@ -1184,31 +1184,31 @@ impl VeryLongStringsClassBuilder {
     // =========================================================================
 
     /// Access the `shortString` field builder.
-    pub fn property_shortString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_shortString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("shortString")
             .expect("VeryLongStrings.shortString is statically defined in .baml and should always be present")
     }
 
     /// Access the `mediumString` field builder.
-    pub fn property_mediumString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mediumString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mediumString")
             .expect("VeryLongStrings.mediumString is statically defined in .baml and should always be present")
     }
 
     /// Access the `longString` field builder.
-    pub fn property_longString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_longString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("longString")
             .expect("VeryLongStrings.longString is statically defined in .baml and should always be present")
     }
 
     /// Access the `veryLongString` field builder.
-    pub fn property_veryLongString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_veryLongString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("veryLongString")
             .expect("VeryLongStrings.veryLongString is statically defined in .baml and should always be present")
     }
 
     /// Access the `extremelyLongString` field builder.
-    pub fn property_extremelyLongString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_extremelyLongString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("extremelyLongString")
             .expect("VeryLongStrings.extremelyLongString is statically defined in .baml and should always be present")
     }

--- a/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -212,27 +210,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -241,17 +239,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -260,22 +258,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -284,12 +282,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -298,17 +296,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -317,29 +318,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/types/classes.rs
@@ -6,378 +6,297 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AllNullable {
     pub nullString: Option<String>,
-
     pub nullInt: Option<i64>,
-
     pub nullFloat: Option<f64>,
-
     pub nullBool: Option<bool>,
-
     pub nullArray: Option<Vec<String>>,
-
     pub nullObject: Option<User>,
 }
 
-impl AsRef<AllNullable> for AllNullable {
+impl ::std::convert::AsRef<AllNullable> for AllNullable {
     fn as_ref(&self) -> &AllNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BooleanEdgeCases {
     pub explicitTrue: bool,
-
     pub explicitFalse: bool,
-
     pub arrayOfTrue: Vec<bool>,
-
     pub arrayOfFalse: Vec<bool>,
-
     pub mixedBoolArray: Vec<bool>,
 }
 
-impl AsRef<BooleanEdgeCases> for BooleanEdgeCases {
+impl ::std::convert::AsRef<BooleanEdgeCases> for BooleanEdgeCases {
     fn as_ref(&self) -> &BooleanEdgeCases {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CircularReference {
     pub id: i64,
-
     pub name: String,
-
     pub parent: Option<Box<CircularReference>>,
-
     pub children: Vec<Box<CircularReference>>,
-
     pub relatedItems: Vec<Box<CircularReference>>,
 }
 
-impl AsRef<CircularReference> for CircularReference {
+impl ::std::convert::AsRef<CircularReference> for CircularReference {
     fn as_ref(&self) -> &CircularReference {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DeepRecursion {
     pub value: String,
-
     pub next: Option<Box<DeepRecursion>>,
 }
 
-impl AsRef<DeepRecursion> for DeepRecursion {
+impl ::std::convert::AsRef<DeepRecursion> for DeepRecursion {
     fn as_ref(&self) -> &DeepRecursion {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct EmptyCollections {
     pub emptyStringArray: Vec<String>,
-
     pub emptyIntArray: Vec<i64>,
-
     pub emptyObjectArray: Vec<User>,
-
     pub emptyMap: std::collections::HashMap<String, String>,
-
     pub emptyNestedArray: Vec<Vec<String>>,
 }
 
-impl AsRef<EmptyCollections> for EmptyCollections {
+impl ::std::convert::AsRef<EmptyCollections> for EmptyCollections {
     fn as_ref(&self) -> &EmptyCollections {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InnerNullable {
     pub value: Option<String>,
 }
 
-impl AsRef<InnerNullable> for InnerNullable {
+impl ::std::convert::AsRef<InnerNullable> for InnerNullable {
     fn as_ref(&self) -> &InnerNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LargeStructure {
     pub field1: String,
-
     pub field2: String,
-
     pub field3: String,
-
     pub field4: String,
-
     pub field5: String,
-
     pub field6: i64,
-
     pub field7: i64,
-
     pub field8: i64,
-
     pub field9: i64,
-
     pub field10: i64,
-
     pub field11: f64,
-
     pub field12: f64,
-
     pub field13: f64,
-
     pub field14: f64,
-
     pub field15: f64,
-
     pub field16: bool,
-
     pub field17: bool,
-
     pub field18: bool,
-
     pub field19: bool,
-
     pub field20: bool,
-
     pub array1: Vec<String>,
-
     pub array2: Vec<i64>,
-
     pub array3: Vec<f64>,
-
     pub array4: Vec<bool>,
-
     pub array5: Vec<User>,
-
     pub map1: std::collections::HashMap<String, String>,
-
     pub map2: std::collections::HashMap<String, i64>,
-
     pub map3: std::collections::HashMap<String, f64>,
-
     pub map4: std::collections::HashMap<String, bool>,
-
     pub map5: std::collections::HashMap<String, User>,
 }
 
-impl AsRef<LargeStructure> for LargeStructure {
+impl ::std::convert::AsRef<LargeStructure> for LargeStructure {
     fn as_ref(&self) -> &LargeStructure {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedEdgeCases {
     pub emptyString: String,
-
     pub singleChar: String,
-
     pub veryLongArray: Vec<String>,
-
     pub deeplyNestedMap: std::collections::HashMap<
         String,
         std::collections::HashMap<String, std::collections::HashMap<String, String>>,
     >,
-
     pub mixedTypeArray: Vec<Option<Union3BoolOrIntOrString>>,
-
     pub optionalEverything: Option<OptionalEverything>,
 }
 
-impl AsRef<MixedEdgeCases> for MixedEdgeCases {
+impl ::std::convert::AsRef<MixedEdgeCases> for MixedEdgeCases {
     fn as_ref(&self) -> &MixedEdgeCases {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedNullable {
     pub outer: Option<OuterNullable>,
 }
 
-impl AsRef<NestedNullable> for NestedNullable {
+impl ::std::convert::AsRef<NestedNullable> for NestedNullable {
     fn as_ref(&self) -> &NestedNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NullEdgeCases {
     pub allNull: AllNullable,
-
     pub someNull: SomeNullable,
-
     pub nestedNull: NestedNullable,
 }
 
-impl AsRef<NullEdgeCases> for NullEdgeCases {
+impl ::std::convert::AsRef<NullEdgeCases> for NullEdgeCases {
     fn as_ref(&self) -> &NullEdgeCases {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NumberEdgeCases {
     pub zero: i64,
-
     pub negativeInt: i64,
-
     pub largeInt: i64,
-
     pub veryLargeInt: i64,
-
     pub smallFloat: f64,
-
     pub largeFloat: f64,
-
     pub negativeFloat: f64,
-
     pub scientificNotation: f64,
-
     pub infinity: Option<f64>,
-
     pub notANumber: Option<f64>,
 }
 
-impl AsRef<NumberEdgeCases> for NumberEdgeCases {
+impl ::std::convert::AsRef<NumberEdgeCases> for NumberEdgeCases {
     fn as_ref(&self) -> &NumberEdgeCases {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalEverything {
     pub optString: Option<String>,
-
     pub optInt: Option<i64>,
-
     pub optFloat: Option<f64>,
-
     pub optBool: Option<bool>,
-
     pub optArray: Option<Vec<String>>,
-
     pub optMap: Option<std::collections::HashMap<String, String>>,
-
     pub optObject: Option<User>,
 }
 
-impl AsRef<OptionalEverything> for OptionalEverything {
+impl ::std::convert::AsRef<OptionalEverything> for OptionalEverything {
     fn as_ref(&self) -> &OptionalEverything {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OuterNullable {
     pub inner: Option<InnerNullable>,
 }
 
-impl AsRef<OuterNullable> for OuterNullable {
+impl ::std::convert::AsRef<OuterNullable> for OuterNullable {
     fn as_ref(&self) -> &OuterNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SomeNullable {
     pub presentString: Option<String>,
-
     pub nullString: Option<String>,
-
     pub presentInt: Option<i64>,
-
     pub nullInt: Option<i64>,
 }
 
-impl AsRef<SomeNullable> for SomeNullable {
+impl ::std::convert::AsRef<SomeNullable> for SomeNullable {
     fn as_ref(&self) -> &SomeNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SpecialCharacters {
     pub normalText: String,
-
     pub withNewlines: String,
-
     pub withTabs: String,
-
     pub withQuotes: String,
-
     pub withBackslashes: String,
-
     pub withUnicode: String,
-
     pub withEmoji: String,
-
     pub withMixedSpecial: String,
 }
 
-impl AsRef<SpecialCharacters> for SpecialCharacters {
+impl ::std::convert::AsRef<SpecialCharacters> for SpecialCharacters {
     fn as_ref(&self) -> &SpecialCharacters {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: i64,
-
     pub name: String,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct VeryLongStrings {
     pub shortString: String,
-
     pub mediumString: String,
-
     pub longString: String,
-
     pub veryLongString: String,
-
     pub extremelyLongString: String,
 }
 
-impl AsRef<VeryLongStrings> for VeryLongStrings {
+impl ::std::convert::AsRef<VeryLongStrings> for VeryLongStrings {
     fn as_ref(&self) -> &VeryLongStrings {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     AllNullable(AllNullable),
 
@@ -61,7 +63,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -103,5 +105,15 @@ impl baml::KnownTypes for Types {
 
             Types::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/types/mod.rs
@@ -62,48 +62,48 @@ pub enum Types {
     Union3BoolOrIntOrString(Union3BoolOrIntOrString),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::AllNullable(_) => "AllNullable",
+            Self::AllNullable(_) => "AllNullable",
 
-            Types::BooleanEdgeCases(_) => "BooleanEdgeCases",
+            Self::BooleanEdgeCases(_) => "BooleanEdgeCases",
 
-            Types::CircularReference(_) => "CircularReference",
+            Self::CircularReference(_) => "CircularReference",
 
-            Types::DeepRecursion(_) => "DeepRecursion",
+            Self::DeepRecursion(_) => "DeepRecursion",
 
-            Types::EmptyCollections(_) => "EmptyCollections",
+            Self::EmptyCollections(_) => "EmptyCollections",
 
-            Types::InnerNullable(_) => "InnerNullable",
+            Self::InnerNullable(_) => "InnerNullable",
 
-            Types::LargeStructure(_) => "LargeStructure",
+            Self::LargeStructure(_) => "LargeStructure",
 
-            Types::MixedEdgeCases(_) => "MixedEdgeCases",
+            Self::MixedEdgeCases(_) => "MixedEdgeCases",
 
-            Types::NestedNullable(_) => "NestedNullable",
+            Self::NestedNullable(_) => "NestedNullable",
 
-            Types::NullEdgeCases(_) => "NullEdgeCases",
+            Self::NullEdgeCases(_) => "NullEdgeCases",
 
-            Types::NumberEdgeCases(_) => "NumberEdgeCases",
+            Self::NumberEdgeCases(_) => "NumberEdgeCases",
 
-            Types::OptionalEverything(_) => "OptionalEverything",
+            Self::OptionalEverything(_) => "OptionalEverything",
 
-            Types::OuterNullable(_) => "OuterNullable",
+            Self::OuterNullable(_) => "OuterNullable",
 
-            Types::SomeNullable(_) => "SomeNullable",
+            Self::SomeNullable(_) => "SomeNullable",
 
-            Types::SpecialCharacters(_) => "SpecialCharacters",
+            Self::SpecialCharacters(_) => "SpecialCharacters",
 
-            Types::User(_) => "User",
+            Self::User(_) => "User",
 
-            Types::VeryLongStrings(_) => "VeryLongStrings",
+            Self::VeryLongStrings(_) => "VeryLongStrings",
 
-            Types::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
+            Self::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/edge_cases/baml_client/types/unions.rs
@@ -6,11 +6,15 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (string | int | bool | null)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BoolOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -22,14 +26,14 @@ pub enum Union3BoolOrIntOrString {
     Bool(bool),
 }
 
-impl AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
+impl ::std::convert::AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
     fn as_ref(&self) -> &Union3BoolOrIntOrString {
         self
     }
 }
 
-impl Default for Union3BoolOrIntOrString {
+impl ::std::default::Default for Union3BoolOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/enums/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/enums/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/enums/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/enums/baml_client/stream_types/mod.rs
@@ -15,12 +15,15 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {}
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -28,5 +31,15 @@ impl baml::KnownTypes for StreamTypes {
         match self {
             _ => unreachable!("StreamTypes has no variants"),
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/enums/baml_client/type_builder/enums.rs
+++ b/engine/generators/languages/rust/generated_tests/enums/baml_client/type_builder/enums.rs
@@ -11,22 +11,22 @@
 /// Access values via methods: `builder.ValueName()`
 
 pub struct TestEnumEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl TestEnumEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("TestEnum is statically defined in .baml and should always have a type")
@@ -37,49 +37,49 @@ impl TestEnumEnumBuilder {
     // =========================================================================
 
     /// Access the `Angry` value builder.
-    pub fn value_Angry(&self) -> baml::EnumValueBuilder {
+    pub fn value_Angry(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Angry")
             .expect("TestEnum.Angry is statically defined in .baml and should always be present")
     }
 
     /// Access the `Happy` value builder.
-    pub fn value_Happy(&self) -> baml::EnumValueBuilder {
+    pub fn value_Happy(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Happy")
             .expect("TestEnum.Happy is statically defined in .baml and should always be present")
     }
 
     /// Access the `Sad` value builder.
-    pub fn value_Sad(&self) -> baml::EnumValueBuilder {
+    pub fn value_Sad(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Sad")
             .expect("TestEnum.Sad is statically defined in .baml and should always be present")
     }
 
     /// Access the `Confused` value builder.
-    pub fn value_Confused(&self) -> baml::EnumValueBuilder {
+    pub fn value_Confused(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Confused")
             .expect("TestEnum.Confused is statically defined in .baml and should always be present")
     }
 
     /// Access the `Excited` value builder.
-    pub fn value_Excited(&self) -> baml::EnumValueBuilder {
+    pub fn value_Excited(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Excited")
             .expect("TestEnum.Excited is statically defined in .baml and should always be present")
     }
 
     /// Access the `Exclamation` value builder.
-    pub fn value_Exclamation(&self) -> baml::EnumValueBuilder {
+    pub fn value_Exclamation(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("Exclamation").expect(
             "TestEnum.Exclamation is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `Bored` value builder.
-    pub fn value_Bored(&self) -> baml::EnumValueBuilder {
+    pub fn value_Bored(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Bored")
             .expect("TestEnum.Bored is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/enums/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/enums/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -68,27 +66,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -97,17 +95,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -116,22 +114,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -140,12 +138,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -154,17 +152,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -173,29 +174,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/enums/baml_client/types/enums.rs
+++ b/engine/generators/languages/rust/generated_tests/enums/baml_client/types/enums.rs
@@ -5,10 +5,13 @@
 
 //! Generated enum types.
 
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum TestEnum {
     Angry,
 
@@ -25,14 +28,14 @@ pub enum TestEnum {
     Bored,
 }
 
-impl Default for TestEnum {
+impl ::std::default::Default for TestEnum {
     fn default() -> Self {
         Self::Angry
     }
 }
 
-impl std::fmt::Display for TestEnum {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for TestEnum {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::Angry => write!(f, "Angry"),
 
@@ -51,31 +54,31 @@ impl std::fmt::Display for TestEnum {
     }
 }
 
-impl std::str::FromStr for TestEnum {
+impl ::std::str::FromStr for TestEnum {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Angry" => Ok(Self::Angry),
+            "Angry" => ::std::result::Result::Ok(Self::ANGRY),
 
-            "Happy" => Ok(Self::Happy),
+            "Happy" => ::std::result::Result::Ok(Self::HAPPY),
 
-            "Sad" => Ok(Self::Sad),
+            "Sad" => ::std::result::Result::Ok(Self::SAD),
 
-            "Confused" => Ok(Self::Confused),
+            "Confused" => ::std::result::Result::Ok(Self::CONFUSED),
 
-            "Excited" => Ok(Self::Excited),
+            "Excited" => ::std::result::Result::Ok(Self::EXCITED),
 
-            "Exclamation" => Ok(Self::Exclamation),
+            "Exclamation" => ::std::result::Result::Ok(Self::EXCLAMATION),
 
-            "Bored" => Ok(Self::Bored),
+            "Bored" => ::std::result::Result::Ok(Self::BORED),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<TestEnum> for TestEnum {
+impl ::std::convert::AsRef<TestEnum> for TestEnum {
     fn as_ref(&self) -> &TestEnum {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/enums/baml_client/types/enums.rs
+++ b/engine/generators/languages/rust/generated_tests/enums/baml_client/types/enums.rs
@@ -59,19 +59,19 @@ impl ::std::str::FromStr for TestEnum {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Angry" => ::std::result::Result::Ok(Self::ANGRY),
+            "Angry" => ::std::result::Result::Ok(Self::Angry),
 
-            "Happy" => ::std::result::Result::Ok(Self::HAPPY),
+            "Happy" => ::std::result::Result::Ok(Self::Happy),
 
-            "Sad" => ::std::result::Result::Ok(Self::SAD),
+            "Sad" => ::std::result::Result::Ok(Self::Sad),
 
-            "Confused" => ::std::result::Result::Ok(Self::CONFUSED),
+            "Confused" => ::std::result::Result::Ok(Self::Confused),
 
-            "Excited" => ::std::result::Result::Ok(Self::EXCITED),
+            "Excited" => ::std::result::Result::Ok(Self::Excited),
 
-            "Exclamation" => ::std::result::Result::Ok(Self::EXCLAMATION),
+            "Exclamation" => ::std::result::Result::Ok(Self::Exclamation),
 
-            "Bored" => ::std::result::Result::Ok(Self::BORED),
+            "Bored" => ::std::result::Result::Ok(Self::Bored),
 
             _ => ::std::result::Result::Err(()),
         }

--- a/engine/generators/languages/rust/generated_tests/enums/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/enums/baml_client/types/mod.rs
@@ -16,18 +16,20 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     TestEnum(TestEnum),
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -35,5 +37,15 @@ impl baml::KnownTypes for Types {
         match self {
             Types::TestEnum(_) => "TestEnum",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/enums/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/enums/baml_client/types/mod.rs
@@ -28,14 +28,14 @@ pub enum Types {
     TestEnum(TestEnum),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::TestEnum(_) => "TestEnum",
+            Self::TestEnum(_) => "TestEnum",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/literal_types/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/literal_types/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/literal_types/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/literal_types/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BooleanLiterals {
     pub alwaysTrue: Option<bool>,
 
@@ -22,14 +22,14 @@ pub struct BooleanLiterals {
     pub eitherBool: Option<types::Union2BoolKFalseOrBoolKTrue>,
 }
 
-impl AsRef<BooleanLiterals> for BooleanLiterals {
+impl ::std::convert::AsRef<BooleanLiterals> for BooleanLiterals {
     fn as_ref(&self) -> &BooleanLiterals {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexLiterals {
     pub state: Option<types::Union4KarchivedOrKdeletedOrKdraftOrKpublished>,
 
@@ -42,14 +42,14 @@ pub struct ComplexLiterals {
     pub codes: Vec<types::Union3IntK200OrIntK404OrIntK500>,
 }
 
-impl AsRef<ComplexLiterals> for ComplexLiterals {
+impl ::std::convert::AsRef<ComplexLiterals> for ComplexLiterals {
     fn as_ref(&self) -> &ComplexLiterals {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct IntegerLiterals {
     pub priority: Option<types::Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5>,
 
@@ -58,14 +58,14 @@ pub struct IntegerLiterals {
     pub maxRetries: Option<types::Union4IntK0OrIntK1OrIntK3OrIntK5>,
 }
 
-impl AsRef<IntegerLiterals> for IntegerLiterals {
+impl ::std::convert::AsRef<IntegerLiterals> for IntegerLiterals {
     fn as_ref(&self) -> &IntegerLiterals {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedLiterals {
     pub id: Option<i64>,
 
@@ -79,14 +79,14 @@ pub struct MixedLiterals {
     pub apiVersion: Option<types::Union3Kv1OrKv2OrKv3>,
 }
 
-impl AsRef<MixedLiterals> for MixedLiterals {
+impl ::std::convert::AsRef<MixedLiterals> for MixedLiterals {
     fn as_ref(&self) -> &MixedLiterals {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct StringLiterals {
     pub status: Option<types::Union3KactiveOrKinactiveOrKpending>,
 
@@ -95,7 +95,7 @@ pub struct StringLiterals {
     pub method: Option<types::Union4KDELETEOrKGETOrKPOSTOrKPUT>,
 }
 
-impl AsRef<StringLiterals> for StringLiterals {
+impl ::std::convert::AsRef<StringLiterals> for StringLiterals {
     fn as_ref(&self) -> &StringLiterals {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/literal_types/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/literal_types/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     BooleanLiterals(BooleanLiterals),
 
@@ -30,7 +33,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -46,5 +49,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::StringLiterals(_) => "StringLiterals",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/literal_types/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/literal_types/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BooleanLiteralsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BooleanLiteralsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("BooleanLiterals is statically defined in .baml and should always have a type")
@@ -37,19 +37,19 @@ impl BooleanLiteralsClassBuilder {
     // =========================================================================
 
     /// Access the `alwaysTrue` field builder.
-    pub fn property_alwaysTrue(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_alwaysTrue(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("alwaysTrue")
             .expect("BooleanLiterals.alwaysTrue is statically defined in .baml and should always be present")
     }
 
     /// Access the `alwaysFalse` field builder.
-    pub fn property_alwaysFalse(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_alwaysFalse(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("alwaysFalse")
             .expect("BooleanLiterals.alwaysFalse is statically defined in .baml and should always be present")
     }
 
     /// Access the `eitherBool` field builder.
-    pub fn property_eitherBool(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_eitherBool(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("eitherBool")
             .expect("BooleanLiterals.eitherBool is statically defined in .baml and should always be present")
     }
@@ -61,22 +61,22 @@ impl BooleanLiteralsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ComplexLiteralsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ComplexLiteralsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ComplexLiterals is statically defined in .baml and should always have a type")
@@ -87,34 +87,34 @@ impl ComplexLiteralsClassBuilder {
     // =========================================================================
 
     /// Access the `state` field builder.
-    pub fn property_state(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_state(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("state").expect(
             "ComplexLiterals.state is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `retryCount` field builder.
-    pub fn property_retryCount(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_retryCount(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("retryCount")
             .expect("ComplexLiterals.retryCount is statically defined in .baml and should always be present")
     }
 
     /// Access the `response` field builder.
-    pub fn property_response(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_response(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("response").expect(
             "ComplexLiterals.response is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `flags` field builder.
-    pub fn property_flags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_flags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("flags").expect(
             "ComplexLiterals.flags is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `codes` field builder.
-    pub fn property_codes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_codes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("codes").expect(
             "ComplexLiterals.codes is statically defined in .baml and should always be present",
         )
@@ -127,22 +127,22 @@ impl ComplexLiteralsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct IntegerLiteralsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl IntegerLiteralsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("IntegerLiterals is statically defined in .baml and should always have a type")
@@ -153,20 +153,20 @@ impl IntegerLiteralsClassBuilder {
     // =========================================================================
 
     /// Access the `priority` field builder.
-    pub fn property_priority(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_priority(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("priority").expect(
             "IntegerLiterals.priority is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `httpStatus` field builder.
-    pub fn property_httpStatus(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_httpStatus(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("httpStatus")
             .expect("IntegerLiterals.httpStatus is statically defined in .baml and should always be present")
     }
 
     /// Access the `maxRetries` field builder.
-    pub fn property_maxRetries(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_maxRetries(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("maxRetries")
             .expect("IntegerLiterals.maxRetries is statically defined in .baml and should always be present")
     }
@@ -178,22 +178,22 @@ impl IntegerLiteralsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MixedLiteralsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MixedLiteralsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("MixedLiterals is statically defined in .baml and should always have a type")
@@ -204,35 +204,35 @@ impl MixedLiteralsClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("MixedLiterals.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("type").expect(
             "MixedLiterals.type is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `level` field builder.
-    pub fn property_level(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_level(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("level").expect(
             "MixedLiterals.level is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `isActive` field builder.
-    pub fn property_isActive(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_isActive(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("isActive").expect(
             "MixedLiterals.isActive is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `apiVersion` field builder.
-    pub fn property_apiVersion(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_apiVersion(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("apiVersion").expect(
             "MixedLiterals.apiVersion is statically defined in .baml and should always be present",
         )
@@ -245,22 +245,22 @@ impl MixedLiteralsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct StringLiteralsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl StringLiteralsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("StringLiterals is statically defined in .baml and should always have a type")
@@ -271,20 +271,20 @@ impl StringLiteralsClassBuilder {
     // =========================================================================
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("status").expect(
             "StringLiterals.status is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `environment` field builder.
-    pub fn property_environment(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_environment(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("environment")
             .expect("StringLiterals.environment is statically defined in .baml and should always be present")
     }
 
     /// Access the `method` field builder.
-    pub fn property_method(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_method(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("method").expect(
             "StringLiterals.method is statically defined in .baml and should always be present",
         )

--- a/engine/generators/languages/rust/generated_tests/literal_types/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/literal_types/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -104,27 +102,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -133,17 +131,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -152,22 +150,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -176,12 +174,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -190,17 +188,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -209,29 +210,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/literal_types/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/literal_types/baml_client/types/classes.rs
@@ -6,92 +6,82 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BooleanLiterals {
     pub alwaysTrue: bool,
-
     pub alwaysFalse: bool,
-
     pub eitherBool: Union2BoolKFalseOrBoolKTrue,
 }
 
-impl AsRef<BooleanLiterals> for BooleanLiterals {
+impl ::std::convert::AsRef<BooleanLiterals> for BooleanLiterals {
     fn as_ref(&self) -> &BooleanLiterals {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexLiterals {
     pub state: Union4KarchivedOrKdeletedOrKdraftOrKpublished,
-
     pub retryCount: Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8,
-
     pub response: Union3KerrorOrKsuccessOrKtimeout,
-
     pub flags: Vec<Union2BoolKFalseOrBoolKTrue>,
-
     pub codes: Vec<Union3IntK200OrIntK404OrIntK500>,
 }
 
-impl AsRef<ComplexLiterals> for ComplexLiterals {
+impl ::std::convert::AsRef<ComplexLiterals> for ComplexLiterals {
     fn as_ref(&self) -> &ComplexLiterals {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct IntegerLiterals {
     pub priority: Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5,
-
     pub httpStatus: Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500,
-
     pub maxRetries: Union4IntK0OrIntK1OrIntK3OrIntK5,
 }
 
-impl AsRef<IntegerLiterals> for IntegerLiterals {
+impl ::std::convert::AsRef<IntegerLiterals> for IntegerLiterals {
     fn as_ref(&self) -> &IntegerLiterals {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedLiterals {
     pub id: i64,
-
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: Union3KadminOrKguestOrKuser,
-
     pub level: Union3IntK1OrIntK2OrIntK3,
-
     pub isActive: Union2BoolKFalseOrBoolKTrue,
-
     pub apiVersion: Union3Kv1OrKv2OrKv3,
 }
 
-impl AsRef<MixedLiterals> for MixedLiterals {
+impl ::std::convert::AsRef<MixedLiterals> for MixedLiterals {
     fn as_ref(&self) -> &MixedLiterals {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct StringLiterals {
     pub status: Union3KactiveOrKinactiveOrKpending,
-
     pub environment: Union3KdevOrKprodOrKstaging,
-
     pub method: Union4KDELETEOrKGETOrKPOSTOrKPUT,
 }
 
-impl AsRef<StringLiterals> for StringLiterals {
+impl ::std::convert::AsRef<StringLiterals> for StringLiterals {
     fn as_ref(&self) -> &StringLiterals {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/literal_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/literal_types/baml_client/types/mod.rs
@@ -68,56 +68,56 @@ pub enum Types {
     ),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::BooleanLiterals(_) => "BooleanLiterals",
+            Self::BooleanLiterals(_) => "BooleanLiterals",
 
-            Types::ComplexLiterals(_) => "ComplexLiterals",
+            Self::ComplexLiterals(_) => "ComplexLiterals",
 
-            Types::IntegerLiterals(_) => "IntegerLiterals",
+            Self::IntegerLiterals(_) => "IntegerLiterals",
 
-            Types::MixedLiterals(_) => "MixedLiterals",
+            Self::MixedLiterals(_) => "MixedLiterals",
 
-            Types::StringLiterals(_) => "StringLiterals",
+            Self::StringLiterals(_) => "StringLiterals",
 
-            Types::Union2BoolKFalseOrBoolKTrue(_) => "Union2BoolKFalseOrBoolKTrue",
+            Self::Union2BoolKFalseOrBoolKTrue(_) => "Union2BoolKFalseOrBoolKTrue",
 
-            Types::Union3IntK1OrIntK2OrIntK3(_) => "Union3IntK1OrIntK2OrIntK3",
+            Self::Union3IntK1OrIntK2OrIntK3(_) => "Union3IntK1OrIntK2OrIntK3",
 
-            Types::Union3IntK200OrIntK404OrIntK500(_) => "Union3IntK200OrIntK404OrIntK500",
+            Self::Union3IntK200OrIntK404OrIntK500(_) => "Union3IntK200OrIntK404OrIntK500",
 
-            Types::Union3KactiveOrKinactiveOrKpending(_) => "Union3KactiveOrKinactiveOrKpending",
+            Self::Union3KactiveOrKinactiveOrKpending(_) => "Union3KactiveOrKinactiveOrKpending",
 
-            Types::Union3KadminOrKguestOrKuser(_) => "Union3KadminOrKguestOrKuser",
+            Self::Union3KadminOrKguestOrKuser(_) => "Union3KadminOrKguestOrKuser",
 
-            Types::Union3KdevOrKprodOrKstaging(_) => "Union3KdevOrKprodOrKstaging",
+            Self::Union3KdevOrKprodOrKstaging(_) => "Union3KdevOrKprodOrKstaging",
 
-            Types::Union3KerrorOrKsuccessOrKtimeout(_) => "Union3KerrorOrKsuccessOrKtimeout",
+            Self::Union3KerrorOrKsuccessOrKtimeout(_) => "Union3KerrorOrKsuccessOrKtimeout",
 
-            Types::Union3Kv1OrKv2OrKv3(_) => "Union3Kv1OrKv2OrKv3",
+            Self::Union3Kv1OrKv2OrKv3(_) => "Union3Kv1OrKv2OrKv3",
 
-            Types::Union4IntK0OrIntK1OrIntK3OrIntK5(_) => "Union4IntK0OrIntK1OrIntK3OrIntK5",
+            Self::Union4IntK0OrIntK1OrIntK3OrIntK5(_) => "Union4IntK0OrIntK1OrIntK3OrIntK5",
 
-            Types::Union4KDELETEOrKGETOrKPOSTOrKPUT(_) => "Union4KDELETEOrKGETOrKPOSTOrKPUT",
+            Self::Union4KDELETEOrKGETOrKPOSTOrKPUT(_) => "Union4KDELETEOrKGETOrKPOSTOrKPUT",
 
-            Types::Union4KarchivedOrKdeletedOrKdraftOrKpublished(_) => {
+            Self::Union4KarchivedOrKdeletedOrKdraftOrKpublished(_) => {
                 "Union4KarchivedOrKdeletedOrKdraftOrKpublished"
             }
 
-            Types::Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5(_) => {
+            Self::Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5(_) => {
                 "Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5"
             }
 
-            Types::Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500(_) => {
+            Self::Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500(_) => {
                 "Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500"
             }
 
-            Types::Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8(_) => {
+            Self::Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8(_) => {
                 "Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8"
             }
         }

--- a/engine/generators/languages/rust/generated_tests/literal_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/literal_types/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     BooleanLiterals(BooleanLiterals),
 
@@ -67,7 +69,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -119,5 +121,15 @@ impl baml::KnownTypes for Types {
                 "Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8"
             }
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/literal_types/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/literal_types/baml_client/types/unions.rs
@@ -6,289 +6,370 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (true | false)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2BoolKFalseOrBoolKTrue {
     #[baml(name = "bool_true", literal_bool = true)]
+    #[serde(with = "__baml_serde_union_literal_Union2BoolKFalseOrBoolKTrue::BoolKTrue")]
     BoolKTrue,
 
     #[baml(name = "bool_false", literal_bool = false)]
+    #[serde(with = "__baml_serde_union_literal_Union2BoolKFalseOrBoolKTrue::BoolKFalse")]
     BoolKFalse,
 }
 
-impl AsRef<Union2BoolKFalseOrBoolKTrue> for Union2BoolKFalseOrBoolKTrue {
+impl ::std::convert::AsRef<Union2BoolKFalseOrBoolKTrue> for Union2BoolKFalseOrBoolKTrue {
     fn as_ref(&self) -> &Union2BoolKFalseOrBoolKTrue {
         self
     }
 }
 
-impl Default for Union2BoolKFalseOrBoolKTrue {
+impl ::std::default::Default for Union2BoolKFalseOrBoolKTrue {
     fn default() -> Self {
         Self::BoolKTrue
     }
 }
 
 /// Generated from: (1 | 2 | 3)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3IntK1OrIntK2OrIntK3 {
     #[baml(name = "int_1", literal_int = 1)]
+    #[serde(with = "__baml_serde_union_literal_Union3IntK1OrIntK2OrIntK3::IntK1")]
     IntK1,
 
     #[baml(name = "int_2", literal_int = 2)]
+    #[serde(with = "__baml_serde_union_literal_Union3IntK1OrIntK2OrIntK3::IntK2")]
     IntK2,
 
     #[baml(name = "int_3", literal_int = 3)]
+    #[serde(with = "__baml_serde_union_literal_Union3IntK1OrIntK2OrIntK3::IntK3")]
     IntK3,
 }
 
-impl AsRef<Union3IntK1OrIntK2OrIntK3> for Union3IntK1OrIntK2OrIntK3 {
+impl ::std::convert::AsRef<Union3IntK1OrIntK2OrIntK3> for Union3IntK1OrIntK2OrIntK3 {
     fn as_ref(&self) -> &Union3IntK1OrIntK2OrIntK3 {
         self
     }
 }
 
-impl Default for Union3IntK1OrIntK2OrIntK3 {
+impl ::std::default::Default for Union3IntK1OrIntK2OrIntK3 {
     fn default() -> Self {
         Self::IntK1
     }
 }
 
 /// Generated from: (200 | 404 | 500)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3IntK200OrIntK404OrIntK500 {
     #[baml(name = "int_200", literal_int = 200)]
+    #[serde(with = "__baml_serde_union_literal_Union3IntK200OrIntK404OrIntK500::IntK200")]
     IntK200,
 
     #[baml(name = "int_404", literal_int = 404)]
+    #[serde(with = "__baml_serde_union_literal_Union3IntK200OrIntK404OrIntK500::IntK404")]
     IntK404,
 
     #[baml(name = "int_500", literal_int = 500)]
+    #[serde(with = "__baml_serde_union_literal_Union3IntK200OrIntK404OrIntK500::IntK500")]
     IntK500,
 }
 
-impl AsRef<Union3IntK200OrIntK404OrIntK500> for Union3IntK200OrIntK404OrIntK500 {
+impl ::std::convert::AsRef<Union3IntK200OrIntK404OrIntK500> for Union3IntK200OrIntK404OrIntK500 {
     fn as_ref(&self) -> &Union3IntK200OrIntK404OrIntK500 {
         self
     }
 }
 
-impl Default for Union3IntK200OrIntK404OrIntK500 {
+impl ::std::default::Default for Union3IntK200OrIntK404OrIntK500 {
     fn default() -> Self {
         Self::IntK200
     }
 }
 
 /// Generated from: ("active" | "inactive" | "pending")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KactiveOrKinactiveOrKpending {
     #[baml(name = "string_active", literal_string = "active")]
+    #[serde(with = "__baml_serde_union_literal_Union3KactiveOrKinactiveOrKpending::Kactive")]
     Kactive,
 
     #[baml(name = "string_inactive", literal_string = "inactive")]
+    #[serde(with = "__baml_serde_union_literal_Union3KactiveOrKinactiveOrKpending::Kinactive")]
     Kinactive,
 
     #[baml(name = "string_pending", literal_string = "pending")]
+    #[serde(with = "__baml_serde_union_literal_Union3KactiveOrKinactiveOrKpending::Kpending")]
     Kpending,
 }
 
-impl AsRef<Union3KactiveOrKinactiveOrKpending> for Union3KactiveOrKinactiveOrKpending {
+impl ::std::convert::AsRef<Union3KactiveOrKinactiveOrKpending>
+    for Union3KactiveOrKinactiveOrKpending
+{
     fn as_ref(&self) -> &Union3KactiveOrKinactiveOrKpending {
         self
     }
 }
 
-impl Default for Union3KactiveOrKinactiveOrKpending {
+impl ::std::default::Default for Union3KactiveOrKinactiveOrKpending {
     fn default() -> Self {
         Self::Kactive
     }
 }
 
 /// Generated from: ("user" | "admin" | "guest")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KadminOrKguestOrKuser {
     #[baml(name = "string_user", literal_string = "user")]
+    #[serde(with = "__baml_serde_union_literal_Union3KadminOrKguestOrKuser::Kuser")]
     Kuser,
 
     #[baml(name = "string_admin", literal_string = "admin")]
+    #[serde(with = "__baml_serde_union_literal_Union3KadminOrKguestOrKuser::Kadmin")]
     Kadmin,
 
     #[baml(name = "string_guest", literal_string = "guest")]
+    #[serde(with = "__baml_serde_union_literal_Union3KadminOrKguestOrKuser::Kguest")]
     Kguest,
 }
 
-impl AsRef<Union3KadminOrKguestOrKuser> for Union3KadminOrKguestOrKuser {
+impl ::std::convert::AsRef<Union3KadminOrKguestOrKuser> for Union3KadminOrKguestOrKuser {
     fn as_ref(&self) -> &Union3KadminOrKguestOrKuser {
         self
     }
 }
 
-impl Default for Union3KadminOrKguestOrKuser {
+impl ::std::default::Default for Union3KadminOrKguestOrKuser {
     fn default() -> Self {
         Self::Kuser
     }
 }
 
 /// Generated from: ("dev" | "staging" | "prod")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KdevOrKprodOrKstaging {
     #[baml(name = "string_dev", literal_string = "dev")]
+    #[serde(with = "__baml_serde_union_literal_Union3KdevOrKprodOrKstaging::Kdev")]
     Kdev,
 
     #[baml(name = "string_staging", literal_string = "staging")]
+    #[serde(with = "__baml_serde_union_literal_Union3KdevOrKprodOrKstaging::Kstaging")]
     Kstaging,
 
     #[baml(name = "string_prod", literal_string = "prod")]
+    #[serde(with = "__baml_serde_union_literal_Union3KdevOrKprodOrKstaging::Kprod")]
     Kprod,
 }
 
-impl AsRef<Union3KdevOrKprodOrKstaging> for Union3KdevOrKprodOrKstaging {
+impl ::std::convert::AsRef<Union3KdevOrKprodOrKstaging> for Union3KdevOrKprodOrKstaging {
     fn as_ref(&self) -> &Union3KdevOrKprodOrKstaging {
         self
     }
 }
 
-impl Default for Union3KdevOrKprodOrKstaging {
+impl ::std::default::Default for Union3KdevOrKprodOrKstaging {
     fn default() -> Self {
         Self::Kdev
     }
 }
 
 /// Generated from: ("success" | "error" | "timeout")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KerrorOrKsuccessOrKtimeout {
     #[baml(name = "string_success", literal_string = "success")]
+    #[serde(with = "__baml_serde_union_literal_Union3KerrorOrKsuccessOrKtimeout::Ksuccess")]
     Ksuccess,
 
     #[baml(name = "string_error", literal_string = "error")]
+    #[serde(with = "__baml_serde_union_literal_Union3KerrorOrKsuccessOrKtimeout::Kerror")]
     Kerror,
 
     #[baml(name = "string_timeout", literal_string = "timeout")]
+    #[serde(with = "__baml_serde_union_literal_Union3KerrorOrKsuccessOrKtimeout::Ktimeout")]
     Ktimeout,
 }
 
-impl AsRef<Union3KerrorOrKsuccessOrKtimeout> for Union3KerrorOrKsuccessOrKtimeout {
+impl ::std::convert::AsRef<Union3KerrorOrKsuccessOrKtimeout> for Union3KerrorOrKsuccessOrKtimeout {
     fn as_ref(&self) -> &Union3KerrorOrKsuccessOrKtimeout {
         self
     }
 }
 
-impl Default for Union3KerrorOrKsuccessOrKtimeout {
+impl ::std::default::Default for Union3KerrorOrKsuccessOrKtimeout {
     fn default() -> Self {
         Self::Ksuccess
     }
 }
 
 /// Generated from: ("v1" | "v2" | "v3")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3Kv1OrKv2OrKv3 {
     #[baml(name = "string_v1", literal_string = "v1")]
+    #[serde(with = "__baml_serde_union_literal_Union3Kv1OrKv2OrKv3::Kv1")]
     Kv1,
 
     #[baml(name = "string_v2", literal_string = "v2")]
+    #[serde(with = "__baml_serde_union_literal_Union3Kv1OrKv2OrKv3::Kv2")]
     Kv2,
 
     #[baml(name = "string_v3", literal_string = "v3")]
+    #[serde(with = "__baml_serde_union_literal_Union3Kv1OrKv2OrKv3::Kv3")]
     Kv3,
 }
 
-impl AsRef<Union3Kv1OrKv2OrKv3> for Union3Kv1OrKv2OrKv3 {
+impl ::std::convert::AsRef<Union3Kv1OrKv2OrKv3> for Union3Kv1OrKv2OrKv3 {
     fn as_ref(&self) -> &Union3Kv1OrKv2OrKv3 {
         self
     }
 }
 
-impl Default for Union3Kv1OrKv2OrKv3 {
+impl ::std::default::Default for Union3Kv1OrKv2OrKv3 {
     fn default() -> Self {
         Self::Kv1
     }
 }
 
 /// Generated from: (0 | 1 | 3 | 5)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4IntK0OrIntK1OrIntK3OrIntK5 {
     #[baml(name = "int_0", literal_int = 0)]
+    #[serde(with = "__baml_serde_union_literal_Union4IntK0OrIntK1OrIntK3OrIntK5::IntK0")]
     IntK0,
 
     #[baml(name = "int_1", literal_int = 1)]
+    #[serde(with = "__baml_serde_union_literal_Union4IntK0OrIntK1OrIntK3OrIntK5::IntK1")]
     IntK1,
 
     #[baml(name = "int_3", literal_int = 3)]
+    #[serde(with = "__baml_serde_union_literal_Union4IntK0OrIntK1OrIntK3OrIntK5::IntK3")]
     IntK3,
 
     #[baml(name = "int_5", literal_int = 5)]
+    #[serde(with = "__baml_serde_union_literal_Union4IntK0OrIntK1OrIntK3OrIntK5::IntK5")]
     IntK5,
 }
 
-impl AsRef<Union4IntK0OrIntK1OrIntK3OrIntK5> for Union4IntK0OrIntK1OrIntK3OrIntK5 {
+impl ::std::convert::AsRef<Union4IntK0OrIntK1OrIntK3OrIntK5> for Union4IntK0OrIntK1OrIntK3OrIntK5 {
     fn as_ref(&self) -> &Union4IntK0OrIntK1OrIntK3OrIntK5 {
         self
     }
 }
 
-impl Default for Union4IntK0OrIntK1OrIntK3OrIntK5 {
+impl ::std::default::Default for Union4IntK0OrIntK1OrIntK3OrIntK5 {
     fn default() -> Self {
         Self::IntK0
     }
 }
 
 /// Generated from: ("GET" | "POST" | "PUT" | "DELETE")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4KDELETEOrKGETOrKPOSTOrKPUT {
     #[baml(name = "string_GET", literal_string = "GET")]
+    #[serde(with = "__baml_serde_union_literal_Union4KDELETEOrKGETOrKPOSTOrKPUT::KGET")]
     KGET,
 
     #[baml(name = "string_POST", literal_string = "POST")]
+    #[serde(with = "__baml_serde_union_literal_Union4KDELETEOrKGETOrKPOSTOrKPUT::KPOST")]
     KPOST,
 
     #[baml(name = "string_PUT", literal_string = "PUT")]
+    #[serde(with = "__baml_serde_union_literal_Union4KDELETEOrKGETOrKPOSTOrKPUT::KPUT")]
     KPUT,
 
     #[baml(name = "string_DELETE", literal_string = "DELETE")]
+    #[serde(with = "__baml_serde_union_literal_Union4KDELETEOrKGETOrKPOSTOrKPUT::KDELETE")]
     KDELETE,
 }
 
-impl AsRef<Union4KDELETEOrKGETOrKPOSTOrKPUT> for Union4KDELETEOrKGETOrKPOSTOrKPUT {
+impl ::std::convert::AsRef<Union4KDELETEOrKGETOrKPOSTOrKPUT> for Union4KDELETEOrKGETOrKPOSTOrKPUT {
     fn as_ref(&self) -> &Union4KDELETEOrKGETOrKPOSTOrKPUT {
         self
     }
 }
 
-impl Default for Union4KDELETEOrKGETOrKPOSTOrKPUT {
+impl ::std::default::Default for Union4KDELETEOrKGETOrKPOSTOrKPUT {
     fn default() -> Self {
         Self::KGET
     }
 }
 
 /// Generated from: ("draft" | "published" | "archived" | "deleted")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4KarchivedOrKdeletedOrKdraftOrKpublished {
     #[baml(name = "string_draft", literal_string = "draft")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KarchivedOrKdeletedOrKdraftOrKpublished::Kdraft"
+    )]
     Kdraft,
 
     #[baml(name = "string_published", literal_string = "published")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KarchivedOrKdeletedOrKdraftOrKpublished::Kpublished"
+    )]
     Kpublished,
 
     #[baml(name = "string_archived", literal_string = "archived")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KarchivedOrKdeletedOrKdraftOrKpublished::Karchived"
+    )]
     Karchived,
 
     #[baml(name = "string_deleted", literal_string = "deleted")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KarchivedOrKdeletedOrKdraftOrKpublished::Kdeleted"
+    )]
     Kdeleted,
 }
 
-impl AsRef<Union4KarchivedOrKdeletedOrKdraftOrKpublished>
+impl ::std::convert::AsRef<Union4KarchivedOrKdeletedOrKdraftOrKpublished>
     for Union4KarchivedOrKdeletedOrKdraftOrKpublished
 {
     fn as_ref(&self) -> &Union4KarchivedOrKdeletedOrKdraftOrKpublished {
@@ -296,65 +377,93 @@ impl AsRef<Union4KarchivedOrKdeletedOrKdraftOrKpublished>
     }
 }
 
-impl Default for Union4KarchivedOrKdeletedOrKdraftOrKpublished {
+impl ::std::default::Default for Union4KarchivedOrKdeletedOrKdraftOrKpublished {
     fn default() -> Self {
         Self::Kdraft
     }
 }
 
 /// Generated from: (1 | 2 | 3 | 4 | 5)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
     #[baml(name = "int_1", literal_int = 1)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK1")]
     IntK1,
 
     #[baml(name = "int_2", literal_int = 2)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK2")]
     IntK2,
 
     #[baml(name = "int_3", literal_int = 3)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK3")]
     IntK3,
 
     #[baml(name = "int_4", literal_int = 4)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK4")]
     IntK4,
 
     #[baml(name = "int_5", literal_int = 5)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK5")]
     IntK5,
 }
 
-impl AsRef<Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5> for Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
+impl ::std::convert::AsRef<Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5>
+    for Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5
+{
     fn as_ref(&self) -> &Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
         self
     }
 }
 
-impl Default for Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
+impl ::std::default::Default for Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
     fn default() -> Self {
         Self::IntK1
     }
 }
 
 /// Generated from: (200 | 201 | 400 | 404 | 500)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500 {
     #[baml(name = "int_200", literal_int = 200)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500::IntK200"
+    )]
     IntK200,
 
     #[baml(name = "int_201", literal_int = 201)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500::IntK201"
+    )]
     IntK201,
 
     #[baml(name = "int_400", literal_int = 400)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500::IntK400"
+    )]
     IntK400,
 
     #[baml(name = "int_404", literal_int = 404)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500::IntK404"
+    )]
     IntK404,
 
     #[baml(name = "int_500", literal_int = 500)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500::IntK500"
+    )]
     IntK500,
 }
 
-impl AsRef<Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500>
+impl ::std::convert::AsRef<Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500>
     for Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500
 {
     fn as_ref(&self) -> &Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500 {
@@ -362,39 +471,63 @@ impl AsRef<Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500>
     }
 }
 
-impl Default for Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500 {
+impl ::std::default::Default for Union5IntK200OrIntK201OrIntK400OrIntK404OrIntK500 {
     fn default() -> Self {
         Self::IntK200
     }
 }
 
 /// Generated from: (0 | 1 | 2 | 3 | 5 | 8 | 13)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8 {
     #[baml(name = "int_0", literal_int = 0)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8::IntK0"
+    )]
     IntK0,
 
     #[baml(name = "int_1", literal_int = 1)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8::IntK1"
+    )]
     IntK1,
 
     #[baml(name = "int_2", literal_int = 2)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8::IntK2"
+    )]
     IntK2,
 
     #[baml(name = "int_3", literal_int = 3)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8::IntK3"
+    )]
     IntK3,
 
     #[baml(name = "int_5", literal_int = 5)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8::IntK5"
+    )]
     IntK5,
 
     #[baml(name = "int_8", literal_int = 8)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8::IntK8"
+    )]
     IntK8,
 
     #[baml(name = "int_13", literal_int = 13)]
+    #[serde(
+        with = "__baml_serde_union_literal_Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8::IntK13"
+    )]
     IntK13,
 }
 
-impl AsRef<Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8>
+impl ::std::convert::AsRef<Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8>
     for Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8
 {
     fn as_ref(&self) -> &Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8 {
@@ -402,7 +535,7 @@ impl AsRef<Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8>
     }
 }
 
-impl Default for Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8 {
+impl ::std::default::Default for Union7IntK0OrIntK1OrIntK13OrIntK2OrIntK3OrIntK5OrIntK8 {
     fn default() -> Self {
         Self::IntK0
     }

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexMaps {
     pub userMap: std::collections::HashMap<String, User>,
 
@@ -26,14 +26,14 @@ pub struct ComplexMaps {
     pub mapArray: Vec<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<ComplexMaps> for ComplexMaps {
+impl ::std::convert::AsRef<ComplexMaps> for ComplexMaps {
     fn as_ref(&self) -> &ComplexMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Config {
     pub url: Option<String>,
 
@@ -42,14 +42,14 @@ pub struct Config {
     pub debug: Option<bool>,
 }
 
-impl AsRef<Config> for Config {
+impl ::std::convert::AsRef<Config> for Config {
     fn as_ref(&self) -> &Config {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct EdgeCaseMaps {
     pub emptyMap: std::collections::HashMap<String, String>,
 
@@ -60,14 +60,14 @@ pub struct EdgeCaseMaps {
     pub unionValues: std::collections::HashMap<String, types::Union3BoolOrIntOrString>,
 }
 
-impl AsRef<EdgeCaseMaps> for EdgeCaseMaps {
+impl ::std::convert::AsRef<EdgeCaseMaps> for EdgeCaseMaps {
     fn as_ref(&self) -> &EdgeCaseMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedKeyMaps {
     pub stringIntMap: std::collections::HashMap<String, i64>,
 
@@ -78,14 +78,14 @@ pub struct MixedKeyMaps {
     pub literalMap: std::collections::HashMap<String, Config>,
 }
 
-impl AsRef<MixedKeyMaps> for MixedKeyMaps {
+impl ::std::convert::AsRef<MixedKeyMaps> for MixedKeyMaps {
     fn as_ref(&self) -> &MixedKeyMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedMaps {
     pub simple: std::collections::HashMap<String, String>,
 
@@ -101,14 +101,14 @@ pub struct NestedMaps {
     pub mapOfMaps: std::collections::HashMap<String, std::collections::HashMap<String, f64>>,
 }
 
-impl AsRef<NestedMaps> for NestedMaps {
+impl ::std::convert::AsRef<NestedMaps> for NestedMaps {
     fn as_ref(&self) -> &NestedMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Product {
     pub id: Option<i64>,
 
@@ -119,14 +119,14 @@ pub struct Product {
     pub tags: Vec<String>,
 }
 
-impl AsRef<Product> for Product {
+impl ::std::convert::AsRef<Product> for Product {
     fn as_ref(&self) -> &Product {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleMaps {
     pub stringToString: std::collections::HashMap<String, String>,
 
@@ -139,14 +139,14 @@ pub struct SimpleMaps {
     pub intToString: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<SimpleMaps> for SimpleMaps {
+impl ::std::convert::AsRef<SimpleMaps> for SimpleMaps {
     fn as_ref(&self) -> &SimpleMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: Option<i64>,
 
@@ -157,7 +157,7 @@ pub struct User {
     pub active: Option<bool>,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     ComplexMaps(ComplexMaps),
 
@@ -36,7 +39,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -58,5 +61,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::User(_) => "User",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ComplexMapsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ComplexMapsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ComplexMaps is statically defined in .baml and should always have a type")
@@ -37,35 +37,35 @@ impl ComplexMapsClassBuilder {
     // =========================================================================
 
     /// Access the `userMap` field builder.
-    pub fn property_userMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_userMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("userMap").expect(
             "ComplexMaps.userMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `productMap` field builder.
-    pub fn property_productMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_productMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("productMap").expect(
             "ComplexMaps.productMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nestedMap` field builder.
-    pub fn property_nestedMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nestedMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nestedMap").expect(
             "ComplexMaps.nestedMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `arrayMap` field builder.
-    pub fn property_arrayMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_arrayMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("arrayMap").expect(
             "ComplexMaps.arrayMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `mapArray` field builder.
-    pub fn property_mapArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mapArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mapArray").expect(
             "ComplexMaps.mapArray is statically defined in .baml and should always be present",
         )
@@ -78,22 +78,22 @@ impl ComplexMapsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ConfigClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ConfigClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Config is statically defined in .baml and should always have a type")
@@ -104,21 +104,21 @@ impl ConfigClassBuilder {
     // =========================================================================
 
     /// Access the `url` field builder.
-    pub fn property_url(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_url(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("url")
             .expect("Config.url is statically defined in .baml and should always be present")
     }
 
     /// Access the `port` field builder.
-    pub fn property_port(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_port(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("port")
             .expect("Config.port is statically defined in .baml and should always be present")
     }
 
     /// Access the `debug` field builder.
-    pub fn property_debug(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_debug(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("debug")
             .expect("Config.debug is statically defined in .baml and should always be present")
@@ -131,22 +131,22 @@ impl ConfigClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct EdgeCaseMapsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl EdgeCaseMapsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("EdgeCaseMaps is statically defined in .baml and should always have a type")
@@ -157,26 +157,26 @@ impl EdgeCaseMapsClassBuilder {
     // =========================================================================
 
     /// Access the `emptyMap` field builder.
-    pub fn property_emptyMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_emptyMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("emptyMap").expect(
             "EdgeCaseMaps.emptyMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullableValues` field builder.
-    pub fn property_nullableValues(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableValues(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableValues")
             .expect("EdgeCaseMaps.nullableValues is statically defined in .baml and should always be present")
     }
 
     /// Access the `optionalValues` field builder.
-    pub fn property_optionalValues(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optionalValues(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optionalValues")
             .expect("EdgeCaseMaps.optionalValues is statically defined in .baml and should always be present")
     }
 
     /// Access the `unionValues` field builder.
-    pub fn property_unionValues(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_unionValues(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("unionValues").expect(
             "EdgeCaseMaps.unionValues is statically defined in .baml and should always be present",
         )
@@ -189,22 +189,22 @@ impl EdgeCaseMapsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MixedKeyMapsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MixedKeyMapsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("MixedKeyMaps is statically defined in .baml and should always have a type")
@@ -215,28 +215,28 @@ impl MixedKeyMapsClassBuilder {
     // =========================================================================
 
     /// Access the `stringIntMap` field builder.
-    pub fn property_stringIntMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringIntMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringIntMap").expect(
             "MixedKeyMaps.stringIntMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `intStringMap` field builder.
-    pub fn property_intStringMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_intStringMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("intStringMap").expect(
             "MixedKeyMaps.intStringMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `enumMap` field builder.
-    pub fn property_enumMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_enumMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("enumMap").expect(
             "MixedKeyMaps.enumMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `literalMap` field builder.
-    pub fn property_literalMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_literalMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("literalMap").expect(
             "MixedKeyMaps.literalMap is statically defined in .baml and should always be present",
         )
@@ -249,22 +249,22 @@ impl MixedKeyMapsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NestedMapsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NestedMapsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("NestedMaps is statically defined in .baml and should always have a type")
@@ -275,35 +275,35 @@ impl NestedMapsClassBuilder {
     // =========================================================================
 
     /// Access the `simple` field builder.
-    pub fn property_simple(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_simple(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("simple")
             .expect("NestedMaps.simple is statically defined in .baml and should always be present")
     }
 
     /// Access the `oneLevelNested` field builder.
-    pub fn property_oneLevelNested(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_oneLevelNested(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("oneLevelNested").expect(
             "NestedMaps.oneLevelNested is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `twoLevelNested` field builder.
-    pub fn property_twoLevelNested(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_twoLevelNested(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("twoLevelNested").expect(
             "NestedMaps.twoLevelNested is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `mapOfArrays` field builder.
-    pub fn property_mapOfArrays(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mapOfArrays(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mapOfArrays").expect(
             "NestedMaps.mapOfArrays is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `mapOfMaps` field builder.
-    pub fn property_mapOfMaps(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mapOfMaps(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mapOfMaps").expect(
             "NestedMaps.mapOfMaps is statically defined in .baml and should always be present",
         )
@@ -316,22 +316,22 @@ impl NestedMapsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ProductClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ProductClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Product is statically defined in .baml and should always have a type")
@@ -342,28 +342,28 @@ impl ProductClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Product.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Product.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `price` field builder.
-    pub fn property_price(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_price(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("price")
             .expect("Product.price is statically defined in .baml and should always be present")
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tags")
             .expect("Product.tags is statically defined in .baml and should always be present")
@@ -376,22 +376,22 @@ impl ProductClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SimpleMapsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SimpleMapsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SimpleMaps is statically defined in .baml and should always have a type")
@@ -402,35 +402,35 @@ impl SimpleMapsClassBuilder {
     // =========================================================================
 
     /// Access the `stringToString` field builder.
-    pub fn property_stringToString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringToString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringToString").expect(
             "SimpleMaps.stringToString is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `stringToInt` field builder.
-    pub fn property_stringToInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringToInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringToInt").expect(
             "SimpleMaps.stringToInt is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `stringToFloat` field builder.
-    pub fn property_stringToFloat(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringToFloat(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringToFloat").expect(
             "SimpleMaps.stringToFloat is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `stringToBool` field builder.
-    pub fn property_stringToBool(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringToBool(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringToBool").expect(
             "SimpleMaps.stringToBool is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `intToString` field builder.
-    pub fn property_intToString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_intToString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("intToString").expect(
             "SimpleMaps.intToString is statically defined in .baml and should always be present",
         )
@@ -443,22 +443,22 @@ impl SimpleMapsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("User is statically defined in .baml and should always have a type")
@@ -469,28 +469,28 @@ impl UserClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("User.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("User.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `email` field builder.
-    pub fn property_email(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_email(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("email")
             .expect("User.email is statically defined in .baml and should always be present")
     }
 
     /// Access the `active` field builder.
-    pub fn property_active(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_active(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("active")
             .expect("User.active is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/type_builder/enums.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/type_builder/enums.rs
@@ -11,22 +11,22 @@
 /// Access values via methods: `builder.ValueName()`
 
 pub struct StatusEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl StatusEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Status is statically defined in .baml and should always have a type")
@@ -37,21 +37,21 @@ impl StatusEnumBuilder {
     // =========================================================================
 
     /// Access the `ACTIVE` value builder.
-    pub fn value_ACTIVE(&self) -> baml::EnumValueBuilder {
+    pub fn value_ACTIVE(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("ACTIVE")
             .expect("Status.ACTIVE is statically defined in .baml and should always be present")
     }
 
     /// Access the `INACTIVE` value builder.
-    pub fn value_INACTIVE(&self) -> baml::EnumValueBuilder {
+    pub fn value_INACTIVE(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("INACTIVE")
             .expect("Status.INACTIVE is statically defined in .baml and should always be present")
     }
 
     /// Access the `PENDING` value builder.
-    pub fn value_PENDING(&self) -> baml::EnumValueBuilder {
+    pub fn value_PENDING(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("PENDING")
             .expect("Status.PENDING is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -140,27 +138,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -169,17 +167,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -188,22 +186,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -212,12 +210,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -226,17 +224,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -245,29 +246,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/classes.rs
@@ -6,154 +6,131 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexMaps {
     pub userMap: std::collections::HashMap<String, User>,
-
     pub productMap: std::collections::HashMap<String, Product>,
-
     pub nestedMap: std::collections::HashMap<String, std::collections::HashMap<String, String>>,
-
     pub arrayMap: std::collections::HashMap<String, Vec<i64>>,
-
     pub mapArray: Vec<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<ComplexMaps> for ComplexMaps {
+impl ::std::convert::AsRef<ComplexMaps> for ComplexMaps {
     fn as_ref(&self) -> &ComplexMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Config {
     pub url: String,
-
     pub port: i64,
-
     pub debug: bool,
 }
 
-impl AsRef<Config> for Config {
+impl ::std::convert::AsRef<Config> for Config {
     fn as_ref(&self) -> &Config {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct EdgeCaseMaps {
     pub emptyMap: std::collections::HashMap<String, String>,
-
     pub nullableValues: std::collections::HashMap<String, Option<String>>,
-
     pub optionalValues: std::collections::HashMap<String, Option<String>>,
-
     pub unionValues: std::collections::HashMap<String, Union3BoolOrIntOrString>,
 }
 
-impl AsRef<EdgeCaseMaps> for EdgeCaseMaps {
+impl ::std::convert::AsRef<EdgeCaseMaps> for EdgeCaseMaps {
     fn as_ref(&self) -> &EdgeCaseMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedKeyMaps {
     pub stringIntMap: std::collections::HashMap<String, i64>,
-
     pub intStringMap: std::collections::HashMap<String, String>,
-
     pub enumMap: std::collections::HashMap<String, String>,
-
     pub literalMap: std::collections::HashMap<String, Config>,
 }
 
-impl AsRef<MixedKeyMaps> for MixedKeyMaps {
+impl ::std::convert::AsRef<MixedKeyMaps> for MixedKeyMaps {
     fn as_ref(&self) -> &MixedKeyMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedMaps {
     pub simple: std::collections::HashMap<String, String>,
-
     pub oneLevelNested: std::collections::HashMap<String, std::collections::HashMap<String, i64>>,
-
     pub twoLevelNested: std::collections::HashMap<
         String,
         std::collections::HashMap<String, std::collections::HashMap<String, bool>>,
     >,
-
     pub mapOfArrays: std::collections::HashMap<String, Vec<String>>,
-
     pub mapOfMaps: std::collections::HashMap<String, std::collections::HashMap<String, f64>>,
 }
 
-impl AsRef<NestedMaps> for NestedMaps {
+impl ::std::convert::AsRef<NestedMaps> for NestedMaps {
     fn as_ref(&self) -> &NestedMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Product {
     pub id: i64,
-
     pub name: String,
-
     pub price: f64,
-
     pub tags: Vec<String>,
 }
 
-impl AsRef<Product> for Product {
+impl ::std::convert::AsRef<Product> for Product {
     fn as_ref(&self) -> &Product {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleMaps {
     pub stringToString: std::collections::HashMap<String, String>,
-
     pub stringToInt: std::collections::HashMap<String, i64>,
-
     pub stringToFloat: std::collections::HashMap<String, f64>,
-
     pub stringToBool: std::collections::HashMap<String, bool>,
-
     pub intToString: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<SimpleMaps> for SimpleMaps {
+impl ::std::convert::AsRef<SimpleMaps> for SimpleMaps {
     fn as_ref(&self) -> &SimpleMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: i64,
-
     pub name: String,
-
     pub email: String,
-
     pub active: bool,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/enums.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/enums.rs
@@ -5,10 +5,13 @@
 
 //! Generated enum types.
 
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Status {
     ACTIVE,
 
@@ -17,14 +20,14 @@ pub enum Status {
     PENDING,
 }
 
-impl Default for Status {
+impl ::std::default::Default for Status {
     fn default() -> Self {
         Self::ACTIVE
     }
 }
 
-impl std::fmt::Display for Status {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Status {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::ACTIVE => write!(f, "ACTIVE"),
 
@@ -35,23 +38,23 @@ impl std::fmt::Display for Status {
     }
 }
 
-impl std::str::FromStr for Status {
+impl ::std::str::FromStr for Status {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "ACTIVE" => Ok(Self::ACTIVE),
+            "ACTIVE" => ::std::result::Result::Ok(Self::ACTIVE),
 
-            "INACTIVE" => Ok(Self::INACTIVE),
+            "INACTIVE" => ::std::result::Result::Ok(Self::INACTIVE),
 
-            "PENDING" => Ok(Self::PENDING),
+            "PENDING" => ::std::result::Result::Ok(Self::PENDING),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<Status> for Status {
+impl ::std::convert::AsRef<Status> for Status {
     fn as_ref(&self) -> &Status {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     ComplexMaps(ComplexMaps),
 
@@ -45,7 +47,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -71,5 +73,15 @@ impl baml::KnownTypes for Types {
 
             Types::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/mod.rs
@@ -46,32 +46,32 @@ pub enum Types {
     Union3BoolOrIntOrString(Union3BoolOrIntOrString),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::ComplexMaps(_) => "ComplexMaps",
+            Self::ComplexMaps(_) => "ComplexMaps",
 
-            Types::Config(_) => "Config",
+            Self::Config(_) => "Config",
 
-            Types::EdgeCaseMaps(_) => "EdgeCaseMaps",
+            Self::EdgeCaseMaps(_) => "EdgeCaseMaps",
 
-            Types::MixedKeyMaps(_) => "MixedKeyMaps",
+            Self::MixedKeyMaps(_) => "MixedKeyMaps",
 
-            Types::NestedMaps(_) => "NestedMaps",
+            Self::NestedMaps(_) => "NestedMaps",
 
-            Types::Product(_) => "Product",
+            Self::Product(_) => "Product",
 
-            Types::SimpleMaps(_) => "SimpleMaps",
+            Self::SimpleMaps(_) => "SimpleMaps",
 
-            Types::User(_) => "User",
+            Self::User(_) => "User",
 
-            Types::Status(_) => "Status",
+            Self::Status(_) => "Status",
 
-            Types::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
+            Self::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/map_types/baml_client/types/unions.rs
@@ -6,11 +6,15 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (string | int | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BoolOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -22,14 +26,14 @@ pub enum Union3BoolOrIntOrString {
     Bool(bool),
 }
 
-impl AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
+impl ::std::convert::AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
     fn as_ref(&self) -> &Union3BoolOrIntOrString {
         self
     }
 }
 
-impl Default for Union3BoolOrIntOrString {
+impl ::std::default::Default for Union3BoolOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/stream_types/classes.rs
@@ -10,38 +10,38 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MediaAnalysisResult {
     pub topics: Vec<String>,
 
     pub analysisText: Option<String>,
 }
 
-impl AsRef<MediaAnalysisResult> for MediaAnalysisResult {
+impl ::std::convert::AsRef<MediaAnalysisResult> for MediaAnalysisResult {
     fn as_ref(&self) -> &MediaAnalysisResult {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MediaArrayAnalysisResult {
     pub analysisText: Option<String>,
 
     pub mediaCount: Option<i64>,
 }
 
-impl AsRef<MediaArrayAnalysisResult> for MediaArrayAnalysisResult {
+impl ::std::convert::AsRef<MediaArrayAnalysisResult> for MediaArrayAnalysisResult {
     fn as_ref(&self) -> &MediaArrayAnalysisResult {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MediaMapAnalysisResult {
     pub analysisText: Option<String>,
 
@@ -50,14 +50,14 @@ pub struct MediaMapAnalysisResult {
     pub keys: Vec<String>,
 }
 
-impl AsRef<MediaMapAnalysisResult> for MediaMapAnalysisResult {
+impl ::std::convert::AsRef<MediaMapAnalysisResult> for MediaMapAnalysisResult {
     fn as_ref(&self) -> &MediaMapAnalysisResult {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedMediaAnalysisResult {
     pub title: Option<String>,
 
@@ -76,14 +76,14 @@ pub struct MixedMediaAnalysisResult {
     pub metadataKeys: Vec<String>,
 }
 
-impl AsRef<MixedMediaAnalysisResult> for MixedMediaAnalysisResult {
+impl ::std::convert::AsRef<MixedMediaAnalysisResult> for MixedMediaAnalysisResult {
     fn as_ref(&self) -> &MixedMediaAnalysisResult {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalMediaAnalysisResult {
     pub analysisText: Option<String>,
 
@@ -92,7 +92,7 @@ pub struct OptionalMediaAnalysisResult {
     pub missingMediaTypes: Vec<String>,
 }
 
-impl AsRef<OptionalMediaAnalysisResult> for OptionalMediaAnalysisResult {
+impl ::std::convert::AsRef<OptionalMediaAnalysisResult> for OptionalMediaAnalysisResult {
     fn as_ref(&self) -> &OptionalMediaAnalysisResult {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     MediaAnalysisResult(MediaAnalysisResult),
 
@@ -30,7 +33,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -46,5 +49,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::OptionalMediaAnalysisResult(_) => "OptionalMediaAnalysisResult",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MediaAnalysisResultClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MediaAnalysisResultClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "MediaAnalysisResult is statically defined in .baml and should always have a type",
         )
@@ -37,13 +37,13 @@ impl MediaAnalysisResultClassBuilder {
     // =========================================================================
 
     /// Access the `topics` field builder.
-    pub fn property_topics(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_topics(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("topics")
             .expect("MediaAnalysisResult.topics is statically defined in .baml and should always be present")
     }
 
     /// Access the `analysisText` field builder.
-    pub fn property_analysisText(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_analysisText(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("analysisText")
             .expect("MediaAnalysisResult.analysisText is statically defined in .baml and should always be present")
     }
@@ -55,22 +55,22 @@ impl MediaAnalysisResultClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MediaArrayAnalysisResultClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MediaArrayAnalysisResultClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "MediaArrayAnalysisResult is statically defined in .baml and should always have a type",
         )
@@ -81,13 +81,13 @@ impl MediaArrayAnalysisResultClassBuilder {
     // =========================================================================
 
     /// Access the `analysisText` field builder.
-    pub fn property_analysisText(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_analysisText(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("analysisText")
             .expect("MediaArrayAnalysisResult.analysisText is statically defined in .baml and should always be present")
     }
 
     /// Access the `mediaCount` field builder.
-    pub fn property_mediaCount(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mediaCount(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mediaCount")
             .expect("MediaArrayAnalysisResult.mediaCount is statically defined in .baml and should always be present")
     }
@@ -99,22 +99,22 @@ impl MediaArrayAnalysisResultClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MediaMapAnalysisResultClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MediaMapAnalysisResultClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "MediaMapAnalysisResult is statically defined in .baml and should always have a type",
         )
@@ -125,19 +125,19 @@ impl MediaMapAnalysisResultClassBuilder {
     // =========================================================================
 
     /// Access the `analysisText` field builder.
-    pub fn property_analysisText(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_analysisText(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("analysisText")
             .expect("MediaMapAnalysisResult.analysisText is statically defined in .baml and should always be present")
     }
 
     /// Access the `keyCount` field builder.
-    pub fn property_keyCount(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_keyCount(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("keyCount")
             .expect("MediaMapAnalysisResult.keyCount is statically defined in .baml and should always be present")
     }
 
     /// Access the `keys` field builder.
-    pub fn property_keys(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_keys(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("keys")
             .expect("MediaMapAnalysisResult.keys is statically defined in .baml and should always be present")
     }
@@ -149,22 +149,22 @@ impl MediaMapAnalysisResultClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MixedMediaAnalysisResultClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MixedMediaAnalysisResultClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "MixedMediaAnalysisResult is statically defined in .baml and should always have a type",
         )
@@ -175,49 +175,49 @@ impl MixedMediaAnalysisResultClassBuilder {
     // =========================================================================
 
     /// Access the `title` field builder.
-    pub fn property_title(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_title(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("title")
             .expect("MixedMediaAnalysisResult.title is statically defined in .baml and should always be present")
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description")
             .expect("MixedMediaAnalysisResult.description is statically defined in .baml and should always be present")
     }
 
     /// Access the `hasImage` field builder.
-    pub fn property_hasImage(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_hasImage(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("hasImage")
             .expect("MixedMediaAnalysisResult.hasImage is statically defined in .baml and should always be present")
     }
 
     /// Access the `hasVideo` field builder.
-    pub fn property_hasVideo(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_hasVideo(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("hasVideo")
             .expect("MixedMediaAnalysisResult.hasVideo is statically defined in .baml and should always be present")
     }
 
     /// Access the `hasAudio` field builder.
-    pub fn property_hasAudio(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_hasAudio(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("hasAudio")
             .expect("MixedMediaAnalysisResult.hasAudio is statically defined in .baml and should always be present")
     }
 
     /// Access the `hasPdf` field builder.
-    pub fn property_hasPdf(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_hasPdf(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("hasPdf")
             .expect("MixedMediaAnalysisResult.hasPdf is statically defined in .baml and should always be present")
     }
 
     /// Access the `additionalImageCount` field builder.
-    pub fn property_additionalImageCount(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_additionalImageCount(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("additionalImageCount")
             .expect("MixedMediaAnalysisResult.additionalImageCount is statically defined in .baml and should always be present")
     }
 
     /// Access the `metadataKeys` field builder.
-    pub fn property_metadataKeys(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadataKeys(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadataKeys")
             .expect("MixedMediaAnalysisResult.metadataKeys is statically defined in .baml and should always be present")
     }
@@ -229,22 +229,22 @@ impl MixedMediaAnalysisResultClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OptionalMediaAnalysisResultClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OptionalMediaAnalysisResultClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type()
             .expect("OptionalMediaAnalysisResult is statically defined in .baml and should always have a type")
     }
@@ -254,19 +254,19 @@ impl OptionalMediaAnalysisResultClassBuilder {
     // =========================================================================
 
     /// Access the `analysisText` field builder.
-    pub fn property_analysisText(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_analysisText(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("analysisText")
             .expect("OptionalMediaAnalysisResult.analysisText is statically defined in .baml and should always be present")
     }
 
     /// Access the `providedMediaTypes` field builder.
-    pub fn property_providedMediaTypes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_providedMediaTypes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("providedMediaTypes")
             .expect("OptionalMediaAnalysisResult.providedMediaTypes is statically defined in .baml and should always be present")
     }
 
     /// Access the `missingMediaTypes` field builder.
-    pub fn property_missingMediaTypes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_missingMediaTypes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("missingMediaTypes")
             .expect("OptionalMediaAnalysisResult.missingMediaTypes is statically defined in .baml and should always be present")
     }

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -104,27 +102,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -133,17 +131,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -152,22 +150,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -176,12 +174,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -190,17 +188,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -209,29 +210,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/classes.rs
@@ -6,89 +6,79 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MediaAnalysisResult {
     pub topics: Vec<String>,
-
     pub analysisText: String,
 }
 
-impl AsRef<MediaAnalysisResult> for MediaAnalysisResult {
+impl ::std::convert::AsRef<MediaAnalysisResult> for MediaAnalysisResult {
     fn as_ref(&self) -> &MediaAnalysisResult {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MediaArrayAnalysisResult {
     pub analysisText: String,
-
     pub mediaCount: i64,
 }
 
-impl AsRef<MediaArrayAnalysisResult> for MediaArrayAnalysisResult {
+impl ::std::convert::AsRef<MediaArrayAnalysisResult> for MediaArrayAnalysisResult {
     fn as_ref(&self) -> &MediaArrayAnalysisResult {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MediaMapAnalysisResult {
     pub analysisText: String,
-
     pub keyCount: i64,
-
     pub keys: Vec<String>,
 }
 
-impl AsRef<MediaMapAnalysisResult> for MediaMapAnalysisResult {
+impl ::std::convert::AsRef<MediaMapAnalysisResult> for MediaMapAnalysisResult {
     fn as_ref(&self) -> &MediaMapAnalysisResult {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedMediaAnalysisResult {
     pub title: String,
-
     pub description: String,
-
     pub hasImage: bool,
-
     pub hasVideo: bool,
-
     pub hasAudio: bool,
-
     pub hasPdf: bool,
-
     pub additionalImageCount: i64,
-
     pub metadataKeys: Vec<String>,
 }
 
-impl AsRef<MixedMediaAnalysisResult> for MixedMediaAnalysisResult {
+impl ::std::convert::AsRef<MixedMediaAnalysisResult> for MixedMediaAnalysisResult {
     fn as_ref(&self) -> &MixedMediaAnalysisResult {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalMediaAnalysisResult {
     pub analysisText: String,
-
     pub providedMediaTypes: Vec<String>,
-
     pub missingMediaTypes: Vec<String>,
 }
 
-impl AsRef<OptionalMediaAnalysisResult> for OptionalMediaAnalysisResult {
+impl ::std::convert::AsRef<OptionalMediaAnalysisResult> for OptionalMediaAnalysisResult {
     fn as_ref(&self) -> &OptionalMediaAnalysisResult {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/mod.rs
@@ -38,24 +38,24 @@ pub enum Types {
     Union4AudioOrImageOrPDFOrVideo(Union4AudioOrImageOrPDFOrVideo),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::MediaAnalysisResult(_) => "MediaAnalysisResult",
+            Self::MediaAnalysisResult(_) => "MediaAnalysisResult",
 
-            Types::MediaArrayAnalysisResult(_) => "MediaArrayAnalysisResult",
+            Self::MediaArrayAnalysisResult(_) => "MediaArrayAnalysisResult",
 
-            Types::MediaMapAnalysisResult(_) => "MediaMapAnalysisResult",
+            Self::MediaMapAnalysisResult(_) => "MediaMapAnalysisResult",
 
-            Types::MixedMediaAnalysisResult(_) => "MixedMediaAnalysisResult",
+            Self::MixedMediaAnalysisResult(_) => "MixedMediaAnalysisResult",
 
-            Types::OptionalMediaAnalysisResult(_) => "OptionalMediaAnalysisResult",
+            Self::OptionalMediaAnalysisResult(_) => "OptionalMediaAnalysisResult",
 
-            Types::Union4AudioOrImageOrPDFOrVideo(_) => "Union4AudioOrImageOrPDFOrVideo",
+            Self::Union4AudioOrImageOrPDFOrVideo(_) => "Union4AudioOrImageOrPDFOrVideo",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     MediaAnalysisResult(MediaAnalysisResult),
 
@@ -37,7 +39,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -55,5 +57,15 @@ impl baml::KnownTypes for Types {
 
             Types::Union4AudioOrImageOrPDFOrVideo(_) => "Union4AudioOrImageOrPDFOrVideo",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/unions.rs
@@ -6,33 +6,41 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (image | audio | pdf | video)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4AudioOrImageOrPDFOrVideo {
     #[baml(name = "image")]
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
     Image(Image),
 
     #[baml(name = "audio")]
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_audio")]
     Audio(Audio),
 
     #[baml(name = "pdf")]
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_pdf")]
     PDF(Pdf),
 
     #[baml(name = "video")]
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_video")]
     Video(Video),
 }
 
-impl AsRef<Union4AudioOrImageOrPDFOrVideo> for Union4AudioOrImageOrPDFOrVideo {
+impl ::std::convert::AsRef<Union4AudioOrImageOrPDFOrVideo> for Union4AudioOrImageOrPDFOrVideo {
     fn as_ref(&self) -> &Union4AudioOrImageOrPDFOrVideo {
         self
     }
 }
 
-impl Default for Union4AudioOrImageOrPDFOrVideo {
+impl ::std::default::Default for Union4AudioOrImageOrPDFOrVideo {
     fn default() -> Self {
-        Self::Image(Default::default())
+        Self::Image(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/media_types/baml_client/types/unions.rs
@@ -17,19 +17,19 @@ use baml::{
 #[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4AudioOrImageOrPDFOrVideo {
     #[baml(name = "image")]
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_image")]
     Image(Image),
 
     #[baml(name = "audio")]
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_audio")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_audio")]
     Audio(Audio),
 
     #[baml(name = "pdf")]
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_pdf")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_pdf")]
     PDF(Pdf),
 
     #[baml(name = "video")]
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_video")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_video")]
     Video(Video),
 }
 

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Action {
     #[baml(name = "type")]
     pub r#type: Option<String>,
@@ -23,14 +23,14 @@ pub struct Action {
     pub async_: Option<bool>,
 }
 
-impl AsRef<Action> for Action {
+impl ::std::convert::AsRef<Action> for Action {
     fn as_ref(&self) -> &Action {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Asset {
     pub id: Option<i64>,
 
@@ -42,14 +42,14 @@ pub struct Asset {
     pub tags: Vec<String>,
 }
 
-impl AsRef<Asset> for Asset {
+impl ::std::convert::AsRef<Asset> for Asset {
     fn as_ref(&self) -> &Asset {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AssetMetadata {
     pub filename: Option<String>,
 
@@ -62,14 +62,14 @@ pub struct AssetMetadata {
     pub checksum: Option<String>,
 }
 
-impl AsRef<AssetMetadata> for AssetMetadata {
+impl ::std::convert::AsRef<AssetMetadata> for AssetMetadata {
     fn as_ref(&self) -> &AssetMetadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ButtonWidget {
     pub label: Option<String>,
 
@@ -78,14 +78,14 @@ pub struct ButtonWidget {
     pub style: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<ButtonWidget> for ButtonWidget {
+impl ::std::convert::AsRef<ButtonWidget> for ButtonWidget {
     fn as_ref(&self) -> &ButtonWidget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexData {
     pub primary: Option<PrimaryData>,
 
@@ -94,14 +94,14 @@ pub struct ComplexData {
     pub tertiary: Option<TertiaryData>,
 }
 
-impl AsRef<ComplexData> for ComplexData {
+impl ::std::convert::AsRef<ComplexData> for ComplexData {
     fn as_ref(&self) -> &ComplexData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Condition {
     #[baml(name = "type")]
     pub r#type: Option<types::Union3KandOrKnotOrKor>,
@@ -109,14 +109,14 @@ pub struct Condition {
     pub conditions: Vec<Union2ConditionOrSimpleCondition>,
 }
 
-impl AsRef<Condition> for Condition {
+impl ::std::convert::AsRef<Condition> for Condition {
     fn as_ref(&self) -> &Condition {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Configuration {
     pub version: Option<String>,
 
@@ -127,14 +127,14 @@ pub struct Configuration {
     pub rules: Vec<Rule>,
 }
 
-impl AsRef<Configuration> for Configuration {
+impl ::std::convert::AsRef<Configuration> for Configuration {
     fn as_ref(&self) -> &Configuration {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ContainerWidget {
     pub layout: Option<types::Union3KflexOrKgridOrKstack>,
 
@@ -143,14 +143,14 @@ pub struct ContainerWidget {
     pub style: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<ContainerWidget> for ContainerWidget {
+impl ::std::convert::AsRef<ContainerWidget> for ContainerWidget {
     fn as_ref(&self) -> &ContainerWidget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DataObject {
     #[baml(name = "type")]
     pub r#type: Option<String>,
@@ -158,28 +158,28 @@ pub struct DataObject {
     pub value: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<DataObject> for DataObject {
+impl ::std::convert::AsRef<DataObject> for DataObject {
     fn as_ref(&self) -> &DataObject {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Dimensions {
     pub width: Option<i64>,
 
     pub height: Option<i64>,
 }
 
-impl AsRef<Dimensions> for Dimensions {
+impl ::std::convert::AsRef<Dimensions> for Dimensions {
     fn as_ref(&self) -> &Dimensions {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Environment {
     pub name: Option<String>,
 
@@ -190,14 +190,14 @@ pub struct Environment {
     pub secrets: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<Environment> for Environment {
+impl ::std::convert::AsRef<Environment> for Environment {
     fn as_ref(&self) -> &Environment {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Error {
     #[baml(name = "type")]
     pub r#type: Option<String>,
@@ -207,14 +207,14 @@ pub struct Error {
     pub code: Option<i64>,
 }
 
-impl AsRef<Error> for Error {
+impl ::std::convert::AsRef<Error> for Error {
     fn as_ref(&self) -> &Error {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ErrorDetail {
     pub code: Option<String>,
 
@@ -223,14 +223,14 @@ pub struct ErrorDetail {
     pub details: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<ErrorDetail> for ErrorDetail {
+impl ::std::convert::AsRef<ErrorDetail> for ErrorDetail {
     fn as_ref(&self) -> &ErrorDetail {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Feature {
     pub name: Option<String>,
 
@@ -241,28 +241,28 @@ pub struct Feature {
     pub dependencies: Vec<String>,
 }
 
-impl AsRef<Feature> for Feature {
+impl ::std::convert::AsRef<Feature> for Feature {
     fn as_ref(&self) -> &Feature {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ImageWidget {
     pub alt: Option<String>,
 
     pub dimensions: Option<Dimensions>,
 }
 
-impl AsRef<ImageWidget> for ImageWidget {
+impl ::std::convert::AsRef<ImageWidget> for ImageWidget {
     fn as_ref(&self) -> &ImageWidget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Item {
     pub id: Option<i64>,
 
@@ -273,14 +273,14 @@ pub struct Item {
     pub attributes: std::collections::HashMap<String, types::Union4BoolOrFloatOrIntOrString>,
 }
 
-impl AsRef<Item> for Item {
+impl ::std::convert::AsRef<Item> for Item {
     fn as_ref(&self) -> &Item {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct KitchenSink {
     pub id: Option<i64>,
 
@@ -321,14 +321,14 @@ pub struct KitchenSink {
     pub config: Option<Configuration>,
 }
 
-impl AsRef<KitchenSink> for KitchenSink {
+impl ::std::convert::AsRef<KitchenSink> for KitchenSink {
     fn as_ref(&self) -> &KitchenSink {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Node {
     pub id: Option<i64>,
 
@@ -340,14 +340,14 @@ pub struct Node {
     pub metadata: Option<NodeMetadata>,
 }
 
-impl AsRef<Node> for Node {
+impl ::std::convert::AsRef<Node> for Node {
     fn as_ref(&self) -> &Node {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NodeMetadata {
     pub created: Option<String>,
 
@@ -358,14 +358,14 @@ pub struct NodeMetadata {
     pub attributes: std::collections::HashMap<String, Option<types::Union3BoolOrIntOrString>>,
 }
 
-impl AsRef<NodeMetadata> for NodeMetadata {
+impl ::std::convert::AsRef<NodeMetadata> for NodeMetadata {
     fn as_ref(&self) -> &NodeMetadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimaryData {
     pub values: Vec<types::Union3FloatOrIntOrString>,
 
@@ -374,14 +374,14 @@ pub struct PrimaryData {
     pub flags: Vec<bool>,
 }
 
-impl AsRef<PrimaryData> for PrimaryData {
+impl ::std::convert::AsRef<PrimaryData> for PrimaryData {
     fn as_ref(&self) -> &PrimaryData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Record {
     pub id: Option<i64>,
 
@@ -390,14 +390,14 @@ pub struct Record {
     pub related: Option<Vec<Box<Record>>>,
 }
 
-impl AsRef<Record> for Record {
+impl ::std::convert::AsRef<Record> for Record {
     fn as_ref(&self) -> &Record {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ResponseMetadata {
     pub timestamp: Option<String>,
 
@@ -408,14 +408,14 @@ pub struct ResponseMetadata {
     pub retries: Option<i64>,
 }
 
-impl AsRef<ResponseMetadata> for ResponseMetadata {
+impl ::std::convert::AsRef<ResponseMetadata> for ResponseMetadata {
     fn as_ref(&self) -> &ResponseMetadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Rule {
     pub id: Option<i64>,
 
@@ -428,28 +428,28 @@ pub struct Rule {
     pub priority: Option<i64>,
 }
 
-impl AsRef<Rule> for Rule {
+impl ::std::convert::AsRef<Rule> for Rule {
     fn as_ref(&self) -> &Rule {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SecondaryData {
     pub records: Vec<Record>,
 
     pub index: std::collections::HashMap<String, Record>,
 }
 
-impl AsRef<SecondaryData> for SecondaryData {
+impl ::std::convert::AsRef<SecondaryData> for SecondaryData {
     fn as_ref(&self) -> &SecondaryData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Setting {
     pub key: Option<String>,
 
@@ -458,14 +458,14 @@ pub struct Setting {
     pub metadata: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<Setting> for Setting {
+impl ::std::convert::AsRef<Setting> for Setting {
     fn as_ref(&self) -> &Setting {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleCondition {
     pub field: Option<String>,
 
@@ -474,14 +474,14 @@ pub struct SimpleCondition {
     pub value: Option<types::Union4BoolOrFloatOrIntOrString>,
 }
 
-impl AsRef<SimpleCondition> for SimpleCondition {
+impl ::std::convert::AsRef<SimpleCondition> for SimpleCondition {
     fn as_ref(&self) -> &SimpleCondition {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Success {
     #[baml(name = "type")]
     pub r#type: Option<String>,
@@ -489,14 +489,14 @@ pub struct Success {
     pub data: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Success> for Success {
+impl ::std::convert::AsRef<Success> for Success {
     fn as_ref(&self) -> &Success {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TertiaryData {
     pub raw: Option<String>,
 
@@ -505,14 +505,14 @@ pub struct TertiaryData {
     pub valid: Option<bool>,
 }
 
-impl AsRef<TertiaryData> for TertiaryData {
+impl ::std::convert::AsRef<TertiaryData> for TertiaryData {
     fn as_ref(&self) -> &TertiaryData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TextWidget {
     pub content: Option<String>,
 
@@ -521,14 +521,14 @@ pub struct TextWidget {
     pub style: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<TextWidget> for TextWidget {
+impl ::std::convert::AsRef<TextWidget> for TextWidget {
     fn as_ref(&self) -> &TextWidget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UltraComplex {
     pub tree: Option<Node>,
 
@@ -541,14 +541,14 @@ pub struct UltraComplex {
     pub assets: Vec<Asset>,
 }
 
-impl AsRef<UltraComplex> for UltraComplex {
+impl ::std::convert::AsRef<UltraComplex> for UltraComplex {
     fn as_ref(&self) -> &UltraComplex {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: Option<i64>,
 
@@ -557,14 +557,14 @@ pub struct User {
     pub settings: std::collections::HashMap<String, Setting>,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UserProfile {
     pub name: Option<String>,
 
@@ -575,14 +575,14 @@ pub struct UserProfile {
     pub links: Vec<String>,
 }
 
-impl AsRef<UserProfile> for UserProfile {
+impl ::std::convert::AsRef<UserProfile> for UserProfile {
     fn as_ref(&self) -> &UserProfile {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UserResponse {
     pub status: Option<types::Union2KerrorOrKsuccess>,
 
@@ -593,14 +593,14 @@ pub struct UserResponse {
     pub metadata: Option<ResponseMetadata>,
 }
 
-impl AsRef<UserResponse> for UserResponse {
+impl ::std::convert::AsRef<UserResponse> for UserResponse {
     fn as_ref(&self) -> &UserResponse {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Variant {
     pub sku: Option<String>,
 
@@ -611,14 +611,14 @@ pub struct Variant {
     pub options: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Variant> for Variant {
+impl ::std::convert::AsRef<Variant> for Variant {
     fn as_ref(&self) -> &Variant {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Widget {
     #[baml(name = "type")]
     pub r#type: Option<types::Union4KbuttonOrKcontainerOrKimageOrKtext>,
@@ -632,7 +632,7 @@ pub struct Widget {
     pub container: Option<Box<ContainerWidget>>,
 }
 
-impl AsRef<Widget> for Widget {
+impl ::std::convert::AsRef<Widget> for Widget {
     fn as_ref(&self) -> &Widget {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     Action(Action),
 
@@ -100,7 +103,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -186,5 +189,15 @@ impl baml::KnownTypes for StreamTypes {
                 "Union4IntOrListNodeOrMapStringKeyNodeValueOrString"
             }
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/stream_types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/stream_types/unions.rs
@@ -7,11 +7,15 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{
+    BamlDecode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (Streaming.Condition | Streaming.SimpleCondition)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ConditionOrSimpleCondition {
     #[baml(name = "Condition")]
     Condition(Box<Condition>),
@@ -20,21 +24,22 @@ pub enum Union2ConditionOrSimpleCondition {
     SimpleCondition(SimpleCondition),
 }
 
-impl AsRef<Union2ConditionOrSimpleCondition> for Union2ConditionOrSimpleCondition {
+impl ::std::convert::AsRef<Union2ConditionOrSimpleCondition> for Union2ConditionOrSimpleCondition {
     fn as_ref(&self) -> &Union2ConditionOrSimpleCondition {
         self
     }
 }
 
-impl Default for Union2ConditionOrSimpleCondition {
+impl ::std::default::Default for Union2ConditionOrSimpleCondition {
     fn default() -> Self {
-        Self::Condition(Default::default())
+        Self::Condition(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Streaming.Success | Streaming.Error | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ErrorOrSuccess {
     #[baml(name = "Success")]
     Success(Success),
@@ -43,21 +48,22 @@ pub enum Union2ErrorOrSuccess {
     Error(Error),
 }
 
-impl AsRef<Union2ErrorOrSuccess> for Union2ErrorOrSuccess {
+impl ::std::convert::AsRef<Union2ErrorOrSuccess> for Union2ErrorOrSuccess {
     fn as_ref(&self) -> &Union2ErrorOrSuccess {
         self
     }
 }
 
-impl Default for Union2ErrorOrSuccess {
+impl ::std::default::Default for Union2ErrorOrSuccess {
     fn default() -> Self {
-        Self::Success(Default::default())
+        Self::Success(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int @stream.done | Streaming.DataObject | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3DataObjectOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -69,21 +75,22 @@ pub enum Union3DataObjectOrIntOrString {
     DataObject(DataObject),
 }
 
-impl AsRef<Union3DataObjectOrIntOrString> for Union3DataObjectOrIntOrString {
+impl ::std::convert::AsRef<Union3DataObjectOrIntOrString> for Union3DataObjectOrIntOrString {
     fn as_ref(&self) -> &Union3DataObjectOrIntOrString {
         self
     }
 }
 
-impl Default for Union3DataObjectOrIntOrString {
+impl ::std::default::Default for Union3DataObjectOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int @stream.done | Streaming.Node[] | map<string, Streaming.Node> | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
     #[baml(name = "string")]
     String(String),
@@ -98,7 +105,7 @@ pub enum Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
     MapStringKeyNodeValue(std::collections::HashMap<String, Node>),
 }
 
-impl AsRef<Union4IntOrListNodeOrMapStringKeyNodeValueOrString>
+impl ::std::convert::AsRef<Union4IntOrListNodeOrMapStringKeyNodeValueOrString>
     for Union4IntOrListNodeOrMapStringKeyNodeValueOrString
 {
     fn as_ref(&self) -> &Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
@@ -106,8 +113,8 @@ impl AsRef<Union4IntOrListNodeOrMapStringKeyNodeValueOrString>
     }
 }
 
-impl Default for Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
+impl ::std::default::Default for Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ActionClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ActionClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Action is statically defined in .baml and should always have a type")
@@ -37,21 +37,21 @@ impl ActionClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Action.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `parameters` field builder.
-    pub fn property_parameters(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_parameters(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("parameters")
             .expect("Action.parameters is statically defined in .baml and should always be present")
     }
 
     /// Access the `async_` field builder.
-    pub fn property_async_(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_async_(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("async_")
             .expect("Action.async_ is statically defined in .baml and should always be present")
@@ -64,22 +64,22 @@ impl ActionClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct AssetClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl AssetClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Asset is statically defined in .baml and should always have a type")
@@ -90,28 +90,28 @@ impl AssetClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Asset.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Asset.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("metadata")
             .expect("Asset.metadata is statically defined in .baml and should always be present")
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tags")
             .expect("Asset.tags is statically defined in .baml and should always be present")
@@ -124,22 +124,22 @@ impl AssetClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct AssetMetadataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl AssetMetadataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("AssetMetadata is statically defined in .baml and should always have a type")
@@ -150,35 +150,35 @@ impl AssetMetadataClassBuilder {
     // =========================================================================
 
     /// Access the `filename` field builder.
-    pub fn property_filename(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_filename(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("filename").expect(
             "AssetMetadata.filename is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `size` field builder.
-    pub fn property_size(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_size(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("size").expect(
             "AssetMetadata.size is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `mimeType` field builder.
-    pub fn property_mimeType(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mimeType(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mimeType").expect(
             "AssetMetadata.mimeType is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `uploaded` field builder.
-    pub fn property_uploaded(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_uploaded(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("uploaded").expect(
             "AssetMetadata.uploaded is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `checksum` field builder.
-    pub fn property_checksum(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_checksum(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("checksum").expect(
             "AssetMetadata.checksum is statically defined in .baml and should always be present",
         )
@@ -191,22 +191,22 @@ impl AssetMetadataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ButtonWidgetClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ButtonWidgetClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ButtonWidget is statically defined in .baml and should always have a type")
@@ -217,21 +217,21 @@ impl ButtonWidgetClassBuilder {
     // =========================================================================
 
     /// Access the `label` field builder.
-    pub fn property_label(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_label(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("label").expect(
             "ButtonWidget.label is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `action` field builder.
-    pub fn property_action(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_action(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("action").expect(
             "ButtonWidget.action is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `style` field builder.
-    pub fn property_style(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_style(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("style").expect(
             "ButtonWidget.style is statically defined in .baml and should always be present",
         )
@@ -244,22 +244,22 @@ impl ButtonWidgetClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ComplexDataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ComplexDataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ComplexData is statically defined in .baml and should always have a type")
@@ -270,21 +270,21 @@ impl ComplexDataClassBuilder {
     // =========================================================================
 
     /// Access the `primary` field builder.
-    pub fn property_primary(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_primary(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("primary").expect(
             "ComplexData.primary is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `secondary` field builder.
-    pub fn property_secondary(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_secondary(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("secondary").expect(
             "ComplexData.secondary is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `tertiary` field builder.
-    pub fn property_tertiary(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tertiary(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("tertiary").expect(
             "ComplexData.tertiary is statically defined in .baml and should always be present",
         )
@@ -297,22 +297,22 @@ impl ComplexDataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ConditionClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ConditionClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Condition is statically defined in .baml and should always have a type")
@@ -323,14 +323,14 @@ impl ConditionClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Condition.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `conditions` field builder.
-    pub fn property_conditions(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_conditions(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("conditions").expect(
             "Condition.conditions is statically defined in .baml and should always be present",
         )
@@ -343,22 +343,22 @@ impl ConditionClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ConfigurationClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ConfigurationClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Configuration is statically defined in .baml and should always have a type")
@@ -369,27 +369,27 @@ impl ConfigurationClassBuilder {
     // =========================================================================
 
     /// Access the `version` field builder.
-    pub fn property_version(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_version(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("version").expect(
             "Configuration.version is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `features` field builder.
-    pub fn property_features(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_features(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("features").expect(
             "Configuration.features is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `environments` field builder.
-    pub fn property_environments(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_environments(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("environments")
             .expect("Configuration.environments is statically defined in .baml and should always be present")
     }
 
     /// Access the `rules` field builder.
-    pub fn property_rules(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_rules(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("rules").expect(
             "Configuration.rules is statically defined in .baml and should always be present",
         )
@@ -402,22 +402,22 @@ impl ConfigurationClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ContainerWidgetClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ContainerWidgetClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ContainerWidget is statically defined in .baml and should always have a type")
@@ -428,21 +428,21 @@ impl ContainerWidgetClassBuilder {
     // =========================================================================
 
     /// Access the `layout` field builder.
-    pub fn property_layout(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_layout(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("layout").expect(
             "ContainerWidget.layout is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `children` field builder.
-    pub fn property_children(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_children(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("children").expect(
             "ContainerWidget.children is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `style` field builder.
-    pub fn property_style(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_style(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("style").expect(
             "ContainerWidget.style is statically defined in .baml and should always be present",
         )
@@ -455,22 +455,22 @@ impl ContainerWidgetClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DataObjectClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DataObjectClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DataObject is statically defined in .baml and should always have a type")
@@ -481,14 +481,14 @@ impl DataObjectClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("DataObject.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("value")
             .expect("DataObject.value is statically defined in .baml and should always be present")
@@ -501,22 +501,22 @@ impl DataObjectClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DimensionsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DimensionsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Dimensions is statically defined in .baml and should always have a type")
@@ -527,14 +527,14 @@ impl DimensionsClassBuilder {
     // =========================================================================
 
     /// Access the `width` field builder.
-    pub fn property_width(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_width(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("width")
             .expect("Dimensions.width is statically defined in .baml and should always be present")
     }
 
     /// Access the `height` field builder.
-    pub fn property_height(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_height(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("height")
             .expect("Dimensions.height is statically defined in .baml and should always be present")
@@ -547,22 +547,22 @@ impl DimensionsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct EnvironmentClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl EnvironmentClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Environment is statically defined in .baml and should always have a type")
@@ -573,28 +573,28 @@ impl EnvironmentClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Environment.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `url` field builder.
-    pub fn property_url(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_url(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("url")
             .expect("Environment.url is statically defined in .baml and should always be present")
     }
 
     /// Access the `variables` field builder.
-    pub fn property_variables(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_variables(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("variables").expect(
             "Environment.variables is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `secrets` field builder.
-    pub fn property_secrets(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_secrets(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("secrets").expect(
             "Environment.secrets is statically defined in .baml and should always be present",
         )
@@ -607,22 +607,22 @@ impl EnvironmentClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ErrorClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ErrorClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Error is statically defined in .baml and should always have a type")
@@ -633,21 +633,21 @@ impl ErrorClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Error.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `message` field builder.
-    pub fn property_message(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_message(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("message")
             .expect("Error.message is statically defined in .baml and should always be present")
     }
 
     /// Access the `code` field builder.
-    pub fn property_code(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_code(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("code")
             .expect("Error.code is statically defined in .baml and should always be present")
@@ -660,22 +660,22 @@ impl ErrorClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ErrorDetailClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ErrorDetailClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ErrorDetail is statically defined in .baml and should always have a type")
@@ -686,21 +686,21 @@ impl ErrorDetailClassBuilder {
     // =========================================================================
 
     /// Access the `code` field builder.
-    pub fn property_code(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_code(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("code")
             .expect("ErrorDetail.code is statically defined in .baml and should always be present")
     }
 
     /// Access the `message` field builder.
-    pub fn property_message(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_message(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("message").expect(
             "ErrorDetail.message is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `details` field builder.
-    pub fn property_details(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_details(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("details").expect(
             "ErrorDetail.details is statically defined in .baml and should always be present",
         )
@@ -713,22 +713,22 @@ impl ErrorDetailClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct FeatureClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl FeatureClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Feature is statically defined in .baml and should always have a type")
@@ -739,28 +739,28 @@ impl FeatureClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Feature.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `enabled` field builder.
-    pub fn property_enabled(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_enabled(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("enabled")
             .expect("Feature.enabled is statically defined in .baml and should always be present")
     }
 
     /// Access the `config` field builder.
-    pub fn property_config(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_config(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("config")
             .expect("Feature.config is statically defined in .baml and should always be present")
     }
 
     /// Access the `dependencies` field builder.
-    pub fn property_dependencies(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_dependencies(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("dependencies").expect(
             "Feature.dependencies is statically defined in .baml and should always be present",
         )
@@ -773,22 +773,22 @@ impl FeatureClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ImageWidgetClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ImageWidgetClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ImageWidget is statically defined in .baml and should always have a type")
@@ -799,14 +799,14 @@ impl ImageWidgetClassBuilder {
     // =========================================================================
 
     /// Access the `alt` field builder.
-    pub fn property_alt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_alt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("alt")
             .expect("ImageWidget.alt is statically defined in .baml and should always be present")
     }
 
     /// Access the `dimensions` field builder.
-    pub fn property_dimensions(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_dimensions(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("dimensions").expect(
             "ImageWidget.dimensions is statically defined in .baml and should always be present",
         )
@@ -819,22 +819,22 @@ impl ImageWidgetClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ItemClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ItemClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Item is statically defined in .baml and should always have a type")
@@ -845,28 +845,28 @@ impl ItemClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Item.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Item.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `variants` field builder.
-    pub fn property_variants(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_variants(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("variants")
             .expect("Item.variants is statically defined in .baml and should always be present")
     }
 
     /// Access the `attributes` field builder.
-    pub fn property_attributes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_attributes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("attributes")
             .expect("Item.attributes is statically defined in .baml and should always be present")
@@ -879,22 +879,22 @@ impl ItemClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct KitchenSinkClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl KitchenSinkClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("KitchenSink is statically defined in .baml and should always have a type")
@@ -905,133 +905,133 @@ impl KitchenSinkClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("KitchenSink.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("KitchenSink.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `score` field builder.
-    pub fn property_score(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_score(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("score")
             .expect("KitchenSink.score is statically defined in .baml and should always be present")
     }
 
     /// Access the `active` field builder.
-    pub fn property_active(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_active(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("active").expect(
             "KitchenSink.active is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nothing` field builder.
-    pub fn property_nothing(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nothing(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nothing").expect(
             "KitchenSink.nothing is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("status").expect(
             "KitchenSink.status is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `priority` field builder.
-    pub fn property_priority(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_priority(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("priority").expect(
             "KitchenSink.priority is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tags")
             .expect("KitchenSink.tags is statically defined in .baml and should always be present")
     }
 
     /// Access the `numbers` field builder.
-    pub fn property_numbers(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_numbers(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("numbers").expect(
             "KitchenSink.numbers is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `matrix` field builder.
-    pub fn property_matrix(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_matrix(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("matrix").expect(
             "KitchenSink.matrix is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadata").expect(
             "KitchenSink.metadata is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `scores` field builder.
-    pub fn property_scores(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_scores(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("scores").expect(
             "KitchenSink.scores is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description").expect(
             "KitchenSink.description is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `notes` field builder.
-    pub fn property_notes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_notes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("notes")
             .expect("KitchenSink.notes is statically defined in .baml and should always be present")
     }
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("KitchenSink.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `result` field builder.
-    pub fn property_result(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_result(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("result").expect(
             "KitchenSink.result is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `user` field builder.
-    pub fn property_user(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_user(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("user")
             .expect("KitchenSink.user is statically defined in .baml and should always be present")
     }
 
     /// Access the `items` field builder.
-    pub fn property_items(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_items(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("items")
             .expect("KitchenSink.items is statically defined in .baml and should always be present")
     }
 
     /// Access the `config` field builder.
-    pub fn property_config(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_config(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("config").expect(
             "KitchenSink.config is statically defined in .baml and should always be present",
         )
@@ -1044,22 +1044,22 @@ impl KitchenSinkClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NodeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NodeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Node is statically defined in .baml and should always have a type")
@@ -1070,28 +1070,28 @@ impl NodeClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Node.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Node.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("value")
             .expect("Node.value is statically defined in .baml and should always be present")
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("metadata")
             .expect("Node.metadata is statically defined in .baml and should always be present")
@@ -1104,22 +1104,22 @@ impl NodeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NodeMetadataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NodeMetadataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("NodeMetadata is statically defined in .baml and should always have a type")
@@ -1130,28 +1130,28 @@ impl NodeMetadataClassBuilder {
     // =========================================================================
 
     /// Access the `created` field builder.
-    pub fn property_created(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_created(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("created").expect(
             "NodeMetadata.created is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `modified` field builder.
-    pub fn property_modified(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_modified(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("modified").expect(
             "NodeMetadata.modified is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tags")
             .expect("NodeMetadata.tags is statically defined in .baml and should always be present")
     }
 
     /// Access the `attributes` field builder.
-    pub fn property_attributes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_attributes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("attributes").expect(
             "NodeMetadata.attributes is statically defined in .baml and should always be present",
         )
@@ -1164,22 +1164,22 @@ impl NodeMetadataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PrimaryDataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PrimaryDataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("PrimaryData is statically defined in .baml and should always have a type")
@@ -1190,21 +1190,21 @@ impl PrimaryDataClassBuilder {
     // =========================================================================
 
     /// Access the `values` field builder.
-    pub fn property_values(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_values(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("values").expect(
             "PrimaryData.values is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `mappings` field builder.
-    pub fn property_mappings(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mappings(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mappings").expect(
             "PrimaryData.mappings is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `flags` field builder.
-    pub fn property_flags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_flags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("flags")
             .expect("PrimaryData.flags is statically defined in .baml and should always be present")
@@ -1217,22 +1217,22 @@ impl PrimaryDataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct RecordClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RecordClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Record is statically defined in .baml and should always have a type")
@@ -1243,21 +1243,21 @@ impl RecordClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Record.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Record.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `related` field builder.
-    pub fn property_related(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_related(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("related")
             .expect("Record.related is statically defined in .baml and should always be present")
@@ -1270,22 +1270,22 @@ impl RecordClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ResponseMetadataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ResponseMetadataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ResponseMetadata is statically defined in .baml and should always have a type")
@@ -1296,26 +1296,26 @@ impl ResponseMetadataClassBuilder {
     // =========================================================================
 
     /// Access the `timestamp` field builder.
-    pub fn property_timestamp(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_timestamp(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("timestamp")
             .expect("ResponseMetadata.timestamp is statically defined in .baml and should always be present")
     }
 
     /// Access the `requestId` field builder.
-    pub fn property_requestId(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_requestId(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("requestId")
             .expect("ResponseMetadata.requestId is statically defined in .baml and should always be present")
     }
 
     /// Access the `duration` field builder.
-    pub fn property_duration(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_duration(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("duration").expect(
             "ResponseMetadata.duration is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `retries` field builder.
-    pub fn property_retries(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_retries(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("retries").expect(
             "ResponseMetadata.retries is statically defined in .baml and should always be present",
         )
@@ -1328,22 +1328,22 @@ impl ResponseMetadataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct RuleClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RuleClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Rule is statically defined in .baml and should always have a type")
@@ -1354,35 +1354,35 @@ impl RuleClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Rule.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Rule.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `condition` field builder.
-    pub fn property_condition(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_condition(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("condition")
             .expect("Rule.condition is statically defined in .baml and should always be present")
     }
 
     /// Access the `actions` field builder.
-    pub fn property_actions(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_actions(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("actions")
             .expect("Rule.actions is statically defined in .baml and should always be present")
     }
 
     /// Access the `priority` field builder.
-    pub fn property_priority(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_priority(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("priority")
             .expect("Rule.priority is statically defined in .baml and should always be present")
@@ -1395,22 +1395,22 @@ impl RuleClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SecondaryDataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SecondaryDataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SecondaryData is statically defined in .baml and should always have a type")
@@ -1421,14 +1421,14 @@ impl SecondaryDataClassBuilder {
     // =========================================================================
 
     /// Access the `records` field builder.
-    pub fn property_records(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_records(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("records").expect(
             "SecondaryData.records is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `index` field builder.
-    pub fn property_index(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_index(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("index").expect(
             "SecondaryData.index is statically defined in .baml and should always be present",
         )
@@ -1441,22 +1441,22 @@ impl SecondaryDataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SettingClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SettingClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Setting is statically defined in .baml and should always have a type")
@@ -1467,21 +1467,21 @@ impl SettingClassBuilder {
     // =========================================================================
 
     /// Access the `key` field builder.
-    pub fn property_key(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("key")
             .expect("Setting.key is statically defined in .baml and should always be present")
     }
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("value")
             .expect("Setting.value is statically defined in .baml and should always be present")
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("metadata")
             .expect("Setting.metadata is statically defined in .baml and should always be present")
@@ -1494,22 +1494,22 @@ impl SettingClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SimpleConditionClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SimpleConditionClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SimpleCondition is statically defined in .baml and should always have a type")
@@ -1520,21 +1520,21 @@ impl SimpleConditionClassBuilder {
     // =========================================================================
 
     /// Access the `field` field builder.
-    pub fn property_field(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("field").expect(
             "SimpleCondition.field is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `operator` field builder.
-    pub fn property_operator(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_operator(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("operator").expect(
             "SimpleCondition.operator is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value").expect(
             "SimpleCondition.value is statically defined in .baml and should always be present",
         )
@@ -1547,22 +1547,22 @@ impl SimpleConditionClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SuccessClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SuccessClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Success is statically defined in .baml and should always have a type")
@@ -1573,14 +1573,14 @@ impl SuccessClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Success.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Success.data is statically defined in .baml and should always be present")
@@ -1593,22 +1593,22 @@ impl SuccessClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TertiaryDataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TertiaryDataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("TertiaryData is statically defined in .baml and should always have a type")
@@ -1619,21 +1619,21 @@ impl TertiaryDataClassBuilder {
     // =========================================================================
 
     /// Access the `raw` field builder.
-    pub fn property_raw(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_raw(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("raw")
             .expect("TertiaryData.raw is statically defined in .baml and should always be present")
     }
 
     /// Access the `parsed` field builder.
-    pub fn property_parsed(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_parsed(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("parsed").expect(
             "TertiaryData.parsed is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `valid` field builder.
-    pub fn property_valid(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_valid(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("valid").expect(
             "TertiaryData.valid is statically defined in .baml and should always be present",
         )
@@ -1646,22 +1646,22 @@ impl TertiaryDataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TextWidgetClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TextWidgetClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("TextWidget is statically defined in .baml and should always have a type")
@@ -1672,21 +1672,21 @@ impl TextWidgetClassBuilder {
     // =========================================================================
 
     /// Access the `content` field builder.
-    pub fn property_content(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_content(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("content").expect(
             "TextWidget.content is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `format` field builder.
-    pub fn property_format(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_format(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("format")
             .expect("TextWidget.format is statically defined in .baml and should always be present")
     }
 
     /// Access the `style` field builder.
-    pub fn property_style(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_style(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("style")
             .expect("TextWidget.style is statically defined in .baml and should always be present")
@@ -1699,22 +1699,22 @@ impl TextWidgetClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UltraComplexClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UltraComplexClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("UltraComplex is statically defined in .baml and should always have a type")
@@ -1725,35 +1725,35 @@ impl UltraComplexClassBuilder {
     // =========================================================================
 
     /// Access the `tree` field builder.
-    pub fn property_tree(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tree(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tree")
             .expect("UltraComplex.tree is statically defined in .baml and should always be present")
     }
 
     /// Access the `widgets` field builder.
-    pub fn property_widgets(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_widgets(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("widgets").expect(
             "UltraComplex.widgets is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("UltraComplex.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `response` field builder.
-    pub fn property_response(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_response(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("response").expect(
             "UltraComplex.response is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `assets` field builder.
-    pub fn property_assets(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_assets(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("assets").expect(
             "UltraComplex.assets is statically defined in .baml and should always be present",
         )
@@ -1766,22 +1766,22 @@ impl UltraComplexClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("User is statically defined in .baml and should always have a type")
@@ -1792,21 +1792,21 @@ impl UserClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("User.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `profile` field builder.
-    pub fn property_profile(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_profile(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("profile")
             .expect("User.profile is statically defined in .baml and should always be present")
     }
 
     /// Access the `settings` field builder.
-    pub fn property_settings(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_settings(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("settings")
             .expect("User.settings is statically defined in .baml and should always be present")
@@ -1819,22 +1819,22 @@ impl UserClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserProfileClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserProfileClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("UserProfile is statically defined in .baml and should always have a type")
@@ -1845,28 +1845,28 @@ impl UserProfileClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("UserProfile.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `email` field builder.
-    pub fn property_email(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_email(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("email")
             .expect("UserProfile.email is statically defined in .baml and should always be present")
     }
 
     /// Access the `bio` field builder.
-    pub fn property_bio(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_bio(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("bio")
             .expect("UserProfile.bio is statically defined in .baml and should always be present")
     }
 
     /// Access the `links` field builder.
-    pub fn property_links(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_links(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("links")
             .expect("UserProfile.links is statically defined in .baml and should always be present")
@@ -1879,22 +1879,22 @@ impl UserProfileClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserResponseClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserResponseClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("UserResponse is statically defined in .baml and should always have a type")
@@ -1905,28 +1905,28 @@ impl UserResponseClassBuilder {
     // =========================================================================
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("status").expect(
             "UserResponse.status is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("UserResponse.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `error` field builder.
-    pub fn property_error(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_error(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("error").expect(
             "UserResponse.error is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadata").expect(
             "UserResponse.metadata is statically defined in .baml and should always be present",
         )
@@ -1939,22 +1939,22 @@ impl UserResponseClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct VariantClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl VariantClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Variant is statically defined in .baml and should always have a type")
@@ -1965,28 +1965,28 @@ impl VariantClassBuilder {
     // =========================================================================
 
     /// Access the `sku` field builder.
-    pub fn property_sku(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_sku(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("sku")
             .expect("Variant.sku is statically defined in .baml and should always be present")
     }
 
     /// Access the `price` field builder.
-    pub fn property_price(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_price(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("price")
             .expect("Variant.price is statically defined in .baml and should always be present")
     }
 
     /// Access the `stock` field builder.
-    pub fn property_stock(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stock(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("stock")
             .expect("Variant.stock is statically defined in .baml and should always be present")
     }
 
     /// Access the `options` field builder.
-    pub fn property_options(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_options(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("options")
             .expect("Variant.options is statically defined in .baml and should always be present")
@@ -1999,22 +1999,22 @@ impl VariantClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct WidgetClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl WidgetClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Widget is statically defined in .baml and should always have a type")
@@ -2025,35 +2025,35 @@ impl WidgetClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Widget.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `button` field builder.
-    pub fn property_button(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_button(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("button")
             .expect("Widget.button is statically defined in .baml and should always be present")
     }
 
     /// Access the `text` field builder.
-    pub fn property_text(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_text(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("text")
             .expect("Widget.text is statically defined in .baml and should always be present")
     }
 
     /// Access the `img` field builder.
-    pub fn property_img(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_img(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("img")
             .expect("Widget.img is statically defined in .baml and should always be present")
     }
 
     /// Access the `container` field builder.
-    pub fn property_container(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_container(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("container")
             .expect("Widget.container is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -374,27 +372,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -403,17 +401,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -422,22 +420,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -446,12 +444,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -460,17 +458,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -479,29 +480,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/types/classes.rs
@@ -6,629 +6,541 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Action {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub parameters: std::collections::HashMap<String, Union3BoolOrIntOrString>,
-
     pub async_: bool,
 }
 
-impl AsRef<Action> for Action {
+impl ::std::convert::AsRef<Action> for Action {
     fn as_ref(&self) -> &Action {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Asset {
     pub id: i64,
-
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: Union3KaudioOrKdocumentOrKimage,
-
     pub metadata: AssetMetadata,
-
     pub tags: Vec<String>,
 }
 
-impl AsRef<Asset> for Asset {
+impl ::std::convert::AsRef<Asset> for Asset {
     fn as_ref(&self) -> &Asset {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AssetMetadata {
     pub filename: String,
-
     pub size: i64,
-
     pub mimeType: String,
-
     pub uploaded: String,
-
     pub checksum: String,
 }
 
-impl AsRef<AssetMetadata> for AssetMetadata {
+impl ::std::convert::AsRef<AssetMetadata> for AssetMetadata {
     fn as_ref(&self) -> &AssetMetadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ButtonWidget {
     pub label: String,
-
     pub action: String,
-
     pub style: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<ButtonWidget> for ButtonWidget {
+impl ::std::convert::AsRef<ButtonWidget> for ButtonWidget {
     fn as_ref(&self) -> &ButtonWidget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexData {
     pub primary: PrimaryData,
-
     pub secondary: Option<SecondaryData>,
-
     pub tertiary: Option<TertiaryData>,
 }
 
-impl AsRef<ComplexData> for ComplexData {
+impl ::std::convert::AsRef<ComplexData> for ComplexData {
     fn as_ref(&self) -> &ComplexData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Condition {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: Union3KandOrKnotOrKor,
-
     pub conditions: Vec<Union2ConditionOrSimpleCondition>,
 }
 
-impl AsRef<Condition> for Condition {
+impl ::std::convert::AsRef<Condition> for Condition {
     fn as_ref(&self) -> &Condition {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Configuration {
     pub version: String,
-
     pub features: Vec<Feature>,
-
     pub environments: std::collections::HashMap<String, Environment>,
-
     pub rules: Vec<Rule>,
 }
 
-impl AsRef<Configuration> for Configuration {
+impl ::std::convert::AsRef<Configuration> for Configuration {
     fn as_ref(&self) -> &Configuration {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ContainerWidget {
     pub layout: Union3KflexOrKgridOrKstack,
-
     pub children: Vec<Box<Widget>>,
-
     pub style: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<ContainerWidget> for ContainerWidget {
+impl ::std::convert::AsRef<ContainerWidget> for ContainerWidget {
     fn as_ref(&self) -> &ContainerWidget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DataObject {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub value: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<DataObject> for DataObject {
+impl ::std::convert::AsRef<DataObject> for DataObject {
     fn as_ref(&self) -> &DataObject {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Dimensions {
     pub width: i64,
-
     pub height: i64,
 }
 
-impl AsRef<Dimensions> for Dimensions {
+impl ::std::convert::AsRef<Dimensions> for Dimensions {
     fn as_ref(&self) -> &Dimensions {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Environment {
     pub name: String,
-
     pub url: String,
-
     pub variables: std::collections::HashMap<String, String>,
-
     pub secrets: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<Environment> for Environment {
+impl ::std::convert::AsRef<Environment> for Environment {
     fn as_ref(&self) -> &Environment {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Error {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub message: String,
-
     pub code: i64,
 }
 
-impl AsRef<Error> for Error {
+impl ::std::convert::AsRef<Error> for Error {
     fn as_ref(&self) -> &Error {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ErrorDetail {
     pub code: String,
-
     pub message: String,
-
     pub details: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<ErrorDetail> for ErrorDetail {
+impl ::std::convert::AsRef<ErrorDetail> for ErrorDetail {
     fn as_ref(&self) -> &ErrorDetail {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Feature {
     pub name: String,
-
     pub enabled: bool,
-
     pub config: Option<std::collections::HashMap<String, Union3BoolOrIntOrString>>,
-
     pub dependencies: Vec<String>,
 }
 
-impl AsRef<Feature> for Feature {
+impl ::std::convert::AsRef<Feature> for Feature {
     fn as_ref(&self) -> &Feature {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ImageWidget {
     pub alt: String,
-
     pub dimensions: Dimensions,
 }
 
-impl AsRef<ImageWidget> for ImageWidget {
+impl ::std::convert::AsRef<ImageWidget> for ImageWidget {
     fn as_ref(&self) -> &ImageWidget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Item {
     pub id: i64,
-
     pub name: String,
-
     pub variants: Vec<Variant>,
-
     pub attributes: std::collections::HashMap<String, Union4BoolOrFloatOrIntOrString>,
 }
 
-impl AsRef<Item> for Item {
+impl ::std::convert::AsRef<Item> for Item {
     fn as_ref(&self) -> &Item {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct KitchenSink {
     pub id: i64,
-
     pub name: String,
-
     pub score: f64,
-
     pub active: bool,
-
     pub nothing: (),
-
     pub status: Union3KarchivedOrKdraftOrKpublished,
-
     pub priority: Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5,
-
     pub tags: Vec<String>,
-
     pub numbers: Vec<i64>,
-
     pub matrix: Vec<Vec<i64>>,
-
     pub metadata: std::collections::HashMap<String, String>,
-
     pub scores: std::collections::HashMap<String, f64>,
-
     pub description: Option<String>,
-
     pub notes: Option<String>,
-
     pub data: Union3DataObjectOrIntOrString,
-
     pub result: Union2ErrorOrSuccess,
-
     pub user: User,
-
     pub items: Vec<Item>,
-
     pub config: Configuration,
 }
 
-impl AsRef<KitchenSink> for KitchenSink {
+impl ::std::convert::AsRef<KitchenSink> for KitchenSink {
     fn as_ref(&self) -> &KitchenSink {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Node {
     pub id: i64,
-
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: Union2KbranchOrKleaf,
-
     pub value: Union4IntOrListNodeOrMapStringKeyNodeValueOrString,
-
     pub metadata: Option<NodeMetadata>,
 }
 
-impl AsRef<Node> for Node {
+impl ::std::convert::AsRef<Node> for Node {
     fn as_ref(&self) -> &Node {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NodeMetadata {
     pub created: String,
-
     pub modified: String,
-
     pub tags: Vec<String>,
-
     pub attributes: std::collections::HashMap<String, Option<Union3BoolOrIntOrString>>,
 }
 
-impl AsRef<NodeMetadata> for NodeMetadata {
+impl ::std::convert::AsRef<NodeMetadata> for NodeMetadata {
     fn as_ref(&self) -> &NodeMetadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimaryData {
     pub values: Vec<Union3FloatOrIntOrString>,
-
     pub mappings: std::collections::HashMap<String, std::collections::HashMap<String, String>>,
-
     pub flags: Vec<bool>,
 }
 
-impl AsRef<PrimaryData> for PrimaryData {
+impl ::std::convert::AsRef<PrimaryData> for PrimaryData {
     fn as_ref(&self) -> &PrimaryData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Record {
     pub id: i64,
-
     pub data: std::collections::HashMap<String, Option<Union3BoolOrIntOrString>>,
-
     pub related: Option<Vec<Box<Record>>>,
 }
 
-impl AsRef<Record> for Record {
+impl ::std::convert::AsRef<Record> for Record {
     fn as_ref(&self) -> &Record {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ResponseMetadata {
     pub timestamp: String,
-
     pub requestId: String,
-
     pub duration: i64,
-
     pub retries: i64,
 }
 
-impl AsRef<ResponseMetadata> for ResponseMetadata {
+impl ::std::convert::AsRef<ResponseMetadata> for ResponseMetadata {
     fn as_ref(&self) -> &ResponseMetadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Rule {
     pub id: i64,
-
     pub name: String,
-
     pub condition: Condition,
-
     pub actions: Vec<Action>,
-
     pub priority: i64,
 }
 
-impl AsRef<Rule> for Rule {
+impl ::std::convert::AsRef<Rule> for Rule {
     fn as_ref(&self) -> &Rule {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SecondaryData {
     pub records: Vec<Record>,
-
     pub index: std::collections::HashMap<String, Record>,
 }
 
-impl AsRef<SecondaryData> for SecondaryData {
+impl ::std::convert::AsRef<SecondaryData> for SecondaryData {
     fn as_ref(&self) -> &SecondaryData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Setting {
     pub key: String,
-
     pub value: Union3BoolOrIntOrString,
-
     pub metadata: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<Setting> for Setting {
+impl ::std::convert::AsRef<Setting> for Setting {
     fn as_ref(&self) -> &Setting {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleCondition {
     pub field: String,
-
     pub operator: Union5KcontainsOrKeqOrKgtOrKltOrKne,
-
     pub value: Union4BoolOrFloatOrIntOrString,
 }
 
-impl AsRef<SimpleCondition> for SimpleCondition {
+impl ::std::convert::AsRef<SimpleCondition> for SimpleCondition {
     fn as_ref(&self) -> &SimpleCondition {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Success {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub data: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Success> for Success {
+impl ::std::convert::AsRef<Success> for Success {
     fn as_ref(&self) -> &Success {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TertiaryData {
     pub raw: String,
-
     pub parsed: Option<std::collections::HashMap<String, String>>,
-
     pub valid: bool,
 }
 
-impl AsRef<TertiaryData> for TertiaryData {
+impl ::std::convert::AsRef<TertiaryData> for TertiaryData {
     fn as_ref(&self) -> &TertiaryData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TextWidget {
     pub content: String,
-
     pub format: Union3KhtmlOrKmarkdownOrKplain,
-
     pub style: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<TextWidget> for TextWidget {
+impl ::std::convert::AsRef<TextWidget> for TextWidget {
     fn as_ref(&self) -> &TextWidget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UltraComplex {
     pub tree: Node,
-
     pub widgets: Vec<Widget>,
-
     pub data: Option<ComplexData>,
-
     pub response: UserResponse,
-
     pub assets: Vec<Asset>,
 }
 
-impl AsRef<UltraComplex> for UltraComplex {
+impl ::std::convert::AsRef<UltraComplex> for UltraComplex {
     fn as_ref(&self) -> &UltraComplex {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: i64,
-
     pub profile: UserProfile,
-
     pub settings: std::collections::HashMap<String, Setting>,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UserProfile {
     pub name: String,
-
     pub email: String,
-
     pub bio: Option<String>,
-
     pub links: Vec<String>,
 }
 
-impl AsRef<UserProfile> for UserProfile {
+impl ::std::convert::AsRef<UserProfile> for UserProfile {
     fn as_ref(&self) -> &UserProfile {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UserResponse {
     pub status: Union2KerrorOrKsuccess,
-
     pub data: Option<User>,
-
     pub error: Option<ErrorDetail>,
-
     pub metadata: ResponseMetadata,
 }
 
-impl AsRef<UserResponse> for UserResponse {
+impl ::std::convert::AsRef<UserResponse> for UserResponse {
     fn as_ref(&self) -> &UserResponse {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Variant {
     pub sku: String,
-
     pub price: f64,
-
     pub stock: i64,
-
     pub options: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Variant> for Variant {
+impl ::std::convert::AsRef<Variant> for Variant {
     fn as_ref(&self) -> &Variant {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Widget {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: Union4KbuttonOrKcontainerOrKimageOrKtext,
-
     pub button: Option<ButtonWidget>,
-
     pub text: Option<TextWidget>,
-
     pub img: Option<ImageWidget>,
-
     pub container: Option<Box<ContainerWidget>>,
 }
 
-impl AsRef<Widget> for Widget {
+impl ::std::convert::AsRef<Widget> for Widget {
     fn as_ref(&self) -> &Widget {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/types/mod.rs
@@ -132,122 +132,122 @@ pub enum Types {
     Union5KcontainsOrKeqOrKgtOrKltOrKne(Union5KcontainsOrKeqOrKgtOrKltOrKne),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::Action(_) => "Action",
+            Self::Action(_) => "Action",
 
-            Types::Asset(_) => "Asset",
+            Self::Asset(_) => "Asset",
 
-            Types::AssetMetadata(_) => "AssetMetadata",
+            Self::AssetMetadata(_) => "AssetMetadata",
 
-            Types::ButtonWidget(_) => "ButtonWidget",
+            Self::ButtonWidget(_) => "ButtonWidget",
 
-            Types::ComplexData(_) => "ComplexData",
+            Self::ComplexData(_) => "ComplexData",
 
-            Types::Condition(_) => "Condition",
+            Self::Condition(_) => "Condition",
 
-            Types::Configuration(_) => "Configuration",
+            Self::Configuration(_) => "Configuration",
 
-            Types::ContainerWidget(_) => "ContainerWidget",
+            Self::ContainerWidget(_) => "ContainerWidget",
 
-            Types::DataObject(_) => "DataObject",
+            Self::DataObject(_) => "DataObject",
 
-            Types::Dimensions(_) => "Dimensions",
+            Self::Dimensions(_) => "Dimensions",
 
-            Types::Environment(_) => "Environment",
+            Self::Environment(_) => "Environment",
 
-            Types::Error(_) => "Error",
+            Self::Error(_) => "Error",
 
-            Types::ErrorDetail(_) => "ErrorDetail",
+            Self::ErrorDetail(_) => "ErrorDetail",
 
-            Types::Feature(_) => "Feature",
+            Self::Feature(_) => "Feature",
 
-            Types::ImageWidget(_) => "ImageWidget",
+            Self::ImageWidget(_) => "ImageWidget",
 
-            Types::Item(_) => "Item",
+            Self::Item(_) => "Item",
 
-            Types::KitchenSink(_) => "KitchenSink",
+            Self::KitchenSink(_) => "KitchenSink",
 
-            Types::Node(_) => "Node",
+            Self::Node(_) => "Node",
 
-            Types::NodeMetadata(_) => "NodeMetadata",
+            Self::NodeMetadata(_) => "NodeMetadata",
 
-            Types::PrimaryData(_) => "PrimaryData",
+            Self::PrimaryData(_) => "PrimaryData",
 
-            Types::Record(_) => "Record",
+            Self::Record(_) => "Record",
 
-            Types::ResponseMetadata(_) => "ResponseMetadata",
+            Self::ResponseMetadata(_) => "ResponseMetadata",
 
-            Types::Rule(_) => "Rule",
+            Self::Rule(_) => "Rule",
 
-            Types::SecondaryData(_) => "SecondaryData",
+            Self::SecondaryData(_) => "SecondaryData",
 
-            Types::Setting(_) => "Setting",
+            Self::Setting(_) => "Setting",
 
-            Types::SimpleCondition(_) => "SimpleCondition",
+            Self::SimpleCondition(_) => "SimpleCondition",
 
-            Types::Success(_) => "Success",
+            Self::Success(_) => "Success",
 
-            Types::TertiaryData(_) => "TertiaryData",
+            Self::TertiaryData(_) => "TertiaryData",
 
-            Types::TextWidget(_) => "TextWidget",
+            Self::TextWidget(_) => "TextWidget",
 
-            Types::UltraComplex(_) => "UltraComplex",
+            Self::UltraComplex(_) => "UltraComplex",
 
-            Types::User(_) => "User",
+            Self::User(_) => "User",
 
-            Types::UserProfile(_) => "UserProfile",
+            Self::UserProfile(_) => "UserProfile",
 
-            Types::UserResponse(_) => "UserResponse",
+            Self::UserResponse(_) => "UserResponse",
 
-            Types::Variant(_) => "Variant",
+            Self::Variant(_) => "Variant",
 
-            Types::Widget(_) => "Widget",
+            Self::Widget(_) => "Widget",
 
-            Types::Union2ConditionOrSimpleCondition(_) => "Union2ConditionOrSimpleCondition",
+            Self::Union2ConditionOrSimpleCondition(_) => "Union2ConditionOrSimpleCondition",
 
-            Types::Union2ErrorOrSuccess(_) => "Union2ErrorOrSuccess",
+            Self::Union2ErrorOrSuccess(_) => "Union2ErrorOrSuccess",
 
-            Types::Union2KbranchOrKleaf(_) => "Union2KbranchOrKleaf",
+            Self::Union2KbranchOrKleaf(_) => "Union2KbranchOrKleaf",
 
-            Types::Union2KerrorOrKsuccess(_) => "Union2KerrorOrKsuccess",
+            Self::Union2KerrorOrKsuccess(_) => "Union2KerrorOrKsuccess",
 
-            Types::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
+            Self::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
 
-            Types::Union3DataObjectOrIntOrString(_) => "Union3DataObjectOrIntOrString",
+            Self::Union3DataObjectOrIntOrString(_) => "Union3DataObjectOrIntOrString",
 
-            Types::Union3FloatOrIntOrString(_) => "Union3FloatOrIntOrString",
+            Self::Union3FloatOrIntOrString(_) => "Union3FloatOrIntOrString",
 
-            Types::Union3KandOrKnotOrKor(_) => "Union3KandOrKnotOrKor",
+            Self::Union3KandOrKnotOrKor(_) => "Union3KandOrKnotOrKor",
 
-            Types::Union3KarchivedOrKdraftOrKpublished(_) => "Union3KarchivedOrKdraftOrKpublished",
+            Self::Union3KarchivedOrKdraftOrKpublished(_) => "Union3KarchivedOrKdraftOrKpublished",
 
-            Types::Union3KaudioOrKdocumentOrKimage(_) => "Union3KaudioOrKdocumentOrKimage",
+            Self::Union3KaudioOrKdocumentOrKimage(_) => "Union3KaudioOrKdocumentOrKimage",
 
-            Types::Union3KflexOrKgridOrKstack(_) => "Union3KflexOrKgridOrKstack",
+            Self::Union3KflexOrKgridOrKstack(_) => "Union3KflexOrKgridOrKstack",
 
-            Types::Union3KhtmlOrKmarkdownOrKplain(_) => "Union3KhtmlOrKmarkdownOrKplain",
+            Self::Union3KhtmlOrKmarkdownOrKplain(_) => "Union3KhtmlOrKmarkdownOrKplain",
 
-            Types::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
+            Self::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
 
-            Types::Union4IntOrListNodeOrMapStringKeyNodeValueOrString(_) => {
+            Self::Union4IntOrListNodeOrMapStringKeyNodeValueOrString(_) => {
                 "Union4IntOrListNodeOrMapStringKeyNodeValueOrString"
             }
 
-            Types::Union4KbuttonOrKcontainerOrKimageOrKtext(_) => {
+            Self::Union4KbuttonOrKcontainerOrKimageOrKtext(_) => {
                 "Union4KbuttonOrKcontainerOrKimageOrKtext"
             }
 
-            Types::Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5(_) => {
+            Self::Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5(_) => {
                 "Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5"
             }
 
-            Types::Union5KcontainsOrKeqOrKgtOrKltOrKne(_) => "Union5KcontainsOrKeqOrKgtOrKltOrKne",
+            Self::Union5KcontainsOrKeqOrKgtOrKltOrKne(_) => "Union5KcontainsOrKeqOrKgtOrKltOrKne",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     Action(Action),
 
@@ -131,7 +133,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -247,5 +249,15 @@ impl baml::KnownTypes for Types {
 
             Types::Union5KcontainsOrKeqOrKgtOrKltOrKne(_) => "Union5KcontainsOrKeqOrKgtOrKltOrKne",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/mixed_complex_types/baml_client/types/unions.rs
@@ -6,11 +6,15 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (Condition | SimpleCondition)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ConditionOrSimpleCondition {
     #[baml(name = "Condition")]
     Condition(Box<Condition>),
@@ -19,21 +23,22 @@ pub enum Union2ConditionOrSimpleCondition {
     SimpleCondition(SimpleCondition),
 }
 
-impl AsRef<Union2ConditionOrSimpleCondition> for Union2ConditionOrSimpleCondition {
+impl ::std::convert::AsRef<Union2ConditionOrSimpleCondition> for Union2ConditionOrSimpleCondition {
     fn as_ref(&self) -> &Union2ConditionOrSimpleCondition {
         self
     }
 }
 
-impl Default for Union2ConditionOrSimpleCondition {
+impl ::std::default::Default for Union2ConditionOrSimpleCondition {
     fn default() -> Self {
-        Self::Condition(Default::default())
+        Self::Condition(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Success | Error)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ErrorOrSuccess {
     #[baml(name = "Success")]
     Success(Success),
@@ -42,67 +47,78 @@ pub enum Union2ErrorOrSuccess {
     Error(Error),
 }
 
-impl AsRef<Union2ErrorOrSuccess> for Union2ErrorOrSuccess {
+impl ::std::convert::AsRef<Union2ErrorOrSuccess> for Union2ErrorOrSuccess {
     fn as_ref(&self) -> &Union2ErrorOrSuccess {
         self
     }
 }
 
-impl Default for Union2ErrorOrSuccess {
+impl ::std::default::Default for Union2ErrorOrSuccess {
     fn default() -> Self {
-        Self::Success(Default::default())
+        Self::Success(::std::default::Default::default())
     }
 }
 
 /// Generated from: ("leaf" | "branch")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2KbranchOrKleaf {
     #[baml(name = "string_leaf", literal_string = "leaf")]
+    #[serde(with = "__baml_serde_union_literal_Union2KbranchOrKleaf::Kleaf")]
     Kleaf,
 
     #[baml(name = "string_branch", literal_string = "branch")]
+    #[serde(with = "__baml_serde_union_literal_Union2KbranchOrKleaf::Kbranch")]
     Kbranch,
 }
 
-impl AsRef<Union2KbranchOrKleaf> for Union2KbranchOrKleaf {
+impl ::std::convert::AsRef<Union2KbranchOrKleaf> for Union2KbranchOrKleaf {
     fn as_ref(&self) -> &Union2KbranchOrKleaf {
         self
     }
 }
 
-impl Default for Union2KbranchOrKleaf {
+impl ::std::default::Default for Union2KbranchOrKleaf {
     fn default() -> Self {
         Self::Kleaf
     }
 }
 
 /// Generated from: ("success" | "error")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2KerrorOrKsuccess {
     #[baml(name = "string_success", literal_string = "success")]
+    #[serde(with = "__baml_serde_union_literal_Union2KerrorOrKsuccess::Ksuccess")]
     Ksuccess,
 
     #[baml(name = "string_error", literal_string = "error")]
+    #[serde(with = "__baml_serde_union_literal_Union2KerrorOrKsuccess::Kerror")]
     Kerror,
 }
 
-impl AsRef<Union2KerrorOrKsuccess> for Union2KerrorOrKsuccess {
+impl ::std::convert::AsRef<Union2KerrorOrKsuccess> for Union2KerrorOrKsuccess {
     fn as_ref(&self) -> &Union2KerrorOrKsuccess {
         self
     }
 }
 
-impl Default for Union2KerrorOrKsuccess {
+impl ::std::default::Default for Union2KerrorOrKsuccess {
     fn default() -> Self {
         Self::Ksuccess
     }
 }
 
 /// Generated from: (string | int | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BoolOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -114,21 +130,22 @@ pub enum Union3BoolOrIntOrString {
     Bool(bool),
 }
 
-impl AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
+impl ::std::convert::AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
     fn as_ref(&self) -> &Union3BoolOrIntOrString {
         self
     }
 }
 
-impl Default for Union3BoolOrIntOrString {
+impl ::std::default::Default for Union3BoolOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int | DataObject)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3DataObjectOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -140,21 +157,22 @@ pub enum Union3DataObjectOrIntOrString {
     DataObject(DataObject),
 }
 
-impl AsRef<Union3DataObjectOrIntOrString> for Union3DataObjectOrIntOrString {
+impl ::std::convert::AsRef<Union3DataObjectOrIntOrString> for Union3DataObjectOrIntOrString {
     fn as_ref(&self) -> &Union3DataObjectOrIntOrString {
         self
     }
 }
 
-impl Default for Union3DataObjectOrIntOrString {
+impl ::std::default::Default for Union3DataObjectOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3FloatOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -166,151 +184,184 @@ pub enum Union3FloatOrIntOrString {
     Float(f64),
 }
 
-impl AsRef<Union3FloatOrIntOrString> for Union3FloatOrIntOrString {
+impl ::std::convert::AsRef<Union3FloatOrIntOrString> for Union3FloatOrIntOrString {
     fn as_ref(&self) -> &Union3FloatOrIntOrString {
         self
     }
 }
 
-impl Default for Union3FloatOrIntOrString {
+impl ::std::default::Default for Union3FloatOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: ("and" | "or" | "not")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KandOrKnotOrKor {
     #[baml(name = "string_and", literal_string = "and")]
+    #[serde(with = "__baml_serde_union_literal_Union3KandOrKnotOrKor::Kand")]
     Kand,
 
     #[baml(name = "string_or", literal_string = "or")]
+    #[serde(with = "__baml_serde_union_literal_Union3KandOrKnotOrKor::Kor")]
     Kor,
 
     #[baml(name = "string_not", literal_string = "not")]
+    #[serde(with = "__baml_serde_union_literal_Union3KandOrKnotOrKor::Knot")]
     Knot,
 }
 
-impl AsRef<Union3KandOrKnotOrKor> for Union3KandOrKnotOrKor {
+impl ::std::convert::AsRef<Union3KandOrKnotOrKor> for Union3KandOrKnotOrKor {
     fn as_ref(&self) -> &Union3KandOrKnotOrKor {
         self
     }
 }
 
-impl Default for Union3KandOrKnotOrKor {
+impl ::std::default::Default for Union3KandOrKnotOrKor {
     fn default() -> Self {
         Self::Kand
     }
 }
 
 /// Generated from: ("draft" | "published" | "archived")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KarchivedOrKdraftOrKpublished {
     #[baml(name = "string_draft", literal_string = "draft")]
+    #[serde(with = "__baml_serde_union_literal_Union3KarchivedOrKdraftOrKpublished::Kdraft")]
     Kdraft,
 
     #[baml(name = "string_published", literal_string = "published")]
+    #[serde(with = "__baml_serde_union_literal_Union3KarchivedOrKdraftOrKpublished::Kpublished")]
     Kpublished,
 
     #[baml(name = "string_archived", literal_string = "archived")]
+    #[serde(with = "__baml_serde_union_literal_Union3KarchivedOrKdraftOrKpublished::Karchived")]
     Karchived,
 }
 
-impl AsRef<Union3KarchivedOrKdraftOrKpublished> for Union3KarchivedOrKdraftOrKpublished {
+impl ::std::convert::AsRef<Union3KarchivedOrKdraftOrKpublished>
+    for Union3KarchivedOrKdraftOrKpublished
+{
     fn as_ref(&self) -> &Union3KarchivedOrKdraftOrKpublished {
         self
     }
 }
 
-impl Default for Union3KarchivedOrKdraftOrKpublished {
+impl ::std::default::Default for Union3KarchivedOrKdraftOrKpublished {
     fn default() -> Self {
         Self::Kdraft
     }
 }
 
 /// Generated from: ("image" | "audio" | "document")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KaudioOrKdocumentOrKimage {
     #[baml(name = "string_image", literal_string = "image")]
+    #[serde(with = "__baml_serde_union_literal_Union3KaudioOrKdocumentOrKimage::Kimage")]
     Kimage,
 
     #[baml(name = "string_audio", literal_string = "audio")]
+    #[serde(with = "__baml_serde_union_literal_Union3KaudioOrKdocumentOrKimage::Kaudio")]
     Kaudio,
 
     #[baml(name = "string_document", literal_string = "document")]
+    #[serde(with = "__baml_serde_union_literal_Union3KaudioOrKdocumentOrKimage::Kdocument")]
     Kdocument,
 }
 
-impl AsRef<Union3KaudioOrKdocumentOrKimage> for Union3KaudioOrKdocumentOrKimage {
+impl ::std::convert::AsRef<Union3KaudioOrKdocumentOrKimage> for Union3KaudioOrKdocumentOrKimage {
     fn as_ref(&self) -> &Union3KaudioOrKdocumentOrKimage {
         self
     }
 }
 
-impl Default for Union3KaudioOrKdocumentOrKimage {
+impl ::std::default::Default for Union3KaudioOrKdocumentOrKimage {
     fn default() -> Self {
         Self::Kimage
     }
 }
 
 /// Generated from: ("flex" | "grid" | "stack")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KflexOrKgridOrKstack {
     #[baml(name = "string_flex", literal_string = "flex")]
+    #[serde(with = "__baml_serde_union_literal_Union3KflexOrKgridOrKstack::Kflex")]
     Kflex,
 
     #[baml(name = "string_grid", literal_string = "grid")]
+    #[serde(with = "__baml_serde_union_literal_Union3KflexOrKgridOrKstack::Kgrid")]
     Kgrid,
 
     #[baml(name = "string_stack", literal_string = "stack")]
+    #[serde(with = "__baml_serde_union_literal_Union3KflexOrKgridOrKstack::Kstack")]
     Kstack,
 }
 
-impl AsRef<Union3KflexOrKgridOrKstack> for Union3KflexOrKgridOrKstack {
+impl ::std::convert::AsRef<Union3KflexOrKgridOrKstack> for Union3KflexOrKgridOrKstack {
     fn as_ref(&self) -> &Union3KflexOrKgridOrKstack {
         self
     }
 }
 
-impl Default for Union3KflexOrKgridOrKstack {
+impl ::std::default::Default for Union3KflexOrKgridOrKstack {
     fn default() -> Self {
         Self::Kflex
     }
 }
 
 /// Generated from: ("plain" | "markdown" | "html")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KhtmlOrKmarkdownOrKplain {
     #[baml(name = "string_plain", literal_string = "plain")]
+    #[serde(with = "__baml_serde_union_literal_Union3KhtmlOrKmarkdownOrKplain::Kplain")]
     Kplain,
 
     #[baml(name = "string_markdown", literal_string = "markdown")]
+    #[serde(with = "__baml_serde_union_literal_Union3KhtmlOrKmarkdownOrKplain::Kmarkdown")]
     Kmarkdown,
 
     #[baml(name = "string_html", literal_string = "html")]
+    #[serde(with = "__baml_serde_union_literal_Union3KhtmlOrKmarkdownOrKplain::Khtml")]
     Khtml,
 }
 
-impl AsRef<Union3KhtmlOrKmarkdownOrKplain> for Union3KhtmlOrKmarkdownOrKplain {
+impl ::std::convert::AsRef<Union3KhtmlOrKmarkdownOrKplain> for Union3KhtmlOrKmarkdownOrKplain {
     fn as_ref(&self) -> &Union3KhtmlOrKmarkdownOrKplain {
         self
     }
 }
 
-impl Default for Union3KhtmlOrKmarkdownOrKplain {
+impl ::std::default::Default for Union3KhtmlOrKmarkdownOrKplain {
     fn default() -> Self {
         Self::Kplain
     }
 }
 
 /// Generated from: (string | int | float | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4BoolOrFloatOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -325,21 +376,22 @@ pub enum Union4BoolOrFloatOrIntOrString {
     Bool(bool),
 }
 
-impl AsRef<Union4BoolOrFloatOrIntOrString> for Union4BoolOrFloatOrIntOrString {
+impl ::std::convert::AsRef<Union4BoolOrFloatOrIntOrString> for Union4BoolOrFloatOrIntOrString {
     fn as_ref(&self) -> &Union4BoolOrFloatOrIntOrString {
         self
     }
 }
 
-impl Default for Union4BoolOrFloatOrIntOrString {
+impl ::std::default::Default for Union4BoolOrFloatOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int | Node[] | map<string, Node>)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
     #[baml(name = "string")]
     String(String),
@@ -354,7 +406,7 @@ pub enum Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
     MapStringKeyNodeValue(std::collections::HashMap<String, Node>),
 }
 
-impl AsRef<Union4IntOrListNodeOrMapStringKeyNodeValueOrString>
+impl ::std::convert::AsRef<Union4IntOrListNodeOrMapStringKeyNodeValueOrString>
     for Union4IntOrListNodeOrMapStringKeyNodeValueOrString
 {
     fn as_ref(&self) -> &Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
@@ -362,100 +414,131 @@ impl AsRef<Union4IntOrListNodeOrMapStringKeyNodeValueOrString>
     }
 }
 
-impl Default for Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
+impl ::std::default::Default for Union4IntOrListNodeOrMapStringKeyNodeValueOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: ("button" | "text" | "image" | "container")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4KbuttonOrKcontainerOrKimageOrKtext {
     #[baml(name = "string_button", literal_string = "button")]
+    #[serde(with = "__baml_serde_union_literal_Union4KbuttonOrKcontainerOrKimageOrKtext::Kbutton")]
     Kbutton,
 
     #[baml(name = "string_text", literal_string = "text")]
+    #[serde(with = "__baml_serde_union_literal_Union4KbuttonOrKcontainerOrKimageOrKtext::Ktext")]
     Ktext,
 
     #[baml(name = "string_image", literal_string = "image")]
+    #[serde(with = "__baml_serde_union_literal_Union4KbuttonOrKcontainerOrKimageOrKtext::Kimage")]
     Kimage,
 
     #[baml(name = "string_container", literal_string = "container")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KbuttonOrKcontainerOrKimageOrKtext::Kcontainer"
+    )]
     Kcontainer,
 }
 
-impl AsRef<Union4KbuttonOrKcontainerOrKimageOrKtext> for Union4KbuttonOrKcontainerOrKimageOrKtext {
+impl ::std::convert::AsRef<Union4KbuttonOrKcontainerOrKimageOrKtext>
+    for Union4KbuttonOrKcontainerOrKimageOrKtext
+{
     fn as_ref(&self) -> &Union4KbuttonOrKcontainerOrKimageOrKtext {
         self
     }
 }
 
-impl Default for Union4KbuttonOrKcontainerOrKimageOrKtext {
+impl ::std::default::Default for Union4KbuttonOrKcontainerOrKimageOrKtext {
     fn default() -> Self {
         Self::Kbutton
     }
 }
 
 /// Generated from: (1 | 2 | 3 | 4 | 5)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
     #[baml(name = "int_1", literal_int = 1)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK1")]
     IntK1,
 
     #[baml(name = "int_2", literal_int = 2)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK2")]
     IntK2,
 
     #[baml(name = "int_3", literal_int = 3)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK3")]
     IntK3,
 
     #[baml(name = "int_4", literal_int = 4)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK4")]
     IntK4,
 
     #[baml(name = "int_5", literal_int = 5)]
+    #[serde(with = "__baml_serde_union_literal_Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5::IntK5")]
     IntK5,
 }
 
-impl AsRef<Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5> for Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
+impl ::std::convert::AsRef<Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5>
+    for Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5
+{
     fn as_ref(&self) -> &Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
         self
     }
 }
 
-impl Default for Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
+impl ::std::default::Default for Union5IntK1OrIntK2OrIntK3OrIntK4OrIntK5 {
     fn default() -> Self {
         Self::IntK1
     }
 }
 
 /// Generated from: ("eq" | "ne" | "gt" | "lt" | "contains")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union5KcontainsOrKeqOrKgtOrKltOrKne {
     #[baml(name = "string_eq", literal_string = "eq")]
+    #[serde(with = "__baml_serde_union_literal_Union5KcontainsOrKeqOrKgtOrKltOrKne::Keq")]
     Keq,
 
     #[baml(name = "string_ne", literal_string = "ne")]
+    #[serde(with = "__baml_serde_union_literal_Union5KcontainsOrKeqOrKgtOrKltOrKne::Kne")]
     Kne,
 
     #[baml(name = "string_gt", literal_string = "gt")]
+    #[serde(with = "__baml_serde_union_literal_Union5KcontainsOrKeqOrKgtOrKltOrKne::Kgt")]
     Kgt,
 
     #[baml(name = "string_lt", literal_string = "lt")]
+    #[serde(with = "__baml_serde_union_literal_Union5KcontainsOrKeqOrKgtOrKltOrKne::Klt")]
     Klt,
 
     #[baml(name = "string_contains", literal_string = "contains")]
+    #[serde(with = "__baml_serde_union_literal_Union5KcontainsOrKeqOrKgtOrKltOrKne::Kcontains")]
     Kcontains,
 }
 
-impl AsRef<Union5KcontainsOrKeqOrKgtOrKltOrKne> for Union5KcontainsOrKeqOrKgtOrKltOrKne {
+impl ::std::convert::AsRef<Union5KcontainsOrKeqOrKgtOrKltOrKne>
+    for Union5KcontainsOrKeqOrKgtOrKltOrKne
+{
     fn as_ref(&self) -> &Union5KcontainsOrKeqOrKgtOrKltOrKne {
         self
     }
 }
 
-impl Default for Union5KcontainsOrKeqOrKgtOrKltOrKne {
+impl ::std::default::Default for Union5KcontainsOrKeqOrKgtOrKltOrKne {
     fn default() -> Self {
         Self::Keq
     }

--- a/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Address {
     pub street: Option<String>,
 
@@ -28,14 +28,14 @@ pub struct Address {
     pub coordinates: Option<Coordinates>,
 }
 
-impl AsRef<Address> for Address {
+impl ::std::convert::AsRef<Address> for Address {
     fn as_ref(&self) -> &Address {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Approval {
     pub approver: Option<String>,
 
@@ -46,14 +46,14 @@ pub struct Approval {
     pub notes: Option<String>,
 }
 
-impl AsRef<Approval> for Approval {
+impl ::std::convert::AsRef<Approval> for Approval {
     fn as_ref(&self) -> &Approval {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Budget {
     pub total: Option<f64>,
 
@@ -64,14 +64,14 @@ pub struct Budget {
     pub approvals: Vec<Approval>,
 }
 
-impl AsRef<Budget> for Budget {
+impl ::std::convert::AsRef<Budget> for Budget {
     fn as_ref(&self) -> &Budget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Company {
     pub id: Option<i64>,
 
@@ -84,14 +84,14 @@ pub struct Company {
     pub metadata: Option<Box<CompanyMetadata>>,
 }
 
-impl AsRef<Company> for Company {
+impl ::std::convert::AsRef<Company> for Company {
     fn as_ref(&self) -> &Company {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CompanyMetadata {
     pub founded: Option<String>,
 
@@ -104,14 +104,14 @@ pub struct CompanyMetadata {
     pub partnerships: Option<Vec<Box<Company>>>,
 }
 
-impl AsRef<CompanyMetadata> for CompanyMetadata {
+impl ::std::convert::AsRef<CompanyMetadata> for CompanyMetadata {
     fn as_ref(&self) -> &CompanyMetadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexNested {
     pub company: Option<Company>,
 
@@ -120,14 +120,14 @@ pub struct ComplexNested {
     pub projects: Vec<Project>,
 }
 
-impl AsRef<ComplexNested> for ComplexNested {
+impl ::std::convert::AsRef<ComplexNested> for ComplexNested {
     fn as_ref(&self) -> &ComplexNested {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Contact {
     pub name: Option<String>,
 
@@ -138,40 +138,40 @@ pub struct Contact {
     pub email: Option<String>,
 }
 
-impl AsRef<Contact> for Contact {
+impl ::std::convert::AsRef<Contact> for Contact {
     fn as_ref(&self) -> &Contact {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Coordinates {
     pub latitude: Option<f64>,
 
     pub longitude: Option<f64>,
 }
 
-impl AsRef<Coordinates> for Coordinates {
+impl ::std::convert::AsRef<Coordinates> for Coordinates {
     fn as_ref(&self) -> &Coordinates {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DeeplyNested {
     pub level1: Option<Level1>,
 }
 
-impl AsRef<DeeplyNested> for DeeplyNested {
+impl ::std::convert::AsRef<DeeplyNested> for DeeplyNested {
     fn as_ref(&self) -> &DeeplyNested {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Department {
     pub id: Option<i64>,
 
@@ -186,14 +186,14 @@ pub struct Department {
     pub projects: Vec<Project>,
 }
 
-impl AsRef<Department> for Department {
+impl ::std::convert::AsRef<Department> for Department {
     fn as_ref(&self) -> &Department {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DisplaySettings {
     pub fontSize: Option<i64>,
 
@@ -202,14 +202,14 @@ pub struct DisplaySettings {
     pub layout: Option<types::Union2KgridOrKlist>,
 }
 
-impl AsRef<DisplaySettings> for DisplaySettings {
+impl ::std::convert::AsRef<DisplaySettings> for DisplaySettings {
     fn as_ref(&self) -> &DisplaySettings {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Employee {
     pub id: Option<i64>,
 
@@ -228,70 +228,70 @@ pub struct Employee {
     pub emergencyContact: Option<Contact>,
 }
 
-impl AsRef<Employee> for Employee {
+impl ::std::convert::AsRef<Employee> for Employee {
     fn as_ref(&self) -> &Employee {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level1 {
     pub data: Option<String>,
 
     pub level2: Option<Level2>,
 }
 
-impl AsRef<Level1> for Level1 {
+impl ::std::convert::AsRef<Level1> for Level1 {
     fn as_ref(&self) -> &Level1 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level2 {
     pub data: Option<String>,
 
     pub level3: Option<Level3>,
 }
 
-impl AsRef<Level2> for Level2 {
+impl ::std::convert::AsRef<Level2> for Level2 {
     fn as_ref(&self) -> &Level2 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level3 {
     pub data: Option<String>,
 
     pub level4: Option<Level4>,
 }
 
-impl AsRef<Level3> for Level3 {
+impl ::std::convert::AsRef<Level3> for Level3 {
     fn as_ref(&self) -> &Level3 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level4 {
     pub data: Option<String>,
 
     pub level5: Option<Level5>,
 }
 
-impl AsRef<Level4> for Level4 {
+impl ::std::convert::AsRef<Level4> for Level4 {
     fn as_ref(&self) -> &Level4 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level5 {
     pub data: Option<String>,
 
@@ -300,14 +300,14 @@ pub struct Level5 {
     pub mapping: std::collections::HashMap<String, i64>,
 }
 
-impl AsRef<Level5> for Level5 {
+impl ::std::convert::AsRef<Level5> for Level5 {
     fn as_ref(&self) -> &Level5 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Metadata {
     pub createdAt: Option<String>,
 
@@ -320,14 +320,14 @@ pub struct Metadata {
     pub attributes: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Metadata> for Metadata {
+impl ::std::convert::AsRef<Metadata> for Metadata {
     fn as_ref(&self) -> &Metadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Milestone {
     pub id: Option<i64>,
 
@@ -340,14 +340,14 @@ pub struct Milestone {
     pub tasks: Vec<Task>,
 }
 
-impl AsRef<Milestone> for Milestone {
+impl ::std::convert::AsRef<Milestone> for Milestone {
     fn as_ref(&self) -> &Milestone {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NotificationSettings {
     pub email: Option<bool>,
 
@@ -358,14 +358,14 @@ pub struct NotificationSettings {
     pub frequency: Option<types::Union3KdailyOrKimmediateOrKweekly>,
 }
 
-impl AsRef<NotificationSettings> for NotificationSettings {
+impl ::std::convert::AsRef<NotificationSettings> for NotificationSettings {
     fn as_ref(&self) -> &NotificationSettings {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Preferences {
     pub theme: Option<types::Union2KdarkOrKlight>,
 
@@ -374,14 +374,14 @@ pub struct Preferences {
     pub notifications: Option<NotificationSettings>,
 }
 
-impl AsRef<Preferences> for Preferences {
+impl ::std::convert::AsRef<Preferences> for Preferences {
     fn as_ref(&self) -> &Preferences {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrivacySettings {
     pub profileVisibility: Option<types::Union3KfriendsOrKprivateOrKpublic>,
 
@@ -390,14 +390,14 @@ pub struct PrivacySettings {
     pub showPhone: Option<bool>,
 }
 
-impl AsRef<PrivacySettings> for PrivacySettings {
+impl ::std::convert::AsRef<PrivacySettings> for PrivacySettings {
     fn as_ref(&self) -> &PrivacySettings {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Profile {
     pub bio: Option<String>,
 
@@ -408,14 +408,14 @@ pub struct Profile {
     pub preferences: Option<Preferences>,
 }
 
-impl AsRef<Profile> for Profile {
+impl ::std::convert::AsRef<Profile> for Profile {
     fn as_ref(&self) -> &Profile {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Project {
     pub id: Option<i64>,
 
@@ -432,14 +432,14 @@ pub struct Project {
     pub budget: Option<Budget>,
 }
 
-impl AsRef<Project> for Project {
+impl ::std::convert::AsRef<Project> for Project {
     fn as_ref(&self) -> &Project {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RecursiveStructure {
     pub id: Option<i64>,
 
@@ -452,14 +452,14 @@ pub struct RecursiveStructure {
     pub metadata: std::collections::HashMap<String, types::Union3BoolOrIntOrString>,
 }
 
-impl AsRef<RecursiveStructure> for RecursiveStructure {
+impl ::std::convert::AsRef<RecursiveStructure> for RecursiveStructure {
     fn as_ref(&self) -> &RecursiveStructure {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleNested {
     pub user: Option<User>,
 
@@ -468,14 +468,14 @@ pub struct SimpleNested {
     pub metadata: Option<Metadata>,
 }
 
-impl AsRef<SimpleNested> for SimpleNested {
+impl ::std::convert::AsRef<SimpleNested> for SimpleNested {
     fn as_ref(&self) -> &SimpleNested {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SocialLinks {
     pub twitter: Option<String>,
 
@@ -486,14 +486,14 @@ pub struct SocialLinks {
     pub website: Option<String>,
 }
 
-impl AsRef<SocialLinks> for SocialLinks {
+impl ::std::convert::AsRef<SocialLinks> for SocialLinks {
     fn as_ref(&self) -> &SocialLinks {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Task {
     pub id: Option<i64>,
 
@@ -510,14 +510,14 @@ pub struct Task {
     pub subtasks: Option<Vec<Box<Task>>>,
 }
 
-impl AsRef<Task> for Task {
+impl ::std::convert::AsRef<Task> for Task {
     fn as_ref(&self) -> &Task {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: Option<i64>,
 
@@ -528,14 +528,14 @@ pub struct User {
     pub settings: Option<UserSettings>,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UserSettings {
     pub privacy: Option<PrivacySettings>,
 
@@ -544,7 +544,7 @@ pub struct UserSettings {
     pub advanced: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<UserSettings> for UserSettings {
+impl ::std::convert::AsRef<UserSettings> for UserSettings {
     fn as_ref(&self) -> &UserSettings {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     Address(Address),
 
@@ -80,7 +83,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -146,5 +149,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::UserSettings(_) => "UserSettings",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct AddressClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl AddressClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Address is statically defined in .baml and should always have a type")
@@ -37,42 +37,42 @@ impl AddressClassBuilder {
     // =========================================================================
 
     /// Access the `street` field builder.
-    pub fn property_street(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_street(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("street")
             .expect("Address.street is statically defined in .baml and should always be present")
     }
 
     /// Access the `city` field builder.
-    pub fn property_city(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_city(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("city")
             .expect("Address.city is statically defined in .baml and should always be present")
     }
 
     /// Access the `state` field builder.
-    pub fn property_state(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_state(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("state")
             .expect("Address.state is statically defined in .baml and should always be present")
     }
 
     /// Access the `country` field builder.
-    pub fn property_country(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_country(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("country")
             .expect("Address.country is statically defined in .baml and should always be present")
     }
 
     /// Access the `postalCode` field builder.
-    pub fn property_postalCode(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_postalCode(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("postalCode").expect(
             "Address.postalCode is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `coordinates` field builder.
-    pub fn property_coordinates(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_coordinates(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("coordinates").expect(
             "Address.coordinates is statically defined in .baml and should always be present",
         )
@@ -85,22 +85,22 @@ impl AddressClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ApprovalClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ApprovalClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Approval is statically defined in .baml and should always have a type")
@@ -111,28 +111,28 @@ impl ApprovalClassBuilder {
     // =========================================================================
 
     /// Access the `approver` field builder.
-    pub fn property_approver(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_approver(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("approver")
             .expect("Approval.approver is statically defined in .baml and should always be present")
     }
 
     /// Access the `date` field builder.
-    pub fn property_date(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_date(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("date")
             .expect("Approval.date is statically defined in .baml and should always be present")
     }
 
     /// Access the `amount` field builder.
-    pub fn property_amount(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_amount(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("amount")
             .expect("Approval.amount is statically defined in .baml and should always be present")
     }
 
     /// Access the `notes` field builder.
-    pub fn property_notes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_notes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("notes")
             .expect("Approval.notes is statically defined in .baml and should always be present")
@@ -145,22 +145,22 @@ impl ApprovalClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BudgetClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BudgetClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Budget is statically defined in .baml and should always have a type")
@@ -171,28 +171,28 @@ impl BudgetClassBuilder {
     // =========================================================================
 
     /// Access the `total` field builder.
-    pub fn property_total(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_total(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("total")
             .expect("Budget.total is statically defined in .baml and should always be present")
     }
 
     /// Access the `spent` field builder.
-    pub fn property_spent(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_spent(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("spent")
             .expect("Budget.spent is statically defined in .baml and should always be present")
     }
 
     /// Access the `categories` field builder.
-    pub fn property_categories(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_categories(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("categories")
             .expect("Budget.categories is statically defined in .baml and should always be present")
     }
 
     /// Access the `approvals` field builder.
-    pub fn property_approvals(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_approvals(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("approvals")
             .expect("Budget.approvals is statically defined in .baml and should always be present")
@@ -205,22 +205,22 @@ impl BudgetClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct CompanyClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl CompanyClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Company is statically defined in .baml and should always have a type")
@@ -231,35 +231,35 @@ impl CompanyClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Company.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Company.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `address` field builder.
-    pub fn property_address(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_address(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("address")
             .expect("Company.address is statically defined in .baml and should always be present")
     }
 
     /// Access the `departments` field builder.
-    pub fn property_departments(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_departments(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("departments").expect(
             "Company.departments is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("metadata")
             .expect("Company.metadata is statically defined in .baml and should always be present")
@@ -272,22 +272,22 @@ impl CompanyClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct CompanyMetadataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl CompanyMetadataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("CompanyMetadata is statically defined in .baml and should always have a type")
@@ -298,34 +298,34 @@ impl CompanyMetadataClassBuilder {
     // =========================================================================
 
     /// Access the `founded` field builder.
-    pub fn property_founded(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_founded(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("founded").expect(
             "CompanyMetadata.founded is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `industry` field builder.
-    pub fn property_industry(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_industry(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("industry").expect(
             "CompanyMetadata.industry is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `size` field builder.
-    pub fn property_size(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_size(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("size").expect(
             "CompanyMetadata.size is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `certifications` field builder.
-    pub fn property_certifications(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_certifications(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("certifications")
             .expect("CompanyMetadata.certifications is statically defined in .baml and should always be present")
     }
 
     /// Access the `partnerships` field builder.
-    pub fn property_partnerships(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_partnerships(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("partnerships")
             .expect("CompanyMetadata.partnerships is statically defined in .baml and should always be present")
     }
@@ -337,22 +337,22 @@ impl CompanyMetadataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ComplexNestedClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ComplexNestedClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ComplexNested is statically defined in .baml and should always have a type")
@@ -363,21 +363,21 @@ impl ComplexNestedClassBuilder {
     // =========================================================================
 
     /// Access the `company` field builder.
-    pub fn property_company(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_company(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("company").expect(
             "ComplexNested.company is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `employees` field builder.
-    pub fn property_employees(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_employees(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("employees").expect(
             "ComplexNested.employees is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `projects` field builder.
-    pub fn property_projects(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_projects(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("projects").expect(
             "ComplexNested.projects is statically defined in .baml and should always be present",
         )
@@ -390,22 +390,22 @@ impl ComplexNestedClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ContactClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ContactClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Contact is statically defined in .baml and should always have a type")
@@ -416,28 +416,28 @@ impl ContactClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Contact.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `relationship` field builder.
-    pub fn property_relationship(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_relationship(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("relationship").expect(
             "Contact.relationship is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `phone` field builder.
-    pub fn property_phone(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_phone(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("phone")
             .expect("Contact.phone is statically defined in .baml and should always be present")
     }
 
     /// Access the `email` field builder.
-    pub fn property_email(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_email(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("email")
             .expect("Contact.email is statically defined in .baml and should always be present")
@@ -450,22 +450,22 @@ impl ContactClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct CoordinatesClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl CoordinatesClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Coordinates is statically defined in .baml and should always have a type")
@@ -476,14 +476,14 @@ impl CoordinatesClassBuilder {
     // =========================================================================
 
     /// Access the `latitude` field builder.
-    pub fn property_latitude(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_latitude(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("latitude").expect(
             "Coordinates.latitude is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `longitude` field builder.
-    pub fn property_longitude(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_longitude(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("longitude").expect(
             "Coordinates.longitude is statically defined in .baml and should always be present",
         )
@@ -496,22 +496,22 @@ impl CoordinatesClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DeeplyNestedClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DeeplyNestedClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DeeplyNested is statically defined in .baml and should always have a type")
@@ -522,7 +522,7 @@ impl DeeplyNestedClassBuilder {
     // =========================================================================
 
     /// Access the `level1` field builder.
-    pub fn property_level1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_level1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("level1").expect(
             "DeeplyNested.level1 is statically defined in .baml and should always be present",
         )
@@ -535,22 +535,22 @@ impl DeeplyNestedClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DepartmentClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DepartmentClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Department is statically defined in .baml and should always have a type")
@@ -561,42 +561,42 @@ impl DepartmentClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Department.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Department.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `manager` field builder.
-    pub fn property_manager(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_manager(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("manager").expect(
             "Department.manager is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `members` field builder.
-    pub fn property_members(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_members(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("members").expect(
             "Department.members is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `budget` field builder.
-    pub fn property_budget(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_budget(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("budget")
             .expect("Department.budget is statically defined in .baml and should always be present")
     }
 
     /// Access the `projects` field builder.
-    pub fn property_projects(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_projects(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("projects").expect(
             "Department.projects is statically defined in .baml and should always be present",
         )
@@ -609,22 +609,22 @@ impl DepartmentClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DisplaySettingsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DisplaySettingsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DisplaySettings is statically defined in .baml and should always have a type")
@@ -635,20 +635,20 @@ impl DisplaySettingsClassBuilder {
     // =========================================================================
 
     /// Access the `fontSize` field builder.
-    pub fn property_fontSize(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_fontSize(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("fontSize").expect(
             "DisplaySettings.fontSize is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `colorScheme` field builder.
-    pub fn property_colorScheme(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_colorScheme(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("colorScheme")
             .expect("DisplaySettings.colorScheme is statically defined in .baml and should always be present")
     }
 
     /// Access the `layout` field builder.
-    pub fn property_layout(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_layout(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("layout").expect(
             "DisplaySettings.layout is statically defined in .baml and should always be present",
         )
@@ -661,22 +661,22 @@ impl DisplaySettingsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct EmployeeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl EmployeeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Employee is statically defined in .baml and should always have a type")
@@ -687,56 +687,56 @@ impl EmployeeClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Employee.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Employee.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `email` field builder.
-    pub fn property_email(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_email(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("email")
             .expect("Employee.email is statically defined in .baml and should always be present")
     }
 
     /// Access the `role` field builder.
-    pub fn property_role(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_role(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("role")
             .expect("Employee.role is statically defined in .baml and should always be present")
     }
 
     /// Access the `department` field builder.
-    pub fn property_department(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_department(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("department").expect(
             "Employee.department is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `skills` field builder.
-    pub fn property_skills(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_skills(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("skills")
             .expect("Employee.skills is statically defined in .baml and should always be present")
     }
 
     /// Access the `address` field builder.
-    pub fn property_address(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_address(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("address")
             .expect("Employee.address is statically defined in .baml and should always be present")
     }
 
     /// Access the `emergencyContact` field builder.
-    pub fn property_emergencyContact(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_emergencyContact(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("emergencyContact").expect(
             "Employee.emergencyContact is statically defined in .baml and should always be present",
         )
@@ -749,22 +749,22 @@ impl EmployeeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct Level1ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl Level1ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Level1 is statically defined in .baml and should always have a type")
@@ -775,14 +775,14 @@ impl Level1ClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Level1.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `level2` field builder.
-    pub fn property_level2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_level2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("level2")
             .expect("Level1.level2 is statically defined in .baml and should always be present")
@@ -795,22 +795,22 @@ impl Level1ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct Level2ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl Level2ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Level2 is statically defined in .baml and should always have a type")
@@ -821,14 +821,14 @@ impl Level2ClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Level2.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `level3` field builder.
-    pub fn property_level3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_level3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("level3")
             .expect("Level2.level3 is statically defined in .baml and should always be present")
@@ -841,22 +841,22 @@ impl Level2ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct Level3ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl Level3ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Level3 is statically defined in .baml and should always have a type")
@@ -867,14 +867,14 @@ impl Level3ClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Level3.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `level4` field builder.
-    pub fn property_level4(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_level4(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("level4")
             .expect("Level3.level4 is statically defined in .baml and should always be present")
@@ -887,22 +887,22 @@ impl Level3ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct Level4ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl Level4ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Level4 is statically defined in .baml and should always have a type")
@@ -913,14 +913,14 @@ impl Level4ClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Level4.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `level5` field builder.
-    pub fn property_level5(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_level5(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("level5")
             .expect("Level4.level5 is statically defined in .baml and should always be present")
@@ -933,22 +933,22 @@ impl Level4ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct Level5ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl Level5ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Level5 is statically defined in .baml and should always have a type")
@@ -959,21 +959,21 @@ impl Level5ClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Level5.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `items` field builder.
-    pub fn property_items(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_items(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("items")
             .expect("Level5.items is statically defined in .baml and should always be present")
     }
 
     /// Access the `mapping` field builder.
-    pub fn property_mapping(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mapping(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("mapping")
             .expect("Level5.mapping is statically defined in .baml and should always be present")
@@ -986,22 +986,22 @@ impl Level5ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MetadataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MetadataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Metadata is statically defined in .baml and should always have a type")
@@ -1012,35 +1012,35 @@ impl MetadataClassBuilder {
     // =========================================================================
 
     /// Access the `createdAt` field builder.
-    pub fn property_createdAt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_createdAt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("createdAt").expect(
             "Metadata.createdAt is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `updatedAt` field builder.
-    pub fn property_updatedAt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_updatedAt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("updatedAt").expect(
             "Metadata.updatedAt is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `version` field builder.
-    pub fn property_version(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_version(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("version")
             .expect("Metadata.version is statically defined in .baml and should always be present")
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tags")
             .expect("Metadata.tags is statically defined in .baml and should always be present")
     }
 
     /// Access the `attributes` field builder.
-    pub fn property_attributes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_attributes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("attributes").expect(
             "Metadata.attributes is statically defined in .baml and should always be present",
         )
@@ -1053,22 +1053,22 @@ impl MetadataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MilestoneClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MilestoneClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Milestone is statically defined in .baml and should always have a type")
@@ -1079,35 +1079,35 @@ impl MilestoneClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Milestone.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Milestone.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `dueDate` field builder.
-    pub fn property_dueDate(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_dueDate(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("dueDate")
             .expect("Milestone.dueDate is statically defined in .baml and should always be present")
     }
 
     /// Access the `completed` field builder.
-    pub fn property_completed(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_completed(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("completed").expect(
             "Milestone.completed is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `tasks` field builder.
-    pub fn property_tasks(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tasks(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tasks")
             .expect("Milestone.tasks is statically defined in .baml and should always be present")
@@ -1120,22 +1120,22 @@ impl MilestoneClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NotificationSettingsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NotificationSettingsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "NotificationSettings is statically defined in .baml and should always have a type",
         )
@@ -1146,27 +1146,27 @@ impl NotificationSettingsClassBuilder {
     // =========================================================================
 
     /// Access the `email` field builder.
-    pub fn property_email(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_email(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("email")
             .expect("NotificationSettings.email is statically defined in .baml and should always be present")
     }
 
     /// Access the `push` field builder.
-    pub fn property_push(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_push(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("push").expect(
             "NotificationSettings.push is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `sms` field builder.
-    pub fn property_sms(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_sms(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("sms").expect(
             "NotificationSettings.sms is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `frequency` field builder.
-    pub fn property_frequency(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_frequency(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("frequency")
             .expect("NotificationSettings.frequency is statically defined in .baml and should always be present")
     }
@@ -1178,22 +1178,22 @@ impl NotificationSettingsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PreferencesClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PreferencesClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Preferences is statically defined in .baml and should always have a type")
@@ -1204,21 +1204,21 @@ impl PreferencesClassBuilder {
     // =========================================================================
 
     /// Access the `theme` field builder.
-    pub fn property_theme(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_theme(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("theme")
             .expect("Preferences.theme is statically defined in .baml and should always be present")
     }
 
     /// Access the `language` field builder.
-    pub fn property_language(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_language(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("language").expect(
             "Preferences.language is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `notifications` field builder.
-    pub fn property_notifications(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_notifications(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("notifications").expect(
             "Preferences.notifications is statically defined in .baml and should always be present",
         )
@@ -1231,22 +1231,22 @@ impl PreferencesClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PrivacySettingsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PrivacySettingsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("PrivacySettings is statically defined in .baml and should always have a type")
@@ -1257,20 +1257,20 @@ impl PrivacySettingsClassBuilder {
     // =========================================================================
 
     /// Access the `profileVisibility` field builder.
-    pub fn property_profileVisibility(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_profileVisibility(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("profileVisibility")
             .expect("PrivacySettings.profileVisibility is statically defined in .baml and should always be present")
     }
 
     /// Access the `showEmail` field builder.
-    pub fn property_showEmail(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_showEmail(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("showEmail").expect(
             "PrivacySettings.showEmail is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `showPhone` field builder.
-    pub fn property_showPhone(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_showPhone(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("showPhone").expect(
             "PrivacySettings.showPhone is statically defined in .baml and should always be present",
         )
@@ -1283,22 +1283,22 @@ impl PrivacySettingsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ProfileClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ProfileClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Profile is statically defined in .baml and should always have a type")
@@ -1309,28 +1309,28 @@ impl ProfileClassBuilder {
     // =========================================================================
 
     /// Access the `bio` field builder.
-    pub fn property_bio(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_bio(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("bio")
             .expect("Profile.bio is statically defined in .baml and should always be present")
     }
 
     /// Access the `avatar` field builder.
-    pub fn property_avatar(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_avatar(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("avatar")
             .expect("Profile.avatar is statically defined in .baml and should always be present")
     }
 
     /// Access the `social` field builder.
-    pub fn property_social(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_social(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("social")
             .expect("Profile.social is statically defined in .baml and should always be present")
     }
 
     /// Access the `preferences` field builder.
-    pub fn property_preferences(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_preferences(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("preferences").expect(
             "Profile.preferences is statically defined in .baml and should always be present",
         )
@@ -1343,22 +1343,22 @@ impl ProfileClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ProjectClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ProjectClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Project is statically defined in .baml and should always have a type")
@@ -1369,49 +1369,49 @@ impl ProjectClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Project.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Project.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description").expect(
             "Project.description is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("status")
             .expect("Project.status is statically defined in .baml and should always be present")
     }
 
     /// Access the `team` field builder.
-    pub fn property_team(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_team(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("team")
             .expect("Project.team is statically defined in .baml and should always be present")
     }
 
     /// Access the `milestones` field builder.
-    pub fn property_milestones(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_milestones(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("milestones").expect(
             "Project.milestones is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `budget` field builder.
-    pub fn property_budget(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_budget(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("budget")
             .expect("Project.budget is statically defined in .baml and should always be present")
@@ -1424,22 +1424,22 @@ impl ProjectClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct RecursiveStructureClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RecursiveStructureClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "RecursiveStructure is statically defined in .baml and should always have a type",
         )
@@ -1450,34 +1450,34 @@ impl RecursiveStructureClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("id").expect(
             "RecursiveStructure.id is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("name").expect(
             "RecursiveStructure.name is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `children` field builder.
-    pub fn property_children(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_children(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("children")
             .expect("RecursiveStructure.children is statically defined in .baml and should always be present")
     }
 
     /// Access the `parent` field builder.
-    pub fn property_parent(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_parent(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("parent").expect(
             "RecursiveStructure.parent is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadata")
             .expect("RecursiveStructure.metadata is statically defined in .baml and should always be present")
     }
@@ -1489,22 +1489,22 @@ impl RecursiveStructureClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SimpleNestedClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SimpleNestedClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SimpleNested is statically defined in .baml and should always have a type")
@@ -1515,21 +1515,21 @@ impl SimpleNestedClassBuilder {
     // =========================================================================
 
     /// Access the `user` field builder.
-    pub fn property_user(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_user(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("user")
             .expect("SimpleNested.user is statically defined in .baml and should always be present")
     }
 
     /// Access the `address` field builder.
-    pub fn property_address(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_address(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("address").expect(
             "SimpleNested.address is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadata").expect(
             "SimpleNested.metadata is statically defined in .baml and should always be present",
         )
@@ -1542,22 +1542,22 @@ impl SimpleNestedClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SocialLinksClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SocialLinksClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SocialLinks is statically defined in .baml and should always have a type")
@@ -1568,28 +1568,28 @@ impl SocialLinksClassBuilder {
     // =========================================================================
 
     /// Access the `twitter` field builder.
-    pub fn property_twitter(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_twitter(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("twitter").expect(
             "SocialLinks.twitter is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `github` field builder.
-    pub fn property_github(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_github(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("github").expect(
             "SocialLinks.github is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `linkedin` field builder.
-    pub fn property_linkedin(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_linkedin(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("linkedin").expect(
             "SocialLinks.linkedin is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `website` field builder.
-    pub fn property_website(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_website(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("website").expect(
             "SocialLinks.website is statically defined in .baml and should always be present",
         )
@@ -1602,22 +1602,22 @@ impl SocialLinksClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TaskClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TaskClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Task is statically defined in .baml and should always have a type")
@@ -1628,49 +1628,49 @@ impl TaskClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Task.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `title` field builder.
-    pub fn property_title(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_title(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("title")
             .expect("Task.title is statically defined in .baml and should always be present")
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("description")
             .expect("Task.description is statically defined in .baml and should always be present")
     }
 
     /// Access the `assignee` field builder.
-    pub fn property_assignee(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_assignee(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("assignee")
             .expect("Task.assignee is statically defined in .baml and should always be present")
     }
 
     /// Access the `priority` field builder.
-    pub fn property_priority(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_priority(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("priority")
             .expect("Task.priority is statically defined in .baml and should always be present")
     }
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("status")
             .expect("Task.status is statically defined in .baml and should always be present")
     }
 
     /// Access the `subtasks` field builder.
-    pub fn property_subtasks(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_subtasks(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("subtasks")
             .expect("Task.subtasks is statically defined in .baml and should always be present")
@@ -1683,22 +1683,22 @@ impl TaskClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("User is statically defined in .baml and should always have a type")
@@ -1709,28 +1709,28 @@ impl UserClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("User.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("User.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `profile` field builder.
-    pub fn property_profile(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_profile(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("profile")
             .expect("User.profile is statically defined in .baml and should always be present")
     }
 
     /// Access the `settings` field builder.
-    pub fn property_settings(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_settings(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("settings")
             .expect("User.settings is statically defined in .baml and should always be present")
@@ -1743,22 +1743,22 @@ impl UserClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserSettingsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserSettingsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("UserSettings is statically defined in .baml and should always have a type")
@@ -1769,21 +1769,21 @@ impl UserSettingsClassBuilder {
     // =========================================================================
 
     /// Access the `privacy` field builder.
-    pub fn property_privacy(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_privacy(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("privacy").expect(
             "UserSettings.privacy is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `display` field builder.
-    pub fn property_display(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_display(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("display").expect(
             "UserSettings.display is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `advanced` field builder.
-    pub fn property_advanced(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_advanced(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("advanced").expect(
             "UserSettings.advanced is statically defined in .baml and should always be present",
         )

--- a/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -329,27 +327,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -358,17 +356,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -377,22 +375,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -401,12 +399,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -415,17 +413,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -434,29 +435,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/types/classes.rs
@@ -6,541 +6,455 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Address {
     pub street: String,
-
     pub city: String,
-
     pub state: String,
-
     pub country: String,
-
     pub postalCode: String,
-
     pub coordinates: Option<Coordinates>,
 }
 
-impl AsRef<Address> for Address {
+impl ::std::convert::AsRef<Address> for Address {
     fn as_ref(&self) -> &Address {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Approval {
     pub approver: String,
-
     pub date: String,
-
     pub amount: f64,
-
     pub notes: Option<String>,
 }
 
-impl AsRef<Approval> for Approval {
+impl ::std::convert::AsRef<Approval> for Approval {
     fn as_ref(&self) -> &Approval {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Budget {
     pub total: f64,
-
     pub spent: f64,
-
     pub categories: std::collections::HashMap<String, f64>,
-
     pub approvals: Vec<Approval>,
 }
 
-impl AsRef<Budget> for Budget {
+impl ::std::convert::AsRef<Budget> for Budget {
     fn as_ref(&self) -> &Budget {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Company {
     pub id: i64,
-
     pub name: String,
-
     pub address: Address,
-
     pub departments: Vec<Department>,
-
     pub metadata: Box<CompanyMetadata>,
 }
 
-impl AsRef<Company> for Company {
+impl ::std::convert::AsRef<Company> for Company {
     fn as_ref(&self) -> &Company {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CompanyMetadata {
     pub founded: String,
-
     pub industry: String,
-
     pub size: Union4KenterpriseOrKlargeOrKmediumOrKsmall,
-
     pub certifications: Vec<String>,
-
     pub partnerships: Option<Vec<Box<Company>>>,
 }
 
-impl AsRef<CompanyMetadata> for CompanyMetadata {
+impl ::std::convert::AsRef<CompanyMetadata> for CompanyMetadata {
     fn as_ref(&self) -> &CompanyMetadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexNested {
     pub company: Company,
-
     pub employees: Vec<Employee>,
-
     pub projects: Vec<Project>,
 }
 
-impl AsRef<ComplexNested> for ComplexNested {
+impl ::std::convert::AsRef<ComplexNested> for ComplexNested {
     fn as_ref(&self) -> &ComplexNested {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Contact {
     pub name: String,
-
     pub relationship: String,
-
     pub phone: String,
-
     pub email: Option<String>,
 }
 
-impl AsRef<Contact> for Contact {
+impl ::std::convert::AsRef<Contact> for Contact {
     fn as_ref(&self) -> &Contact {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Coordinates {
     pub latitude: f64,
-
     pub longitude: f64,
 }
 
-impl AsRef<Coordinates> for Coordinates {
+impl ::std::convert::AsRef<Coordinates> for Coordinates {
     fn as_ref(&self) -> &Coordinates {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DeeplyNested {
     pub level1: Level1,
 }
 
-impl AsRef<DeeplyNested> for DeeplyNested {
+impl ::std::convert::AsRef<DeeplyNested> for DeeplyNested {
     fn as_ref(&self) -> &DeeplyNested {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Department {
     pub id: i64,
-
     pub name: String,
-
     pub manager: Option<Employee>,
-
     pub members: Vec<Employee>,
-
     pub budget: f64,
-
     pub projects: Vec<Project>,
 }
 
-impl AsRef<Department> for Department {
+impl ::std::convert::AsRef<Department> for Department {
     fn as_ref(&self) -> &Department {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DisplaySettings {
     pub fontSize: i64,
-
     pub colorScheme: String,
-
     pub layout: Union2KgridOrKlist,
 }
 
-impl AsRef<DisplaySettings> for DisplaySettings {
+impl ::std::convert::AsRef<DisplaySettings> for DisplaySettings {
     fn as_ref(&self) -> &DisplaySettings {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Employee {
     pub id: i64,
-
     pub name: String,
-
     pub email: String,
-
     pub role: String,
-
     pub department: String,
-
     pub skills: Vec<String>,
-
     pub address: Option<Address>,
-
     pub emergencyContact: Option<Contact>,
 }
 
-impl AsRef<Employee> for Employee {
+impl ::std::convert::AsRef<Employee> for Employee {
     fn as_ref(&self) -> &Employee {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level1 {
     pub data: String,
-
     pub level2: Level2,
 }
 
-impl AsRef<Level1> for Level1 {
+impl ::std::convert::AsRef<Level1> for Level1 {
     fn as_ref(&self) -> &Level1 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level2 {
     pub data: String,
-
     pub level3: Level3,
 }
 
-impl AsRef<Level2> for Level2 {
+impl ::std::convert::AsRef<Level2> for Level2 {
     fn as_ref(&self) -> &Level2 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level3 {
     pub data: String,
-
     pub level4: Level4,
 }
 
-impl AsRef<Level3> for Level3 {
+impl ::std::convert::AsRef<Level3> for Level3 {
     fn as_ref(&self) -> &Level3 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level4 {
     pub data: String,
-
     pub level5: Level5,
 }
 
-impl AsRef<Level4> for Level4 {
+impl ::std::convert::AsRef<Level4> for Level4 {
     fn as_ref(&self) -> &Level4 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Level5 {
     pub data: String,
-
     pub items: Vec<String>,
-
     pub mapping: std::collections::HashMap<String, i64>,
 }
 
-impl AsRef<Level5> for Level5 {
+impl ::std::convert::AsRef<Level5> for Level5 {
     fn as_ref(&self) -> &Level5 {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Metadata {
     pub createdAt: String,
-
     pub updatedAt: String,
-
     pub version: i64,
-
     pub tags: Vec<String>,
-
     pub attributes: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Metadata> for Metadata {
+impl ::std::convert::AsRef<Metadata> for Metadata {
     fn as_ref(&self) -> &Metadata {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Milestone {
     pub id: i64,
-
     pub name: String,
-
     pub dueDate: String,
-
     pub completed: bool,
-
     pub tasks: Vec<Task>,
 }
 
-impl AsRef<Milestone> for Milestone {
+impl ::std::convert::AsRef<Milestone> for Milestone {
     fn as_ref(&self) -> &Milestone {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NotificationSettings {
     pub email: bool,
-
     pub push: bool,
-
     pub sms: bool,
-
     pub frequency: Union3KdailyOrKimmediateOrKweekly,
 }
 
-impl AsRef<NotificationSettings> for NotificationSettings {
+impl ::std::convert::AsRef<NotificationSettings> for NotificationSettings {
     fn as_ref(&self) -> &NotificationSettings {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Preferences {
     pub theme: Union2KdarkOrKlight,
-
     pub language: String,
-
     pub notifications: NotificationSettings,
 }
 
-impl AsRef<Preferences> for Preferences {
+impl ::std::convert::AsRef<Preferences> for Preferences {
     fn as_ref(&self) -> &Preferences {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrivacySettings {
     pub profileVisibility: Union3KfriendsOrKprivateOrKpublic,
-
     pub showEmail: bool,
-
     pub showPhone: bool,
 }
 
-impl AsRef<PrivacySettings> for PrivacySettings {
+impl ::std::convert::AsRef<PrivacySettings> for PrivacySettings {
     fn as_ref(&self) -> &PrivacySettings {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Profile {
     pub bio: String,
-
     pub avatar: String,
-
     pub social: SocialLinks,
-
     pub preferences: Preferences,
 }
 
-impl AsRef<Profile> for Profile {
+impl ::std::convert::AsRef<Profile> for Profile {
     fn as_ref(&self) -> &Profile {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Project {
     pub id: i64,
-
     pub name: String,
-
     pub description: String,
-
     pub status: Union4KactiveOrKcancelledOrKcompletedOrKplanning,
-
     pub team: Vec<Employee>,
-
     pub milestones: Vec<Milestone>,
-
     pub budget: Budget,
 }
 
-impl AsRef<Project> for Project {
+impl ::std::convert::AsRef<Project> for Project {
     fn as_ref(&self) -> &Project {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RecursiveStructure {
     pub id: i64,
-
     pub name: String,
-
     pub children: Vec<Box<RecursiveStructure>>,
-
     pub parent: Option<Box<RecursiveStructure>>,
-
     pub metadata: std::collections::HashMap<String, Union3BoolOrIntOrString>,
 }
 
-impl AsRef<RecursiveStructure> for RecursiveStructure {
+impl ::std::convert::AsRef<RecursiveStructure> for RecursiveStructure {
     fn as_ref(&self) -> &RecursiveStructure {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleNested {
     pub user: User,
-
     pub address: Address,
-
     pub metadata: Metadata,
 }
 
-impl AsRef<SimpleNested> for SimpleNested {
+impl ::std::convert::AsRef<SimpleNested> for SimpleNested {
     fn as_ref(&self) -> &SimpleNested {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SocialLinks {
     pub twitter: Option<String>,
-
     pub github: Option<String>,
-
     pub linkedin: Option<String>,
-
     pub website: Option<String>,
 }
 
-impl AsRef<SocialLinks> for SocialLinks {
+impl ::std::convert::AsRef<SocialLinks> for SocialLinks {
     fn as_ref(&self) -> &SocialLinks {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Task {
     pub id: i64,
-
     pub title: String,
-
     pub description: String,
-
     pub assignee: String,
-
     pub priority: Union3KhighOrKlowOrKmedium,
-
     pub status: Union3KdoneOrKin_progressOrKtodo,
-
     pub subtasks: Option<Vec<Box<Task>>>,
 }
 
-impl AsRef<Task> for Task {
+impl ::std::convert::AsRef<Task> for Task {
     fn as_ref(&self) -> &Task {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: i64,
-
     pub name: String,
-
     pub profile: Profile,
-
     pub settings: UserSettings,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UserSettings {
     pub privacy: PrivacySettings,
-
     pub display: DisplaySettings,
-
     pub advanced: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<UserSettings> for UserSettings {
+impl ::std::convert::AsRef<UserSettings> for UserSettings {
     fn as_ref(&self) -> &UserSettings {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     Address(Address),
 
@@ -105,7 +107,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -193,5 +195,15 @@ impl baml::KnownTypes for Types {
                 "Union4KenterpriseOrKlargeOrKmediumOrKsmall"
             }
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/types/mod.rs
@@ -106,92 +106,92 @@ pub enum Types {
     Union4KenterpriseOrKlargeOrKmediumOrKsmall(Union4KenterpriseOrKlargeOrKmediumOrKsmall),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::Address(_) => "Address",
+            Self::Address(_) => "Address",
 
-            Types::Approval(_) => "Approval",
+            Self::Approval(_) => "Approval",
 
-            Types::Budget(_) => "Budget",
+            Self::Budget(_) => "Budget",
 
-            Types::Company(_) => "Company",
+            Self::Company(_) => "Company",
 
-            Types::CompanyMetadata(_) => "CompanyMetadata",
+            Self::CompanyMetadata(_) => "CompanyMetadata",
 
-            Types::ComplexNested(_) => "ComplexNested",
+            Self::ComplexNested(_) => "ComplexNested",
 
-            Types::Contact(_) => "Contact",
+            Self::Contact(_) => "Contact",
 
-            Types::Coordinates(_) => "Coordinates",
+            Self::Coordinates(_) => "Coordinates",
 
-            Types::DeeplyNested(_) => "DeeplyNested",
+            Self::DeeplyNested(_) => "DeeplyNested",
 
-            Types::Department(_) => "Department",
+            Self::Department(_) => "Department",
 
-            Types::DisplaySettings(_) => "DisplaySettings",
+            Self::DisplaySettings(_) => "DisplaySettings",
 
-            Types::Employee(_) => "Employee",
+            Self::Employee(_) => "Employee",
 
-            Types::Level1(_) => "Level1",
+            Self::Level1(_) => "Level1",
 
-            Types::Level2(_) => "Level2",
+            Self::Level2(_) => "Level2",
 
-            Types::Level3(_) => "Level3",
+            Self::Level3(_) => "Level3",
 
-            Types::Level4(_) => "Level4",
+            Self::Level4(_) => "Level4",
 
-            Types::Level5(_) => "Level5",
+            Self::Level5(_) => "Level5",
 
-            Types::Metadata(_) => "Metadata",
+            Self::Metadata(_) => "Metadata",
 
-            Types::Milestone(_) => "Milestone",
+            Self::Milestone(_) => "Milestone",
 
-            Types::NotificationSettings(_) => "NotificationSettings",
+            Self::NotificationSettings(_) => "NotificationSettings",
 
-            Types::Preferences(_) => "Preferences",
+            Self::Preferences(_) => "Preferences",
 
-            Types::PrivacySettings(_) => "PrivacySettings",
+            Self::PrivacySettings(_) => "PrivacySettings",
 
-            Types::Profile(_) => "Profile",
+            Self::Profile(_) => "Profile",
 
-            Types::Project(_) => "Project",
+            Self::Project(_) => "Project",
 
-            Types::RecursiveStructure(_) => "RecursiveStructure",
+            Self::RecursiveStructure(_) => "RecursiveStructure",
 
-            Types::SimpleNested(_) => "SimpleNested",
+            Self::SimpleNested(_) => "SimpleNested",
 
-            Types::SocialLinks(_) => "SocialLinks",
+            Self::SocialLinks(_) => "SocialLinks",
 
-            Types::Task(_) => "Task",
+            Self::Task(_) => "Task",
 
-            Types::User(_) => "User",
+            Self::User(_) => "User",
 
-            Types::UserSettings(_) => "UserSettings",
+            Self::UserSettings(_) => "UserSettings",
 
-            Types::Union2KdarkOrKlight(_) => "Union2KdarkOrKlight",
+            Self::Union2KdarkOrKlight(_) => "Union2KdarkOrKlight",
 
-            Types::Union2KgridOrKlist(_) => "Union2KgridOrKlist",
+            Self::Union2KgridOrKlist(_) => "Union2KgridOrKlist",
 
-            Types::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
+            Self::Union3BoolOrIntOrString(_) => "Union3BoolOrIntOrString",
 
-            Types::Union3KdailyOrKimmediateOrKweekly(_) => "Union3KdailyOrKimmediateOrKweekly",
+            Self::Union3KdailyOrKimmediateOrKweekly(_) => "Union3KdailyOrKimmediateOrKweekly",
 
-            Types::Union3KdoneOrKin_progressOrKtodo(_) => "Union3KdoneOrKin_progressOrKtodo",
+            Self::Union3KdoneOrKin_progressOrKtodo(_) => "Union3KdoneOrKin_progressOrKtodo",
 
-            Types::Union3KfriendsOrKprivateOrKpublic(_) => "Union3KfriendsOrKprivateOrKpublic",
+            Self::Union3KfriendsOrKprivateOrKpublic(_) => "Union3KfriendsOrKprivateOrKpublic",
 
-            Types::Union3KhighOrKlowOrKmedium(_) => "Union3KhighOrKlowOrKmedium",
+            Self::Union3KhighOrKlowOrKmedium(_) => "Union3KhighOrKlowOrKmedium",
 
-            Types::Union4KactiveOrKcancelledOrKcompletedOrKplanning(_) => {
+            Self::Union4KactiveOrKcancelledOrKcompletedOrKplanning(_) => {
                 "Union4KactiveOrKcancelledOrKcompletedOrKplanning"
             }
 
-            Types::Union4KenterpriseOrKlargeOrKmediumOrKsmall(_) => {
+            Self::Union4KenterpriseOrKlargeOrKmediumOrKsmall(_) => {
                 "Union4KenterpriseOrKlargeOrKmediumOrKsmall"
             }
         }

--- a/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/nested_structures/baml_client/types/unions.rs
@@ -6,57 +6,71 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: ("light" | "dark")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2KdarkOrKlight {
     #[baml(name = "string_light", literal_string = "light")]
+    #[serde(with = "__baml_serde_union_literal_Union2KdarkOrKlight::Klight")]
     Klight,
 
     #[baml(name = "string_dark", literal_string = "dark")]
+    #[serde(with = "__baml_serde_union_literal_Union2KdarkOrKlight::Kdark")]
     Kdark,
 }
 
-impl AsRef<Union2KdarkOrKlight> for Union2KdarkOrKlight {
+impl ::std::convert::AsRef<Union2KdarkOrKlight> for Union2KdarkOrKlight {
     fn as_ref(&self) -> &Union2KdarkOrKlight {
         self
     }
 }
 
-impl Default for Union2KdarkOrKlight {
+impl ::std::default::Default for Union2KdarkOrKlight {
     fn default() -> Self {
         Self::Klight
     }
 }
 
 /// Generated from: ("grid" | "list")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2KgridOrKlist {
     #[baml(name = "string_grid", literal_string = "grid")]
+    #[serde(with = "__baml_serde_union_literal_Union2KgridOrKlist::Kgrid")]
     Kgrid,
 
     #[baml(name = "string_list", literal_string = "list")]
+    #[serde(with = "__baml_serde_union_literal_Union2KgridOrKlist::Klist")]
     Klist,
 }
 
-impl AsRef<Union2KgridOrKlist> for Union2KgridOrKlist {
+impl ::std::convert::AsRef<Union2KgridOrKlist> for Union2KgridOrKlist {
     fn as_ref(&self) -> &Union2KgridOrKlist {
         self
     }
 }
 
-impl Default for Union2KgridOrKlist {
+impl ::std::default::Default for Union2KgridOrKlist {
     fn default() -> Self {
         Self::Kgrid
     }
 }
 
 /// Generated from: (string | int | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BoolOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -68,140 +82,183 @@ pub enum Union3BoolOrIntOrString {
     Bool(bool),
 }
 
-impl AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
+impl ::std::convert::AsRef<Union3BoolOrIntOrString> for Union3BoolOrIntOrString {
     fn as_ref(&self) -> &Union3BoolOrIntOrString {
         self
     }
 }
 
-impl Default for Union3BoolOrIntOrString {
+impl ::std::default::Default for Union3BoolOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: ("immediate" | "daily" | "weekly")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KdailyOrKimmediateOrKweekly {
     #[baml(name = "string_immediate", literal_string = "immediate")]
+    #[serde(with = "__baml_serde_union_literal_Union3KdailyOrKimmediateOrKweekly::Kimmediate")]
     Kimmediate,
 
     #[baml(name = "string_daily", literal_string = "daily")]
+    #[serde(with = "__baml_serde_union_literal_Union3KdailyOrKimmediateOrKweekly::Kdaily")]
     Kdaily,
 
     #[baml(name = "string_weekly", literal_string = "weekly")]
+    #[serde(with = "__baml_serde_union_literal_Union3KdailyOrKimmediateOrKweekly::Kweekly")]
     Kweekly,
 }
 
-impl AsRef<Union3KdailyOrKimmediateOrKweekly> for Union3KdailyOrKimmediateOrKweekly {
+impl ::std::convert::AsRef<Union3KdailyOrKimmediateOrKweekly>
+    for Union3KdailyOrKimmediateOrKweekly
+{
     fn as_ref(&self) -> &Union3KdailyOrKimmediateOrKweekly {
         self
     }
 }
 
-impl Default for Union3KdailyOrKimmediateOrKweekly {
+impl ::std::default::Default for Union3KdailyOrKimmediateOrKweekly {
     fn default() -> Self {
         Self::Kimmediate
     }
 }
 
 /// Generated from: ("todo" | "in_progress" | "done")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KdoneOrKin_progressOrKtodo {
     #[baml(name = "string_todo", literal_string = "todo")]
+    #[serde(with = "__baml_serde_union_literal_Union3KdoneOrKin_progressOrKtodo::Ktodo")]
     Ktodo,
 
     #[baml(name = "string_in_progress", literal_string = "in_progress")]
+    #[serde(with = "__baml_serde_union_literal_Union3KdoneOrKin_progressOrKtodo::Kin_progress")]
     Kin_progress,
 
     #[baml(name = "string_done", literal_string = "done")]
+    #[serde(with = "__baml_serde_union_literal_Union3KdoneOrKin_progressOrKtodo::Kdone")]
     Kdone,
 }
 
-impl AsRef<Union3KdoneOrKin_progressOrKtodo> for Union3KdoneOrKin_progressOrKtodo {
+impl ::std::convert::AsRef<Union3KdoneOrKin_progressOrKtodo> for Union3KdoneOrKin_progressOrKtodo {
     fn as_ref(&self) -> &Union3KdoneOrKin_progressOrKtodo {
         self
     }
 }
 
-impl Default for Union3KdoneOrKin_progressOrKtodo {
+impl ::std::default::Default for Union3KdoneOrKin_progressOrKtodo {
     fn default() -> Self {
         Self::Ktodo
     }
 }
 
 /// Generated from: ("public" | "private" | "friends")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KfriendsOrKprivateOrKpublic {
     #[baml(name = "string_public", literal_string = "public")]
+    #[serde(with = "__baml_serde_union_literal_Union3KfriendsOrKprivateOrKpublic::Kpublic")]
     Kpublic,
 
     #[baml(name = "string_private", literal_string = "private")]
+    #[serde(with = "__baml_serde_union_literal_Union3KfriendsOrKprivateOrKpublic::Kprivate")]
     Kprivate,
 
     #[baml(name = "string_friends", literal_string = "friends")]
+    #[serde(with = "__baml_serde_union_literal_Union3KfriendsOrKprivateOrKpublic::Kfriends")]
     Kfriends,
 }
 
-impl AsRef<Union3KfriendsOrKprivateOrKpublic> for Union3KfriendsOrKprivateOrKpublic {
+impl ::std::convert::AsRef<Union3KfriendsOrKprivateOrKpublic>
+    for Union3KfriendsOrKprivateOrKpublic
+{
     fn as_ref(&self) -> &Union3KfriendsOrKprivateOrKpublic {
         self
     }
 }
 
-impl Default for Union3KfriendsOrKprivateOrKpublic {
+impl ::std::default::Default for Union3KfriendsOrKprivateOrKpublic {
     fn default() -> Self {
         Self::Kpublic
     }
 }
 
 /// Generated from: ("low" | "medium" | "high")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3KhighOrKlowOrKmedium {
     #[baml(name = "string_low", literal_string = "low")]
+    #[serde(with = "__baml_serde_union_literal_Union3KhighOrKlowOrKmedium::Klow")]
     Klow,
 
     #[baml(name = "string_medium", literal_string = "medium")]
+    #[serde(with = "__baml_serde_union_literal_Union3KhighOrKlowOrKmedium::Kmedium")]
     Kmedium,
 
     #[baml(name = "string_high", literal_string = "high")]
+    #[serde(with = "__baml_serde_union_literal_Union3KhighOrKlowOrKmedium::Khigh")]
     Khigh,
 }
 
-impl AsRef<Union3KhighOrKlowOrKmedium> for Union3KhighOrKlowOrKmedium {
+impl ::std::convert::AsRef<Union3KhighOrKlowOrKmedium> for Union3KhighOrKlowOrKmedium {
     fn as_ref(&self) -> &Union3KhighOrKlowOrKmedium {
         self
     }
 }
 
-impl Default for Union3KhighOrKlowOrKmedium {
+impl ::std::default::Default for Union3KhighOrKlowOrKmedium {
     fn default() -> Self {
         Self::Klow
     }
 }
 
 /// Generated from: ("planning" | "active" | "completed" | "cancelled")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4KactiveOrKcancelledOrKcompletedOrKplanning {
     #[baml(name = "string_planning", literal_string = "planning")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KactiveOrKcancelledOrKcompletedOrKplanning::Kplanning"
+    )]
     Kplanning,
 
     #[baml(name = "string_active", literal_string = "active")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KactiveOrKcancelledOrKcompletedOrKplanning::Kactive"
+    )]
     Kactive,
 
     #[baml(name = "string_completed", literal_string = "completed")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KactiveOrKcancelledOrKcompletedOrKplanning::Kcompleted"
+    )]
     Kcompleted,
 
     #[baml(name = "string_cancelled", literal_string = "cancelled")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KactiveOrKcancelledOrKcompletedOrKplanning::Kcancelled"
+    )]
     Kcancelled,
 }
 
-impl AsRef<Union4KactiveOrKcancelledOrKcompletedOrKplanning>
+impl ::std::convert::AsRef<Union4KactiveOrKcancelledOrKcompletedOrKplanning>
     for Union4KactiveOrKcancelledOrKcompletedOrKplanning
 {
     fn as_ref(&self) -> &Union4KactiveOrKcancelledOrKcompletedOrKplanning {
@@ -209,30 +266,45 @@ impl AsRef<Union4KactiveOrKcancelledOrKcompletedOrKplanning>
     }
 }
 
-impl Default for Union4KactiveOrKcancelledOrKcompletedOrKplanning {
+impl ::std::default::Default for Union4KactiveOrKcancelledOrKcompletedOrKplanning {
     fn default() -> Self {
         Self::Kplanning
     }
 }
 
 /// Generated from: ("small" | "medium" | "large" | "enterprise")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4KenterpriseOrKlargeOrKmediumOrKsmall {
     #[baml(name = "string_small", literal_string = "small")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KenterpriseOrKlargeOrKmediumOrKsmall::Ksmall"
+    )]
     Ksmall,
 
     #[baml(name = "string_medium", literal_string = "medium")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KenterpriseOrKlargeOrKmediumOrKsmall::Kmedium"
+    )]
     Kmedium,
 
     #[baml(name = "string_large", literal_string = "large")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KenterpriseOrKlargeOrKmediumOrKsmall::Klarge"
+    )]
     Klarge,
 
     #[baml(name = "string_enterprise", literal_string = "enterprise")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union4KenterpriseOrKlargeOrKmediumOrKsmall::Kenterprise"
+    )]
     Kenterprise,
 }
 
-impl AsRef<Union4KenterpriseOrKlargeOrKmediumOrKsmall>
+impl ::std::convert::AsRef<Union4KenterpriseOrKlargeOrKmediumOrKsmall>
     for Union4KenterpriseOrKlargeOrKmediumOrKsmall
 {
     fn as_ref(&self) -> &Union4KenterpriseOrKlargeOrKmediumOrKsmall {
@@ -240,7 +312,7 @@ impl AsRef<Union4KenterpriseOrKlargeOrKmediumOrKsmall>
     }
 }
 
-impl Default for Union4KenterpriseOrKlargeOrKmediumOrKsmall {
+impl ::std::default::Default for Union4KenterpriseOrKlargeOrKmediumOrKsmall {
     fn default() -> Self {
         Self::Ksmall
     }

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexOptional {
     pub data: Option<OptionalData>,
 
@@ -22,14 +22,14 @@ pub struct ComplexOptional {
     pub mapping: std::collections::HashMap<String, Option<OptionalValue>>,
 }
 
-impl AsRef<ComplexOptional> for ComplexOptional {
+impl ::std::convert::AsRef<ComplexOptional> for ComplexOptional {
     fn as_ref(&self) -> &ComplexOptional {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedOptionalNullable {
     pub id: Option<i64>,
 
@@ -52,14 +52,14 @@ pub struct MixedOptionalNullable {
     pub tertiaryUser: Option<User>,
 }
 
-impl AsRef<MixedOptionalNullable> for MixedOptionalNullable {
+impl ::std::convert::AsRef<MixedOptionalNullable> for MixedOptionalNullable {
     fn as_ref(&self) -> &MixedOptionalNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NullableTypes {
     pub nullableString: Option<String>,
 
@@ -74,14 +74,14 @@ pub struct NullableTypes {
     pub nullableObject: Option<User>,
 }
 
-impl AsRef<NullableTypes> for NullableTypes {
+impl ::std::convert::AsRef<NullableTypes> for NullableTypes {
     fn as_ref(&self) -> &NullableTypes {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalData {
     pub value: Option<String>,
 
@@ -90,14 +90,14 @@ pub struct OptionalData {
     pub enabled: Option<bool>,
 }
 
-impl AsRef<OptionalData> for OptionalData {
+impl ::std::convert::AsRef<OptionalData> for OptionalData {
     fn as_ref(&self) -> &OptionalData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalFields {
     pub requiredString: Option<String>,
 
@@ -116,14 +116,14 @@ pub struct OptionalFields {
     pub optionalMap: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<OptionalFields> for OptionalFields {
+impl ::std::convert::AsRef<OptionalFields> for OptionalFields {
     fn as_ref(&self) -> &OptionalFields {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalItem {
     pub id: Option<i64>,
 
@@ -134,28 +134,28 @@ pub struct OptionalItem {
     pub metadata: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<OptionalItem> for OptionalItem {
+impl ::std::convert::AsRef<OptionalItem> for OptionalItem {
     fn as_ref(&self) -> &OptionalItem {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalValue {
     pub data: Option<types::Union2IntOrString>,
 
     pub optional: Option<String>,
 }
 
-impl AsRef<OptionalValue> for OptionalValue {
+impl ::std::convert::AsRef<OptionalValue> for OptionalValue {
     fn as_ref(&self) -> &OptionalValue {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Product {
     pub id: Option<i64>,
 
@@ -164,14 +164,14 @@ pub struct Product {
     pub price: Option<f64>,
 }
 
-impl AsRef<Product> for Product {
+impl ::std::convert::AsRef<Product> for Product {
     fn as_ref(&self) -> &Product {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UnionWithNull {
     pub simpleUnion: Option<types::Union2IntOrString>,
 
@@ -182,14 +182,14 @@ pub struct UnionWithNull {
     pub complexUnion: Option<Union2ProductOrUser>,
 }
 
-impl AsRef<UnionWithNull> for UnionWithNull {
+impl ::std::convert::AsRef<UnionWithNull> for UnionWithNull {
     fn as_ref(&self) -> &UnionWithNull {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: Option<i64>,
 
@@ -200,7 +200,7 @@ pub struct User {
     pub phone: Option<String>,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     ComplexOptional(ComplexOptional),
 
@@ -42,7 +45,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -70,5 +73,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::Union2ProductOrUser(_) => "Union2ProductOrUser",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/stream_types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/stream_types/unions.rs
@@ -7,11 +7,15 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{
+    BamlDecode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (Streaming.User | Streaming.Product | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ProductOrUser {
     #[baml(name = "User")]
     User(User),
@@ -20,14 +24,14 @@ pub enum Union2ProductOrUser {
     Product(Product),
 }
 
-impl AsRef<Union2ProductOrUser> for Union2ProductOrUser {
+impl ::std::convert::AsRef<Union2ProductOrUser> for Union2ProductOrUser {
     fn as_ref(&self) -> &Union2ProductOrUser {
         self
     }
 }
 
-impl Default for Union2ProductOrUser {
+impl ::std::default::Default for Union2ProductOrUser {
     fn default() -> Self {
-        Self::User(Default::default())
+        Self::User(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ComplexOptionalClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ComplexOptionalClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ComplexOptional is statically defined in .baml and should always have a type")
@@ -37,21 +37,21 @@ impl ComplexOptionalClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("data").expect(
             "ComplexOptional.data is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `items` field builder.
-    pub fn property_items(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_items(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("items").expect(
             "ComplexOptional.items is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `mapping` field builder.
-    pub fn property_mapping(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mapping(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mapping").expect(
             "ComplexOptional.mapping is statically defined in .baml and should always be present",
         )
@@ -64,22 +64,22 @@ impl ComplexOptionalClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MixedOptionalNullableClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MixedOptionalNullableClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "MixedOptionalNullable is statically defined in .baml and should always have a type",
         )
@@ -90,62 +90,62 @@ impl MixedOptionalNullableClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("id").expect(
             "MixedOptionalNullable.id is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description")
             .expect("MixedOptionalNullable.description is statically defined in .baml and should always be present")
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadata")
             .expect("MixedOptionalNullable.metadata is statically defined in .baml and should always be present")
     }
 
     /// Access the `notes` field builder.
-    pub fn property_notes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_notes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("notes")
             .expect("MixedOptionalNullable.notes is statically defined in .baml and should always be present")
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("tags")
             .expect("MixedOptionalNullable.tags is statically defined in .baml and should always be present")
     }
 
     /// Access the `categories` field builder.
-    pub fn property_categories(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_categories(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("categories")
             .expect("MixedOptionalNullable.categories is statically defined in .baml and should always be present")
     }
 
     /// Access the `keywords` field builder.
-    pub fn property_keywords(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_keywords(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("keywords")
             .expect("MixedOptionalNullable.keywords is statically defined in .baml and should always be present")
     }
 
     /// Access the `primaryUser` field builder.
-    pub fn property_primaryUser(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_primaryUser(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("primaryUser")
             .expect("MixedOptionalNullable.primaryUser is statically defined in .baml and should always be present")
     }
 
     /// Access the `secondaryUser` field builder.
-    pub fn property_secondaryUser(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_secondaryUser(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("secondaryUser")
             .expect("MixedOptionalNullable.secondaryUser is statically defined in .baml and should always be present")
     }
 
     /// Access the `tertiaryUser` field builder.
-    pub fn property_tertiaryUser(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tertiaryUser(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("tertiaryUser")
             .expect("MixedOptionalNullable.tertiaryUser is statically defined in .baml and should always be present")
     }
@@ -157,22 +157,22 @@ impl MixedOptionalNullableClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NullableTypesClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NullableTypesClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("NullableTypes is statically defined in .baml and should always have a type")
@@ -183,38 +183,38 @@ impl NullableTypesClassBuilder {
     // =========================================================================
 
     /// Access the `nullableString` field builder.
-    pub fn property_nullableString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableString")
             .expect("NullableTypes.nullableString is statically defined in .baml and should always be present")
     }
 
     /// Access the `nullableInt` field builder.
-    pub fn property_nullableInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableInt").expect(
             "NullableTypes.nullableInt is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullableFloat` field builder.
-    pub fn property_nullableFloat(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableFloat(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableFloat")
             .expect("NullableTypes.nullableFloat is statically defined in .baml and should always be present")
     }
 
     /// Access the `nullableBool` field builder.
-    pub fn property_nullableBool(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableBool(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableBool")
             .expect("NullableTypes.nullableBool is statically defined in .baml and should always be present")
     }
 
     /// Access the `nullableArray` field builder.
-    pub fn property_nullableArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableArray")
             .expect("NullableTypes.nullableArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `nullableObject` field builder.
-    pub fn property_nullableObject(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableObject(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableObject")
             .expect("NullableTypes.nullableObject is statically defined in .baml and should always be present")
     }
@@ -226,22 +226,22 @@ impl NullableTypesClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OptionalDataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OptionalDataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("OptionalData is statically defined in .baml and should always have a type")
@@ -252,21 +252,21 @@ impl OptionalDataClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value").expect(
             "OptionalData.value is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `count` field builder.
-    pub fn property_count(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_count(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("count").expect(
             "OptionalData.count is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `enabled` field builder.
-    pub fn property_enabled(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_enabled(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("enabled").expect(
             "OptionalData.enabled is statically defined in .baml and should always be present",
         )
@@ -279,22 +279,22 @@ impl OptionalDataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OptionalFieldsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OptionalFieldsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("OptionalFields is statically defined in .baml and should always have a type")
@@ -305,49 +305,49 @@ impl OptionalFieldsClassBuilder {
     // =========================================================================
 
     /// Access the `requiredString` field builder.
-    pub fn property_requiredString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_requiredString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("requiredString")
             .expect("OptionalFields.requiredString is statically defined in .baml and should always be present")
     }
 
     /// Access the `optionalString` field builder.
-    pub fn property_optionalString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optionalString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optionalString")
             .expect("OptionalFields.optionalString is statically defined in .baml and should always be present")
     }
 
     /// Access the `requiredInt` field builder.
-    pub fn property_requiredInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_requiredInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("requiredInt")
             .expect("OptionalFields.requiredInt is statically defined in .baml and should always be present")
     }
 
     /// Access the `optionalInt` field builder.
-    pub fn property_optionalInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optionalInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optionalInt")
             .expect("OptionalFields.optionalInt is statically defined in .baml and should always be present")
     }
 
     /// Access the `requiredBool` field builder.
-    pub fn property_requiredBool(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_requiredBool(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("requiredBool")
             .expect("OptionalFields.requiredBool is statically defined in .baml and should always be present")
     }
 
     /// Access the `optionalBool` field builder.
-    pub fn property_optionalBool(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optionalBool(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optionalBool")
             .expect("OptionalFields.optionalBool is statically defined in .baml and should always be present")
     }
 
     /// Access the `optionalArray` field builder.
-    pub fn property_optionalArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optionalArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optionalArray")
             .expect("OptionalFields.optionalArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `optionalMap` field builder.
-    pub fn property_optionalMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optionalMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optionalMap")
             .expect("OptionalFields.optionalMap is statically defined in .baml and should always be present")
     }
@@ -359,22 +359,22 @@ impl OptionalFieldsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OptionalItemClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OptionalItemClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("OptionalItem is statically defined in .baml and should always have a type")
@@ -385,28 +385,28 @@ impl OptionalItemClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("OptionalItem.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("OptionalItem.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description").expect(
             "OptionalItem.description is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadata").expect(
             "OptionalItem.metadata is statically defined in .baml and should always be present",
         )
@@ -419,22 +419,22 @@ impl OptionalItemClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OptionalValueClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OptionalValueClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("OptionalValue is statically defined in .baml and should always have a type")
@@ -445,14 +445,14 @@ impl OptionalValueClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("data").expect(
             "OptionalValue.data is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `optional` field builder.
-    pub fn property_optional(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optional(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optional").expect(
             "OptionalValue.optional is statically defined in .baml and should always be present",
         )
@@ -465,22 +465,22 @@ impl OptionalValueClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ProductClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ProductClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Product is statically defined in .baml and should always have a type")
@@ -491,21 +491,21 @@ impl ProductClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Product.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Product.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `price` field builder.
-    pub fn property_price(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_price(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("price")
             .expect("Product.price is statically defined in .baml and should always be present")
@@ -518,22 +518,22 @@ impl ProductClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UnionWithNullClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UnionWithNullClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("UnionWithNull is statically defined in .baml and should always have a type")
@@ -544,26 +544,26 @@ impl UnionWithNullClassBuilder {
     // =========================================================================
 
     /// Access the `simpleUnion` field builder.
-    pub fn property_simpleUnion(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_simpleUnion(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("simpleUnion").expect(
             "UnionWithNull.simpleUnion is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullableUnion` field builder.
-    pub fn property_nullableUnion(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableUnion(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableUnion")
             .expect("UnionWithNull.nullableUnion is statically defined in .baml and should always be present")
     }
 
     /// Access the `optionalUnion` field builder.
-    pub fn property_optionalUnion(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_optionalUnion(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("optionalUnion")
             .expect("UnionWithNull.optionalUnion is statically defined in .baml and should always be present")
     }
 
     /// Access the `complexUnion` field builder.
-    pub fn property_complexUnion(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_complexUnion(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("complexUnion")
             .expect("UnionWithNull.complexUnion is statically defined in .baml and should always be present")
     }
@@ -575,22 +575,22 @@ impl UnionWithNullClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("User is statically defined in .baml and should always have a type")
@@ -601,28 +601,28 @@ impl UserClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("User.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("User.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `email` field builder.
-    pub fn property_email(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_email(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("email")
             .expect("User.email is statically defined in .baml and should always be present")
     }
 
     /// Access the `phone` field builder.
-    pub fn property_phone(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_phone(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("phone")
             .expect("User.phone is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -149,27 +147,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -178,17 +176,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -197,22 +195,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -221,12 +219,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -235,17 +233,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -254,29 +255,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/types/classes.rs
@@ -6,197 +6,163 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexOptional {
     pub data: Option<OptionalData>,
-
     pub items: Vec<OptionalItem>,
-
     pub mapping: std::collections::HashMap<String, Option<OptionalValue>>,
 }
 
-impl AsRef<ComplexOptional> for ComplexOptional {
+impl ::std::convert::AsRef<ComplexOptional> for ComplexOptional {
     fn as_ref(&self) -> &ComplexOptional {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedOptionalNullable {
     pub id: i64,
-
     pub description: Option<String>,
-
     pub metadata: Option<String>,
-
     pub notes: Option<String>,
-
     pub tags: Vec<String>,
-
     pub categories: Option<Vec<String>>,
-
     pub keywords: Option<Vec<String>>,
-
     pub primaryUser: User,
-
     pub secondaryUser: Option<User>,
-
     pub tertiaryUser: Option<User>,
 }
 
-impl AsRef<MixedOptionalNullable> for MixedOptionalNullable {
+impl ::std::convert::AsRef<MixedOptionalNullable> for MixedOptionalNullable {
     fn as_ref(&self) -> &MixedOptionalNullable {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NullableTypes {
     pub nullableString: Option<String>,
-
     pub nullableInt: Option<i64>,
-
     pub nullableFloat: Option<f64>,
-
     pub nullableBool: Option<bool>,
-
     pub nullableArray: Option<Vec<String>>,
-
     pub nullableObject: Option<User>,
 }
 
-impl AsRef<NullableTypes> for NullableTypes {
+impl ::std::convert::AsRef<NullableTypes> for NullableTypes {
     fn as_ref(&self) -> &NullableTypes {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalData {
     pub value: String,
-
     pub count: Option<i64>,
-
     pub enabled: Option<bool>,
 }
 
-impl AsRef<OptionalData> for OptionalData {
+impl ::std::convert::AsRef<OptionalData> for OptionalData {
     fn as_ref(&self) -> &OptionalData {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalFields {
     pub requiredString: String,
-
     pub optionalString: Option<String>,
-
     pub requiredInt: i64,
-
     pub optionalInt: Option<i64>,
-
     pub requiredBool: bool,
-
     pub optionalBool: Option<bool>,
-
     pub optionalArray: Option<Vec<String>>,
-
     pub optionalMap: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<OptionalFields> for OptionalFields {
+impl ::std::convert::AsRef<OptionalFields> for OptionalFields {
     fn as_ref(&self) -> &OptionalFields {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalItem {
     pub id: i64,
-
     pub name: String,
-
     pub description: Option<String>,
-
     pub metadata: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<OptionalItem> for OptionalItem {
+impl ::std::convert::AsRef<OptionalItem> for OptionalItem {
     fn as_ref(&self) -> &OptionalItem {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalValue {
     pub data: Option<Union2IntOrString>,
-
     pub optional: Option<String>,
 }
 
-impl AsRef<OptionalValue> for OptionalValue {
+impl ::std::convert::AsRef<OptionalValue> for OptionalValue {
     fn as_ref(&self) -> &OptionalValue {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Product {
     pub id: i64,
-
     pub name: String,
-
     pub price: Option<f64>,
 }
 
-impl AsRef<Product> for Product {
+impl ::std::convert::AsRef<Product> for Product {
     fn as_ref(&self) -> &Product {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UnionWithNull {
     pub simpleUnion: Union2IntOrString,
-
     pub nullableUnion: Option<Union2IntOrString>,
-
     pub optionalUnion: Option<Union2IntOrString>,
-
     pub complexUnion: Option<Union2ProductOrUser>,
 }
 
-impl AsRef<UnionWithNull> for UnionWithNull {
+impl ::std::convert::AsRef<UnionWithNull> for UnionWithNull {
     fn as_ref(&self) -> &UnionWithNull {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: i64,
-
     pub name: String,
-
     pub email: Option<String>,
-
     pub phone: Option<String>,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     ComplexOptional(ComplexOptional),
 
@@ -49,7 +51,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -79,5 +81,15 @@ impl baml::KnownTypes for Types {
 
             Types::Union2ProductOrUser(_) => "Union2ProductOrUser",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/types/mod.rs
@@ -50,36 +50,36 @@ pub enum Types {
     Union2ProductOrUser(Union2ProductOrUser),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::ComplexOptional(_) => "ComplexOptional",
+            Self::ComplexOptional(_) => "ComplexOptional",
 
-            Types::MixedOptionalNullable(_) => "MixedOptionalNullable",
+            Self::MixedOptionalNullable(_) => "MixedOptionalNullable",
 
-            Types::NullableTypes(_) => "NullableTypes",
+            Self::NullableTypes(_) => "NullableTypes",
 
-            Types::OptionalData(_) => "OptionalData",
+            Self::OptionalData(_) => "OptionalData",
 
-            Types::OptionalFields(_) => "OptionalFields",
+            Self::OptionalFields(_) => "OptionalFields",
 
-            Types::OptionalItem(_) => "OptionalItem",
+            Self::OptionalItem(_) => "OptionalItem",
 
-            Types::OptionalValue(_) => "OptionalValue",
+            Self::OptionalValue(_) => "OptionalValue",
 
-            Types::Product(_) => "Product",
+            Self::Product(_) => "Product",
 
-            Types::UnionWithNull(_) => "UnionWithNull",
+            Self::UnionWithNull(_) => "UnionWithNull",
 
-            Types::User(_) => "User",
+            Self::User(_) => "User",
 
-            Types::Union2IntOrString(_) => "Union2IntOrString",
+            Self::Union2IntOrString(_) => "Union2IntOrString",
 
-            Types::Union2ProductOrUser(_) => "Union2ProductOrUser",
+            Self::Union2ProductOrUser(_) => "Union2ProductOrUser",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/optional_nullable/baml_client/types/unions.rs
@@ -6,11 +6,15 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (string | int | null)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2IntOrString {
     #[baml(name = "string")]
     String(String),
@@ -19,21 +23,22 @@ pub enum Union2IntOrString {
     Int(i64),
 }
 
-impl AsRef<Union2IntOrString> for Union2IntOrString {
+impl ::std::convert::AsRef<Union2IntOrString> for Union2IntOrString {
     fn as_ref(&self) -> &Union2IntOrString {
         self
     }
 }
 
-impl Default for Union2IntOrString {
+impl ::std::default::Default for Union2IntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (User | Product | null)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ProductOrUser {
     #[baml(name = "User")]
     User(User),
@@ -42,14 +47,14 @@ pub enum Union2ProductOrUser {
     Product(Product),
 }
 
-impl AsRef<Union2ProductOrUser> for Union2ProductOrUser {
+impl ::std::convert::AsRef<Union2ProductOrUser> for Union2ProductOrUser {
     fn as_ref(&self) -> &Union2ProductOrUser {
         self
     }
 }
 
-impl Default for Union2ProductOrUser {
+impl ::std::default::Default for Union2ProductOrUser {
     fn default() -> Self {
-        Self::User(Default::default())
+        Self::User(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedPrimitives {
     pub name: Option<String>,
 
@@ -34,14 +34,14 @@ pub struct MixedPrimitives {
     pub flags: Vec<bool>,
 }
 
-impl AsRef<MixedPrimitives> for MixedPrimitives {
+impl ::std::convert::AsRef<MixedPrimitives> for MixedPrimitives {
     fn as_ref(&self) -> &MixedPrimitives {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimitiveArrays {
     pub stringArray: Vec<String>,
 
@@ -52,14 +52,14 @@ pub struct PrimitiveArrays {
     pub boolArray: Vec<bool>,
 }
 
-impl AsRef<PrimitiveArrays> for PrimitiveArrays {
+impl ::std::convert::AsRef<PrimitiveArrays> for PrimitiveArrays {
     fn as_ref(&self) -> &PrimitiveArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimitiveMaps {
     pub stringMap: std::collections::HashMap<String, String>,
 
@@ -70,14 +70,14 @@ pub struct PrimitiveMaps {
     pub boolMap: std::collections::HashMap<String, bool>,
 }
 
-impl AsRef<PrimitiveMaps> for PrimitiveMaps {
+impl ::std::convert::AsRef<PrimitiveMaps> for PrimitiveMaps {
     fn as_ref(&self) -> &PrimitiveMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimitiveTypes {
     pub stringField: Option<String>,
 
@@ -90,7 +90,7 @@ pub struct PrimitiveTypes {
     pub nullField: (),
 }
 
-impl AsRef<PrimitiveTypes> for PrimitiveTypes {
+impl ::std::convert::AsRef<PrimitiveTypes> for PrimitiveTypes {
     fn as_ref(&self) -> &PrimitiveTypes {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     MixedPrimitives(MixedPrimitives),
 
@@ -28,7 +31,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -42,5 +45,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::PrimitiveTypes(_) => "PrimitiveTypes",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MixedPrimitivesClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MixedPrimitivesClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("MixedPrimitives is statically defined in .baml and should always have a type")
@@ -37,62 +37,62 @@ impl MixedPrimitivesClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("name").expect(
             "MixedPrimitives.name is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `age` field builder.
-    pub fn property_age(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_age(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("age").expect(
             "MixedPrimitives.age is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `height` field builder.
-    pub fn property_height(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_height(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("height").expect(
             "MixedPrimitives.height is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `isActive` field builder.
-    pub fn property_isActive(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_isActive(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("isActive").expect(
             "MixedPrimitives.isActive is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadata").expect(
             "MixedPrimitives.metadata is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("tags").expect(
             "MixedPrimitives.tags is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `scores` field builder.
-    pub fn property_scores(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_scores(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("scores").expect(
             "MixedPrimitives.scores is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `measurements` field builder.
-    pub fn property_measurements(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_measurements(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("measurements")
             .expect("MixedPrimitives.measurements is statically defined in .baml and should always be present")
     }
 
     /// Access the `flags` field builder.
-    pub fn property_flags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_flags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("flags").expect(
             "MixedPrimitives.flags is statically defined in .baml and should always be present",
         )
@@ -105,22 +105,22 @@ impl MixedPrimitivesClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PrimitiveArraysClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PrimitiveArraysClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("PrimitiveArrays is statically defined in .baml and should always have a type")
@@ -131,26 +131,26 @@ impl PrimitiveArraysClassBuilder {
     // =========================================================================
 
     /// Access the `stringArray` field builder.
-    pub fn property_stringArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringArray")
             .expect("PrimitiveArrays.stringArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `intArray` field builder.
-    pub fn property_intArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_intArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("intArray").expect(
             "PrimitiveArrays.intArray is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `floatArray` field builder.
-    pub fn property_floatArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_floatArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("floatArray")
             .expect("PrimitiveArrays.floatArray is statically defined in .baml and should always be present")
     }
 
     /// Access the `boolArray` field builder.
-    pub fn property_boolArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_boolArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("boolArray").expect(
             "PrimitiveArrays.boolArray is statically defined in .baml and should always be present",
         )
@@ -163,22 +163,22 @@ impl PrimitiveArraysClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PrimitiveMapsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PrimitiveMapsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("PrimitiveMaps is statically defined in .baml and should always have a type")
@@ -189,28 +189,28 @@ impl PrimitiveMapsClassBuilder {
     // =========================================================================
 
     /// Access the `stringMap` field builder.
-    pub fn property_stringMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringMap").expect(
             "PrimitiveMaps.stringMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `intMap` field builder.
-    pub fn property_intMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_intMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("intMap").expect(
             "PrimitiveMaps.intMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `floatMap` field builder.
-    pub fn property_floatMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_floatMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("floatMap").expect(
             "PrimitiveMaps.floatMap is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `boolMap` field builder.
-    pub fn property_boolMap(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_boolMap(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("boolMap").expect(
             "PrimitiveMaps.boolMap is statically defined in .baml and should always be present",
         )
@@ -223,22 +223,22 @@ impl PrimitiveMapsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PrimitiveTypesClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PrimitiveTypesClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("PrimitiveTypes is statically defined in .baml and should always have a type")
@@ -249,34 +249,34 @@ impl PrimitiveTypesClassBuilder {
     // =========================================================================
 
     /// Access the `stringField` field builder.
-    pub fn property_stringField(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringField(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringField")
             .expect("PrimitiveTypes.stringField is statically defined in .baml and should always be present")
     }
 
     /// Access the `intField` field builder.
-    pub fn property_intField(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_intField(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("intField").expect(
             "PrimitiveTypes.intField is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `floatField` field builder.
-    pub fn property_floatField(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_floatField(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("floatField").expect(
             "PrimitiveTypes.floatField is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `boolField` field builder.
-    pub fn property_boolField(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_boolField(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("boolField").expect(
             "PrimitiveTypes.boolField is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullField` field builder.
-    pub fn property_nullField(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullField(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullField").expect(
             "PrimitiveTypes.nullField is statically defined in .baml and should always be present",
         )

--- a/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -95,27 +93,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -124,17 +122,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -143,22 +141,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -167,12 +165,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -181,17 +179,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -200,29 +201,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/types/classes.rs
@@ -6,87 +6,72 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MixedPrimitives {
     pub name: String,
-
     pub age: i64,
-
     pub height: f64,
-
     pub isActive: bool,
-
     pub metadata: (),
-
     pub tags: Vec<String>,
-
     pub scores: Vec<i64>,
-
     pub measurements: Vec<f64>,
-
     pub flags: Vec<bool>,
 }
 
-impl AsRef<MixedPrimitives> for MixedPrimitives {
+impl ::std::convert::AsRef<MixedPrimitives> for MixedPrimitives {
     fn as_ref(&self) -> &MixedPrimitives {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimitiveArrays {
     pub stringArray: Vec<String>,
-
     pub intArray: Vec<i64>,
-
     pub floatArray: Vec<f64>,
-
     pub boolArray: Vec<bool>,
 }
 
-impl AsRef<PrimitiveArrays> for PrimitiveArrays {
+impl ::std::convert::AsRef<PrimitiveArrays> for PrimitiveArrays {
     fn as_ref(&self) -> &PrimitiveArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimitiveMaps {
     pub stringMap: std::collections::HashMap<String, String>,
-
     pub intMap: std::collections::HashMap<String, i64>,
-
     pub floatMap: std::collections::HashMap<String, f64>,
-
     pub boolMap: std::collections::HashMap<String, bool>,
 }
 
-impl AsRef<PrimitiveMaps> for PrimitiveMaps {
+impl ::std::convert::AsRef<PrimitiveMaps> for PrimitiveMaps {
     fn as_ref(&self) -> &PrimitiveMaps {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimitiveTypes {
     pub stringField: String,
-
     pub intField: i64,
-
     pub floatField: f64,
-
     pub boolField: bool,
-
     pub nullField: (),
 }
 
-impl AsRef<PrimitiveTypes> for PrimitiveTypes {
+impl ::std::convert::AsRef<PrimitiveTypes> for PrimitiveTypes {
     fn as_ref(&self) -> &PrimitiveTypes {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     MixedPrimitives(MixedPrimitives),
 
@@ -33,7 +35,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -47,5 +49,15 @@ impl baml::KnownTypes for Types {
 
             Types::PrimitiveTypes(_) => "PrimitiveTypes",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/primitive_types/baml_client/types/mod.rs
@@ -34,20 +34,20 @@ pub enum Types {
     PrimitiveTypes(PrimitiveTypes),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::MixedPrimitives(_) => "MixedPrimitives",
+            Self::MixedPrimitives(_) => "MixedPrimitives",
 
-            Types::PrimitiveArrays(_) => "PrimitiveArrays",
+            Self::PrimitiveArrays(_) => "PrimitiveArrays",
 
-            Types::PrimitiveMaps(_) => "PrimitiveMaps",
+            Self::PrimitiveMaps(_) => "PrimitiveMaps",
 
-            Types::PrimitiveTypes(_) => "PrimitiveTypes",
+            Self::PrimitiveTypes(_) => "PrimitiveTypes",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/stream_types/classes.rs
@@ -10,15 +10,15 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UseMyUnion {
     pub u: Option<Union3IntOrRecursive1OrString>,
 }
 
-impl AsRef<UseMyUnion> for UseMyUnion {
+impl ::std::convert::AsRef<UseMyUnion> for UseMyUnion {
     fn as_ref(&self) -> &UseMyUnion {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     UseMyUnion(UseMyUnion),
 
@@ -30,7 +33,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -46,5 +49,15 @@ impl baml::KnownTypes for StreamTypes {
                 "Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString"
             }
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/stream_types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/stream_types/unions.rs
@@ -7,11 +7,15 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{
+    BamlDecode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (int @stream.done | Streaming.Recursive1[] | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2IntOrListRecursive1 {
     #[baml(name = "int")]
     Int(i64),
@@ -20,21 +24,22 @@ pub enum Union2IntOrListRecursive1 {
     ListRecursive1(Vec<Recursive1>),
 }
 
-impl AsRef<Union2IntOrListRecursive1> for Union2IntOrListRecursive1 {
+impl ::std::convert::AsRef<Union2IntOrListRecursive1> for Union2IntOrListRecursive1 {
     fn as_ref(&self) -> &Union2IntOrListRecursive1 {
         self
     }
 }
 
-impl Default for Union2IntOrListRecursive1 {
+impl ::std::default::Default for Union2IntOrListRecursive1 {
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Streaming.Recursive1 | int @stream.done | string | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3IntOrRecursive1OrString {
     #[baml(name = "Recursive1")]
     Recursive1(Recursive1),
@@ -46,21 +51,22 @@ pub enum Union3IntOrRecursive1OrString {
     String(String),
 }
 
-impl AsRef<Union3IntOrRecursive1OrString> for Union3IntOrRecursive1OrString {
+impl ::std::convert::AsRef<Union3IntOrRecursive1OrString> for Union3IntOrRecursive1OrString {
     fn as_ref(&self) -> &Union3IntOrRecursive1OrString {
         self
     }
 }
 
-impl Default for Union3IntOrRecursive1OrString {
+impl ::std::default::Default for Union3IntOrRecursive1OrString {
     fn default() -> Self {
-        Self::Recursive1(Default::default())
+        Self::Recursive1(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int @stream.done | float @stream.done | map<string, Streaming.JSON> | Streaming.JSON[] | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
     #[baml(name = "string")]
     String(String),
@@ -78,7 +84,7 @@ pub enum Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
     ListJSON(Vec<JSON>),
 }
 
-impl AsRef<Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString>
+impl ::std::convert::AsRef<Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString>
     for Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString
 {
     fn as_ref(&self) -> &Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
@@ -86,8 +92,8 @@ impl AsRef<Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString>
     }
 }
 
-impl Default for Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
+impl ::std::default::Default for Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UseMyUnionClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UseMyUnionClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("UseMyUnion is statically defined in .baml and should always have a type")
@@ -37,7 +37,7 @@ impl UseMyUnionClassBuilder {
     // =========================================================================
 
     /// Access the `u` field builder.
-    pub fn property_u(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_u(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("u")
             .expect("UseMyUnion.u is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -68,27 +66,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -97,17 +95,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -116,22 +114,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -140,12 +138,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -154,17 +152,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -173,29 +174,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/types/classes.rs
@@ -6,15 +6,18 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UseMyUnion {
     pub u: Option<Union3IntOrRecursive1OrString>,
 }
 
-impl AsRef<UseMyUnion> for UseMyUnion {
+impl ::std::convert::AsRef<UseMyUnion> for UseMyUnion {
     fn as_ref(&self) -> &UseMyUnion {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     UseMyUnion(UseMyUnion),
 
@@ -35,7 +37,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -51,5 +53,15 @@ impl baml::KnownTypes for Types {
                 "Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString"
             }
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/types/mod.rs
@@ -36,20 +36,20 @@ pub enum Types {
     ),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::UseMyUnion(_) => "UseMyUnion",
+            Self::UseMyUnion(_) => "UseMyUnion",
 
-            Types::Union2IntOrListRecursive1(_) => "Union2IntOrListRecursive1",
+            Self::Union2IntOrListRecursive1(_) => "Union2IntOrListRecursive1",
 
-            Types::Union3IntOrRecursive1OrString(_) => "Union3IntOrRecursive1OrString",
+            Self::Union3IntOrRecursive1OrString(_) => "Union3IntOrRecursive1OrString",
 
-            Types::Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString(_) => {
+            Self::Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString(_) => {
                 "Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString"
             }
         }

--- a/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/recursive_types/baml_client/types/unions.rs
@@ -6,11 +6,15 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (int | Recursive1[])
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2IntOrListRecursive1 {
     #[baml(name = "int")]
     Int(i64),
@@ -19,21 +23,22 @@ pub enum Union2IntOrListRecursive1 {
     ListRecursive1(Vec<Recursive1>),
 }
 
-impl AsRef<Union2IntOrListRecursive1> for Union2IntOrListRecursive1 {
+impl ::std::convert::AsRef<Union2IntOrListRecursive1> for Union2IntOrListRecursive1 {
     fn as_ref(&self) -> &Union2IntOrListRecursive1 {
         self
     }
 }
 
-impl Default for Union2IntOrListRecursive1 {
+impl ::std::default::Default for Union2IntOrListRecursive1 {
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Recursive1 | int | string | null)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3IntOrRecursive1OrString {
     #[baml(name = "Recursive1")]
     Recursive1(Recursive1),
@@ -45,21 +50,22 @@ pub enum Union3IntOrRecursive1OrString {
     String(String),
 }
 
-impl AsRef<Union3IntOrRecursive1OrString> for Union3IntOrRecursive1OrString {
+impl ::std::convert::AsRef<Union3IntOrRecursive1OrString> for Union3IntOrRecursive1OrString {
     fn as_ref(&self) -> &Union3IntOrRecursive1OrString {
         self
     }
 }
 
-impl Default for Union3IntOrRecursive1OrString {
+impl ::std::default::Default for Union3IntOrRecursive1OrString {
     fn default() -> Self {
-        Self::Recursive1(Default::default())
+        Self::Recursive1(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int | float | map<string, JSON> | JSON[] | null)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
     #[baml(name = "string")]
     String(String),
@@ -77,7 +83,7 @@ pub enum Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
     ListJSON(Vec<JSON>),
 }
 
-impl AsRef<Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString>
+impl ::std::convert::AsRef<Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString>
     for Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString
 {
     fn as_ref(&self) -> &Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
@@ -85,8 +91,8 @@ impl AsRef<Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString>
     }
 }
 
-impl Default for Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
+impl ::std::default::Default for Union5FloatOrIntOrListJSONOrMapStringKeyJSONValueOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Example {
     #[baml(name = "type")]
     pub r#type: String,
@@ -23,14 +23,14 @@ pub struct Example {
     pub b: Option<String>,
 }
 
-impl AsRef<Example> for Example {
+impl ::std::convert::AsRef<Example> for Example {
     fn as_ref(&self) -> &Example {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Example2 {
     #[baml(name = "type")]
     pub r#type: String,
@@ -42,7 +42,7 @@ pub struct Example2 {
     pub element2: Option<String>,
 }
 
-impl AsRef<Example2> for Example2 {
+impl ::std::convert::AsRef<Example2> for Example2 {
     fn as_ref(&self) -> &Example2 {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     Example(Example),
 
@@ -26,7 +29,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -38,5 +41,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::Union2ExampleOrExample2(_) => "Union2ExampleOrExample2",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/stream_types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/stream_types/unions.rs
@@ -7,11 +7,15 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{
+    BamlDecode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (Streaming.Example | Streaming.Example2)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ExampleOrExample2 {
     #[baml(name = "Example")]
     Example(Example),
@@ -20,14 +24,14 @@ pub enum Union2ExampleOrExample2 {
     Example2(Example2),
 }
 
-impl AsRef<Union2ExampleOrExample2> for Union2ExampleOrExample2 {
+impl ::std::convert::AsRef<Union2ExampleOrExample2> for Union2ExampleOrExample2 {
     fn as_ref(&self) -> &Union2ExampleOrExample2 {
         self
     }
 }
 
-impl Default for Union2ExampleOrExample2 {
+impl ::std::default::Default for Union2ExampleOrExample2 {
     fn default() -> Self {
-        Self::Example(Default::default())
+        Self::Example(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ExampleClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ExampleClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Example is statically defined in .baml and should always have a type")
@@ -37,21 +37,21 @@ impl ExampleClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Example.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `a` field builder.
-    pub fn property_a(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_a(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("a")
             .expect("Example.a is statically defined in .baml and should always be present")
     }
 
     /// Access the `b` field builder.
-    pub fn property_b(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_b(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("b")
             .expect("Example.b is statically defined in .baml and should always be present")
@@ -64,22 +64,22 @@ impl ExampleClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct Example2ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl Example2ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Example2 is statically defined in .baml and should always have a type")
@@ -90,28 +90,28 @@ impl Example2ClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Example2.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `item` field builder.
-    pub fn property_item(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_item(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("item")
             .expect("Example2.item is statically defined in .baml and should always be present")
     }
 
     /// Access the `element` field builder.
-    pub fn property_element(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_element(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("element")
             .expect("Example2.element is statically defined in .baml and should always be present")
     }
 
     /// Access the `element2` field builder.
-    pub fn property_element2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_element2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("element2")
             .expect("Example2.element2 is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -77,27 +75,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -106,17 +104,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -125,22 +123,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -149,12 +147,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -163,17 +161,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -182,29 +183,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/types/classes.rs
@@ -6,39 +6,39 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Example {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub a: Checked<i64>,
-
     pub b: String,
 }
 
-impl AsRef<Example> for Example {
+impl ::std::convert::AsRef<Example> for Example {
     fn as_ref(&self) -> &Example {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Example2 {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub item: Example,
-
     pub element: String,
-
     pub element2: String,
 }
 
-impl AsRef<Example2> for Example2 {
+impl ::std::convert::AsRef<Example2> for Example2 {
     fn as_ref(&self) -> &Example2 {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     Example(Example),
 
@@ -31,7 +33,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -43,5 +45,15 @@ impl baml::KnownTypes for Types {
 
             Types::Union2ExampleOrExample2(_) => "Union2ExampleOrExample2",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/types/mod.rs
@@ -32,18 +32,18 @@ pub enum Types {
     Union2ExampleOrExample2(Union2ExampleOrExample2),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::Example(_) => "Example",
+            Self::Example(_) => "Example",
 
-            Types::Example2(_) => "Example2",
+            Self::Example2(_) => "Example2",
 
-            Types::Union2ExampleOrExample2(_) => "Union2ExampleOrExample2",
+            Self::Union2ExampleOrExample2(_) => "Union2ExampleOrExample2",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/sample/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/sample/baml_client/types/unions.rs
@@ -6,11 +6,15 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (Example | Example2)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ExampleOrExample2 {
     #[baml(name = "Example")]
     Example(Example),
@@ -19,14 +23,14 @@ pub enum Union2ExampleOrExample2 {
     Example2(Example2),
 }
 
-impl AsRef<Union2ExampleOrExample2> for Union2ExampleOrExample2 {
+impl ::std::convert::AsRef<Union2ExampleOrExample2> for Union2ExampleOrExample2 {
     fn as_ref(&self) -> &Union2ExampleOrExample2 {
         self
     }
 }
 
-impl Default for Union2ExampleOrExample2 {
+impl ::std::default::Default for Union2ExampleOrExample2 {
     fn default() -> Self {
-        Self::Example(Default::default())
+        Self::Example(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/stream_types/classes.rs
@@ -10,38 +10,38 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithBlockDone {
     pub i_16_digits: i64,
 
     pub s_20_words: String,
 }
 
-impl AsRef<ClassWithBlockDone> for ClassWithBlockDone {
+impl ::std::convert::AsRef<ClassWithBlockDone> for ClassWithBlockDone {
     fn as_ref(&self) -> &ClassWithBlockDone {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithoutDone {
     pub i_16_digits: Option<i64>,
 
     pub s_20_words: baml::StreamState<Option<String>>,
 }
 
-impl AsRef<ClassWithoutDone> for ClassWithoutDone {
+impl ::std::convert::AsRef<ClassWithoutDone> for ClassWithoutDone {
     fn as_ref(&self) -> &ClassWithoutDone {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SemanticContainer {
     pub sixteen_digit_number: Option<i64>,
 
@@ -60,21 +60,21 @@ pub struct SemanticContainer {
     pub final_string: Option<String>,
 }
 
-impl AsRef<SemanticContainer> for SemanticContainer {
+impl ::std::convert::AsRef<SemanticContainer> for SemanticContainer {
     fn as_ref(&self) -> &SemanticContainer {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SmallThing {
     pub i_16_digits: i64,
 
     pub i_8_digits: Option<i64>,
 }
 
-impl AsRef<SmallThing> for SmallThing {
+impl ::std::convert::AsRef<SmallThing> for SmallThing {
     fn as_ref(&self) -> &SmallThing {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     ClassWithBlockDone(ClassWithBlockDone),
 
@@ -28,7 +31,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -42,5 +45,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::SmallThing(_) => "SmallThing",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClassWithBlockDoneClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClassWithBlockDoneClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "ClassWithBlockDone is statically defined in .baml and should always have a type",
         )
@@ -37,13 +37,13 @@ impl ClassWithBlockDoneClassBuilder {
     // =========================================================================
 
     /// Access the `i_16_digits` field builder.
-    pub fn property_i_16_digits(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_i_16_digits(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("i_16_digits")
             .expect("ClassWithBlockDone.i_16_digits is statically defined in .baml and should always be present")
     }
 
     /// Access the `s_20_words` field builder.
-    pub fn property_s_20_words(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_s_20_words(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("s_20_words")
             .expect("ClassWithBlockDone.s_20_words is statically defined in .baml and should always be present")
     }
@@ -55,22 +55,22 @@ impl ClassWithBlockDoneClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClassWithoutDoneClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClassWithoutDoneClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ClassWithoutDone is statically defined in .baml and should always have a type")
@@ -81,13 +81,13 @@ impl ClassWithoutDoneClassBuilder {
     // =========================================================================
 
     /// Access the `i_16_digits` field builder.
-    pub fn property_i_16_digits(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_i_16_digits(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("i_16_digits")
             .expect("ClassWithoutDone.i_16_digits is statically defined in .baml and should always be present")
     }
 
     /// Access the `s_20_words` field builder.
-    pub fn property_s_20_words(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_s_20_words(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("s_20_words")
             .expect("ClassWithoutDone.s_20_words is statically defined in .baml and should always be present")
     }
@@ -99,22 +99,22 @@ impl ClassWithoutDoneClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SemanticContainerClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SemanticContainerClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "SemanticContainer is statically defined in .baml and should always have a type",
         )
@@ -125,51 +125,51 @@ impl SemanticContainerClassBuilder {
     // =========================================================================
 
     /// Access the `sixteen_digit_number` field builder.
-    pub fn property_sixteen_digit_number(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_sixteen_digit_number(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("sixteen_digit_number")
             .expect("SemanticContainer.sixteen_digit_number is statically defined in .baml and should always be present")
     }
 
     /// Access the `string_with_twenty_words` field builder.
-    pub fn property_string_with_twenty_words(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_string_with_twenty_words(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("string_with_twenty_words")
             .expect("SemanticContainer.string_with_twenty_words is statically defined in .baml and should always be present")
     }
 
     /// Access the `class_1` field builder.
-    pub fn property_class_1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_class_1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("class_1").expect(
             "SemanticContainer.class_1 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `class_2` field builder.
-    pub fn property_class_2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_class_2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("class_2").expect(
             "SemanticContainer.class_2 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `class_done_needed` field builder.
-    pub fn property_class_done_needed(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_class_done_needed(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("class_done_needed")
             .expect("SemanticContainer.class_done_needed is statically defined in .baml and should always be present")
     }
 
     /// Access the `class_needed` field builder.
-    pub fn property_class_needed(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_class_needed(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("class_needed")
             .expect("SemanticContainer.class_needed is statically defined in .baml and should always be present")
     }
 
     /// Access the `three_small_things` field builder.
-    pub fn property_three_small_things(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_three_small_things(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("three_small_things")
             .expect("SemanticContainer.three_small_things is statically defined in .baml and should always be present")
     }
 
     /// Access the `final_string` field builder.
-    pub fn property_final_string(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_final_string(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("final_string")
             .expect("SemanticContainer.final_string is statically defined in .baml and should always be present")
     }
@@ -181,22 +181,22 @@ impl SemanticContainerClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SmallThingClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SmallThingClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SmallThing is statically defined in .baml and should always have a type")
@@ -207,14 +207,14 @@ impl SmallThingClassBuilder {
     // =========================================================================
 
     /// Access the `i_16_digits` field builder.
-    pub fn property_i_16_digits(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_i_16_digits(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("i_16_digits").expect(
             "SmallThing.i_16_digits is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `i_8_digits` field builder.
-    pub fn property_i_8_digits(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_i_8_digits(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("i_8_digits").expect(
             "SmallThing.i_8_digits is statically defined in .baml and should always be present",
         )

--- a/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -95,27 +93,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -124,17 +122,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -143,22 +141,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -167,12 +165,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -181,17 +179,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -200,29 +201,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/types/classes.rs
@@ -6,71 +6,64 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithBlockDone {
     pub i_16_digits: i64,
-
     pub s_20_words: String,
 }
 
-impl AsRef<ClassWithBlockDone> for ClassWithBlockDone {
+impl ::std::convert::AsRef<ClassWithBlockDone> for ClassWithBlockDone {
     fn as_ref(&self) -> &ClassWithBlockDone {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithoutDone {
     pub i_16_digits: i64,
-
     pub s_20_words: String,
 }
 
-impl AsRef<ClassWithoutDone> for ClassWithoutDone {
+impl ::std::convert::AsRef<ClassWithoutDone> for ClassWithoutDone {
     fn as_ref(&self) -> &ClassWithoutDone {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SemanticContainer {
     pub sixteen_digit_number: i64,
-
     pub string_with_twenty_words: String,
-
     pub class_1: ClassWithoutDone,
-
     pub class_2: ClassWithBlockDone,
-
     pub class_done_needed: ClassWithBlockDone,
-
     pub class_needed: ClassWithoutDone,
-
     pub three_small_things: Vec<SmallThing>,
-
     pub final_string: String,
 }
 
-impl AsRef<SemanticContainer> for SemanticContainer {
+impl ::std::convert::AsRef<SemanticContainer> for SemanticContainer {
     fn as_ref(&self) -> &SemanticContainer {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SmallThing {
     pub i_16_digits: i64,
-
     pub i_8_digits: i64,
 }
 
-impl AsRef<SmallThing> for SmallThing {
+impl ::std::convert::AsRef<SmallThing> for SmallThing {
     fn as_ref(&self) -> &SmallThing {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     ClassWithBlockDone(ClassWithBlockDone),
 
@@ -33,7 +35,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -47,5 +49,15 @@ impl baml::KnownTypes for Types {
 
             Types::SmallThing(_) => "SmallThing",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/semantic_streaming/baml_client/types/mod.rs
@@ -34,20 +34,20 @@ pub enum Types {
     SmallThing(SmallThing),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::ClassWithBlockDone(_) => "ClassWithBlockDone",
+            Self::ClassWithBlockDone(_) => "ClassWithBlockDone",
 
-            Types::ClassWithoutDone(_) => "ClassWithoutDone",
+            Self::ClassWithoutDone(_) => "ClassWithoutDone",
 
-            Types::SemanticContainer(_) => "SemanticContainer",
+            Self::SemanticContainer(_) => "SemanticContainer",
 
-            Types::SmallThing(_) => "SmallThing",
+            Self::SmallThing(_) => "SmallThing",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Admin {
     pub id: Option<i64>,
 
@@ -25,14 +25,14 @@ pub struct Admin {
     pub r#type: Option<String>,
 }
 
-impl AsRef<Admin> for Admin {
+impl ::std::convert::AsRef<Admin> for Admin {
     fn as_ref(&self) -> &Admin {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ApiError {
     pub status: Option<String>,
 
@@ -41,14 +41,14 @@ pub struct ApiError {
     pub code: Option<i64>,
 }
 
-impl AsRef<ApiError> for ApiError {
+impl ::std::convert::AsRef<ApiError> for ApiError {
     fn as_ref(&self) -> &ApiError {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ApiPending {
     pub status: Option<String>,
 
@@ -57,28 +57,28 @@ pub struct ApiPending {
     pub eta: Option<i64>,
 }
 
-impl AsRef<ApiPending> for ApiPending {
+impl ::std::convert::AsRef<ApiPending> for ApiPending {
     fn as_ref(&self) -> &ApiPending {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ApiSuccess {
     pub status: Option<String>,
 
     pub data: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<ApiSuccess> for ApiSuccess {
+impl ::std::convert::AsRef<ApiSuccess> for ApiSuccess {
     fn as_ref(&self) -> &ApiSuccess {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Bird {
     pub species: Option<String>,
 
@@ -87,14 +87,14 @@ pub struct Bird {
     pub wingspan: Option<f64>,
 }
 
-impl AsRef<Bird> for Bird {
+impl ::std::convert::AsRef<Bird> for Bird {
     fn as_ref(&self) -> &Bird {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Cat {
     pub species: Option<String>,
 
@@ -103,28 +103,28 @@ pub struct Cat {
     pub lives: Option<i64>,
 }
 
-impl AsRef<Cat> for Cat {
+impl ::std::convert::AsRef<Cat> for Cat {
     fn as_ref(&self) -> &Cat {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Circle {
     pub shape: Option<String>,
 
     pub radius: Option<f64>,
 }
 
-impl AsRef<Circle> for Circle {
+impl ::std::convert::AsRef<Circle> for Circle {
     fn as_ref(&self) -> &Circle {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexUnions {
     pub userOrProduct: Option<Union2ProductOrUser>,
 
@@ -137,14 +137,14 @@ pub struct ComplexUnions {
     pub multiTypeResult: Option<Union3ErrorOrSuccessOrWarning>,
 }
 
-impl AsRef<ComplexUnions> for ComplexUnions {
+impl ::std::convert::AsRef<ComplexUnions> for ComplexUnions {
     fn as_ref(&self) -> &ComplexUnions {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DataResponse {
     pub data: Option<String>,
 
@@ -153,14 +153,14 @@ pub struct DataResponse {
     pub status: Option<String>,
 }
 
-impl AsRef<DataResponse> for DataResponse {
+impl ::std::convert::AsRef<DataResponse> for DataResponse {
     fn as_ref(&self) -> &DataResponse {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DiscriminatedUnions {
     pub shape: Option<Union3CircleOrRectangleOrTriangle>,
 
@@ -169,14 +169,14 @@ pub struct DiscriminatedUnions {
     pub response: Option<Union3ApiErrorOrApiPendingOrApiSuccess>,
 }
 
-impl AsRef<DiscriminatedUnions> for DiscriminatedUnions {
+impl ::std::convert::AsRef<DiscriminatedUnions> for DiscriminatedUnions {
     fn as_ref(&self) -> &DiscriminatedUnions {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Dog {
     pub species: Option<String>,
 
@@ -185,14 +185,14 @@ pub struct Dog {
     pub goodBoy: Option<bool>,
 }
 
-impl AsRef<Dog> for Dog {
+impl ::std::convert::AsRef<Dog> for Dog {
     fn as_ref(&self) -> &Dog {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Error {
     #[baml(name = "type")]
     pub r#type: Option<String>,
@@ -204,14 +204,14 @@ pub struct Error {
     pub details: Option<String>,
 }
 
-impl AsRef<Error> for Error {
+impl ::std::convert::AsRef<Error> for Error {
     fn as_ref(&self) -> &Error {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ErrorResponse {
     pub error: Option<String>,
 
@@ -220,14 +220,14 @@ pub struct ErrorResponse {
     pub status: Option<String>,
 }
 
-impl AsRef<ErrorResponse> for ErrorResponse {
+impl ::std::convert::AsRef<ErrorResponse> for ErrorResponse {
     fn as_ref(&self) -> &ErrorResponse {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimitiveUnions {
     pub stringOrInt: Option<types::Union2IntOrString>,
 
@@ -240,14 +240,14 @@ pub struct PrimitiveUnions {
     pub anyPrimitive: Option<types::Union4BoolOrFloatOrIntOrString>,
 }
 
-impl AsRef<PrimitiveUnions> for PrimitiveUnions {
+impl ::std::convert::AsRef<PrimitiveUnions> for PrimitiveUnions {
     fn as_ref(&self) -> &PrimitiveUnions {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Product {
     pub id: Option<i64>,
 
@@ -259,14 +259,14 @@ pub struct Product {
     pub r#type: Option<String>,
 }
 
-impl AsRef<Product> for Product {
+impl ::std::convert::AsRef<Product> for Product {
     fn as_ref(&self) -> &Product {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Rectangle {
     pub shape: Option<String>,
 
@@ -275,42 +275,42 @@ pub struct Rectangle {
     pub height: Option<f64>,
 }
 
-impl AsRef<Rectangle> for Rectangle {
+impl ::std::convert::AsRef<Rectangle> for Rectangle {
     fn as_ref(&self) -> &Rectangle {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RecursiveUnion {
     pub value: Option<Union3IntOrRecursiveUnionOrString>,
 
     pub children: Vec<Union2RecursiveUnionOrString>,
 }
 
-impl AsRef<RecursiveUnion> for RecursiveUnion {
+impl ::std::convert::AsRef<RecursiveUnion> for RecursiveUnion {
     fn as_ref(&self) -> &RecursiveUnion {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Result {
     pub value: Option<types::Union3FloatOrIntOrString>,
 
     pub metadata: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Result> for Result {
+impl ::std::convert::AsRef<Result> for Result {
     fn as_ref(&self) -> &Result {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Success {
     #[baml(name = "type")]
     pub r#type: Option<String>,
@@ -320,14 +320,14 @@ pub struct Success {
     pub data: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Success> for Success {
+impl ::std::convert::AsRef<Success> for Success {
     fn as_ref(&self) -> &Success {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Triangle {
     pub shape: Option<String>,
 
@@ -336,14 +336,14 @@ pub struct Triangle {
     pub height: Option<f64>,
 }
 
-impl AsRef<Triangle> for Triangle {
+impl ::std::convert::AsRef<Triangle> for Triangle {
     fn as_ref(&self) -> &Triangle {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UnionArrays {
     pub mixedArray: Vec<types::Union2IntOrString>,
 
@@ -354,14 +354,14 @@ pub struct UnionArrays {
     pub nestedUnionArray: Vec<types::Union2ListIntOrString>,
 }
 
-impl AsRef<UnionArrays> for UnionArrays {
+impl ::std::convert::AsRef<UnionArrays> for UnionArrays {
     fn as_ref(&self) -> &UnionArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: Option<i64>,
 
@@ -371,14 +371,14 @@ pub struct User {
     pub r#type: Option<String>,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Warning {
     #[baml(name = "type")]
     pub r#type: Option<String>,
@@ -388,7 +388,7 @@ pub struct Warning {
     pub level: Option<i64>,
 }
 
-impl AsRef<Warning> for Warning {
+impl ::std::convert::AsRef<Warning> for Warning {
     fn as_ref(&self) -> &Warning {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     Admin(Admin),
 
@@ -84,7 +87,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -162,5 +165,15 @@ impl baml::KnownTypes for StreamTypes {
                 "Union3IntOrRecursiveUnionOrString"
             }
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/stream_types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/stream_types/unions.rs
@@ -7,11 +7,15 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{
+    BamlDecode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (Streaming.DataResponse | Streaming.ErrorResponse | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2DataResponseOrErrorResponse {
     #[baml(name = "DataResponse")]
     DataResponse(DataResponse),
@@ -20,21 +24,24 @@ pub enum Union2DataResponseOrErrorResponse {
     ErrorResponse(ErrorResponse),
 }
 
-impl AsRef<Union2DataResponseOrErrorResponse> for Union2DataResponseOrErrorResponse {
+impl ::std::convert::AsRef<Union2DataResponseOrErrorResponse>
+    for Union2DataResponseOrErrorResponse
+{
     fn as_ref(&self) -> &Union2DataResponseOrErrorResponse {
         self
     }
 }
 
-impl Default for Union2DataResponseOrErrorResponse {
+impl ::std::default::Default for Union2DataResponseOrErrorResponse {
     fn default() -> Self {
-        Self::DataResponse(Default::default())
+        Self::DataResponse(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Streaming.User | Streaming.Product | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ProductOrUser {
     #[baml(name = "User")]
     User(User),
@@ -43,21 +50,22 @@ pub enum Union2ProductOrUser {
     Product(Product),
 }
 
-impl AsRef<Union2ProductOrUser> for Union2ProductOrUser {
+impl ::std::convert::AsRef<Union2ProductOrUser> for Union2ProductOrUser {
     fn as_ref(&self) -> &Union2ProductOrUser {
         self
     }
 }
 
-impl Default for Union2ProductOrUser {
+impl ::std::default::Default for Union2ProductOrUser {
     fn default() -> Self {
-        Self::User(Default::default())
+        Self::User(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | Streaming.RecursiveUnion)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2RecursiveUnionOrString {
     #[baml(name = "string")]
     String(String),
@@ -66,21 +74,22 @@ pub enum Union2RecursiveUnionOrString {
     RecursiveUnion(Box<RecursiveUnion>),
 }
 
-impl AsRef<Union2RecursiveUnionOrString> for Union2RecursiveUnionOrString {
+impl ::std::convert::AsRef<Union2RecursiveUnionOrString> for Union2RecursiveUnionOrString {
     fn as_ref(&self) -> &Union2RecursiveUnionOrString {
         self
     }
 }
 
-impl Default for Union2RecursiveUnionOrString {
+impl ::std::default::Default for Union2RecursiveUnionOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Streaming.User | Streaming.Product | Streaming.Admin | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3AdminOrProductOrUser {
     #[baml(name = "User")]
     User(User),
@@ -92,21 +101,22 @@ pub enum Union3AdminOrProductOrUser {
     Admin(Admin),
 }
 
-impl AsRef<Union3AdminOrProductOrUser> for Union3AdminOrProductOrUser {
+impl ::std::convert::AsRef<Union3AdminOrProductOrUser> for Union3AdminOrProductOrUser {
     fn as_ref(&self) -> &Union3AdminOrProductOrUser {
         self
     }
 }
 
-impl Default for Union3AdminOrProductOrUser {
+impl ::std::default::Default for Union3AdminOrProductOrUser {
     fn default() -> Self {
-        Self::User(Default::default())
+        Self::User(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Streaming.ApiSuccess | Streaming.ApiError | Streaming.ApiPending | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3ApiErrorOrApiPendingOrApiSuccess {
     #[baml(name = "ApiSuccess")]
     ApiSuccess(ApiSuccess),
@@ -118,21 +128,24 @@ pub enum Union3ApiErrorOrApiPendingOrApiSuccess {
     ApiPending(ApiPending),
 }
 
-impl AsRef<Union3ApiErrorOrApiPendingOrApiSuccess> for Union3ApiErrorOrApiPendingOrApiSuccess {
+impl ::std::convert::AsRef<Union3ApiErrorOrApiPendingOrApiSuccess>
+    for Union3ApiErrorOrApiPendingOrApiSuccess
+{
     fn as_ref(&self) -> &Union3ApiErrorOrApiPendingOrApiSuccess {
         self
     }
 }
 
-impl Default for Union3ApiErrorOrApiPendingOrApiSuccess {
+impl ::std::default::Default for Union3ApiErrorOrApiPendingOrApiSuccess {
     fn default() -> Self {
-        Self::ApiSuccess(Default::default())
+        Self::ApiSuccess(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Streaming.Dog | Streaming.Cat | Streaming.Bird | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BirdOrCatOrDog {
     #[baml(name = "Dog")]
     Dog(Dog),
@@ -144,21 +157,22 @@ pub enum Union3BirdOrCatOrDog {
     Bird(Bird),
 }
 
-impl AsRef<Union3BirdOrCatOrDog> for Union3BirdOrCatOrDog {
+impl ::std::convert::AsRef<Union3BirdOrCatOrDog> for Union3BirdOrCatOrDog {
     fn as_ref(&self) -> &Union3BirdOrCatOrDog {
         self
     }
 }
 
-impl Default for Union3BirdOrCatOrDog {
+impl ::std::default::Default for Union3BirdOrCatOrDog {
     fn default() -> Self {
-        Self::Dog(Default::default())
+        Self::Dog(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Streaming.Circle | Streaming.Rectangle | Streaming.Triangle | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3CircleOrRectangleOrTriangle {
     #[baml(name = "Circle")]
     Circle(Circle),
@@ -170,21 +184,24 @@ pub enum Union3CircleOrRectangleOrTriangle {
     Triangle(Triangle),
 }
 
-impl AsRef<Union3CircleOrRectangleOrTriangle> for Union3CircleOrRectangleOrTriangle {
+impl ::std::convert::AsRef<Union3CircleOrRectangleOrTriangle>
+    for Union3CircleOrRectangleOrTriangle
+{
     fn as_ref(&self) -> &Union3CircleOrRectangleOrTriangle {
         self
     }
 }
 
-impl Default for Union3CircleOrRectangleOrTriangle {
+impl ::std::default::Default for Union3CircleOrRectangleOrTriangle {
     fn default() -> Self {
-        Self::Circle(Default::default())
+        Self::Circle(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Streaming.Success | Streaming.Warning | Streaming.Error | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3ErrorOrSuccessOrWarning {
     #[baml(name = "Success")]
     Success(Success),
@@ -196,21 +213,22 @@ pub enum Union3ErrorOrSuccessOrWarning {
     Error(Error),
 }
 
-impl AsRef<Union3ErrorOrSuccessOrWarning> for Union3ErrorOrSuccessOrWarning {
+impl ::std::convert::AsRef<Union3ErrorOrSuccessOrWarning> for Union3ErrorOrSuccessOrWarning {
     fn as_ref(&self) -> &Union3ErrorOrSuccessOrWarning {
         self
     }
 }
 
-impl Default for Union3ErrorOrSuccessOrWarning {
+impl ::std::default::Default for Union3ErrorOrSuccessOrWarning {
     fn default() -> Self {
-        Self::Success(Default::default())
+        Self::Success(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int @stream.done | Streaming.RecursiveUnion | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3IntOrRecursiveUnionOrString {
     #[baml(name = "string")]
     String(String),
@@ -222,14 +240,16 @@ pub enum Union3IntOrRecursiveUnionOrString {
     RecursiveUnion(Box<RecursiveUnion>),
 }
 
-impl AsRef<Union3IntOrRecursiveUnionOrString> for Union3IntOrRecursiveUnionOrString {
+impl ::std::convert::AsRef<Union3IntOrRecursiveUnionOrString>
+    for Union3IntOrRecursiveUnionOrString
+{
     fn as_ref(&self) -> &Union3IntOrRecursiveUnionOrString {
         self
     }
 }
 
-impl Default for Union3IntOrRecursiveUnionOrString {
+impl ::std::default::Default for Union3IntOrRecursiveUnionOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct AdminClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl AdminClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Admin is statically defined in .baml and should always have a type")
@@ -37,28 +37,28 @@ impl AdminClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Admin.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Admin.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `permissions` field builder.
-    pub fn property_permissions(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_permissions(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("permissions")
             .expect("Admin.permissions is statically defined in .baml and should always be present")
     }
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Admin.type is statically defined in .baml and should always be present")
@@ -71,22 +71,22 @@ impl AdminClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ApiErrorClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ApiErrorClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ApiError is statically defined in .baml and should always have a type")
@@ -97,21 +97,21 @@ impl ApiErrorClassBuilder {
     // =========================================================================
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("status")
             .expect("ApiError.status is statically defined in .baml and should always be present")
     }
 
     /// Access the `message` field builder.
-    pub fn property_message(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_message(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("message")
             .expect("ApiError.message is statically defined in .baml and should always be present")
     }
 
     /// Access the `code` field builder.
-    pub fn property_code(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_code(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("code")
             .expect("ApiError.code is statically defined in .baml and should always be present")
@@ -124,22 +124,22 @@ impl ApiErrorClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ApiPendingClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ApiPendingClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ApiPending is statically defined in .baml and should always have a type")
@@ -150,21 +150,21 @@ impl ApiPendingClassBuilder {
     // =========================================================================
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("status")
             .expect("ApiPending.status is statically defined in .baml and should always be present")
     }
 
     /// Access the `progress` field builder.
-    pub fn property_progress(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_progress(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("progress").expect(
             "ApiPending.progress is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `eta` field builder.
-    pub fn property_eta(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_eta(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("eta")
             .expect("ApiPending.eta is statically defined in .baml and should always be present")
@@ -177,22 +177,22 @@ impl ApiPendingClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ApiSuccessClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ApiSuccessClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ApiSuccess is statically defined in .baml and should always have a type")
@@ -203,14 +203,14 @@ impl ApiSuccessClassBuilder {
     // =========================================================================
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("status")
             .expect("ApiSuccess.status is statically defined in .baml and should always be present")
     }
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("ApiSuccess.data is statically defined in .baml and should always be present")
@@ -223,22 +223,22 @@ impl ApiSuccessClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BirdClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BirdClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Bird is statically defined in .baml and should always have a type")
@@ -249,21 +249,21 @@ impl BirdClassBuilder {
     // =========================================================================
 
     /// Access the `species` field builder.
-    pub fn property_species(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_species(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("species")
             .expect("Bird.species is statically defined in .baml and should always be present")
     }
 
     /// Access the `canFly` field builder.
-    pub fn property_canFly(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_canFly(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("canFly")
             .expect("Bird.canFly is statically defined in .baml and should always be present")
     }
 
     /// Access the `wingspan` field builder.
-    pub fn property_wingspan(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_wingspan(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("wingspan")
             .expect("Bird.wingspan is statically defined in .baml and should always be present")
@@ -276,22 +276,22 @@ impl BirdClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct CatClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl CatClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Cat is statically defined in .baml and should always have a type")
@@ -302,21 +302,21 @@ impl CatClassBuilder {
     // =========================================================================
 
     /// Access the `species` field builder.
-    pub fn property_species(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_species(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("species")
             .expect("Cat.species is statically defined in .baml and should always be present")
     }
 
     /// Access the `color` field builder.
-    pub fn property_color(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_color(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("color")
             .expect("Cat.color is statically defined in .baml and should always be present")
     }
 
     /// Access the `lives` field builder.
-    pub fn property_lives(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_lives(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("lives")
             .expect("Cat.lives is statically defined in .baml and should always be present")
@@ -329,22 +329,22 @@ impl CatClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct CircleClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl CircleClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Circle is statically defined in .baml and should always have a type")
@@ -355,14 +355,14 @@ impl CircleClassBuilder {
     // =========================================================================
 
     /// Access the `shape` field builder.
-    pub fn property_shape(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_shape(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("shape")
             .expect("Circle.shape is statically defined in .baml and should always be present")
     }
 
     /// Access the `radius` field builder.
-    pub fn property_radius(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_radius(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("radius")
             .expect("Circle.radius is statically defined in .baml and should always be present")
@@ -375,22 +375,22 @@ impl CircleClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ComplexUnionsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ComplexUnionsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ComplexUnions is statically defined in .baml and should always have a type")
@@ -401,32 +401,32 @@ impl ComplexUnionsClassBuilder {
     // =========================================================================
 
     /// Access the `userOrProduct` field builder.
-    pub fn property_userOrProduct(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_userOrProduct(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("userOrProduct")
             .expect("ComplexUnions.userOrProduct is statically defined in .baml and should always be present")
     }
 
     /// Access the `userOrProductOrAdmin` field builder.
-    pub fn property_userOrProductOrAdmin(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_userOrProductOrAdmin(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("userOrProductOrAdmin")
             .expect("ComplexUnions.userOrProductOrAdmin is statically defined in .baml and should always be present")
     }
 
     /// Access the `dataOrError` field builder.
-    pub fn property_dataOrError(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_dataOrError(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("dataOrError").expect(
             "ComplexUnions.dataOrError is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `resultOrNull` field builder.
-    pub fn property_resultOrNull(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_resultOrNull(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("resultOrNull")
             .expect("ComplexUnions.resultOrNull is statically defined in .baml and should always be present")
     }
 
     /// Access the `multiTypeResult` field builder.
-    pub fn property_multiTypeResult(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_multiTypeResult(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("multiTypeResult")
             .expect("ComplexUnions.multiTypeResult is statically defined in .baml and should always be present")
     }
@@ -438,22 +438,22 @@ impl ComplexUnionsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DataResponseClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DataResponseClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DataResponse is statically defined in .baml and should always have a type")
@@ -464,21 +464,21 @@ impl DataResponseClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("DataResponse.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `timestamp` field builder.
-    pub fn property_timestamp(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_timestamp(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("timestamp").expect(
             "DataResponse.timestamp is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("status").expect(
             "DataResponse.status is statically defined in .baml and should always be present",
         )
@@ -491,22 +491,22 @@ impl DataResponseClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DiscriminatedUnionsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DiscriminatedUnionsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "DiscriminatedUnions is statically defined in .baml and should always have a type",
         )
@@ -517,20 +517,20 @@ impl DiscriminatedUnionsClassBuilder {
     // =========================================================================
 
     /// Access the `shape` field builder.
-    pub fn property_shape(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_shape(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("shape").expect(
             "DiscriminatedUnions.shape is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `animal` field builder.
-    pub fn property_animal(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_animal(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("animal")
             .expect("DiscriminatedUnions.animal is statically defined in .baml and should always be present")
     }
 
     /// Access the `response` field builder.
-    pub fn property_response(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_response(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("response")
             .expect("DiscriminatedUnions.response is statically defined in .baml and should always be present")
     }
@@ -542,22 +542,22 @@ impl DiscriminatedUnionsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DogClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DogClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Dog is statically defined in .baml and should always have a type")
@@ -568,21 +568,21 @@ impl DogClassBuilder {
     // =========================================================================
 
     /// Access the `species` field builder.
-    pub fn property_species(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_species(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("species")
             .expect("Dog.species is statically defined in .baml and should always be present")
     }
 
     /// Access the `breed` field builder.
-    pub fn property_breed(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_breed(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("breed")
             .expect("Dog.breed is statically defined in .baml and should always be present")
     }
 
     /// Access the `goodBoy` field builder.
-    pub fn property_goodBoy(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_goodBoy(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("goodBoy")
             .expect("Dog.goodBoy is statically defined in .baml and should always be present")
@@ -595,22 +595,22 @@ impl DogClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ErrorClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ErrorClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Error is statically defined in .baml and should always have a type")
@@ -621,28 +621,28 @@ impl ErrorClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Error.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `message` field builder.
-    pub fn property_message(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_message(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("message")
             .expect("Error.message is statically defined in .baml and should always be present")
     }
 
     /// Access the `code` field builder.
-    pub fn property_code(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_code(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("code")
             .expect("Error.code is statically defined in .baml and should always be present")
     }
 
     /// Access the `details` field builder.
-    pub fn property_details(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_details(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("details")
             .expect("Error.details is statically defined in .baml and should always be present")
@@ -655,22 +655,22 @@ impl ErrorClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ErrorResponseClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ErrorResponseClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ErrorResponse is statically defined in .baml and should always have a type")
@@ -681,21 +681,21 @@ impl ErrorResponseClassBuilder {
     // =========================================================================
 
     /// Access the `error` field builder.
-    pub fn property_error(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_error(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("error").expect(
             "ErrorResponse.error is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `code` field builder.
-    pub fn property_code(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_code(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("code").expect(
             "ErrorResponse.code is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("status").expect(
             "ErrorResponse.status is statically defined in .baml and should always be present",
         )
@@ -708,22 +708,22 @@ impl ErrorResponseClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PrimitiveUnionsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PrimitiveUnionsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("PrimitiveUnions is statically defined in .baml and should always have a type")
@@ -734,31 +734,31 @@ impl PrimitiveUnionsClassBuilder {
     // =========================================================================
 
     /// Access the `stringOrInt` field builder.
-    pub fn property_stringOrInt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringOrInt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringOrInt")
             .expect("PrimitiveUnions.stringOrInt is statically defined in .baml and should always be present")
     }
 
     /// Access the `stringOrFloat` field builder.
-    pub fn property_stringOrFloat(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_stringOrFloat(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("stringOrFloat")
             .expect("PrimitiveUnions.stringOrFloat is statically defined in .baml and should always be present")
     }
 
     /// Access the `intOrFloat` field builder.
-    pub fn property_intOrFloat(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_intOrFloat(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("intOrFloat")
             .expect("PrimitiveUnions.intOrFloat is statically defined in .baml and should always be present")
     }
 
     /// Access the `boolOrString` field builder.
-    pub fn property_boolOrString(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_boolOrString(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("boolOrString")
             .expect("PrimitiveUnions.boolOrString is statically defined in .baml and should always be present")
     }
 
     /// Access the `anyPrimitive` field builder.
-    pub fn property_anyPrimitive(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_anyPrimitive(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("anyPrimitive")
             .expect("PrimitiveUnions.anyPrimitive is statically defined in .baml and should always be present")
     }
@@ -770,22 +770,22 @@ impl PrimitiveUnionsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ProductClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ProductClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Product is statically defined in .baml and should always have a type")
@@ -796,28 +796,28 @@ impl ProductClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("Product.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Product.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `price` field builder.
-    pub fn property_price(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_price(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("price")
             .expect("Product.price is statically defined in .baml and should always be present")
     }
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Product.type is statically defined in .baml and should always be present")
@@ -830,22 +830,22 @@ impl ProductClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct RectangleClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RectangleClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Rectangle is statically defined in .baml and should always have a type")
@@ -856,21 +856,21 @@ impl RectangleClassBuilder {
     // =========================================================================
 
     /// Access the `shape` field builder.
-    pub fn property_shape(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_shape(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("shape")
             .expect("Rectangle.shape is statically defined in .baml and should always be present")
     }
 
     /// Access the `width` field builder.
-    pub fn property_width(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_width(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("width")
             .expect("Rectangle.width is statically defined in .baml and should always be present")
     }
 
     /// Access the `height` field builder.
-    pub fn property_height(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_height(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("height")
             .expect("Rectangle.height is statically defined in .baml and should always be present")
@@ -883,22 +883,22 @@ impl RectangleClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct RecursiveUnionClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RecursiveUnionClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("RecursiveUnion is statically defined in .baml and should always have a type")
@@ -909,14 +909,14 @@ impl RecursiveUnionClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value").expect(
             "RecursiveUnion.value is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `children` field builder.
-    pub fn property_children(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_children(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("children").expect(
             "RecursiveUnion.children is statically defined in .baml and should always be present",
         )
@@ -929,22 +929,22 @@ impl RecursiveUnionClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ResultClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ResultClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Result is statically defined in .baml and should always have a type")
@@ -955,14 +955,14 @@ impl ResultClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("value")
             .expect("Result.value is statically defined in .baml and should always be present")
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("metadata")
             .expect("Result.metadata is statically defined in .baml and should always be present")
@@ -975,22 +975,22 @@ impl ResultClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SuccessClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SuccessClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Success is statically defined in .baml and should always have a type")
@@ -1001,21 +1001,21 @@ impl SuccessClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Success.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `message` field builder.
-    pub fn property_message(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_message(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("message")
             .expect("Success.message is statically defined in .baml and should always be present")
     }
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Success.data is statically defined in .baml and should always be present")
@@ -1028,22 +1028,22 @@ impl SuccessClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TriangleClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TriangleClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Triangle is statically defined in .baml and should always have a type")
@@ -1054,21 +1054,21 @@ impl TriangleClassBuilder {
     // =========================================================================
 
     /// Access the `shape` field builder.
-    pub fn property_shape(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_shape(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("shape")
             .expect("Triangle.shape is statically defined in .baml and should always be present")
     }
 
     /// Access the `base` field builder.
-    pub fn property_base(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_base(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("base")
             .expect("Triangle.base is statically defined in .baml and should always be present")
     }
 
     /// Access the `height` field builder.
-    pub fn property_height(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_height(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("height")
             .expect("Triangle.height is statically defined in .baml and should always be present")
@@ -1081,22 +1081,22 @@ impl TriangleClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UnionArraysClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UnionArraysClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("UnionArrays is statically defined in .baml and should always have a type")
@@ -1107,28 +1107,28 @@ impl UnionArraysClassBuilder {
     // =========================================================================
 
     /// Access the `mixedArray` field builder.
-    pub fn property_mixedArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_mixedArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("mixedArray").expect(
             "UnionArrays.mixedArray is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nullableItems` field builder.
-    pub fn property_nullableItems(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nullableItems(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nullableItems").expect(
             "UnionArrays.nullableItems is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `objectArray` field builder.
-    pub fn property_objectArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_objectArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("objectArray").expect(
             "UnionArrays.objectArray is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nestedUnionArray` field builder.
-    pub fn property_nestedUnionArray(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nestedUnionArray(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nestedUnionArray")
             .expect("UnionArrays.nestedUnionArray is statically defined in .baml and should always be present")
     }
@@ -1140,22 +1140,22 @@ impl UnionArraysClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UserClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UserClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("User is statically defined in .baml and should always have a type")
@@ -1166,21 +1166,21 @@ impl UserClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("User.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("User.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("User.type is statically defined in .baml and should always be present")
@@ -1193,22 +1193,22 @@ impl UserClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct WarningClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl WarningClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Warning is statically defined in .baml and should always have a type")
@@ -1219,21 +1219,21 @@ impl WarningClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("Warning.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `message` field builder.
-    pub fn property_message(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_message(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("message")
             .expect("Warning.message is statically defined in .baml and should always be present")
     }
 
     /// Access the `level` field builder.
-    pub fn property_level(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_level(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("level")
             .expect("Warning.level is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -266,27 +264,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -295,17 +293,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -314,22 +312,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -338,12 +336,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -352,17 +350,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -371,29 +372,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/types/classes.rs
@@ -6,385 +6,344 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Admin {
     pub id: i64,
-
     pub name: String,
-
     pub permissions: Vec<String>,
-
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
 }
 
-impl AsRef<Admin> for Admin {
+impl ::std::convert::AsRef<Admin> for Admin {
     fn as_ref(&self) -> &Admin {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ApiError {
     pub status: String,
-
     pub message: String,
-
     pub code: i64,
 }
 
-impl AsRef<ApiError> for ApiError {
+impl ::std::convert::AsRef<ApiError> for ApiError {
     fn as_ref(&self) -> &ApiError {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ApiPending {
     pub status: String,
-
     pub progress: f64,
-
     pub eta: Option<i64>,
 }
 
-impl AsRef<ApiPending> for ApiPending {
+impl ::std::convert::AsRef<ApiPending> for ApiPending {
     fn as_ref(&self) -> &ApiPending {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ApiSuccess {
     pub status: String,
-
     pub data: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<ApiSuccess> for ApiSuccess {
+impl ::std::convert::AsRef<ApiSuccess> for ApiSuccess {
     fn as_ref(&self) -> &ApiSuccess {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Bird {
     pub species: String,
-
     pub canFly: bool,
-
     pub wingspan: Option<f64>,
 }
 
-impl AsRef<Bird> for Bird {
+impl ::std::convert::AsRef<Bird> for Bird {
     fn as_ref(&self) -> &Bird {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Cat {
     pub species: String,
-
     pub color: String,
-
     pub lives: i64,
 }
 
-impl AsRef<Cat> for Cat {
+impl ::std::convert::AsRef<Cat> for Cat {
     fn as_ref(&self) -> &Cat {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Circle {
     pub shape: String,
-
     pub radius: f64,
 }
 
-impl AsRef<Circle> for Circle {
+impl ::std::convert::AsRef<Circle> for Circle {
     fn as_ref(&self) -> &Circle {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexUnions {
     pub userOrProduct: Union2ProductOrUser,
-
     pub userOrProductOrAdmin: Union3AdminOrProductOrUser,
-
     pub dataOrError: Union2DataResponseOrErrorResponse,
-
     pub resultOrNull: Option<Result>,
-
     pub multiTypeResult: Union3ErrorOrSuccessOrWarning,
 }
 
-impl AsRef<ComplexUnions> for ComplexUnions {
+impl ::std::convert::AsRef<ComplexUnions> for ComplexUnions {
     fn as_ref(&self) -> &ComplexUnions {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DataResponse {
     pub data: String,
-
     pub timestamp: i64,
-
     pub status: String,
 }
 
-impl AsRef<DataResponse> for DataResponse {
+impl ::std::convert::AsRef<DataResponse> for DataResponse {
     fn as_ref(&self) -> &DataResponse {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DiscriminatedUnions {
     pub shape: Union3CircleOrRectangleOrTriangle,
-
     pub animal: Union3BirdOrCatOrDog,
-
     pub response: Union3ApiErrorOrApiPendingOrApiSuccess,
 }
 
-impl AsRef<DiscriminatedUnions> for DiscriminatedUnions {
+impl ::std::convert::AsRef<DiscriminatedUnions> for DiscriminatedUnions {
     fn as_ref(&self) -> &DiscriminatedUnions {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Dog {
     pub species: String,
-
     pub breed: String,
-
     pub goodBoy: bool,
 }
 
-impl AsRef<Dog> for Dog {
+impl ::std::convert::AsRef<Dog> for Dog {
     fn as_ref(&self) -> &Dog {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Error {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub message: String,
-
     pub code: i64,
-
     pub details: Option<String>,
 }
 
-impl AsRef<Error> for Error {
+impl ::std::convert::AsRef<Error> for Error {
     fn as_ref(&self) -> &Error {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ErrorResponse {
     pub error: String,
-
     pub code: i64,
-
     pub status: String,
 }
 
-impl AsRef<ErrorResponse> for ErrorResponse {
+impl ::std::convert::AsRef<ErrorResponse> for ErrorResponse {
     fn as_ref(&self) -> &ErrorResponse {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PrimitiveUnions {
     pub stringOrInt: Union2IntOrString,
-
     pub stringOrFloat: Union2FloatOrString,
-
     pub intOrFloat: Union2FloatOrInt,
-
     pub boolOrString: Union2BoolOrString,
-
     pub anyPrimitive: Union4BoolOrFloatOrIntOrString,
 }
 
-impl AsRef<PrimitiveUnions> for PrimitiveUnions {
+impl ::std::convert::AsRef<PrimitiveUnions> for PrimitiveUnions {
     fn as_ref(&self) -> &PrimitiveUnions {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Product {
     pub id: i64,
-
     pub name: String,
-
     pub price: f64,
-
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
 }
 
-impl AsRef<Product> for Product {
+impl ::std::convert::AsRef<Product> for Product {
     fn as_ref(&self) -> &Product {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Rectangle {
     pub shape: String,
-
     pub width: f64,
-
     pub height: f64,
 }
 
-impl AsRef<Rectangle> for Rectangle {
+impl ::std::convert::AsRef<Rectangle> for Rectangle {
     fn as_ref(&self) -> &Rectangle {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RecursiveUnion {
     pub value: Union3IntOrRecursiveUnionOrString,
-
     pub children: Vec<Union2RecursiveUnionOrString>,
 }
 
-impl AsRef<RecursiveUnion> for RecursiveUnion {
+impl ::std::convert::AsRef<RecursiveUnion> for RecursiveUnion {
     fn as_ref(&self) -> &RecursiveUnion {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Result {
     pub value: Union3FloatOrIntOrString,
-
     pub metadata: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Result> for Result {
+impl ::std::convert::AsRef<Result> for Result {
     fn as_ref(&self) -> &Result {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Success {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub message: String,
-
     pub data: std::collections::HashMap<String, String>,
 }
 
-impl AsRef<Success> for Success {
+impl ::std::convert::AsRef<Success> for Success {
     fn as_ref(&self) -> &Success {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Triangle {
     pub shape: String,
-
     pub base: f64,
-
     pub height: f64,
 }
 
-impl AsRef<Triangle> for Triangle {
+impl ::std::convert::AsRef<Triangle> for Triangle {
     fn as_ref(&self) -> &Triangle {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UnionArrays {
     pub mixedArray: Vec<Union2IntOrString>,
-
     pub nullableItems: Vec<Option<String>>,
-
     pub objectArray: Vec<Union2ProductOrUser>,
-
     pub nestedUnionArray: Vec<Union2ListIntOrString>,
 }
 
-impl AsRef<UnionArrays> for UnionArrays {
+impl ::std::convert::AsRef<UnionArrays> for UnionArrays {
     fn as_ref(&self) -> &UnionArrays {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct User {
     pub id: i64,
-
     pub name: String,
-
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
 }
 
-impl AsRef<User> for User {
+impl ::std::convert::AsRef<User> for User {
     fn as_ref(&self) -> &User {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Warning {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub message: String,
-
     pub level: i64,
 }
 
-impl AsRef<Warning> for Warning {
+impl ::std::convert::AsRef<Warning> for Warning {
     fn as_ref(&self) -> &Warning {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     Admin(Admin),
 
@@ -103,7 +105,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -189,5 +191,15 @@ impl baml::KnownTypes for Types {
 
             Types::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/types/mod.rs
@@ -104,92 +104,92 @@ pub enum Types {
     Union4BoolOrFloatOrIntOrString(Union4BoolOrFloatOrIntOrString),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::Admin(_) => "Admin",
+            Self::Admin(_) => "Admin",
 
-            Types::ApiError(_) => "ApiError",
+            Self::ApiError(_) => "ApiError",
 
-            Types::ApiPending(_) => "ApiPending",
+            Self::ApiPending(_) => "ApiPending",
 
-            Types::ApiSuccess(_) => "ApiSuccess",
+            Self::ApiSuccess(_) => "ApiSuccess",
 
-            Types::Bird(_) => "Bird",
+            Self::Bird(_) => "Bird",
 
-            Types::Cat(_) => "Cat",
+            Self::Cat(_) => "Cat",
 
-            Types::Circle(_) => "Circle",
+            Self::Circle(_) => "Circle",
 
-            Types::ComplexUnions(_) => "ComplexUnions",
+            Self::ComplexUnions(_) => "ComplexUnions",
 
-            Types::DataResponse(_) => "DataResponse",
+            Self::DataResponse(_) => "DataResponse",
 
-            Types::DiscriminatedUnions(_) => "DiscriminatedUnions",
+            Self::DiscriminatedUnions(_) => "DiscriminatedUnions",
 
-            Types::Dog(_) => "Dog",
+            Self::Dog(_) => "Dog",
 
-            Types::Error(_) => "Error",
+            Self::Error(_) => "Error",
 
-            Types::ErrorResponse(_) => "ErrorResponse",
+            Self::ErrorResponse(_) => "ErrorResponse",
 
-            Types::PrimitiveUnions(_) => "PrimitiveUnions",
+            Self::PrimitiveUnions(_) => "PrimitiveUnions",
 
-            Types::Product(_) => "Product",
+            Self::Product(_) => "Product",
 
-            Types::Rectangle(_) => "Rectangle",
+            Self::Rectangle(_) => "Rectangle",
 
-            Types::RecursiveUnion(_) => "RecursiveUnion",
+            Self::RecursiveUnion(_) => "RecursiveUnion",
 
-            Types::Result(_) => "Result",
+            Self::Result(_) => "Result",
 
-            Types::Success(_) => "Success",
+            Self::Success(_) => "Success",
 
-            Types::Triangle(_) => "Triangle",
+            Self::Triangle(_) => "Triangle",
 
-            Types::UnionArrays(_) => "UnionArrays",
+            Self::UnionArrays(_) => "UnionArrays",
 
-            Types::User(_) => "User",
+            Self::User(_) => "User",
 
-            Types::Warning(_) => "Warning",
+            Self::Warning(_) => "Warning",
 
-            Types::Union2BoolOrString(_) => "Union2BoolOrString",
+            Self::Union2BoolOrString(_) => "Union2BoolOrString",
 
-            Types::Union2DataResponseOrErrorResponse(_) => "Union2DataResponseOrErrorResponse",
+            Self::Union2DataResponseOrErrorResponse(_) => "Union2DataResponseOrErrorResponse",
 
-            Types::Union2FloatOrInt(_) => "Union2FloatOrInt",
+            Self::Union2FloatOrInt(_) => "Union2FloatOrInt",
 
-            Types::Union2FloatOrString(_) => "Union2FloatOrString",
+            Self::Union2FloatOrString(_) => "Union2FloatOrString",
 
-            Types::Union2IntOrString(_) => "Union2IntOrString",
+            Self::Union2IntOrString(_) => "Union2IntOrString",
 
-            Types::Union2ListIntOrString(_) => "Union2ListIntOrString",
+            Self::Union2ListIntOrString(_) => "Union2ListIntOrString",
 
-            Types::Union2ProductOrUser(_) => "Union2ProductOrUser",
+            Self::Union2ProductOrUser(_) => "Union2ProductOrUser",
 
-            Types::Union2RecursiveUnionOrString(_) => "Union2RecursiveUnionOrString",
+            Self::Union2RecursiveUnionOrString(_) => "Union2RecursiveUnionOrString",
 
-            Types::Union3AdminOrProductOrUser(_) => "Union3AdminOrProductOrUser",
+            Self::Union3AdminOrProductOrUser(_) => "Union3AdminOrProductOrUser",
 
-            Types::Union3ApiErrorOrApiPendingOrApiSuccess(_) => {
+            Self::Union3ApiErrorOrApiPendingOrApiSuccess(_) => {
                 "Union3ApiErrorOrApiPendingOrApiSuccess"
             }
 
-            Types::Union3BirdOrCatOrDog(_) => "Union3BirdOrCatOrDog",
+            Self::Union3BirdOrCatOrDog(_) => "Union3BirdOrCatOrDog",
 
-            Types::Union3CircleOrRectangleOrTriangle(_) => "Union3CircleOrRectangleOrTriangle",
+            Self::Union3CircleOrRectangleOrTriangle(_) => "Union3CircleOrRectangleOrTriangle",
 
-            Types::Union3ErrorOrSuccessOrWarning(_) => "Union3ErrorOrSuccessOrWarning",
+            Self::Union3ErrorOrSuccessOrWarning(_) => "Union3ErrorOrSuccessOrWarning",
 
-            Types::Union3FloatOrIntOrString(_) => "Union3FloatOrIntOrString",
+            Self::Union3FloatOrIntOrString(_) => "Union3FloatOrIntOrString",
 
-            Types::Union3IntOrRecursiveUnionOrString(_) => "Union3IntOrRecursiveUnionOrString",
+            Self::Union3IntOrRecursiveUnionOrString(_) => "Union3IntOrRecursiveUnionOrString",
 
-            Types::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
+            Self::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/union_types_extended/baml_client/types/unions.rs
@@ -6,11 +6,15 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (bool | string)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2BoolOrString {
     #[baml(name = "bool")]
     Bool(bool),
@@ -19,21 +23,22 @@ pub enum Union2BoolOrString {
     String(String),
 }
 
-impl AsRef<Union2BoolOrString> for Union2BoolOrString {
+impl ::std::convert::AsRef<Union2BoolOrString> for Union2BoolOrString {
     fn as_ref(&self) -> &Union2BoolOrString {
         self
     }
 }
 
-impl Default for Union2BoolOrString {
+impl ::std::default::Default for Union2BoolOrString {
     fn default() -> Self {
-        Self::Bool(Default::default())
+        Self::Bool(::std::default::Default::default())
     }
 }
 
 /// Generated from: (DataResponse | ErrorResponse)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2DataResponseOrErrorResponse {
     #[baml(name = "DataResponse")]
     DataResponse(DataResponse),
@@ -42,21 +47,24 @@ pub enum Union2DataResponseOrErrorResponse {
     ErrorResponse(ErrorResponse),
 }
 
-impl AsRef<Union2DataResponseOrErrorResponse> for Union2DataResponseOrErrorResponse {
+impl ::std::convert::AsRef<Union2DataResponseOrErrorResponse>
+    for Union2DataResponseOrErrorResponse
+{
     fn as_ref(&self) -> &Union2DataResponseOrErrorResponse {
         self
     }
 }
 
-impl Default for Union2DataResponseOrErrorResponse {
+impl ::std::default::Default for Union2DataResponseOrErrorResponse {
     fn default() -> Self {
-        Self::DataResponse(Default::default())
+        Self::DataResponse(::std::default::Default::default())
     }
 }
 
 /// Generated from: (int | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2FloatOrInt {
     #[baml(name = "int")]
     Int(i64),
@@ -65,21 +73,22 @@ pub enum Union2FloatOrInt {
     Float(f64),
 }
 
-impl AsRef<Union2FloatOrInt> for Union2FloatOrInt {
+impl ::std::convert::AsRef<Union2FloatOrInt> for Union2FloatOrInt {
     fn as_ref(&self) -> &Union2FloatOrInt {
         self
     }
 }
 
-impl Default for Union2FloatOrInt {
+impl ::std::default::Default for Union2FloatOrInt {
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2FloatOrString {
     #[baml(name = "string")]
     String(String),
@@ -88,21 +97,22 @@ pub enum Union2FloatOrString {
     Float(f64),
 }
 
-impl AsRef<Union2FloatOrString> for Union2FloatOrString {
+impl ::std::convert::AsRef<Union2FloatOrString> for Union2FloatOrString {
     fn as_ref(&self) -> &Union2FloatOrString {
         self
     }
 }
 
-impl Default for Union2FloatOrString {
+impl ::std::default::Default for Union2FloatOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2IntOrString {
     #[baml(name = "string")]
     String(String),
@@ -111,21 +121,22 @@ pub enum Union2IntOrString {
     Int(i64),
 }
 
-impl AsRef<Union2IntOrString> for Union2IntOrString {
+impl ::std::convert::AsRef<Union2IntOrString> for Union2IntOrString {
     fn as_ref(&self) -> &Union2IntOrString {
         self
     }
 }
 
-impl Default for Union2IntOrString {
+impl ::std::default::Default for Union2IntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int[])
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ListIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -134,21 +145,22 @@ pub enum Union2ListIntOrString {
     ListInt(Vec<i64>),
 }
 
-impl AsRef<Union2ListIntOrString> for Union2ListIntOrString {
+impl ::std::convert::AsRef<Union2ListIntOrString> for Union2ListIntOrString {
     fn as_ref(&self) -> &Union2ListIntOrString {
         self
     }
 }
 
-impl Default for Union2ListIntOrString {
+impl ::std::default::Default for Union2ListIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (User | Product)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ProductOrUser {
     #[baml(name = "User")]
     User(User),
@@ -157,21 +169,22 @@ pub enum Union2ProductOrUser {
     Product(Product),
 }
 
-impl AsRef<Union2ProductOrUser> for Union2ProductOrUser {
+impl ::std::convert::AsRef<Union2ProductOrUser> for Union2ProductOrUser {
     fn as_ref(&self) -> &Union2ProductOrUser {
         self
     }
 }
 
-impl Default for Union2ProductOrUser {
+impl ::std::default::Default for Union2ProductOrUser {
     fn default() -> Self {
-        Self::User(Default::default())
+        Self::User(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | RecursiveUnion)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2RecursiveUnionOrString {
     #[baml(name = "string")]
     String(String),
@@ -180,21 +193,22 @@ pub enum Union2RecursiveUnionOrString {
     RecursiveUnion(Box<RecursiveUnion>),
 }
 
-impl AsRef<Union2RecursiveUnionOrString> for Union2RecursiveUnionOrString {
+impl ::std::convert::AsRef<Union2RecursiveUnionOrString> for Union2RecursiveUnionOrString {
     fn as_ref(&self) -> &Union2RecursiveUnionOrString {
         self
     }
 }
 
-impl Default for Union2RecursiveUnionOrString {
+impl ::std::default::Default for Union2RecursiveUnionOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (User | Product | Admin)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3AdminOrProductOrUser {
     #[baml(name = "User")]
     User(User),
@@ -206,21 +220,22 @@ pub enum Union3AdminOrProductOrUser {
     Admin(Admin),
 }
 
-impl AsRef<Union3AdminOrProductOrUser> for Union3AdminOrProductOrUser {
+impl ::std::convert::AsRef<Union3AdminOrProductOrUser> for Union3AdminOrProductOrUser {
     fn as_ref(&self) -> &Union3AdminOrProductOrUser {
         self
     }
 }
 
-impl Default for Union3AdminOrProductOrUser {
+impl ::std::default::Default for Union3AdminOrProductOrUser {
     fn default() -> Self {
-        Self::User(Default::default())
+        Self::User(::std::default::Default::default())
     }
 }
 
 /// Generated from: (ApiSuccess | ApiError | ApiPending)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3ApiErrorOrApiPendingOrApiSuccess {
     #[baml(name = "ApiSuccess")]
     ApiSuccess(ApiSuccess),
@@ -232,21 +247,24 @@ pub enum Union3ApiErrorOrApiPendingOrApiSuccess {
     ApiPending(ApiPending),
 }
 
-impl AsRef<Union3ApiErrorOrApiPendingOrApiSuccess> for Union3ApiErrorOrApiPendingOrApiSuccess {
+impl ::std::convert::AsRef<Union3ApiErrorOrApiPendingOrApiSuccess>
+    for Union3ApiErrorOrApiPendingOrApiSuccess
+{
     fn as_ref(&self) -> &Union3ApiErrorOrApiPendingOrApiSuccess {
         self
     }
 }
 
-impl Default for Union3ApiErrorOrApiPendingOrApiSuccess {
+impl ::std::default::Default for Union3ApiErrorOrApiPendingOrApiSuccess {
     fn default() -> Self {
-        Self::ApiSuccess(Default::default())
+        Self::ApiSuccess(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Dog | Cat | Bird)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BirdOrCatOrDog {
     #[baml(name = "Dog")]
     Dog(Dog),
@@ -258,21 +276,22 @@ pub enum Union3BirdOrCatOrDog {
     Bird(Bird),
 }
 
-impl AsRef<Union3BirdOrCatOrDog> for Union3BirdOrCatOrDog {
+impl ::std::convert::AsRef<Union3BirdOrCatOrDog> for Union3BirdOrCatOrDog {
     fn as_ref(&self) -> &Union3BirdOrCatOrDog {
         self
     }
 }
 
-impl Default for Union3BirdOrCatOrDog {
+impl ::std::default::Default for Union3BirdOrCatOrDog {
     fn default() -> Self {
-        Self::Dog(Default::default())
+        Self::Dog(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Circle | Rectangle | Triangle)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3CircleOrRectangleOrTriangle {
     #[baml(name = "Circle")]
     Circle(Circle),
@@ -284,21 +303,24 @@ pub enum Union3CircleOrRectangleOrTriangle {
     Triangle(Triangle),
 }
 
-impl AsRef<Union3CircleOrRectangleOrTriangle> for Union3CircleOrRectangleOrTriangle {
+impl ::std::convert::AsRef<Union3CircleOrRectangleOrTriangle>
+    for Union3CircleOrRectangleOrTriangle
+{
     fn as_ref(&self) -> &Union3CircleOrRectangleOrTriangle {
         self
     }
 }
 
-impl Default for Union3CircleOrRectangleOrTriangle {
+impl ::std::default::Default for Union3CircleOrRectangleOrTriangle {
     fn default() -> Self {
-        Self::Circle(Default::default())
+        Self::Circle(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Success | Warning | Error)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3ErrorOrSuccessOrWarning {
     #[baml(name = "Success")]
     Success(Success),
@@ -310,21 +332,22 @@ pub enum Union3ErrorOrSuccessOrWarning {
     Error(Error),
 }
 
-impl AsRef<Union3ErrorOrSuccessOrWarning> for Union3ErrorOrSuccessOrWarning {
+impl ::std::convert::AsRef<Union3ErrorOrSuccessOrWarning> for Union3ErrorOrSuccessOrWarning {
     fn as_ref(&self) -> &Union3ErrorOrSuccessOrWarning {
         self
     }
 }
 
-impl Default for Union3ErrorOrSuccessOrWarning {
+impl ::std::default::Default for Union3ErrorOrSuccessOrWarning {
     fn default() -> Self {
-        Self::Success(Default::default())
+        Self::Success(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3FloatOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -336,21 +359,22 @@ pub enum Union3FloatOrIntOrString {
     Float(f64),
 }
 
-impl AsRef<Union3FloatOrIntOrString> for Union3FloatOrIntOrString {
+impl ::std::convert::AsRef<Union3FloatOrIntOrString> for Union3FloatOrIntOrString {
     fn as_ref(&self) -> &Union3FloatOrIntOrString {
         self
     }
 }
 
-impl Default for Union3FloatOrIntOrString {
+impl ::std::default::Default for Union3FloatOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int | RecursiveUnion)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3IntOrRecursiveUnionOrString {
     #[baml(name = "string")]
     String(String),
@@ -362,21 +386,24 @@ pub enum Union3IntOrRecursiveUnionOrString {
     RecursiveUnion(Box<RecursiveUnion>),
 }
 
-impl AsRef<Union3IntOrRecursiveUnionOrString> for Union3IntOrRecursiveUnionOrString {
+impl ::std::convert::AsRef<Union3IntOrRecursiveUnionOrString>
+    for Union3IntOrRecursiveUnionOrString
+{
     fn as_ref(&self) -> &Union3IntOrRecursiveUnionOrString {
         self
     }
 }
 
-impl Default for Union3IntOrRecursiveUnionOrString {
+impl ::std::default::Default for Union3IntOrRecursiveUnionOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
 /// Generated from: (string | int | float | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4BoolOrFloatOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -391,14 +418,14 @@ pub enum Union4BoolOrFloatOrIntOrString {
     Bool(bool),
 }
 
-impl AsRef<Union4BoolOrFloatOrIntOrString> for Union4BoolOrFloatOrIntOrString {
+impl ::std::convert::AsRef<Union4BoolOrFloatOrIntOrString> for Union4BoolOrFloatOrIntOrString {
     fn as_ref(&self) -> &Union4BoolOrFloatOrIntOrString {
         self
     }
 }
 
-impl Default for Union4BoolOrFloatOrIntOrString {
+impl ::std::default::Default for Union4BoolOrFloatOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/runtime.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        serde::{self, Deserialize, Deserializer},
+        BamlMediaRepr, BamlMediaReprContent,
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/stream_types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ExistingSystemComponent {
     pub id: Option<i64>,
 
@@ -27,19 +27,19 @@ pub struct ExistingSystemComponent {
     pub explanation: Option<String>,
 }
 
-impl AsRef<ExistingSystemComponent> for ExistingSystemComponent {
+impl ::std::convert::AsRef<ExistingSystemComponent> for ExistingSystemComponent {
     fn as_ref(&self) -> &ExistingSystemComponent {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UseMyUnion {
     pub u: Option<Union3IntOrRecursive1OrString>,
 }
 
-impl AsRef<UseMyUnion> for UseMyUnion {
+impl ::std::convert::AsRef<UseMyUnion> for UseMyUnion {
     fn as_ref(&self) -> &UseMyUnion {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/stream_types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     ExistingSystemComponent(ExistingSystemComponent),
 
@@ -28,7 +31,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -42,5 +45,15 @@ impl baml::KnownTypes for StreamTypes {
 
             StreamTypes::Union3IntOrRecursive1OrString(_) => "Union3IntOrRecursive1OrString",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/stream_types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/stream_types/unions.rs
@@ -7,11 +7,15 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{
+    BamlDecode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (int @stream.done | Streaming.Recursive1[] | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2IntOrListRecursive1 {
     #[baml(name = "int")]
     Int(i64),
@@ -20,21 +24,22 @@ pub enum Union2IntOrListRecursive1 {
     ListRecursive1(Vec<Recursive1>),
 }
 
-impl AsRef<Union2IntOrListRecursive1> for Union2IntOrListRecursive1 {
+impl ::std::convert::AsRef<Union2IntOrListRecursive1> for Union2IntOrListRecursive1 {
     fn as_ref(&self) -> &Union2IntOrListRecursive1 {
         self
     }
 }
 
-impl Default for Union2IntOrListRecursive1 {
+impl ::std::default::Default for Union2IntOrListRecursive1 {
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }
 
 /// Generated from: (Streaming.Recursive1 | int @stream.done | string | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3IntOrRecursive1OrString {
     #[baml(name = "Recursive1")]
     Recursive1(Recursive1),
@@ -46,14 +51,14 @@ pub enum Union3IntOrRecursive1OrString {
     String(String),
 }
 
-impl AsRef<Union3IntOrRecursive1OrString> for Union3IntOrRecursive1OrString {
+impl ::std::convert::AsRef<Union3IntOrRecursive1OrString> for Union3IntOrRecursive1OrString {
     fn as_ref(&self) -> &Union3IntOrRecursive1OrString {
         self
     }
 }
 
-impl Default for Union3IntOrRecursive1OrString {
+impl ::std::default::Default for Union3IntOrRecursive1OrString {
     fn default() -> Self {
-        Self::Recursive1(Default::default())
+        Self::Recursive1(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/type_builder/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ExistingSystemComponentClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ExistingSystemComponentClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "ExistingSystemComponent is statically defined in .baml and should always have a type",
         )
@@ -37,31 +37,31 @@ impl ExistingSystemComponentClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("id")
             .expect("ExistingSystemComponent.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("name")
             .expect("ExistingSystemComponent.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("type")
             .expect("ExistingSystemComponent.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `category` field builder.
-    pub fn property_category(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_category(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("category")
             .expect("ExistingSystemComponent.category is statically defined in .baml and should always be present")
     }
 
     /// Access the `explanation` field builder.
-    pub fn property_explanation(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_explanation(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("explanation")
             .expect("ExistingSystemComponent.explanation is statically defined in .baml and should always be present")
     }
@@ -73,22 +73,22 @@ impl ExistingSystemComponentClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UseMyUnionClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UseMyUnionClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("UseMyUnion is statically defined in .baml and should always have a type")
@@ -99,7 +99,7 @@ impl UseMyUnionClassBuilder {
     // =========================================================================
 
     /// Access the `u` field builder.
-    pub fn property_u(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_u(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("u")
             .expect("UseMyUnion.u is statically defined in .baml and should always be present")

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/type_builder/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -77,27 +75,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -106,17 +104,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -125,22 +123,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -149,12 +147,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -163,17 +161,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -182,29 +183,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/types/classes.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/types/classes.rs
@@ -6,36 +6,36 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode,
+    __internal::serde::{Deserialize, Serialize},
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ExistingSystemComponent {
     pub id: i64,
-
     pub name: String,
-
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
-
     pub category: Union2KresourceOrKservice,
-
     pub explanation: String,
 }
 
-impl AsRef<ExistingSystemComponent> for ExistingSystemComponent {
+impl ::std::convert::AsRef<ExistingSystemComponent> for ExistingSystemComponent {
     fn as_ref(&self) -> &ExistingSystemComponent {
         self
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UseMyUnion {
     pub u: Option<Union3IntOrRecursive1OrString>,
 }
 
-impl AsRef<UseMyUnion> for UseMyUnion {
+impl ::std::convert::AsRef<UseMyUnion> for UseMyUnion {
     fn as_ref(&self) -> &UseMyUnion {
         self
     }

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     ExistingSystemComponent(ExistingSystemComponent),
 
@@ -35,7 +37,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
@@ -51,5 +53,15 @@ impl baml::KnownTypes for Types {
 
             Types::Union3IntOrRecursive1OrString(_) => "Union3IntOrRecursive1OrString",
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/types/mod.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/types/mod.rs
@@ -36,22 +36,22 @@ pub enum Types {
     Union3IntOrRecursive1OrString(Union3IntOrRecursive1OrString),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::ExistingSystemComponent(_) => "ExistingSystemComponent",
+            Self::ExistingSystemComponent(_) => "ExistingSystemComponent",
 
-            Types::UseMyUnion(_) => "UseMyUnion",
+            Self::UseMyUnion(_) => "UseMyUnion",
 
-            Types::Union2IntOrListRecursive1(_) => "Union2IntOrListRecursive1",
+            Self::Union2IntOrListRecursive1(_) => "Union2IntOrListRecursive1",
 
-            Types::Union2KresourceOrKservice(_) => "Union2KresourceOrKservice",
+            Self::Union2KresourceOrKservice(_) => "Union2KresourceOrKservice",
 
-            Types::Union3IntOrRecursive1OrString(_) => "Union3IntOrRecursive1OrString",
+            Self::Union3IntOrRecursive1OrString(_) => "Union3IntOrRecursive1OrString",
         }
     }
 }

--- a/engine/generators/languages/rust/generated_tests/unions/baml_client/types/unions.rs
+++ b/engine/generators/languages/rust/generated_tests/unions/baml_client/types/unions.rs
@@ -6,11 +6,15 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    BamlDecode, BamlEncode, BamlSerde,
+    __internal::serde::{Deserialize, Serialize},
+};
 
 /// Generated from: (int | Recursive1[])
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2IntOrListRecursive1 {
     #[baml(name = "int")]
     Int(i64),
@@ -19,44 +23,50 @@ pub enum Union2IntOrListRecursive1 {
     ListRecursive1(Vec<Recursive1>),
 }
 
-impl AsRef<Union2IntOrListRecursive1> for Union2IntOrListRecursive1 {
+impl ::std::convert::AsRef<Union2IntOrListRecursive1> for Union2IntOrListRecursive1 {
     fn as_ref(&self) -> &Union2IntOrListRecursive1 {
         self
     }
 }
 
-impl Default for Union2IntOrListRecursive1 {
+impl ::std::default::Default for Union2IntOrListRecursive1 {
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }
 
 /// Generated from: ("service" | "resource")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2KresourceOrKservice {
     #[baml(name = "string_service", literal_string = "service")]
+    #[serde(with = "__baml_serde_union_literal_Union2KresourceOrKservice::Kservice")]
     Kservice,
 
     #[baml(name = "string_resource", literal_string = "resource")]
+    #[serde(with = "__baml_serde_union_literal_Union2KresourceOrKservice::Kresource")]
     Kresource,
 }
 
-impl AsRef<Union2KresourceOrKservice> for Union2KresourceOrKservice {
+impl ::std::convert::AsRef<Union2KresourceOrKservice> for Union2KresourceOrKservice {
     fn as_ref(&self) -> &Union2KresourceOrKservice {
         self
     }
 }
 
-impl Default for Union2KresourceOrKservice {
+impl ::std::default::Default for Union2KresourceOrKservice {
     fn default() -> Self {
         Self::Kservice
     }
 }
 
 /// Generated from: (Recursive1 | int | string | null)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3IntOrRecursive1OrString {
     #[baml(name = "Recursive1")]
     Recursive1(Recursive1),
@@ -68,14 +78,14 @@ pub enum Union3IntOrRecursive1OrString {
     String(String),
 }
 
-impl AsRef<Union3IntOrRecursive1OrString> for Union3IntOrRecursive1OrString {
+impl ::std::convert::AsRef<Union3IntOrRecursive1OrString> for Union3IntOrRecursive1OrString {
     fn as_ref(&self) -> &Union3IntOrRecursive1OrString {
         self
     }
 }
 
-impl Default for Union3IntOrRecursive1OrString {
+impl ::std::default::Default for Union3IntOrRecursive1OrString {
     fn default() -> Self {
-        Self::Recursive1(Default::default())
+        Self::Recursive1(::std::default::Default::default())
     }
 }

--- a/engine/generators/languages/rust/src/_templates/runtime.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/runtime.rs.j2
@@ -220,3 +220,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        BamlMediaRepr, BamlMediaReprContent,
+        serde::{self, Deserialize, Deserializer},
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/engine/generators/languages/rust/src/_templates/stream_types/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/stream_types/classes.rs.j2
@@ -38,7 +38,7 @@ pub struct {{ class.name }} {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 {% endif %}
 }

--- a/engine/generators/languages/rust/src/_templates/stream_types/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/stream_types/classes.rs.j2
@@ -36,26 +36,31 @@ pub struct {{ class.name }} {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<String, baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    >,
 {% endif %}
 }
 
 {% if class.dynamic %}
 impl {{ class.name }} {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
-            .ok_or_else(|| baml::BamlError::internal(format!("dynamic field '{}' not found", field)))
+            .ok_or_else(|| ::baml::BamlError::internal(format!("dynamic field '{}' not found", field)))
             .and_then(|v| v.get())
     }
 
     /// Get a dynamic field as a BamlValue reference (zero-copy).
-    pub fn get_ref(&self, field: &str) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    pub fn get_ref(&self, field: &str) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>
+    > {
         self.__dynamic.get(field)
     }
 
@@ -65,24 +70,24 @@ impl {{ class.name }} {
     }
 
     /// Iterate over all dynamic fields.
-    pub fn dynamic_fields(&self) -> impl Iterator<Item = (&str, &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>)> {
+    pub fn dynamic_fields(&self) -> impl ::std::iter::Iterator<Item = (&str, &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>)> {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for {{ class.name }} {
+impl ::std::default::Default for {{ class.name }} {
     fn default() -> Self {
         Self {
 {% for field in class.fields %}
-            {{ field.name }}: Default::default(),
+            {{ field.name }}: ::std::default::Default::default(),
 {% endfor %}
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 {% endif %}
 
-impl AsRef<{{ class.name }}> for {{ class.name }} {
+impl ::std::convert::AsRef<{{ class.name }}> for {{ class.name }} {
     fn as_ref(&self) -> &{{ class.name }} {
         self
     }

--- a/engine/generators/languages/rust/src/_templates/stream_types/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/stream_types/classes.rs.j2
@@ -6,7 +6,7 @@
 //! These types are used during streaming to hold partial results.
 //! Field types are already wrapped appropriately (Option, StreamState, etc.)
 
-use baml::BamlDecode;
+use baml::{BamlDecode, __internal::serde::Serialize};
 use crate::baml_client::types;
 use super::*;
 
@@ -16,11 +16,12 @@ use super::*;
 {{ crate::utils::prefix_lines(docstring, "/// ") }}
 {%- endif %}
 {% if class.dynamic %}
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
 {% else %}
-#[derive(Debug, Clone, Default, BamlDecode)]
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
 {% endif %}
+#[serde(crate = "::baml::__internal::serde")]
 pub struct {{ class.name }} {
 {% for field in class.fields %}
 {% if let Some(docstring) = field.docstring %}
@@ -34,6 +35,7 @@ pub struct {{ class.name }} {
 {% if class.dynamic %}
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<String, baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>>,
 {% endif %}
 }

--- a/engine/generators/languages/rust/src/_templates/stream_types/mod.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/stream_types/mod.rs.j2
@@ -25,7 +25,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn ::std::any::Any {
         self
     }
 
@@ -45,7 +45,7 @@ impl baml::KnownTypes for StreamTypes {
 }
 
 impl<'de> serde::Deserialize<'de> for StreamTypes {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Err(serde::de::Error::custom("StreamTypes is not deserializable, as we cannot disambiguate the type."))
+    fn deserialize<D: serde::Deserializer<'de>>(_deserializer: D) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom("StreamTypes is not deserializable, as we cannot disambiguate the type."))
     }
 }

--- a/engine/generators/languages/rust/src/_templates/stream_types/mod.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/stream_types/mod.rs.j2
@@ -10,8 +10,11 @@ pub use classes::*;
 pub use unions::*;
 pub use type_aliases::*;
 
+use baml::__internal::serde as serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
 {% for class in classes %}
     {{ class.name }}({{ class.name }}),
@@ -38,5 +41,11 @@ impl baml::KnownTypes for StreamTypes {
             _ => unreachable!("StreamTypes has no variants"),
 {% endif %}
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Err(serde::de::Error::custom("StreamTypes is not deserializable, as we cannot disambiguate the type."))
     }
 }

--- a/engine/generators/languages/rust/src/_templates/stream_types/unions.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/stream_types/unions.rs.j2
@@ -27,19 +27,19 @@ pub enum {{ u.name }} {
 {% endfor %}
 }
 
-impl AsRef<{{ u.name }}> for {{ u.name }} {
+impl ::std::convert::AsRef<{{ u.name }}> for {{ u.name }} {
     fn as_ref(&self) -> &{{ u.name }} {
         self
     }
 }
 
-impl Default for {{ u.name }} {
+impl ::std::default::Default for {{ u.name }} {
     fn default() -> Self {
         {% if u.variants.is_empty() %}
           panic!("{{ u.name }} has no variants")
         {% else %}
            {% let first_variant = u.variants[0] %}
-            Self::{{ first_variant.name }}{% if first_variant.literal_repr.is_none() %}(Default::default()){% endif %}
+            Self::{{ first_variant.name }}{% if first_variant.literal_repr.is_none() %}(::std::default::Default::default()){% endif %}
         {% endif %}
     }
 }

--- a/engine/generators/languages/rust/src/_templates/stream_types/unions.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/stream_types/unions.rs.j2
@@ -3,7 +3,7 @@
 {% else %}
 //! Generated streaming union types.
 
-use baml::BamlDecode;
+use baml::{BamlDecode, BamlSerde, __internal::serde::{Serialize, Deserialize}};
 use crate::baml_client::types;
 use super::*;
 {% for u in unions %}
@@ -11,15 +11,17 @@ use super::*;
 {% if let Some(docstring) = u.docstring -%}
 {{ crate::utils::prefix_lines(docstring, "/// ") }}
 {%- endif %}
-#[derive(Debug, Clone, BamlDecode{% if u.is_all_literals() %}, PartialEq, Eq, Hash{% endif %})]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize{% if u.is_all_literals() %}, PartialEq, Eq, Hash{% endif %})]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum {{ u.name }} {
 {% for variant in u.variants %}
     {% if let Some(literal_repr) = variant.literal_repr -%}
     #[baml(name = "{{ variant.cffi_name }}", literal_{{ variant.cffi_name.split("_").next().unwrap() }} = {{ literal_repr }})]
+    #[serde(with = "__baml_serde_union_literal_{{ u.name }}::{{ variant.name }}")]
     {{ variant.name }},
     {% else -%}
-    #[baml(name = "{{ variant.cffi_name }}",)]
+    #[baml(name = "{{ variant.cffi_name }}")]
     {{ variant.name }}({{ variant.type_str }}),
     {% endif -%}
 {% endfor %}

--- a/engine/generators/languages/rust/src/_templates/type_builder/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/type_builder/classes.rs.j2
@@ -32,7 +32,7 @@ impl {{ cls.name }}ClassBuilder {
 
 {% if cls.dynamic %}
     /// Add a new property to this dynamic class.
-    pub fn add_property(&self, name: &str, field_type: &::baml::TypeDef) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    pub fn add_property(&self, name: &str, field_type: &::baml::TypeDef) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 

--- a/engine/generators/languages/rust/src/_templates/type_builder/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/type_builder/classes.rs.j2
@@ -10,29 +10,29 @@
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 {% endif %}
 pub struct {{ cls.name }}ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl {{ cls.name }}ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type()
             .expect("{{ cls.name }} is statically defined in .baml and should always have a type")
     }
 
 {% if cls.dynamic %}
     /// Add a new property to this dynamic class.
-    pub fn add_property(&self, name: &str, field_type: &baml::TypeDef) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+    pub fn add_property(&self, name: &str, field_type: &::baml::TypeDef) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -43,7 +43,7 @@ impl {{ cls.name }}ClassBuilder {
 {% for field in cls.fields %}
 
     /// Access the `{{ field.name }}` field builder.
-    pub fn property_{{ field.raw_name }}(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_{{ field.raw_name }}(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("{{ field.raw_name }}")
             .expect("{{ cls.name }}.{{ field.raw_name }} is statically defined in .baml and should always be present")
     }

--- a/engine/generators/languages/rust/src/_templates/type_builder/enums.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/type_builder/enums.rs.j2
@@ -10,29 +10,29 @@
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 {% endif %}
 pub struct {{ enm.name }}EnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl {{ enm.name }}EnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type()
             .expect("{{ enm.name }} is statically defined in .baml and should always have a type")
     }
 
 {% if enm.dynamic %}
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(&self, value: &str) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -43,7 +43,7 @@ impl {{ enm.name }}EnumBuilder {
 {% for (val, _) in enm.values %}
 
     /// Access the `{{ val }}` value builder.
-    pub fn value_{{ val }}(&self) -> baml::EnumValueBuilder {
+    pub fn value_{{ val }}(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("{{ val }}")
             .expect("{{ enm.name }}.{{ val }} is statically defined in .baml and should always be present")
     }

--- a/engine/generators/languages/rust/src/_templates/type_builder/mod.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/type_builder/mod.rs.j2
@@ -6,8 +6,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -18,7 +16,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -32,12 +30,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -74,27 +72,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -103,17 +101,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -122,22 +120,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -146,12 +144,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -160,17 +158,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(&self, name: &str) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -179,29 +177,29 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(&self, name: &str) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
@@ -3,7 +3,7 @@
 {% else %}
 //! Generated class types.
 
-use baml::{BamlEncode, BamlDecode};
+use baml::{BamlEncode, BamlDecode, BamlSerde};
 use super::*;
 {% for class in classes %}
 
@@ -11,21 +11,21 @@ use super::*;
 {{ crate::utils::prefix_lines(docstring, "/// ") }}
 {%- endif %}
 {% if class.dynamic %}
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-{% else %}
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-{% endif %}
+{%- else %}
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+{%- endif %}
 pub struct {{ class.name }} {
 {% for field in class.fields %}
-{% if let Some(docstring) = field.docstring %}
+{%- if let Some(docstring) = field.docstring %}
     {{ crate::utils::prefix_lines(docstring, "/// ") }}
-{% endif %}
-{% if let Some(cffi_name) = field.cffi_name %}
+{%- endif %}
+{%- if let Some(cffi_name) = field.cffi_name %}
     #[baml(name = "{{ cffi_name }}")]
-{% endif %}
+{%- endif %}
     pub {{ field.name }}: {{ field.type_str }},
-{% endfor %}
+{%- endfor %}
 {% if class.dynamic %}
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
@@ -68,7 +68,7 @@ impl Default for {{ class.name }} {
         Self {
 {% for field in class.fields %}
             {{ field.name }}: Default::default(),
-{% endfor %}
+{%- endfor %}
             __dynamic: std::collections::HashMap::new(),
         }
     }

--- a/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
@@ -44,26 +44,31 @@ pub struct {{ class.name }} {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<String, baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    >,
 {%- endif %}
 }
 
 {% if class.dynamic %}
 impl {{ class.name }} {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
-            .ok_or_else(|| baml::BamlError::internal(format!("dynamic field '{}' not found", field)))
+            .ok_or_else(|| ::baml::BamlError::internal(format!("dynamic field '{}' not found", field)))
             .and_then(|v| v.get())
     }
 
     /// Get a dynamic field as a BamlValue reference (zero-copy).
-    pub fn get_ref(&self, field: &str) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    pub fn get_ref(&self, field: &str) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>
+    > {
         self.__dynamic.get(field)
     }
 
@@ -73,24 +78,24 @@ impl {{ class.name }} {
     }
 
     /// Iterate over all dynamic fields.
-    pub fn dynamic_fields(&self) -> impl Iterator<Item = (&str, &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>)> {
+    pub fn dynamic_fields(&self) -> impl ::std::iter::Iterator<Item = (&str, &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>)> {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for {{ class.name }} {
+impl ::std::default::Default for {{ class.name }} {
     fn default() -> Self {
         Self {
 {% for field in class.fields %}
-            {{ field.name }}: Default::default(),
+            {{ field.name }}: ::std::default::Default::default(),
 {%- endfor %}
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 {% endif %}
 
-impl AsRef<{{ class.name }}> for {{ class.name }} {
+impl ::std::convert::AsRef<{{ class.name }}> for {{ class.name }} {
     fn as_ref(&self) -> &{{ class.name }} {
         self
     }

--- a/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
@@ -29,13 +29,13 @@ pub struct {{ class.name }} {
 {%- if let Some(media_type) = field.media_type %}
 {%- match media_type %}
 {%- when MediaTypeRust::Image %}
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_image")]
 {%- when MediaTypeRust::Audio %}
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_audio")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_audio")]
 {%- when MediaTypeRust::Pdf %}
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_pdf")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_pdf")]
 {%- when MediaTypeRust::Video %}
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_video")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_video")]
 {%- endmatch %}
 {%- endif %}
     pub {{ field.name }}: {{ field.type_str }},

--- a/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
@@ -18,7 +18,7 @@ use super::*;
 {%- endif %}
 #[serde(crate = "::baml::__internal::serde")]
 pub struct {{ class.name }} {
-{% for field in class.fields %}
+{%- for field in class.fields %}
 {%- if let Some(docstring) = field.docstring %}
     {{ crate::utils::prefix_lines(docstring, "/// ") }}
 {%- endif %}
@@ -26,14 +26,26 @@ pub struct {{ class.name }} {
     #[baml(name = "{{ cffi_name }}")]
     #[serde(rename = "{{ cffi_name }}")]
 {%- endif %}
+{%- if let Some(media_type) = field.media_type %}
+{%- match media_type %}
+{%- when MediaTypeRust::Image %}
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
+{%- when MediaTypeRust::Audio %}
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_audio")]
+{%- when MediaTypeRust::Pdf %}
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_pdf")]
+{%- when MediaTypeRust::Video %}
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_video")]
+{%- endmatch %}
+{%- endif %}
     pub {{ field.name }}: {{ field.type_str }},
 {%- endfor %}
-{% if class.dynamic %}
+{%- if class.dynamic %}
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<String, baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>>,
-{% endif %}
+{%- endif %}
 }
 
 {% if class.dynamic %}

--- a/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/classes.rs.j2
@@ -3,7 +3,7 @@
 {% else %}
 //! Generated class types.
 
-use baml::{BamlEncode, BamlDecode, BamlSerde};
+use baml::{BamlEncode, BamlDecode, __internal::serde::{Serialize, Deserialize}};
 use super::*;
 {% for class in classes %}
 
@@ -11,11 +11,12 @@ use super::*;
 {{ crate::utils::prefix_lines(docstring, "/// ") }}
 {%- endif %}
 {% if class.dynamic %}
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
 {%- else %}
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
 {%- endif %}
+#[serde(crate = "::baml::__internal::serde")]
 pub struct {{ class.name }} {
 {% for field in class.fields %}
 {%- if let Some(docstring) = field.docstring %}
@@ -23,12 +24,14 @@ pub struct {{ class.name }} {
 {%- endif %}
 {%- if let Some(cffi_name) = field.cffi_name %}
     #[baml(name = "{{ cffi_name }}")]
+    #[serde(rename = "{{ cffi_name }}")]
 {%- endif %}
     pub {{ field.name }}: {{ field.type_str }},
 {%- endfor %}
 {% if class.dynamic %}
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<String, baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>>,
 {% endif %}
 }

--- a/engine/generators/languages/rust/src/_templates/types/enums.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/enums.rs.j2
@@ -3,18 +3,19 @@
 {% else %}
 //! Generated enum types.
 
-use baml::{BamlEncode, BamlDecode, BamlSerde};
+use baml::{BamlEncode, BamlDecode, __internal::serde::{Serialize, Deserialize}};
 {% for enum_ in enums %}
 
 {% if let Some(docstring) = enum_.docstring -%}
 {{ crate::utils::prefix_lines(docstring, "/// ") }}
 {%- endif %}
 {% if enum_.dynamic %}
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
 {% else %}
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 {% endif %}
+#[serde(crate = "::baml::__internal::serde")]
 pub enum {{ enum_.name }} {
 {% for (value, docstring) in enum_.values %}
 {% if let Some(docstring) = docstring -%}
@@ -25,6 +26,7 @@ pub enum {{ enum_.name }} {
 {% if enum_.dynamic %}
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
+    #[serde(untagged)]
     _Dynamic(String),
 {% endif %}
 }

--- a/engine/generators/languages/rust/src/_templates/types/enums.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/enums.rs.j2
@@ -27,11 +27,11 @@ pub enum {{ enum_.name }} {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
     #[serde(untagged)]
-    _Dynamic(String),
+    _Dynamic(::std::string::String),
 {% endif %}
 }
 
-impl Default for {{ enum_.name }} {
+impl ::std::default::Default for {{ enum_.name }} {
     fn default() -> Self {
         {% if enum_.values.is_empty() %}
         // Eventually, we will remove the default trait for enums with no values
@@ -43,8 +43,8 @@ impl Default for {{ enum_.name }} {
     }
 }
 
-impl std::fmt::Display for {{ enum_.name }} {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for {{ enum_.name }} {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
 {% for (value, _) in enum_.values %}
             Self::{{ value }} => write!(f, "{{ value }}"),
@@ -56,24 +56,24 @@ impl std::fmt::Display for {{ enum_.name }} {
     }
 }
 
-impl std::str::FromStr for {{ enum_.name }} {
+impl ::std::str::FromStr for {{ enum_.name }} {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
 {% for (value, _) in enum_.values %}
-            "{{ value }}" => Ok(Self::{{ value }}),
+            "{{ value }}" => ::std::result::Result::Ok(Self::{{ value | upper }}),
 {% endfor %}
 {% if enum_.dynamic %}
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
 {% else %}
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
 {% endif %}
         }
     }
 }
 
-impl AsRef<{{ enum_.name }}> for {{ enum_.name }} {
+impl ::std::convert::AsRef<{{ enum_.name }}> for {{ enum_.name }} {
     fn as_ref(&self) -> &{{ enum_.name }} {
         self
     }

--- a/engine/generators/languages/rust/src/_templates/types/enums.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/enums.rs.j2
@@ -3,17 +3,17 @@
 {% else %}
 //! Generated enum types.
 
-use baml::{BamlEncode, BamlDecode};
+use baml::{BamlEncode, BamlDecode, BamlSerde};
 {% for enum_ in enums %}
 
 {% if let Some(docstring) = enum_.docstring -%}
 {{ crate::utils::prefix_lines(docstring, "/// ") }}
 {%- endif %}
 {% if enum_.dynamic %}
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
 {% else %}
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 {% endif %}
 pub enum {{ enum_.name }} {
 {% for (value, docstring) in enum_.values %}

--- a/engine/generators/languages/rust/src/_templates/types/enums.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/enums.rs.j2
@@ -62,7 +62,7 @@ impl ::std::str::FromStr for {{ enum_.name }} {
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
 {% for (value, _) in enum_.values %}
-            "{{ value }}" => ::std::result::Result::Ok(Self::{{ value | upper }}),
+            "{{ value }}" => ::std::result::Result::Ok(Self::{{ value }}),
 {% endfor %}
 {% if enum_.dynamic %}
             other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),

--- a/engine/generators/languages/rust/src/_templates/types/mod.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/mod.rs.j2
@@ -31,7 +31,7 @@ pub enum Types {
 {% endfor %}
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn ::std::any::Any {
         self
     }
@@ -39,13 +39,13 @@ impl baml::KnownTypes for Types {
     fn type_name(&self) -> &'static str {
         match self {
 {% for class in classes %}
-            Types::{{ class.name }}(_) => "{{ class.name }}",
+            Self::{{ class.name }}(_) => "{{ class.name }}",
 {% endfor %}
 {% for enum_ in enums %}
-            Types::{{ enum_.name }}(_) => "{{ enum_.name }}",
+            Self::{{ enum_.name }}(_) => "{{ enum_.name }}",
 {% endfor %}
 {% for union_ in unions %}
-            Types::{{ union_.name }}(_) => "{{ union_.name }}",
+            Self::{{ union_.name }}(_) => "{{ union_.name }}",
 {% endfor %}
 {% if classes.is_empty() && enums.is_empty() && unions.is_empty() %}
             _ => unreachable!("Types has no variants"),

--- a/engine/generators/languages/rust/src/_templates/types/mod.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/mod.rs.j2
@@ -13,10 +13,12 @@ pub use type_aliases::*;
 // Re-export types from baml runtime
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
+use baml::__internal::serde as serde;
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
 {% for class in classes %}
     {{ class.name }}({{ class.name }}),
@@ -49,5 +51,11 @@ impl baml::KnownTypes for Types {
             _ => unreachable!("Types has no variants"),
 {% endif %}
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Err(serde::de::Error::custom("Types is not deserializable, as we cannot disambiguate the type."))
     }
 }

--- a/engine/generators/languages/rust/src/_templates/types/mod.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/mod.rs.j2
@@ -32,7 +32,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn ::std::any::Any {
         self
     }
 
@@ -55,7 +55,7 @@ impl baml::KnownTypes for Types {
 }
 
 impl<'de> serde::Deserialize<'de> for Types {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Err(serde::de::Error::custom("Types is not deserializable, as we cannot disambiguate the type."))
+    fn deserialize<D: serde::Deserializer<'de>>(_deserializer: D) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom("Types is not deserializable, as we cannot disambiguate the type."))
     }
 }

--- a/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
@@ -15,14 +15,26 @@ use super::*;
 #[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum {{ u.name }} {
 {% for variant in u.variants %}
-    {% if let Some(literal_repr) = variant.literal_repr -%}
+{% if let Some(literal_repr) = variant.literal_repr -%}
     #[baml(name = "{{ variant.cffi_name }}", literal_{{ variant.cffi_name.split("_").next().unwrap() }} = {{ literal_repr }})]
     #[serde(with = "__baml_serde_union_literal_{{ u.name }}::{{ variant.name }}")]
     {{ variant.name }},
-    {% else -%}
+{% else -%}
     #[baml(name = "{{ variant.cffi_name }}")]
+{%- if let Some(media_type) = variant.media_type %}
+{%- match media_type %}
+{%- when MediaTypeRust::Image %}
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
+{%- when MediaTypeRust::Audio %}
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_audio")]
+{%- when MediaTypeRust::Pdf %}
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_pdf")]
+{%- when MediaTypeRust::Video %}
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_video")]
+{%- endmatch %}
+{%- endif %}
     {{ variant.name }}({{ variant.type_str }}),
-    {% endif -%}
+{% endif -%}
 {%- endfor %}
 }
 

--- a/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
@@ -38,19 +38,19 @@ pub enum {{ u.name }} {
 {%- endfor %}
 }
 
-impl AsRef<{{ u.name }}> for {{ u.name }} {
+impl ::std::convert::AsRef<{{ u.name }}> for {{ u.name }} {
     fn as_ref(&self) -> &{{ u.name }} {
         self
     }
 }
 
-impl Default for {{ u.name }} {
+impl ::std::default::Default for {{ u.name }} {
     fn default() -> Self {
         {% if u.variants.is_empty() %}
           panic!("{{ u.name }} has no variants")
         {% else %}
            {% let first_variant = u.variants[0] %}
-            Self::{{ first_variant.name }}{% if first_variant.literal_repr.is_none() %}(Default::default()){% endif %}
+            Self::{{ first_variant.name }}{% if first_variant.literal_repr.is_none() %}(::std::default::Default::default()){% endif %}
         {% endif %}
     }
 }

--- a/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
@@ -3,20 +3,21 @@
 {% else %}
 //! Generated union types.
 
-use baml::{BamlEncode, BamlDecode, __internal::serde::{Serialize, Deserialize}};
+use baml::{BamlEncode, BamlDecode, BamlSerde, __internal::serde::{Serialize, Deserialize}};
 use super::*;
 {% for u in unions %}
 
 {% if let Some(docstring) = u.docstring -%}
 {{ crate::utils::prefix_lines(docstring, "/// ") }}
 {%- endif %}
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize{% if u.is_all_literals() %}, PartialEq, Eq, Hash{% endif %})]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize{% if u.is_all_literals() %}, PartialEq, Eq, Hash{% endif %})]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum {{ u.name }} {
 {% for variant in u.variants %}
     {% if let Some(literal_repr) = variant.literal_repr -%}
     #[baml(name = "{{ variant.cffi_name }}", literal_{{ variant.cffi_name.split("_").next().unwrap() }} = {{ literal_repr }})]
+    #[serde(with = "__baml_serde_union_literal_{{ u.name }}::{{ variant.name }}")]
     {{ variant.name }},
     {% else -%}
     #[baml(name = "{{ variant.cffi_name }}")]

--- a/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
@@ -24,13 +24,13 @@ pub enum {{ u.name }} {
 {%- if let Some(media_type) = variant.media_type %}
 {%- match media_type %}
 {%- when MediaTypeRust::Image %}
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_image")]
 {%- when MediaTypeRust::Audio %}
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_audio")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_audio")]
 {%- when MediaTypeRust::Pdf %}
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_pdf")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_pdf")]
 {%- when MediaTypeRust::Video %}
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_video")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_video")]
 {%- endmatch %}
 {%- endif %}
     {{ variant.name }}({{ variant.type_str }}),

--- a/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
+++ b/engine/generators/languages/rust/src/_templates/types/unions.rs.j2
@@ -3,14 +3,15 @@
 {% else %}
 //! Generated union types.
 
-use baml::{BamlEncode, BamlDecode};
+use baml::{BamlEncode, BamlDecode, __internal::serde::{Serialize, Deserialize}};
 use super::*;
 {% for u in unions %}
 
 {% if let Some(docstring) = u.docstring -%}
 {{ crate::utils::prefix_lines(docstring, "/// ") }}
 {%- endif %}
-#[derive(Debug, Clone, BamlEncode, BamlDecode{% if u.is_all_literals() %}, PartialEq, Eq, Hash{% endif %})]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize{% if u.is_all_literals() %}, PartialEq, Eq, Hash{% endif %})]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum {{ u.name }} {
 {% for variant in u.variants %}
@@ -18,10 +19,10 @@ pub enum {{ u.name }} {
     #[baml(name = "{{ variant.cffi_name }}", literal_{{ variant.cffi_name.split("_").next().unwrap() }} = {{ literal_repr }})]
     {{ variant.name }},
     {% else -%}
-        #[baml(name = "{{ variant.cffi_name }}")]
-        {{ variant.name }}({{ variant.type_str }}),
+    #[baml(name = "{{ variant.cffi_name }}")]
+    {{ variant.name }}({{ variant.type_str }}),
     {% endif -%}
-{% endfor %}
+{%- endfor %}
 }
 
 impl AsRef<{{ u.name }}> for {{ u.name }} {

--- a/engine/generators/languages/rust/src/generated_types.rs
+++ b/engine/generators/languages/rust/src/generated_types.rs
@@ -1,6 +1,7 @@
 use crate::{
     package::CurrentRenderPackage,
     r#type::{SerializeType, TypeRust},
+    MediaTypeRust,
 };
 
 #[derive(Debug)]
@@ -117,16 +118,22 @@ pub struct FieldRustRendered {
     pub raw_name: String,
     pub docstring: Option<String>,
     pub type_str: String,
+    pub media_type: Option<MediaTypeRust>,
 }
 
 impl FieldRustRendered {
     pub fn from_field(field: &FieldRust, pkg: &CurrentRenderPackage) -> Self {
+        let media_type = match field.r#type {
+            TypeRust::Media(media_type) => Some(media_type),
+            _ => None,
+        };
         Self {
             name: field.name.clone(),
             cffi_name: field.cffi_name.clone(),
             raw_name: field.raw_name.clone(),
             docstring: field.docstring.clone(),
             type_str: field.r#type.serialize_type(pkg),
+            media_type,
         }
     }
 }
@@ -171,15 +178,21 @@ pub struct VariantRustRendered {
     pub cffi_name: String,
     pub literal_repr: Option<String>,
     pub type_str: String,
+    pub media_type: Option<MediaTypeRust>,
 }
 
 impl VariantRustRendered {
     pub fn from_variant(variant: &VariantRust, pkg: &CurrentRenderPackage) -> Self {
+        let media_type = match variant.type_ {
+            TypeRust::Media(media_type) => Some(media_type),
+            _ => None,
+        };
         Self {
             name: variant.name.clone(),
             cffi_name: variant.cffi_name.clone(),
             literal_repr: variant.literal_repr.clone(),
             type_str: variant.type_.serialize_type(pkg),
+            media_type,
         }
     }
 }

--- a/engine/generators/languages/rust/src/templates.rs
+++ b/engine/generators/languages/rust/src/templates.rs
@@ -6,7 +6,7 @@ use crate::{
     functions::FunctionRust,
     generated_types::{ClassRustRendered, EnumRust, TypeAliasRustRendered, UnionRustRendered},
     package::CurrentRenderPackage,
-    r#type::SerializeType,
+    r#type::{MediaTypeRust, SerializeType},
 };
 
 /// Source map template - embeds BAML source files

--- a/engine/generators/languages/rust/src/type.rs
+++ b/engine/generators/languages/rust/src/type.rs
@@ -1,6 +1,6 @@
 use crate::package::{CurrentRenderPackage, Package};
 
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Copy, PartialEq, Debug)]
 pub enum MediaTypeRust {
     Image,
     Audio,

--- a/integ-tests/rust/Cargo.lock
+++ b/integ-tests/rust/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.218.1"
+version = "0.219.0"
 dependencies = [
  "async-channel",
  "baml-macros",
@@ -48,7 +48,7 @@ dependencies = [
 
 [[package]]
 name = "baml-macros"
-version = "0.218.1"
+version = "0.219.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -57,7 +57,7 @@ dependencies = [
 
 [[package]]
 name = "baml-sys"
-version = "0.218.1"
+version = "0.219.0"
 dependencies = [
  "hex",
  "libc",

--- a/integ-tests/rust/src/baml_client/runtime.rs
+++ b/integ-tests/rust/src/baml_client/runtime.rs
@@ -227,3 +227,77 @@ pub fn new_video_from_base64(base64: &str, mime_type: Option<&str>) -> baml::Vid
 pub fn new_collector(name: &str) -> baml::Collector {
     get_runtime().new_collector(name)
 }
+
+// =============================================================================
+// Serde Deserialize helpers
+// =============================================================================
+
+/// Referenced by `#[serde(deserialize_with = "__internal_media_serde::...")]` in created types,
+/// Since the actual media types don't have access to the runtime.
+pub(super) mod __internal_media_serde {
+    use super::{
+        new_audio_from_base64, new_audio_from_url, new_image_from_base64, new_image_from_url,
+        new_pdf_from_base64, new_pdf_from_url, new_video_from_base64, new_video_from_url,
+    };
+    use baml::__internal::{
+        BamlMediaRepr, BamlMediaReprContent,
+        serde::{self, Deserialize, Deserializer},
+    };
+
+    pub fn deserialize_image<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Image, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let image = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_image_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_image_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(image)
+    }
+    pub fn deserialize_audio<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Audio, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let audio = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_audio_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_audio_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(audio)
+    }
+    pub fn deserialize_pdf<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Pdf, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let pdf = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_pdf_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_pdf_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(pdf)
+    }
+    pub fn deserialize_video<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<baml::Video, D::Error> {
+        let repr = BamlMediaRepr::deserialize(deserializer)?;
+        let video = match repr.content {
+            BamlMediaReprContent::Url { url } => {
+                new_video_from_url(url.as_str(), repr.mime_type.as_deref())
+            }
+            BamlMediaReprContent::Base64 { base64 } => {
+                new_video_from_base64(base64.as_str(), repr.mime_type.as_deref())
+            }
+        };
+        Ok(video)
+    }
+}

--- a/integ-tests/rust/src/baml_client/stream_types/classes.rs
+++ b/integ-tests/rust/src/baml_client/stream_types/classes.rs
@@ -25,7 +25,7 @@ pub struct AddTodoItem {
     pub description: String,
 }
 
-impl AsRef<AddTodoItem> for AddTodoItem {
+impl ::std::convert::AsRef<AddTodoItem> for AddTodoItem {
     fn as_ref(&self) -> &AddTodoItem {
         self
     }
@@ -41,7 +41,7 @@ pub struct AddressWithMeta {
     pub zipcode: Option<String>,
 }
 
-impl AsRef<AddressWithMeta> for AddressWithMeta {
+impl ::std::convert::AsRef<AddressWithMeta> for AddressWithMeta {
     fn as_ref(&self) -> &AddressWithMeta {
         self
     }
@@ -57,7 +57,7 @@ pub struct AnotherObject {
     pub thingy3: Option<String>,
 }
 
-impl AsRef<AnotherObject> for AnotherObject {
+impl ::std::convert::AsRef<AnotherObject> for AnotherObject {
     fn as_ref(&self) -> &AnotherObject {
         self
     }
@@ -71,7 +71,7 @@ pub struct BigNumbers {
     pub b: Option<f64>,
 }
 
-impl AsRef<BigNumbers> for BigNumbers {
+impl ::std::convert::AsRef<BigNumbers> for BigNumbers {
     fn as_ref(&self) -> &BigNumbers {
         self
     }
@@ -87,7 +87,7 @@ pub struct BinaryNode {
     pub right: Option<Box<BinaryNode>>,
 }
 
-impl AsRef<BinaryNode> for BinaryNode {
+impl ::std::convert::AsRef<BinaryNode> for BinaryNode {
     fn as_ref(&self) -> &BinaryNode {
         self
     }
@@ -99,7 +99,7 @@ pub struct Blah {
     pub prop4: Option<String>,
 }
 
-impl AsRef<Blah> for Blah {
+impl ::std::convert::AsRef<Blah> for Blah {
     fn as_ref(&self) -> &Blah {
         self
     }
@@ -113,7 +113,7 @@ pub struct BlockConstraint {
     pub bar: Option<String>,
 }
 
-impl AsRef<BlockConstraint> for BlockConstraint {
+impl ::std::convert::AsRef<BlockConstraint> for BlockConstraint {
     fn as_ref(&self) -> &BlockConstraint {
         self
     }
@@ -127,7 +127,7 @@ pub struct BlockConstraintForParam {
     pub bcfp2: Option<String>,
 }
 
-impl AsRef<BlockConstraintForParam> for BlockConstraintForParam {
+impl ::std::convert::AsRef<BlockConstraintForParam> for BlockConstraintForParam {
     fn as_ref(&self) -> &BlockConstraintForParam {
         self
     }
@@ -145,7 +145,7 @@ pub struct BookOrder {
     pub price: Option<f64>,
 }
 
-impl AsRef<BookOrder> for BookOrder {
+impl ::std::convert::AsRef<BookOrder> for BookOrder {
     fn as_ref(&self) -> &BookOrder {
         self
     }
@@ -157,7 +157,7 @@ pub struct ClassForNullLiteral {
     pub a: Option<String>,
 }
 
-impl AsRef<ClassForNullLiteral> for ClassForNullLiteral {
+impl ::std::convert::AsRef<ClassForNullLiteral> for ClassForNullLiteral {
     fn as_ref(&self) -> &ClassForNullLiteral {
         self
     }
@@ -171,7 +171,7 @@ pub struct ClassOptionalOutput {
     pub prop2: Option<String>,
 }
 
-impl AsRef<ClassOptionalOutput> for ClassOptionalOutput {
+impl ::std::convert::AsRef<ClassOptionalOutput> for ClassOptionalOutput {
     fn as_ref(&self) -> &ClassOptionalOutput {
         self
     }
@@ -187,7 +187,7 @@ pub struct ClassOptionalOutput2 {
     pub prop3: Option<Blah>,
 }
 
-impl AsRef<ClassOptionalOutput2> for ClassOptionalOutput2 {
+impl ::std::convert::AsRef<ClassOptionalOutput2> for ClassOptionalOutput2 {
     fn as_ref(&self) -> &ClassOptionalOutput2 {
         self
     }
@@ -199,7 +199,7 @@ pub struct ClassToRecAlias {
     pub list: Option<LinkedListAliasNode>,
 }
 
-impl AsRef<ClassToRecAlias> for ClassToRecAlias {
+impl ::std::convert::AsRef<ClassToRecAlias> for ClassToRecAlias {
     fn as_ref(&self) -> &ClassToRecAlias {
         self
     }
@@ -213,7 +213,7 @@ pub struct ClassWithBlockDone {
     pub s_20_words: String,
 }
 
-impl AsRef<ClassWithBlockDone> for ClassWithBlockDone {
+impl ::std::convert::AsRef<ClassWithBlockDone> for ClassWithBlockDone {
     fn as_ref(&self) -> &ClassWithBlockDone {
         self
     }
@@ -229,7 +229,7 @@ pub struct ClassWithImage {
     pub fake_image: Option<FakeImage>,
 }
 
-impl AsRef<ClassWithImage> for ClassWithImage {
+impl ::std::convert::AsRef<ClassWithImage> for ClassWithImage {
     fn as_ref(&self) -> &ClassWithImage {
         self
     }
@@ -243,7 +243,7 @@ pub struct ClassWithoutDone {
     pub s_20_words: baml::StreamState<Option<String>>,
 }
 
-impl AsRef<ClassWithoutDone> for ClassWithoutDone {
+impl ::std::convert::AsRef<ClassWithoutDone> for ClassWithoutDone {
     fn as_ref(&self) -> &ClassWithoutDone {
         self
     }
@@ -267,7 +267,7 @@ pub struct ClientDetails1559 {
     pub client_email: Option<String>,
 }
 
-impl AsRef<ClientDetails1559> for ClientDetails1559 {
+impl ::std::convert::AsRef<ClientDetails1559> for ClientDetails1559 {
     fn as_ref(&self) -> &ClientDetails1559 {
         self
     }
@@ -285,7 +285,7 @@ pub struct ComplexMemoryObject {
     pub metadata: Vec<types::Union3FloatOrIntOrString>,
 }
 
-impl AsRef<ComplexMemoryObject> for ComplexMemoryObject {
+impl ::std::convert::AsRef<ComplexMemoryObject> for ComplexMemoryObject {
     fn as_ref(&self) -> &ComplexMemoryObject {
         self
     }
@@ -301,7 +301,7 @@ pub struct CompoundBigNumbers {
     pub another: Option<BigNumbers>,
 }
 
-impl AsRef<CompoundBigNumbers> for CompoundBigNumbers {
+impl ::std::convert::AsRef<CompoundBigNumbers> for CompoundBigNumbers {
     fn as_ref(&self) -> &CompoundBigNumbers {
         self
     }
@@ -315,7 +315,7 @@ pub struct ContactInfo {
     pub secondary: Option<Union2EmailAddressOrPhoneNumber>,
 }
 
-impl AsRef<ContactInfo> for ContactInfo {
+impl ::std::convert::AsRef<ContactInfo> for ContactInfo {
     fn as_ref(&self) -> &ContactInfo {
         self
     }
@@ -331,7 +331,7 @@ pub struct CustomStory {
     pub content: Option<String>,
 }
 
-impl AsRef<CustomStory> for CustomStory {
+impl ::std::convert::AsRef<CustomStory> for CustomStory {
     fn as_ref(&self) -> &CustomStory {
         self
     }
@@ -347,7 +347,7 @@ pub struct CustomTaskResult {
     pub groceryReceipt: Option<GroceryReceipt>,
 }
 
-impl AsRef<CustomTaskResult> for CustomTaskResult {
+impl ::std::convert::AsRef<CustomTaskResult> for CustomTaskResult {
     fn as_ref(&self) -> &CustomTaskResult {
         self
     }
@@ -361,7 +361,7 @@ pub struct Document1559 {
     pub notes: Vec<Note1599>,
 }
 
-impl AsRef<Document1559> for Document1559 {
+impl ::std::convert::AsRef<Document1559> for Document1559 {
     fn as_ref(&self) -> &Document1559 {
         self
     }
@@ -379,7 +379,7 @@ pub struct DummyJsonTodo {
     pub userId: Option<i64>,
 }
 
-impl AsRef<DummyJsonTodo> for DummyJsonTodo {
+impl ::std::convert::AsRef<DummyJsonTodo> for DummyJsonTodo {
     fn as_ref(&self) -> &DummyJsonTodo {
         self
     }
@@ -396,23 +396,23 @@ pub struct DummyOutput {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DummyOutput {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -421,7 +421,9 @@ impl DummyOutput {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -433,29 +435,29 @@ impl DummyOutput {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for DummyOutput {
+impl ::std::default::Default for DummyOutput {
     fn default() -> Self {
         Self {
-            nonce: Default::default(),
+            nonce: ::std::default::Default::default(),
 
-            nonce2: Default::default(),
+            nonce2: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DummyOutput> for DummyOutput {
+impl ::std::convert::AsRef<DummyOutput> for DummyOutput {
     fn as_ref(&self) -> &DummyOutput {
         self
     }
@@ -470,23 +472,23 @@ pub struct DynInputOutput {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynInputOutput {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -495,7 +497,9 @@ impl DynInputOutput {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -507,27 +511,27 @@ impl DynInputOutput {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for DynInputOutput {
+impl ::std::default::Default for DynInputOutput {
     fn default() -> Self {
         Self {
-            testKey: Default::default(),
+            testKey: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynInputOutput> for DynInputOutput {
+impl ::std::convert::AsRef<DynInputOutput> for DynInputOutput {
     fn as_ref(&self) -> &DynInputOutput {
         self
     }
@@ -540,23 +544,23 @@ pub struct DynamicClassOne {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynamicClassOne {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -565,7 +569,9 @@ impl DynamicClassOne {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -577,25 +583,25 @@ impl DynamicClassOne {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for DynamicClassOne {
+impl ::std::default::Default for DynamicClassOne {
     fn default() -> Self {
         Self {
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynamicClassOne> for DynamicClassOne {
+impl ::std::convert::AsRef<DynamicClassOne> for DynamicClassOne {
     fn as_ref(&self) -> &DynamicClassOne {
         self
     }
@@ -614,23 +620,23 @@ pub struct DynamicClassTwo {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynamicClassTwo {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -639,7 +645,9 @@ impl DynamicClassTwo {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -651,31 +659,31 @@ impl DynamicClassTwo {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for DynamicClassTwo {
+impl ::std::default::Default for DynamicClassTwo {
     fn default() -> Self {
         Self {
-            hi: Default::default(),
+            hi: ::std::default::Default::default(),
 
-            some_class: Default::default(),
+            some_class: ::std::default::Default::default(),
 
-            status: Default::default(),
+            status: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynamicClassTwo> for DynamicClassTwo {
+impl ::std::convert::AsRef<DynamicClassTwo> for DynamicClassTwo {
     fn as_ref(&self) -> &DynamicClassTwo {
         self
     }
@@ -688,23 +696,23 @@ pub struct DynamicOutput {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynamicOutput {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -713,7 +721,9 @@ impl DynamicOutput {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -725,25 +735,25 @@ impl DynamicOutput {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for DynamicOutput {
+impl ::std::default::Default for DynamicOutput {
     fn default() -> Self {
         Self {
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynamicOutput> for DynamicOutput {
+impl ::std::convert::AsRef<DynamicOutput> for DynamicOutput {
     fn as_ref(&self) -> &DynamicOutput {
         self
     }
@@ -756,23 +766,23 @@ pub struct DynamicSchema {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynamicSchema {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -781,7 +791,9 @@ impl DynamicSchema {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -793,25 +805,25 @@ impl DynamicSchema {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for DynamicSchema {
+impl ::std::default::Default for DynamicSchema {
     fn default() -> Self {
         Self {
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynamicSchema> for DynamicSchema {
+impl ::std::convert::AsRef<DynamicSchema> for DynamicSchema {
     fn as_ref(&self) -> &DynamicSchema {
         self
     }
@@ -823,7 +835,7 @@ pub struct Earthling {
     pub age: Option<types::Checked<i64>>,
 }
 
-impl AsRef<Earthling> for Earthling {
+impl ::std::convert::AsRef<Earthling> for Earthling {
     fn as_ref(&self) -> &Earthling {
         self
     }
@@ -843,7 +855,7 @@ pub struct Education {
     pub graduation_date: Option<String>,
 }
 
-impl AsRef<Education> for Education {
+impl ::std::convert::AsRef<Education> for Education {
     fn as_ref(&self) -> &Education {
         self
     }
@@ -859,7 +871,7 @@ pub struct Email {
     pub from_address: Option<String>,
 }
 
-impl AsRef<Email> for Email {
+impl ::std::convert::AsRef<Email> for Email {
     fn as_ref(&self) -> &Email {
         self
     }
@@ -871,7 +883,7 @@ pub struct EmailAddress {
     pub value: Option<String>,
 }
 
-impl AsRef<EmailAddress> for EmailAddress {
+impl ::std::convert::AsRef<EmailAddress> for EmailAddress {
     fn as_ref(&self) -> &EmailAddress {
         self
     }
@@ -889,7 +901,7 @@ pub struct Event {
     pub description: Option<String>,
 }
 
-impl AsRef<Event> for Event {
+impl ::std::convert::AsRef<Event> for Event {
     fn as_ref(&self) -> &Event {
         self
     }
@@ -901,7 +913,7 @@ pub struct FakeImage {
     pub url: Option<String>,
 }
 
-impl AsRef<FakeImage> for FakeImage {
+impl ::std::convert::AsRef<FakeImage> for FakeImage {
     fn as_ref(&self) -> &FakeImage {
         self
     }
@@ -921,7 +933,7 @@ pub struct FlightConfirmation {
     pub seatNumber: Option<String>,
 }
 
-impl AsRef<FlightConfirmation> for FlightConfirmation {
+impl ::std::convert::AsRef<FlightConfirmation> for FlightConfirmation {
     fn as_ref(&self) -> &FlightConfirmation {
         self
     }
@@ -937,7 +949,7 @@ pub struct FooAny {
     pub species: Option<types::Checked<String>>,
 }
 
-impl AsRef<FooAny> for FooAny {
+impl ::std::convert::AsRef<FooAny> for FooAny {
     fn as_ref(&self) -> &FooAny {
         self
     }
@@ -949,7 +961,7 @@ pub struct Forest {
     pub trees: Vec<Box<Tree>>,
 }
 
-impl AsRef<Forest> for Forest {
+impl ::std::convert::AsRef<Forest> for Forest {
     fn as_ref(&self) -> &Forest {
         self
     }
@@ -963,7 +975,7 @@ pub struct FormatterTest0 {
     pub ipsum: Option<String>,
 }
 
-impl AsRef<FormatterTest0> for FormatterTest0 {
+impl ::std::convert::AsRef<FormatterTest0> for FormatterTest0 {
     fn as_ref(&self) -> &FormatterTest0 {
         self
     }
@@ -977,7 +989,7 @@ pub struct FormatterTest1 {
     pub ipsum: Option<String>,
 }
 
-impl AsRef<FormatterTest1> for FormatterTest1 {
+impl ::std::convert::AsRef<FormatterTest1> for FormatterTest1 {
     fn as_ref(&self) -> &FormatterTest1 {
         self
     }
@@ -991,7 +1003,7 @@ pub struct FormatterTest2 {
     pub ipsum: Option<String>,
 }
 
-impl AsRef<FormatterTest2> for FormatterTest2 {
+impl ::std::convert::AsRef<FormatterTest2> for FormatterTest2 {
     fn as_ref(&self) -> &FormatterTest2 {
         self
     }
@@ -1005,7 +1017,7 @@ pub struct FormatterTest3 {
     pub ipsum: Option<String>,
 }
 
-impl AsRef<FormatterTest3> for FormatterTest3 {
+impl ::std::convert::AsRef<FormatterTest3> for FormatterTest3 {
     fn as_ref(&self) -> &FormatterTest3 {
         self
     }
@@ -1023,7 +1035,7 @@ pub struct GroceryReceipt {
     pub totalAmount: Option<f64>,
 }
 
-impl AsRef<GroceryReceipt> for GroceryReceipt {
+impl ::std::convert::AsRef<GroceryReceipt> for GroceryReceipt {
     fn as_ref(&self) -> &GroceryReceipt {
         self
     }
@@ -1039,7 +1051,7 @@ pub struct Haiku {
     pub line3: Option<String>,
 }
 
-impl AsRef<Haiku> for Haiku {
+impl ::std::convert::AsRef<Haiku> for Haiku {
     fn as_ref(&self) -> &Haiku {
         self
     }
@@ -1055,7 +1067,7 @@ pub struct InnerClass {
     pub inner: Option<InnerClass2>,
 }
 
-impl AsRef<InnerClass> for InnerClass {
+impl ::std::convert::AsRef<InnerClass> for InnerClass {
     fn as_ref(&self) -> &InnerClass {
         self
     }
@@ -1069,7 +1081,7 @@ pub struct InnerClass2 {
     pub prop3: Option<f64>,
 }
 
-impl AsRef<InnerClass2> for InnerClass2 {
+impl ::std::convert::AsRef<InnerClass2> for InnerClass2 {
     fn as_ref(&self) -> &InnerClass2 {
         self
     }
@@ -1083,7 +1095,7 @@ pub struct InputClass {
     pub key2: Option<String>,
 }
 
-impl AsRef<InputClass> for InputClass {
+impl ::std::convert::AsRef<InputClass> for InputClass {
     fn as_ref(&self) -> &InputClass {
         self
     }
@@ -1097,7 +1109,7 @@ pub struct InputClassNested {
     pub nested: Option<InputClass>,
 }
 
-impl AsRef<InputClassNested> for InputClassNested {
+impl ::std::convert::AsRef<InputClassNested> for InputClassNested {
     fn as_ref(&self) -> &InputClassNested {
         self
     }
@@ -1111,7 +1123,7 @@ pub struct LinkedList {
     pub len: Option<i64>,
 }
 
-impl AsRef<LinkedList> for LinkedList {
+impl ::std::convert::AsRef<LinkedList> for LinkedList {
     fn as_ref(&self) -> &LinkedList {
         self
     }
@@ -1125,7 +1137,7 @@ pub struct LinkedListAliasNode {
     pub next: Option<Box<LinkedListAliasNode>>,
 }
 
-impl AsRef<LinkedListAliasNode> for LinkedListAliasNode {
+impl ::std::convert::AsRef<LinkedListAliasNode> for LinkedListAliasNode {
     fn as_ref(&self) -> &LinkedListAliasNode {
         self
     }
@@ -1137,7 +1149,7 @@ pub struct LiteralClassHello {
     pub prop: Option<String>,
 }
 
-impl AsRef<LiteralClassHello> for LiteralClassHello {
+impl ::std::convert::AsRef<LiteralClassHello> for LiteralClassHello {
     fn as_ref(&self) -> &LiteralClassHello {
         self
     }
@@ -1149,7 +1161,7 @@ pub struct LiteralClassOne {
     pub prop: Option<String>,
 }
 
-impl AsRef<LiteralClassOne> for LiteralClassOne {
+impl ::std::convert::AsRef<LiteralClassOne> for LiteralClassOne {
     fn as_ref(&self) -> &LiteralClassOne {
         self
     }
@@ -1161,7 +1173,7 @@ pub struct LiteralClassTwo {
     pub prop: Option<String>,
 }
 
-impl AsRef<LiteralClassTwo> for LiteralClassTwo {
+impl ::std::convert::AsRef<LiteralClassTwo> for LiteralClassTwo {
     fn as_ref(&self) -> &LiteralClassTwo {
         self
     }
@@ -1177,7 +1189,7 @@ pub struct MaintainFieldOrder {
     pub a: Option<String>,
 }
 
-impl AsRef<MaintainFieldOrder> for MaintainFieldOrder {
+impl ::std::convert::AsRef<MaintainFieldOrder> for MaintainFieldOrder {
     fn as_ref(&self) -> &MaintainFieldOrder {
         self
     }
@@ -1189,7 +1201,7 @@ pub struct MalformedConstraints {
     pub foo: Option<types::Checked<i64>>,
 }
 
-impl AsRef<MalformedConstraints> for MalformedConstraints {
+impl ::std::convert::AsRef<MalformedConstraints> for MalformedConstraints {
     fn as_ref(&self) -> &MalformedConstraints {
         self
     }
@@ -1201,7 +1213,7 @@ pub struct MalformedConstraints2 {
     pub foo: Option<i64>,
 }
 
-impl AsRef<MalformedConstraints2> for MalformedConstraints2 {
+impl ::std::convert::AsRef<MalformedConstraints2> for MalformedConstraints2 {
     fn as_ref(&self) -> &MalformedConstraints2 {
         self
     }
@@ -1218,7 +1230,7 @@ pub struct Martian {
     pub age: Option<types::Checked<i64>>,
 }
 
-impl AsRef<Martian> for Martian {
+impl ::std::convert::AsRef<Martian> for Martian {
     fn as_ref(&self) -> &Martian {
         self
     }
@@ -1234,7 +1246,7 @@ pub struct MemoryObject {
     pub description: Option<String>,
 }
 
-impl AsRef<MemoryObject> for MemoryObject {
+impl ::std::convert::AsRef<MemoryObject> for MemoryObject {
     fn as_ref(&self) -> &MemoryObject {
         self
     }
@@ -1246,7 +1258,7 @@ pub struct MergeAttrs {
     pub amount: Option<types::Checked<i64>>,
 }
 
-impl AsRef<MergeAttrs> for MergeAttrs {
+impl ::std::convert::AsRef<MergeAttrs> for MergeAttrs {
     fn as_ref(&self) -> &MergeAttrs {
         self
     }
@@ -1262,7 +1274,7 @@ pub struct NamedArgsSingleClass {
     pub key_three: Option<i64>,
 }
 
-impl AsRef<NamedArgsSingleClass> for NamedArgsSingleClass {
+impl ::std::convert::AsRef<NamedArgsSingleClass> for NamedArgsSingleClass {
     fn as_ref(&self) -> &NamedArgsSingleClass {
         self
     }
@@ -1278,7 +1290,7 @@ pub struct Nested {
     pub prop20: Option<Nested2>,
 }
 
-impl AsRef<Nested> for Nested {
+impl ::std::convert::AsRef<Nested> for Nested {
     fn as_ref(&self) -> &Nested {
         self
     }
@@ -1292,7 +1304,7 @@ pub struct Nested2 {
     pub prop12: Option<String>,
 }
 
-impl AsRef<Nested2> for Nested2 {
+impl ::std::convert::AsRef<Nested2> for Nested2 {
     fn as_ref(&self) -> &Nested2 {
         self
     }
@@ -1304,7 +1316,7 @@ pub struct NestedBlockConstraint {
     pub nbc: Option<types::Checked<BlockConstraint>>,
 }
 
-impl AsRef<NestedBlockConstraint> for NestedBlockConstraint {
+impl ::std::convert::AsRef<NestedBlockConstraint> for NestedBlockConstraint {
     fn as_ref(&self) -> &NestedBlockConstraint {
         self
     }
@@ -1316,7 +1328,7 @@ pub struct NestedBlockConstraintForParam {
     pub nbcfp: Option<BlockConstraintForParam>,
 }
 
-impl AsRef<NestedBlockConstraintForParam> for NestedBlockConstraintForParam {
+impl ::std::convert::AsRef<NestedBlockConstraintForParam> for NestedBlockConstraintForParam {
     fn as_ref(&self) -> &NestedBlockConstraintForParam {
         self
     }
@@ -1330,7 +1342,7 @@ pub struct Node {
     pub next: Option<Box<Node>>,
 }
 
-impl AsRef<Node> for Node {
+impl ::std::convert::AsRef<Node> for Node {
     fn as_ref(&self) -> &Node {
         self
     }
@@ -1344,7 +1356,7 @@ pub struct NodeWithAliasIndirection {
     pub next: Option<Box<NodeWithAliasIndirection>>,
 }
 
-impl AsRef<NodeWithAliasIndirection> for NodeWithAliasIndirection {
+impl ::std::convert::AsRef<NodeWithAliasIndirection> for NodeWithAliasIndirection {
     fn as_ref(&self) -> &NodeWithAliasIndirection {
         self
     }
@@ -1360,7 +1372,7 @@ pub struct Note1599 {
     pub note_amount: Option<String>,
 }
 
-impl AsRef<Note1599> for Note1599 {
+impl ::std::convert::AsRef<Note1599> for Note1599 {
     fn as_ref(&self) -> &Note1599 {
         self
     }
@@ -1374,7 +1386,7 @@ pub struct OptionalListAndMap {
     pub q: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<OptionalListAndMap> for OptionalListAndMap {
+impl ::std::convert::AsRef<OptionalListAndMap> for OptionalListAndMap {
     fn as_ref(&self) -> &OptionalListAndMap {
         self
     }
@@ -1388,7 +1400,7 @@ pub struct OptionalTest_Prop1 {
     pub omega_b: Option<i64>,
 }
 
-impl AsRef<OptionalTest_Prop1> for OptionalTest_Prop1 {
+impl ::std::convert::AsRef<OptionalTest_Prop1> for OptionalTest_Prop1 {
     fn as_ref(&self) -> &OptionalTest_Prop1 {
         self
     }
@@ -1404,7 +1416,7 @@ pub struct OptionalTest_ReturnType {
     pub omega_3: Vec<Option<types::OptionalTest_CategoryType>>,
 }
 
-impl AsRef<OptionalTest_ReturnType> for OptionalTest_ReturnType {
+impl ::std::convert::AsRef<OptionalTest_ReturnType> for OptionalTest_ReturnType {
     fn as_ref(&self) -> &OptionalTest_ReturnType {
         self
     }
@@ -1420,7 +1432,7 @@ pub struct OrderInfo {
     pub estimated_arrival_date: Option<String>,
 }
 
-impl AsRef<OrderInfo> for OrderInfo {
+impl ::std::convert::AsRef<OrderInfo> for OrderInfo {
     fn as_ref(&self) -> &OrderInfo {
         self
     }
@@ -1432,7 +1444,7 @@ pub struct OriginalA {
     pub value: Option<i64>,
 }
 
-impl AsRef<OriginalA> for OriginalA {
+impl ::std::convert::AsRef<OriginalA> for OriginalA {
     fn as_ref(&self) -> &OriginalA {
         self
     }
@@ -1447,23 +1459,23 @@ pub struct OriginalB {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl OriginalB {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1472,7 +1484,9 @@ impl OriginalB {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1484,27 +1498,27 @@ impl OriginalB {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for OriginalB {
+impl ::std::default::Default for OriginalB {
     fn default() -> Self {
         Self {
-            value: Default::default(),
+            value: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<OriginalB> for OriginalB {
+impl ::std::convert::AsRef<OriginalB> for OriginalB {
     fn as_ref(&self) -> &OriginalB {
         self
     }
@@ -1521,23 +1535,23 @@ pub struct Person {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl Person {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1546,7 +1560,9 @@ impl Person {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1558,29 +1574,29 @@ impl Person {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for Person {
+impl ::std::default::Default for Person {
     fn default() -> Self {
         Self {
-            name: Default::default(),
+            name: ::std::default::Default::default(),
 
-            hair_color: Default::default(),
+            hair_color: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<Person> for Person {
+impl ::std::convert::AsRef<Person> for Person {
     fn as_ref(&self) -> &Person {
         self
     }
@@ -1598,7 +1614,7 @@ pub struct PersonWithMeta {
     pub tags: Vec<String>,
 }
 
-impl AsRef<PersonWithMeta> for PersonWithMeta {
+impl ::std::convert::AsRef<PersonWithMeta> for PersonWithMeta {
     fn as_ref(&self) -> &PersonWithMeta {
         self
     }
@@ -1610,7 +1626,7 @@ pub struct PhoneNumber {
     pub value: Option<String>,
 }
 
-impl AsRef<PhoneNumber> for PhoneNumber {
+impl ::std::convert::AsRef<PhoneNumber> for PhoneNumber {
     fn as_ref(&self) -> &PhoneNumber {
         self
     }
@@ -1624,7 +1640,7 @@ pub struct Quantity {
     pub unit: Option<String>,
 }
 
-impl AsRef<Quantity> for Quantity {
+impl ::std::convert::AsRef<Quantity> for Quantity {
     fn as_ref(&self) -> &Quantity {
         self
     }
@@ -1638,7 +1654,7 @@ pub struct RaysData {
     pub value: Option<Union2EventOrResume>,
 }
 
-impl AsRef<RaysData> for RaysData {
+impl ::std::convert::AsRef<RaysData> for RaysData {
     fn as_ref(&self) -> &RaysData {
         self
     }
@@ -1654,7 +1670,7 @@ pub struct ReceiptInfo {
     pub venue: Option<types::Union2KbarisaOrKox_burger>,
 }
 
-impl AsRef<ReceiptInfo> for ReceiptInfo {
+impl ::std::convert::AsRef<ReceiptInfo> for ReceiptInfo {
     fn as_ref(&self) -> &ReceiptInfo {
         self
     }
@@ -1672,7 +1688,7 @@ pub struct ReceiptItem {
     pub price: Option<f64>,
 }
 
-impl AsRef<ReceiptItem> for ReceiptItem {
+impl ::std::convert::AsRef<ReceiptItem> for ReceiptItem {
     fn as_ref(&self) -> &ReceiptItem {
         self
     }
@@ -1686,7 +1702,7 @@ pub struct Recipe {
     pub recipe_type: Option<types::Union2KbreakfastOrKdinner>,
 }
 
-impl AsRef<Recipe> for Recipe {
+impl ::std::convert::AsRef<Recipe> for Recipe {
     fn as_ref(&self) -> &Recipe {
         self
     }
@@ -1698,7 +1714,7 @@ pub struct RecursiveAliasDependency {
     pub value: Option<JsonValue>,
 }
 
-impl AsRef<RecursiveAliasDependency> for RecursiveAliasDependency {
+impl ::std::convert::AsRef<RecursiveAliasDependency> for RecursiveAliasDependency {
     fn as_ref(&self) -> &RecursiveAliasDependency {
         self
     }
@@ -1713,23 +1729,23 @@ pub struct RenderEnumInput {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl RenderEnumInput {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1738,7 +1754,9 @@ impl RenderEnumInput {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1750,27 +1768,27 @@ impl RenderEnumInput {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for RenderEnumInput {
+impl ::std::default::Default for RenderEnumInput {
     fn default() -> Self {
         Self {
-            testKey: Default::default(),
+            testKey: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<RenderEnumInput> for RenderEnumInput {
+impl ::std::convert::AsRef<RenderEnumInput> for RenderEnumInput {
     fn as_ref(&self) -> &RenderEnumInput {
         self
     }
@@ -1787,23 +1805,23 @@ pub struct RenderTestClass {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl RenderTestClass {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1812,7 +1830,9 @@ impl RenderTestClass {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1824,29 +1844,29 @@ impl RenderTestClass {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for RenderTestClass {
+impl ::std::default::Default for RenderTestClass {
     fn default() -> Self {
         Self {
-            name: Default::default(),
+            name: ::std::default::Default::default(),
 
-            status: Default::default(),
+            status: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<RenderTestClass> for RenderTestClass {
+impl ::std::convert::AsRef<RenderTestClass> for RenderTestClass {
     fn as_ref(&self) -> &RenderTestClass {
         self
     }
@@ -1868,7 +1888,7 @@ pub struct Resume {
     pub skills: Vec<String>,
 }
 
-impl AsRef<Resume> for Resume {
+impl ::std::convert::AsRef<Resume> for Resume {
     fn as_ref(&self) -> &Resume {
         self
     }
@@ -1892,7 +1912,7 @@ pub struct Schema {
     pub other_group: Option<types::Union2IntOrString>,
 }
 
-impl AsRef<Schema> for Schema {
+impl ::std::convert::AsRef<Schema> for Schema {
     fn as_ref(&self) -> &Schema {
         self
     }
@@ -1914,7 +1934,7 @@ pub struct SearchParams {
     pub tags: Vec<types::Union2StringOrTag>,
 }
 
-impl AsRef<SearchParams> for SearchParams {
+impl ::std::convert::AsRef<SearchParams> for SearchParams {
     fn as_ref(&self) -> &SearchParams {
         self
     }
@@ -1940,7 +1960,7 @@ pub struct SemanticContainer {
     pub final_string: Option<String>,
 }
 
-impl AsRef<SemanticContainer> for SemanticContainer {
+impl ::std::convert::AsRef<SemanticContainer> for SemanticContainer {
     fn as_ref(&self) -> &SemanticContainer {
         self
     }
@@ -1952,7 +1972,7 @@ pub struct SimpleTag {
     pub field: Option<String>,
 }
 
-impl AsRef<SimpleTag> for SimpleTag {
+impl ::std::convert::AsRef<SimpleTag> for SimpleTag {
     fn as_ref(&self) -> &SimpleTag {
         self
     }
@@ -1969,23 +1989,23 @@ pub struct SkipDynamicClass {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl SkipDynamicClass {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1994,7 +2014,9 @@ impl SkipDynamicClass {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -2006,29 +2028,29 @@ impl SkipDynamicClass {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for SkipDynamicClass {
+impl ::std::default::Default for SkipDynamicClass {
     fn default() -> Self {
         Self {
-            value: Default::default(),
+            value: ::std::default::Default::default(),
 
-            internal_id: Default::default(),
+            internal_id: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<SkipDynamicClass> for SkipDynamicClass {
+impl ::std::convert::AsRef<SkipDynamicClass> for SkipDynamicClass {
     fn as_ref(&self) -> &SkipDynamicClass {
         self
     }
@@ -2044,7 +2066,7 @@ pub struct SkipNonDynamicClass {
     pub metadata: Option<String>,
 }
 
-impl AsRef<SkipNonDynamicClass> for SkipNonDynamicClass {
+impl ::std::convert::AsRef<SkipNonDynamicClass> for SkipNonDynamicClass {
     fn as_ref(&self) -> &SkipNonDynamicClass {
         self
     }
@@ -2058,7 +2080,7 @@ pub struct SmallThing {
     pub i_8_digits: Option<i64>,
 }
 
-impl AsRef<SmallThing> for SmallThing {
+impl ::std::convert::AsRef<SmallThing> for SmallThing {
     fn as_ref(&self) -> &SmallThing {
         self
     }
@@ -2073,23 +2095,23 @@ pub struct SomeClassNestedDynamic {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl SomeClassNestedDynamic {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<crate::baml_client::types::Types, super::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -2098,7 +2120,9 @@ impl SomeClassNestedDynamic {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -2110,27 +2134,27 @@ impl SomeClassNestedDynamic {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
-            &baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
+            &::baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
         ),
     > {
         self.__dynamic.iter().map(|(k, v)| (k.as_str(), v))
     }
 }
 
-impl Default for SomeClassNestedDynamic {
+impl ::std::default::Default for SomeClassNestedDynamic {
     fn default() -> Self {
         Self {
-            hi: Default::default(),
+            hi: ::std::default::Default::default(),
 
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<SomeClassNestedDynamic> for SomeClassNestedDynamic {
+impl ::std::convert::AsRef<SomeClassNestedDynamic> for SomeClassNestedDynamic {
     fn as_ref(&self) -> &SomeClassNestedDynamic {
         self
     }
@@ -2142,7 +2166,7 @@ pub struct StringToClassEntry {
     pub word: Option<String>,
 }
 
-impl AsRef<StringToClassEntry> for StringToClassEntry {
+impl ::std::convert::AsRef<StringToClassEntry> for StringToClassEntry {
     fn as_ref(&self) -> &StringToClassEntry {
         self
     }
@@ -2162,7 +2186,7 @@ pub struct TestClassAlias {
     pub key5: Option<String>,
 }
 
-impl AsRef<TestClassAlias> for TestClassAlias {
+impl ::std::convert::AsRef<TestClassAlias> for TestClassAlias {
     fn as_ref(&self) -> &TestClassAlias {
         self
     }
@@ -2176,7 +2200,7 @@ pub struct TestClassNested {
     pub prop2: Option<InnerClass>,
 }
 
-impl AsRef<TestClassNested> for TestClassNested {
+impl ::std::convert::AsRef<TestClassNested> for TestClassNested {
     fn as_ref(&self) -> &TestClassNested {
         self
     }
@@ -2190,7 +2214,7 @@ pub struct TestClassWithEnum {
     pub prop2: Option<types::EnumInClass>,
 }
 
-impl AsRef<TestClassWithEnum> for TestClassWithEnum {
+impl ::std::convert::AsRef<TestClassWithEnum> for TestClassWithEnum {
     fn as_ref(&self) -> &TestClassWithEnum {
         self
     }
@@ -2204,7 +2228,7 @@ pub struct TestMemoryOutput {
     pub more_items: Vec<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>,
 }
 
-impl AsRef<TestMemoryOutput> for TestMemoryOutput {
+impl ::std::convert::AsRef<TestMemoryOutput> for TestMemoryOutput {
     fn as_ref(&self) -> &TestMemoryOutput {
         self
     }
@@ -2218,7 +2242,7 @@ pub struct TestOutputClass {
     pub prop2: Option<i64>,
 }
 
-impl AsRef<TestOutputClass> for TestOutputClass {
+impl ::std::convert::AsRef<TestOutputClass> for TestOutputClass {
     fn as_ref(&self) -> &TestOutputClass {
         self
     }
@@ -2233,7 +2257,7 @@ pub struct TodoMessageToUser {
     pub message: Option<String>,
 }
 
-impl AsRef<TodoMessageToUser> for TodoMessageToUser {
+impl ::std::convert::AsRef<TodoMessageToUser> for TodoMessageToUser {
     fn as_ref(&self) -> &TodoMessageToUser {
         self
     }
@@ -2247,7 +2271,7 @@ pub struct Tree {
     pub children: Option<Box<Forest>>,
 }
 
-impl AsRef<Tree> for Tree {
+impl ::std::convert::AsRef<Tree> for Tree {
     fn as_ref(&self) -> &Tree {
         self
     }
@@ -2263,7 +2287,7 @@ pub struct TwoStoriesOneTitle {
     pub story_b: Option<String>,
 }
 
-impl AsRef<TwoStoriesOneTitle> for TwoStoriesOneTitle {
+impl ::std::convert::AsRef<TwoStoriesOneTitle> for TwoStoriesOneTitle {
     fn as_ref(&self) -> &TwoStoriesOneTitle {
         self
     }
@@ -2279,7 +2303,7 @@ pub struct TwoStoriesOneTitleCheck {
     pub story_b: Option<types::Checked<String>>,
 }
 
-impl AsRef<TwoStoriesOneTitleCheck> for TwoStoriesOneTitleCheck {
+impl ::std::convert::AsRef<TwoStoriesOneTitleCheck> for TwoStoriesOneTitleCheck {
     fn as_ref(&self) -> &TwoStoriesOneTitleCheck {
         self
     }
@@ -2295,7 +2319,7 @@ pub struct UnionTest_ReturnType {
     pub prop3: Option<types::Union2ListBoolOrListInt>,
 }
 
-impl AsRef<UnionTest_ReturnType> for UnionTest_ReturnType {
+impl ::std::convert::AsRef<UnionTest_ReturnType> for UnionTest_ReturnType {
     fn as_ref(&self) -> &UnionTest_ReturnType {
         self
     }
@@ -2311,7 +2335,7 @@ pub struct UniverseQuestion {
     pub answer: Option<String>,
 }
 
-impl AsRef<UniverseQuestion> for UniverseQuestion {
+impl ::std::convert::AsRef<UniverseQuestion> for UniverseQuestion {
     fn as_ref(&self) -> &UniverseQuestion {
         self
     }
@@ -2323,7 +2347,7 @@ pub struct UniverseQuestionInput {
     pub question: Option<String>,
 }
 
-impl AsRef<UniverseQuestionInput> for UniverseQuestionInput {
+impl ::std::convert::AsRef<UniverseQuestionInput> for UniverseQuestionInput {
     fn as_ref(&self) -> &UniverseQuestionInput {
         self
     }
@@ -2337,7 +2361,7 @@ pub struct WithReasoning {
     pub reasoning: Option<String>,
 }
 
-impl AsRef<WithReasoning> for WithReasoning {
+impl ::std::convert::AsRef<WithReasoning> for WithReasoning {
     fn as_ref(&self) -> &WithReasoning {
         self
     }

--- a/integ-tests/rust/src/baml_client/stream_types/classes.rs
+++ b/integ-tests/rust/src/baml_client/stream_types/classes.rs
@@ -10,10 +10,10 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{__internal::serde::Serialize, BamlDecode};
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AddTodoItem {
     #[baml(name = "type")]
     pub r#type: String,
@@ -31,8 +31,8 @@ impl AsRef<AddTodoItem> for AddTodoItem {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AddressWithMeta {
     pub street: Option<String>,
 
@@ -47,8 +47,8 @@ impl AsRef<AddressWithMeta> for AddressWithMeta {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AnotherObject {
     pub id: Option<String>,
 
@@ -63,8 +63,8 @@ impl AsRef<AnotherObject> for AnotherObject {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BigNumbers {
     pub a: Option<i64>,
 
@@ -77,8 +77,8 @@ impl AsRef<BigNumbers> for BigNumbers {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BinaryNode {
     pub data: Option<i64>,
 
@@ -93,8 +93,8 @@ impl AsRef<BinaryNode> for BinaryNode {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Blah {
     pub prop4: Option<String>,
 }
@@ -105,8 +105,8 @@ impl AsRef<Blah> for Blah {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BlockConstraint {
     pub foo: Option<i64>,
 
@@ -119,8 +119,8 @@ impl AsRef<BlockConstraint> for BlockConstraint {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BlockConstraintForParam {
     pub bcfp: Option<i64>,
 
@@ -133,8 +133,8 @@ impl AsRef<BlockConstraintForParam> for BlockConstraintForParam {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BookOrder {
     pub orderId: Option<String>,
 
@@ -151,8 +151,8 @@ impl AsRef<BookOrder> for BookOrder {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassForNullLiteral {
     pub a: Option<String>,
 }
@@ -163,8 +163,8 @@ impl AsRef<ClassForNullLiteral> for ClassForNullLiteral {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassOptionalOutput {
     pub prop1: Option<String>,
 
@@ -177,8 +177,8 @@ impl AsRef<ClassOptionalOutput> for ClassOptionalOutput {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassOptionalOutput2 {
     pub prop1: Option<String>,
 
@@ -193,8 +193,8 @@ impl AsRef<ClassOptionalOutput2> for ClassOptionalOutput2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassToRecAlias {
     pub list: Option<LinkedListAliasNode>,
 }
@@ -205,8 +205,8 @@ impl AsRef<ClassToRecAlias> for ClassToRecAlias {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithBlockDone {
     pub i_16_digits: i64,
 
@@ -219,8 +219,8 @@ impl AsRef<ClassWithBlockDone> for ClassWithBlockDone {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithImage {
     pub myImage: Option<types::Image>,
 
@@ -235,8 +235,8 @@ impl AsRef<ClassWithImage> for ClassWithImage {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithoutDone {
     pub i_16_digits: Option<i64>,
 
@@ -249,8 +249,8 @@ impl AsRef<ClassWithoutDone> for ClassWithoutDone {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClientDetails1559 {
     pub client_name: Option<String>,
 
@@ -273,8 +273,8 @@ impl AsRef<ClientDetails1559> for ClientDetails1559 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexMemoryObject {
     pub id: Option<String>,
 
@@ -291,8 +291,8 @@ impl AsRef<ComplexMemoryObject> for ComplexMemoryObject {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CompoundBigNumbers {
     pub big: Option<BigNumbers>,
 
@@ -307,8 +307,8 @@ impl AsRef<CompoundBigNumbers> for CompoundBigNumbers {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ContactInfo {
     pub primary: Option<Union2EmailAddressOrPhoneNumber>,
 
@@ -321,8 +321,8 @@ impl AsRef<ContactInfo> for ContactInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CustomStory {
     pub title: Option<String>,
 
@@ -337,8 +337,8 @@ impl AsRef<CustomStory> for CustomStory {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CustomTaskResult {
     pub bookOrder: Option<BookOrder>,
 
@@ -353,8 +353,8 @@ impl AsRef<CustomTaskResult> for CustomTaskResult {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Document1559 {
     pub client_details: Option<ClientDetails1559>,
 
@@ -367,8 +367,8 @@ impl AsRef<Document1559> for Document1559 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DummyJsonTodo {
     pub id: Option<i64>,
 
@@ -385,9 +385,9 @@ impl AsRef<DummyJsonTodo> for DummyJsonTodo {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DummyOutput {
     pub nonce: Option<String>,
 
@@ -395,6 +395,7 @@ pub struct DummyOutput {
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -460,14 +461,15 @@ impl AsRef<DummyOutput> for DummyOutput {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynInputOutput {
     pub testKey: Option<String>,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -531,12 +533,13 @@ impl AsRef<DynInputOutput> for DynInputOutput {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynamicClassOne {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -598,9 +601,9 @@ impl AsRef<DynamicClassOne> for DynamicClassOne {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynamicClassTwo {
     pub hi: Option<String>,
 
@@ -610,6 +613,7 @@ pub struct DynamicClassTwo {
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -677,12 +681,13 @@ impl AsRef<DynamicClassTwo> for DynamicClassTwo {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynamicOutput {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -744,12 +749,13 @@ impl AsRef<DynamicOutput> for DynamicOutput {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynamicSchema {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -811,8 +817,8 @@ impl AsRef<DynamicSchema> for DynamicSchema {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Earthling {
     pub age: Option<types::Checked<i64>>,
 }
@@ -823,8 +829,8 @@ impl AsRef<Earthling> for Earthling {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Education {
     pub institution: Option<String>,
 
@@ -843,8 +849,8 @@ impl AsRef<Education> for Education {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Email {
     pub subject: Option<String>,
 
@@ -859,8 +865,8 @@ impl AsRef<Email> for Email {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct EmailAddress {
     pub value: Option<String>,
 }
@@ -871,8 +877,8 @@ impl AsRef<EmailAddress> for EmailAddress {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Event {
     pub title: Option<String>,
 
@@ -889,8 +895,8 @@ impl AsRef<Event> for Event {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FakeImage {
     pub url: Option<String>,
 }
@@ -901,8 +907,8 @@ impl AsRef<FakeImage> for FakeImage {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FlightConfirmation {
     pub confirmationNumber: Option<String>,
 
@@ -921,8 +927,8 @@ impl AsRef<FlightConfirmation> for FlightConfirmation {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FooAny {
     pub planetary_age: Option<Union2EarthlingOrMartian>,
 
@@ -937,8 +943,8 @@ impl AsRef<FooAny> for FooAny {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Forest {
     pub trees: Vec<Box<Tree>>,
 }
@@ -949,8 +955,8 @@ impl AsRef<Forest> for Forest {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FormatterTest0 {
     pub lorem: Option<String>,
 
@@ -963,8 +969,8 @@ impl AsRef<FormatterTest0> for FormatterTest0 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FormatterTest1 {
     pub lorem: Option<String>,
 
@@ -977,8 +983,8 @@ impl AsRef<FormatterTest1> for FormatterTest1 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FormatterTest2 {
     pub lorem: Option<String>,
 
@@ -991,8 +997,8 @@ impl AsRef<FormatterTest2> for FormatterTest2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FormatterTest3 {
     pub lorem: Option<String>,
 
@@ -1005,8 +1011,8 @@ impl AsRef<FormatterTest3> for FormatterTest3 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct GroceryReceipt {
     pub receiptId: Option<String>,
 
@@ -1023,8 +1029,8 @@ impl AsRef<GroceryReceipt> for GroceryReceipt {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Haiku {
     pub line1: Option<String>,
 
@@ -1039,8 +1045,8 @@ impl AsRef<Haiku> for Haiku {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InnerClass {
     pub prop1: Option<String>,
 
@@ -1055,8 +1061,8 @@ impl AsRef<InnerClass> for InnerClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InnerClass2 {
     pub prop2: Option<i64>,
 
@@ -1069,8 +1075,8 @@ impl AsRef<InnerClass2> for InnerClass2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InputClass {
     pub key: Option<String>,
 
@@ -1083,8 +1089,8 @@ impl AsRef<InputClass> for InputClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InputClassNested {
     pub key: Option<String>,
 
@@ -1097,8 +1103,8 @@ impl AsRef<InputClassNested> for InputClassNested {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LinkedList {
     pub head: Option<Node>,
 
@@ -1111,8 +1117,8 @@ impl AsRef<LinkedList> for LinkedList {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LinkedListAliasNode {
     pub value: Option<i64>,
 
@@ -1125,8 +1131,8 @@ impl AsRef<LinkedListAliasNode> for LinkedListAliasNode {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LiteralClassHello {
     pub prop: Option<String>,
 }
@@ -1137,8 +1143,8 @@ impl AsRef<LiteralClassHello> for LiteralClassHello {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LiteralClassOne {
     pub prop: Option<String>,
 }
@@ -1149,8 +1155,8 @@ impl AsRef<LiteralClassOne> for LiteralClassOne {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LiteralClassTwo {
     pub prop: Option<String>,
 }
@@ -1161,8 +1167,8 @@ impl AsRef<LiteralClassTwo> for LiteralClassTwo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MaintainFieldOrder {
     pub c: Option<String>,
 
@@ -1177,8 +1183,8 @@ impl AsRef<MaintainFieldOrder> for MaintainFieldOrder {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MalformedConstraints {
     pub foo: Option<types::Checked<i64>>,
 }
@@ -1189,8 +1195,8 @@ impl AsRef<MalformedConstraints> for MalformedConstraints {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MalformedConstraints2 {
     pub foo: Option<i64>,
 }
@@ -1204,8 +1210,8 @@ impl AsRef<MalformedConstraints2> for MalformedConstraints2 {
 /// A Martian organism with an age.
 /// Such a nice type.
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Martian {
     /// The age of the Martian in Mars years.
     /// So many Mars years.
@@ -1218,8 +1224,8 @@ impl AsRef<Martian> for Martian {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MemoryObject {
     pub id: Option<String>,
 
@@ -1234,8 +1240,8 @@ impl AsRef<MemoryObject> for MemoryObject {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MergeAttrs {
     pub amount: Option<types::Checked<i64>>,
 }
@@ -1246,8 +1252,8 @@ impl AsRef<MergeAttrs> for MergeAttrs {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NamedArgsSingleClass {
     pub key: Option<String>,
 
@@ -1262,8 +1268,8 @@ impl AsRef<NamedArgsSingleClass> for NamedArgsSingleClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Nested {
     pub prop3: Option<String>,
 
@@ -1278,8 +1284,8 @@ impl AsRef<Nested> for Nested {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Nested2 {
     pub prop11: Option<String>,
 
@@ -1292,8 +1298,8 @@ impl AsRef<Nested2> for Nested2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedBlockConstraint {
     pub nbc: Option<types::Checked<BlockConstraint>>,
 }
@@ -1304,8 +1310,8 @@ impl AsRef<NestedBlockConstraint> for NestedBlockConstraint {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedBlockConstraintForParam {
     pub nbcfp: Option<BlockConstraintForParam>,
 }
@@ -1316,8 +1322,8 @@ impl AsRef<NestedBlockConstraintForParam> for NestedBlockConstraintForParam {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Node {
     pub data: Option<i64>,
 
@@ -1330,8 +1336,8 @@ impl AsRef<Node> for Node {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NodeWithAliasIndirection {
     pub value: Option<i64>,
 
@@ -1344,8 +1350,8 @@ impl AsRef<NodeWithAliasIndirection> for NodeWithAliasIndirection {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Note1599 {
     pub note_title: Option<String>,
 
@@ -1360,8 +1366,8 @@ impl AsRef<Note1599> for Note1599 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalListAndMap {
     pub p: Option<Vec<String>>,
 
@@ -1374,8 +1380,8 @@ impl AsRef<OptionalListAndMap> for OptionalListAndMap {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalTest_Prop1 {
     pub omega_a: Option<String>,
 
@@ -1388,8 +1394,8 @@ impl AsRef<OptionalTest_Prop1> for OptionalTest_Prop1 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalTest_ReturnType {
     pub omega_1: Option<OptionalTest_Prop1>,
 
@@ -1404,8 +1410,8 @@ impl AsRef<OptionalTest_ReturnType> for OptionalTest_ReturnType {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OrderInfo {
     pub order_status: Option<types::OrderStatus>,
 
@@ -1420,8 +1426,8 @@ impl AsRef<OrderInfo> for OrderInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OriginalA {
     pub value: Option<i64>,
 }
@@ -1432,14 +1438,15 @@ impl AsRef<OriginalA> for OriginalA {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OriginalB {
     pub value: Option<i64>,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -1503,9 +1510,9 @@ impl AsRef<OriginalB> for OriginalB {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Person {
     pub name: Option<String>,
 
@@ -1513,6 +1520,7 @@ pub struct Person {
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -1578,8 +1586,8 @@ impl AsRef<Person> for Person {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PersonWithMeta {
     pub name: Option<String>,
 
@@ -1596,8 +1604,8 @@ impl AsRef<PersonWithMeta> for PersonWithMeta {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PhoneNumber {
     pub value: Option<String>,
 }
@@ -1608,8 +1616,8 @@ impl AsRef<PhoneNumber> for PhoneNumber {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Quantity {
     pub amount: Option<types::Union2FloatOrInt>,
 
@@ -1622,8 +1630,8 @@ impl AsRef<Quantity> for Quantity {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RaysData {
     pub dataType: Option<types::DataType>,
 
@@ -1636,8 +1644,8 @@ impl AsRef<RaysData> for RaysData {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ReceiptInfo {
     pub items: Vec<ReceiptItem>,
 
@@ -1652,8 +1660,8 @@ impl AsRef<ReceiptInfo> for ReceiptInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ReceiptItem {
     pub name: Option<String>,
 
@@ -1670,8 +1678,8 @@ impl AsRef<ReceiptItem> for ReceiptItem {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Recipe {
     pub ingredients: std::collections::HashMap<String, Quantity>,
 
@@ -1684,8 +1692,8 @@ impl AsRef<Recipe> for Recipe {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RecursiveAliasDependency {
     pub value: Option<JsonValue>,
 }
@@ -1696,14 +1704,15 @@ impl AsRef<RecursiveAliasDependency> for RecursiveAliasDependency {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RenderEnumInput {
     pub testKey: Option<String>,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -1767,9 +1776,9 @@ impl AsRef<RenderEnumInput> for RenderEnumInput {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RenderTestClass {
     pub name: Option<String>,
 
@@ -1777,6 +1786,7 @@ pub struct RenderTestClass {
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -1842,8 +1852,8 @@ impl AsRef<RenderTestClass> for RenderTestClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Resume {
     pub name: Option<String>,
 
@@ -1864,8 +1874,8 @@ impl AsRef<Resume> for Resume {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Schema {
     pub prop1: Option<String>,
 
@@ -1888,8 +1898,8 @@ impl AsRef<Schema> for Schema {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SearchParams {
     pub dateRange: Option<i64>,
 
@@ -1910,8 +1920,8 @@ impl AsRef<SearchParams> for SearchParams {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SemanticContainer {
     pub sixteen_digit_number: Option<i64>,
 
@@ -1936,8 +1946,8 @@ impl AsRef<SemanticContainer> for SemanticContainer {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleTag {
     pub field: Option<String>,
 }
@@ -1948,9 +1958,9 @@ impl AsRef<SimpleTag> for SimpleTag {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SkipDynamicClass {
     pub value: Option<String>,
 
@@ -1958,6 +1968,7 @@ pub struct SkipDynamicClass {
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -2023,8 +2034,8 @@ impl AsRef<SkipDynamicClass> for SkipDynamicClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SkipNonDynamicClass {
     pub name: Option<String>,
 
@@ -2039,8 +2050,8 @@ impl AsRef<SkipNonDynamicClass> for SkipNonDynamicClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SmallThing {
     pub i_16_digits: i64,
 
@@ -2053,14 +2064,15 @@ impl AsRef<SmallThing> for SmallThing {
     }
 }
 
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, Serialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SomeClassNestedDynamic {
     pub hi: Option<String>,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<crate::baml_client::types::Types, super::StreamTypes>,
@@ -2124,8 +2136,8 @@ impl AsRef<SomeClassNestedDynamic> for SomeClassNestedDynamic {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct StringToClassEntry {
     pub word: Option<String>,
 }
@@ -2136,8 +2148,8 @@ impl AsRef<StringToClassEntry> for StringToClassEntry {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestClassAlias {
     pub key: Option<String>,
 
@@ -2156,8 +2168,8 @@ impl AsRef<TestClassAlias> for TestClassAlias {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestClassNested {
     pub prop1: Option<String>,
 
@@ -2170,8 +2182,8 @@ impl AsRef<TestClassNested> for TestClassNested {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestClassWithEnum {
     pub prop1: Option<String>,
 
@@ -2184,8 +2196,8 @@ impl AsRef<TestClassWithEnum> for TestClassWithEnum {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestMemoryOutput {
     pub items: Vec<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>,
 
@@ -2198,8 +2210,8 @@ impl AsRef<TestMemoryOutput> for TestMemoryOutput {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestOutputClass {
     pub prop1: Option<String>,
 
@@ -2212,8 +2224,8 @@ impl AsRef<TestOutputClass> for TestOutputClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TodoMessageToUser {
     #[baml(name = "type")]
     pub r#type: String,
@@ -2227,8 +2239,8 @@ impl AsRef<TodoMessageToUser> for TodoMessageToUser {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Tree {
     pub data: Option<i64>,
 
@@ -2241,8 +2253,8 @@ impl AsRef<Tree> for Tree {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TwoStoriesOneTitle {
     pub title: Option<String>,
 
@@ -2257,8 +2269,8 @@ impl AsRef<TwoStoriesOneTitle> for TwoStoriesOneTitle {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TwoStoriesOneTitleCheck {
     pub title: Option<String>,
 
@@ -2273,8 +2285,8 @@ impl AsRef<TwoStoriesOneTitleCheck> for TwoStoriesOneTitleCheck {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UnionTest_ReturnType {
     pub prop1: Option<types::Union2BoolOrString>,
 
@@ -2291,8 +2303,8 @@ impl AsRef<UnionTest_ReturnType> for UnionTest_ReturnType {
 
 /// my docs
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UniverseQuestion {
     pub question: Option<String>,
 
@@ -2305,8 +2317,8 @@ impl AsRef<UniverseQuestion> for UniverseQuestion {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UniverseQuestionInput {
     pub question: Option<String>,
 }
@@ -2317,8 +2329,8 @@ impl AsRef<UniverseQuestionInput> for UniverseQuestionInput {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlDecode, Serialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct WithReasoning {
     pub value: Option<String>,
 

--- a/integ-tests/rust/src/baml_client/stream_types/classes.rs
+++ b/integ-tests/rust/src/baml_client/stream_types/classes.rs
@@ -398,7 +398,7 @@ pub struct DummyOutput {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -474,7 +474,7 @@ pub struct DynInputOutput {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -546,7 +546,7 @@ pub struct DynamicClassOne {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -622,7 +622,7 @@ pub struct DynamicClassTwo {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -698,7 +698,7 @@ pub struct DynamicOutput {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -768,7 +768,7 @@ pub struct DynamicSchema {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -1461,7 +1461,7 @@ pub struct OriginalB {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -1537,7 +1537,7 @@ pub struct Person {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -1731,7 +1731,7 @@ pub struct RenderEnumInput {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -1807,7 +1807,7 @@ pub struct RenderTestClass {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -1991,7 +1991,7 @@ pub struct SkipDynamicClass {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 
@@ -2097,7 +2097,7 @@ pub struct SomeClassNestedDynamic {
     #[serde(flatten)]
     pub __dynamic: ::std::collections::HashMap<
         ::std::string::String,
-        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+        ::baml::BamlValue<super::super::Types, super::StreamTypes>,
     >,
 }
 

--- a/integ-tests/rust/src/baml_client/stream_types/mod.rs
+++ b/integ-tests/rust/src/baml_client/stream_types/mod.rs
@@ -15,8 +15,11 @@ pub use classes::*;
 pub use type_aliases::*;
 pub use unions::*;
 
+use baml::__internal::serde;
+
 /// Streaming variants of types (all fields Optional).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum StreamTypes {
     AddTodoItem(AddTodoItem),
 
@@ -528,5 +531,13 @@ impl baml::KnownTypes for StreamTypes {
                 "Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString"
             }
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for StreamTypes {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Err(serde::de::Error::custom(
+            "StreamTypes is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/integ-tests/rust/src/baml_client/stream_types/mod.rs
+++ b/integ-tests/rust/src/baml_client/stream_types/mod.rs
@@ -271,7 +271,7 @@ pub enum StreamTypes {
 }
 
 impl baml::KnownTypes for StreamTypes {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn ::std::any::Any {
         self
     }
 
@@ -535,8 +535,10 @@ impl baml::KnownTypes for StreamTypes {
 }
 
 impl<'de> serde::Deserialize<'de> for StreamTypes {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Err(serde::de::Error::custom(
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
             "StreamTypes is not deserializable, as we cannot disambiguate the type.",
         ))
     }

--- a/integ-tests/rust/src/baml_client/stream_types/unions.rs
+++ b/integ-tests/rust/src/baml_client/stream_types/unions.rs
@@ -24,15 +24,17 @@ pub enum Union2AddTodoItemOrTodoMessageToUser {
     TodoMessageToUser(TodoMessageToUser),
 }
 
-impl AsRef<Union2AddTodoItemOrTodoMessageToUser> for Union2AddTodoItemOrTodoMessageToUser {
+impl ::std::convert::AsRef<Union2AddTodoItemOrTodoMessageToUser>
+    for Union2AddTodoItemOrTodoMessageToUser
+{
     fn as_ref(&self) -> &Union2AddTodoItemOrTodoMessageToUser {
         self
     }
 }
 
-impl Default for Union2AddTodoItemOrTodoMessageToUser {
+impl ::std::default::Default for Union2AddTodoItemOrTodoMessageToUser {
     fn default() -> Self {
-        Self::AddTodoItem(Default::default())
+        Self::AddTodoItem(::std::default::Default::default())
     }
 }
 
@@ -48,15 +50,15 @@ pub enum Union2EarthlingOrMartian {
     Earthling(Earthling),
 }
 
-impl AsRef<Union2EarthlingOrMartian> for Union2EarthlingOrMartian {
+impl ::std::convert::AsRef<Union2EarthlingOrMartian> for Union2EarthlingOrMartian {
     fn as_ref(&self) -> &Union2EarthlingOrMartian {
         self
     }
 }
 
-impl Default for Union2EarthlingOrMartian {
+impl ::std::default::Default for Union2EarthlingOrMartian {
     fn default() -> Self {
-        Self::Martian(Default::default())
+        Self::Martian(::std::default::Default::default())
     }
 }
 
@@ -72,15 +74,15 @@ pub enum Union2EmailAddressOrPhoneNumber {
     EmailAddress(EmailAddress),
 }
 
-impl AsRef<Union2EmailAddressOrPhoneNumber> for Union2EmailAddressOrPhoneNumber {
+impl ::std::convert::AsRef<Union2EmailAddressOrPhoneNumber> for Union2EmailAddressOrPhoneNumber {
     fn as_ref(&self) -> &Union2EmailAddressOrPhoneNumber {
         self
     }
 }
 
-impl Default for Union2EmailAddressOrPhoneNumber {
+impl ::std::default::Default for Union2EmailAddressOrPhoneNumber {
     fn default() -> Self {
-        Self::PhoneNumber(Default::default())
+        Self::PhoneNumber(::std::default::Default::default())
     }
 }
 
@@ -96,15 +98,15 @@ pub enum Union2EventOrResume {
     Event(Event),
 }
 
-impl AsRef<Union2EventOrResume> for Union2EventOrResume {
+impl ::std::convert::AsRef<Union2EventOrResume> for Union2EventOrResume {
     fn as_ref(&self) -> &Union2EventOrResume {
         self
     }
 }
 
-impl Default for Union2EventOrResume {
+impl ::std::default::Default for Union2EventOrResume {
     fn default() -> Self {
-        Self::Resume(Default::default())
+        Self::Resume(::std::default::Default::default())
     }
 }
 
@@ -120,15 +122,15 @@ pub enum Union2JsonTemplateOrSimpleTag {
     JsonTemplate(JsonTemplate),
 }
 
-impl AsRef<Union2JsonTemplateOrSimpleTag> for Union2JsonTemplateOrSimpleTag {
+impl ::std::convert::AsRef<Union2JsonTemplateOrSimpleTag> for Union2JsonTemplateOrSimpleTag {
     fn as_ref(&self) -> &Union2JsonTemplateOrSimpleTag {
         self
     }
 }
 
-impl Default for Union2JsonTemplateOrSimpleTag {
+impl ::std::default::Default for Union2JsonTemplateOrSimpleTag {
     fn default() -> Self {
-        Self::SimpleTag(Default::default())
+        Self::SimpleTag(::std::default::Default::default())
     }
 }
 
@@ -144,15 +146,15 @@ pub enum Union2ListNestedOrString {
     ListNested(Vec<Nested>),
 }
 
-impl AsRef<Union2ListNestedOrString> for Union2ListNestedOrString {
+impl ::std::convert::AsRef<Union2ListNestedOrString> for Union2ListNestedOrString {
     fn as_ref(&self) -> &Union2ListNestedOrString {
         self
     }
 }
 
-impl Default for Union2ListNestedOrString {
+impl ::std::default::Default for Union2ListNestedOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
@@ -168,15 +170,17 @@ pub enum Union2LiteralClassOneOrLiteralClassTwo {
     LiteralClassTwo(LiteralClassTwo),
 }
 
-impl AsRef<Union2LiteralClassOneOrLiteralClassTwo> for Union2LiteralClassOneOrLiteralClassTwo {
+impl ::std::convert::AsRef<Union2LiteralClassOneOrLiteralClassTwo>
+    for Union2LiteralClassOneOrLiteralClassTwo
+{
     fn as_ref(&self) -> &Union2LiteralClassOneOrLiteralClassTwo {
         self
     }
 }
 
-impl Default for Union2LiteralClassOneOrLiteralClassTwo {
+impl ::std::default::Default for Union2LiteralClassOneOrLiteralClassTwo {
     fn default() -> Self {
-        Self::LiteralClassOne(Default::default())
+        Self::LiteralClassOne(::std::default::Default::default())
     }
 }
 
@@ -192,7 +196,7 @@ pub enum Union2MapStringKeyRecursiveUnionValueOrString {
     MapStringKeyRecursiveUnionValue(std::collections::HashMap<String, RecursiveUnion>),
 }
 
-impl AsRef<Union2MapStringKeyRecursiveUnionValueOrString>
+impl ::std::convert::AsRef<Union2MapStringKeyRecursiveUnionValueOrString>
     for Union2MapStringKeyRecursiveUnionValueOrString
 {
     fn as_ref(&self) -> &Union2MapStringKeyRecursiveUnionValueOrString {
@@ -200,9 +204,9 @@ impl AsRef<Union2MapStringKeyRecursiveUnionValueOrString>
     }
 }
 
-impl Default for Union2MapStringKeyRecursiveUnionValueOrString {
+impl ::std::default::Default for Union2MapStringKeyRecursiveUnionValueOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
@@ -218,15 +222,15 @@ pub enum Union2NestedOrString {
     String(String),
 }
 
-impl AsRef<Union2NestedOrString> for Union2NestedOrString {
+impl ::std::convert::AsRef<Union2NestedOrString> for Union2NestedOrString {
     fn as_ref(&self) -> &Union2NestedOrString {
         self
     }
 }
 
-impl Default for Union2NestedOrString {
+impl ::std::default::Default for Union2NestedOrString {
     fn default() -> Self {
-        Self::Nested(Default::default())
+        Self::Nested(::std::default::Default::default())
     }
 }
 
@@ -242,15 +246,15 @@ pub enum Union2OriginalAOrOriginalB {
     OriginalB(OriginalB),
 }
 
-impl AsRef<Union2OriginalAOrOriginalB> for Union2OriginalAOrOriginalB {
+impl ::std::convert::AsRef<Union2OriginalAOrOriginalB> for Union2OriginalAOrOriginalB {
     fn as_ref(&self) -> &Union2OriginalAOrOriginalB {
         self
     }
 }
 
-impl Default for Union2OriginalAOrOriginalB {
+impl ::std::default::Default for Union2OriginalAOrOriginalB {
     fn default() -> Self {
-        Self::OriginalA(Default::default())
+        Self::OriginalA(::std::default::Default::default())
     }
 }
 
@@ -269,7 +273,7 @@ pub enum Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
     AnotherObject(AnotherObject),
 }
 
-impl AsRef<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>
+impl ::std::convert::AsRef<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>
     for Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject
 {
     fn as_ref(&self) -> &Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
@@ -277,9 +281,9 @@ impl AsRef<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>
     }
 }
 
-impl Default for Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
+impl ::std::default::Default for Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
     fn default() -> Self {
-        Self::MemoryObject(Default::default())
+        Self::MemoryObject(::std::default::Default::default())
     }
 }
 
@@ -298,7 +302,7 @@ pub enum Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
     GroceryReceipt(GroceryReceipt),
 }
 
-impl AsRef<Union3BookOrderOrFlightConfirmationOrGroceryReceipt>
+impl ::std::convert::AsRef<Union3BookOrderOrFlightConfirmationOrGroceryReceipt>
     for Union3BookOrderOrFlightConfirmationOrGroceryReceipt
 {
     fn as_ref(&self) -> &Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
@@ -306,9 +310,9 @@ impl AsRef<Union3BookOrderOrFlightConfirmationOrGroceryReceipt>
     }
 }
 
-impl Default for Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
+impl ::std::default::Default for Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
     fn default() -> Self {
-        Self::BookOrder(Default::default())
+        Self::BookOrder(::std::default::Default::default())
     }
 }
 
@@ -336,7 +340,7 @@ pub enum Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
     JsonArray(JsonArray),
 }
 
-impl AsRef<Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString>
+impl ::std::convert::AsRef<Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString>
     for Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString
 {
     fn as_ref(&self) -> &Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
@@ -344,8 +348,8 @@ impl AsRef<Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString>
     }
 }
 
-impl Default for Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
+impl ::std::default::Default for Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }

--- a/integ-tests/rust/src/baml_client/stream_types/unions.rs
+++ b/integ-tests/rust/src/baml_client/stream_types/unions.rs
@@ -7,11 +7,15 @@
 
 use super::*;
 use crate::baml_client::types;
-use baml::BamlDecode;
+use baml::{
+    __internal::serde::{Deserialize, Serialize},
+    BamlDecode, BamlSerde,
+};
 
 /// Generated from: (Streaming.AddTodoItem | Streaming.TodoMessageToUser | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2AddTodoItemOrTodoMessageToUser {
     #[baml(name = "AddTodoItem")]
     AddTodoItem(AddTodoItem),
@@ -33,8 +37,9 @@ impl Default for Union2AddTodoItemOrTodoMessageToUser {
 }
 
 /// Generated from: (Streaming.Martian | Streaming.Earthling | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2EarthlingOrMartian {
     #[baml(name = "Martian")]
     Martian(Martian),
@@ -56,8 +61,9 @@ impl Default for Union2EarthlingOrMartian {
 }
 
 /// Generated from: (Streaming.PhoneNumber | Streaming.EmailAddress | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2EmailAddressOrPhoneNumber {
     #[baml(name = "PhoneNumber")]
     PhoneNumber(PhoneNumber),
@@ -79,8 +85,9 @@ impl Default for Union2EmailAddressOrPhoneNumber {
 }
 
 /// Generated from: (Streaming.Resume | Streaming.Event | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2EventOrResume {
     #[baml(name = "Resume")]
     Resume(Resume),
@@ -102,8 +109,9 @@ impl Default for Union2EventOrResume {
 }
 
 /// Generated from: (Streaming.SimpleTag | Streaming.JsonTemplate | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2JsonTemplateOrSimpleTag {
     #[baml(name = "SimpleTag")]
     SimpleTag(SimpleTag),
@@ -125,8 +133,9 @@ impl Default for Union2JsonTemplateOrSimpleTag {
 }
 
 /// Generated from: (string | Streaming.Nested[] | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ListNestedOrString {
     #[baml(name = "string")]
     String(String),
@@ -148,8 +157,9 @@ impl Default for Union2ListNestedOrString {
 }
 
 /// Generated from: (Streaming.LiteralClassOne | Streaming.LiteralClassTwo | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2LiteralClassOneOrLiteralClassTwo {
     #[baml(name = "LiteralClassOne")]
     LiteralClassOne(LiteralClassOne),
@@ -171,8 +181,9 @@ impl Default for Union2LiteralClassOneOrLiteralClassTwo {
 }
 
 /// Generated from: (string | map<string, Streaming.RecursiveUnion> | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2MapStringKeyRecursiveUnionValueOrString {
     #[baml(name = "string")]
     String(String),
@@ -196,8 +207,9 @@ impl Default for Union2MapStringKeyRecursiveUnionValueOrString {
 }
 
 /// Generated from: (Streaming.Nested | string | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2NestedOrString {
     #[baml(name = "Nested")]
     Nested(Nested),
@@ -219,8 +231,9 @@ impl Default for Union2NestedOrString {
 }
 
 /// Generated from: (Streaming.OriginalA | Streaming.OriginalB)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2OriginalAOrOriginalB {
     #[baml(name = "OriginalA")]
     OriginalA(OriginalA),
@@ -242,8 +255,9 @@ impl Default for Union2OriginalAOrOriginalB {
 }
 
 /// Generated from: (Streaming.MemoryObject | Streaming.ComplexMemoryObject | Streaming.AnotherObject)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
     #[baml(name = "MemoryObject")]
     MemoryObject(MemoryObject),
@@ -270,8 +284,9 @@ impl Default for Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
 }
 
 /// Generated from: (Streaming.BookOrder | Streaming.FlightConfirmation | Streaming.GroceryReceipt)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
     #[baml(name = "BookOrder")]
     BookOrder(BookOrder),
@@ -298,8 +313,9 @@ impl Default for Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
 }
 
 /// Generated from: (int @stream.done | string | bool @stream.done | float @stream.done | Streaming.JsonObject | Streaming.JsonArray | null)
-#[derive(Debug, Clone, BamlDecode)]
+#[derive(Debug, Clone, BamlDecode, BamlSerde, Serialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
     #[baml(name = "int")]
     Int(i64),

--- a/integ-tests/rust/src/baml_client/type_builder/classes.rs
+++ b/integ-tests/rust/src/baml_client/type_builder/classes.rs
@@ -1246,7 +1246,7 @@ impl DummyOutputClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1304,7 +1304,7 @@ impl DynInputOutputClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1355,7 +1355,7 @@ impl DynamicClassOneClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1399,7 +1399,7 @@ impl DynamicClassTwoClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1463,7 +1463,7 @@ impl DynamicOutputClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1507,7 +1507,7 @@ impl DynamicSchemaClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -3560,7 +3560,7 @@ impl OriginalBClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -3611,7 +3611,7 @@ impl PersonClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -4057,7 +4057,7 @@ impl RenderEnumInputClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -4108,7 +4108,7 @@ impl RenderTestClassClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -4516,7 +4516,7 @@ impl SkipDynamicClassClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -4670,7 +4670,7 @@ impl SomeClassNestedDynamicClassBuilder {
         &self,
         name: &str,
         field_type: &::baml::TypeDef,
-    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
+    ) -> ::std::result::Result<baml::ClassPropertyBuilder, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 

--- a/integ-tests/rust/src/baml_client/type_builder/classes.rs
+++ b/integ-tests/rust/src/baml_client/type_builder/classes.rs
@@ -11,22 +11,22 @@
 /// Access fields via methods: `builder.field_name()`
 
 pub struct AddTodoItemClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl AddTodoItemClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("AddTodoItem is statically defined in .baml and should always have a type")
@@ -37,28 +37,28 @@ impl AddTodoItemClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("type")
             .expect("AddTodoItem.type is statically defined in .baml and should always be present")
     }
 
     /// Access the `item` field builder.
-    pub fn property_item(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_item(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("item")
             .expect("AddTodoItem.item is statically defined in .baml and should always be present")
     }
 
     /// Access the `time` field builder.
-    pub fn property_time(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_time(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("time")
             .expect("AddTodoItem.time is statically defined in .baml and should always be present")
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description").expect(
             "AddTodoItem.description is statically defined in .baml and should always be present",
         )
@@ -71,22 +71,22 @@ impl AddTodoItemClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct AddressWithMetaClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl AddressWithMetaClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("AddressWithMeta is statically defined in .baml and should always have a type")
@@ -97,21 +97,21 @@ impl AddressWithMetaClassBuilder {
     // =========================================================================
 
     /// Access the `street` field builder.
-    pub fn property_street(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_street(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("street").expect(
             "AddressWithMeta.street is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `city` field builder.
-    pub fn property_city(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_city(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("city").expect(
             "AddressWithMeta.city is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `zipcode` field builder.
-    pub fn property_zipcode(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_zipcode(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("zipcode").expect(
             "AddressWithMeta.zipcode is statically defined in .baml and should always be present",
         )
@@ -124,22 +124,22 @@ impl AddressWithMetaClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct AnotherObjectClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl AnotherObjectClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("AnotherObject is statically defined in .baml and should always have a type")
@@ -150,21 +150,21 @@ impl AnotherObjectClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("AnotherObject.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `thingy2` field builder.
-    pub fn property_thingy2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_thingy2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("thingy2").expect(
             "AnotherObject.thingy2 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `thingy3` field builder.
-    pub fn property_thingy3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_thingy3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("thingy3").expect(
             "AnotherObject.thingy3 is statically defined in .baml and should always be present",
         )
@@ -177,22 +177,22 @@ impl AnotherObjectClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BigNumbersClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BigNumbersClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("BigNumbers is statically defined in .baml and should always have a type")
@@ -203,14 +203,14 @@ impl BigNumbersClassBuilder {
     // =========================================================================
 
     /// Access the `a` field builder.
-    pub fn property_a(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_a(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("a")
             .expect("BigNumbers.a is statically defined in .baml and should always be present")
     }
 
     /// Access the `b` field builder.
-    pub fn property_b(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_b(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("b")
             .expect("BigNumbers.b is statically defined in .baml and should always be present")
@@ -223,22 +223,22 @@ impl BigNumbersClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BinaryNodeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BinaryNodeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("BinaryNode is statically defined in .baml and should always have a type")
@@ -249,21 +249,21 @@ impl BinaryNodeClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("BinaryNode.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `left` field builder.
-    pub fn property_left(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_left(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("left")
             .expect("BinaryNode.left is statically defined in .baml and should always be present")
     }
 
     /// Access the `right` field builder.
-    pub fn property_right(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_right(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("right")
             .expect("BinaryNode.right is statically defined in .baml and should always be present")
@@ -276,22 +276,22 @@ impl BinaryNodeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BlahClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BlahClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Blah is statically defined in .baml and should always have a type")
@@ -302,7 +302,7 @@ impl BlahClassBuilder {
     // =========================================================================
 
     /// Access the `prop4` field builder.
-    pub fn property_prop4(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop4(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop4")
             .expect("Blah.prop4 is statically defined in .baml and should always be present")
@@ -315,22 +315,22 @@ impl BlahClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BlockConstraintClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BlockConstraintClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("BlockConstraint is statically defined in .baml and should always have a type")
@@ -341,14 +341,14 @@ impl BlockConstraintClassBuilder {
     // =========================================================================
 
     /// Access the `foo` field builder.
-    pub fn property_foo(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_foo(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("foo").expect(
             "BlockConstraint.foo is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `bar` field builder.
-    pub fn property_bar(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_bar(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("bar").expect(
             "BlockConstraint.bar is statically defined in .baml and should always be present",
         )
@@ -361,22 +361,22 @@ impl BlockConstraintClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BlockConstraintForParamClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BlockConstraintForParamClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "BlockConstraintForParam is statically defined in .baml and should always have a type",
         )
@@ -387,13 +387,13 @@ impl BlockConstraintForParamClassBuilder {
     // =========================================================================
 
     /// Access the `bcfp` field builder.
-    pub fn property_bcfp(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_bcfp(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("bcfp")
             .expect("BlockConstraintForParam.bcfp is statically defined in .baml and should always be present")
     }
 
     /// Access the `bcfp2` field builder.
-    pub fn property_bcfp2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_bcfp2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("bcfp2")
             .expect("BlockConstraintForParam.bcfp2 is statically defined in .baml and should always be present")
     }
@@ -405,22 +405,22 @@ impl BlockConstraintForParamClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct BookOrderClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl BookOrderClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("BookOrder is statically defined in .baml and should always have a type")
@@ -431,28 +431,28 @@ impl BookOrderClassBuilder {
     // =========================================================================
 
     /// Access the `orderId` field builder.
-    pub fn property_orderId(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_orderId(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("orderId")
             .expect("BookOrder.orderId is statically defined in .baml and should always be present")
     }
 
     /// Access the `title` field builder.
-    pub fn property_title(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_title(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("title")
             .expect("BookOrder.title is statically defined in .baml and should always be present")
     }
 
     /// Access the `quantity` field builder.
-    pub fn property_quantity(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_quantity(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("quantity").expect(
             "BookOrder.quantity is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `price` field builder.
-    pub fn property_price(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_price(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("price")
             .expect("BookOrder.price is statically defined in .baml and should always be present")
@@ -465,22 +465,22 @@ impl BookOrderClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClassForNullLiteralClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClassForNullLiteralClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "ClassForNullLiteral is statically defined in .baml and should always have a type",
         )
@@ -491,7 +491,7 @@ impl ClassForNullLiteralClassBuilder {
     // =========================================================================
 
     /// Access the `a` field builder.
-    pub fn property_a(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_a(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("a").expect(
             "ClassForNullLiteral.a is statically defined in .baml and should always be present",
         )
@@ -504,22 +504,22 @@ impl ClassForNullLiteralClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClassOptionalOutputClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClassOptionalOutputClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "ClassOptionalOutput is statically defined in .baml and should always have a type",
         )
@@ -530,14 +530,14 @@ impl ClassOptionalOutputClassBuilder {
     // =========================================================================
 
     /// Access the `prop1` field builder.
-    pub fn property_prop1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop1").expect(
             "ClassOptionalOutput.prop1 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `prop2` field builder.
-    pub fn property_prop2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop2").expect(
             "ClassOptionalOutput.prop2 is statically defined in .baml and should always be present",
         )
@@ -550,22 +550,22 @@ impl ClassOptionalOutputClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClassOptionalOutput2ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClassOptionalOutput2ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "ClassOptionalOutput2 is statically defined in .baml and should always have a type",
         )
@@ -576,19 +576,19 @@ impl ClassOptionalOutput2ClassBuilder {
     // =========================================================================
 
     /// Access the `prop1` field builder.
-    pub fn property_prop1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop1")
             .expect("ClassOptionalOutput2.prop1 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop2` field builder.
-    pub fn property_prop2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop2")
             .expect("ClassOptionalOutput2.prop2 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop3` field builder.
-    pub fn property_prop3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop3")
             .expect("ClassOptionalOutput2.prop3 is statically defined in .baml and should always be present")
     }
@@ -600,22 +600,22 @@ impl ClassOptionalOutput2ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClassToRecAliasClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClassToRecAliasClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ClassToRecAlias is statically defined in .baml and should always have a type")
@@ -626,7 +626,7 @@ impl ClassToRecAliasClassBuilder {
     // =========================================================================
 
     /// Access the `list` field builder.
-    pub fn property_list(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_list(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("list").expect(
             "ClassToRecAlias.list is statically defined in .baml and should always be present",
         )
@@ -639,22 +639,22 @@ impl ClassToRecAliasClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClassWithBlockDoneClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClassWithBlockDoneClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "ClassWithBlockDone is statically defined in .baml and should always have a type",
         )
@@ -665,13 +665,13 @@ impl ClassWithBlockDoneClassBuilder {
     // =========================================================================
 
     /// Access the `i_16_digits` field builder.
-    pub fn property_i_16_digits(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_i_16_digits(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("i_16_digits")
             .expect("ClassWithBlockDone.i_16_digits is statically defined in .baml and should always be present")
     }
 
     /// Access the `s_20_words` field builder.
-    pub fn property_s_20_words(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_s_20_words(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("s_20_words")
             .expect("ClassWithBlockDone.s_20_words is statically defined in .baml and should always be present")
     }
@@ -683,22 +683,22 @@ impl ClassWithBlockDoneClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClassWithImageClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClassWithImageClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ClassWithImage is statically defined in .baml and should always have a type")
@@ -709,21 +709,21 @@ impl ClassWithImageClassBuilder {
     // =========================================================================
 
     /// Access the `myImage` field builder.
-    pub fn property_myImage(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_myImage(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("myImage").expect(
             "ClassWithImage.myImage is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `param2` field builder.
-    pub fn property_param2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_param2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("param2").expect(
             "ClassWithImage.param2 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `fake_image` field builder.
-    pub fn property_fake_image(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_fake_image(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("fake_image").expect(
             "ClassWithImage.fake_image is statically defined in .baml and should always be present",
         )
@@ -736,22 +736,22 @@ impl ClassWithImageClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClassWithoutDoneClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClassWithoutDoneClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ClassWithoutDone is statically defined in .baml and should always have a type")
@@ -762,13 +762,13 @@ impl ClassWithoutDoneClassBuilder {
     // =========================================================================
 
     /// Access the `i_16_digits` field builder.
-    pub fn property_i_16_digits(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_i_16_digits(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("i_16_digits")
             .expect("ClassWithoutDone.i_16_digits is statically defined in .baml and should always be present")
     }
 
     /// Access the `s_20_words` field builder.
-    pub fn property_s_20_words(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_s_20_words(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("s_20_words")
             .expect("ClassWithoutDone.s_20_words is statically defined in .baml and should always be present")
     }
@@ -780,22 +780,22 @@ impl ClassWithoutDoneClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ClientDetails1559ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ClientDetails1559ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "ClientDetails1559 is statically defined in .baml and should always have a type",
         )
@@ -806,43 +806,43 @@ impl ClientDetails1559ClassBuilder {
     // =========================================================================
 
     /// Access the `client_name` field builder.
-    pub fn property_client_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_client_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("client_name")
             .expect("ClientDetails1559.client_name is statically defined in .baml and should always be present")
     }
 
     /// Access the `client_address` field builder.
-    pub fn property_client_address(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_client_address(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("client_address")
             .expect("ClientDetails1559.client_address is statically defined in .baml and should always be present")
     }
 
     /// Access the `client_postal_code` field builder.
-    pub fn property_client_postal_code(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_client_postal_code(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("client_postal_code")
             .expect("ClientDetails1559.client_postal_code is statically defined in .baml and should always be present")
     }
 
     /// Access the `client_city` field builder.
-    pub fn property_client_city(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_client_city(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("client_city")
             .expect("ClientDetails1559.client_city is statically defined in .baml and should always be present")
     }
 
     /// Access the `client_country` field builder.
-    pub fn property_client_country(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_client_country(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("client_country")
             .expect("ClientDetails1559.client_country is statically defined in .baml and should always be present")
     }
 
     /// Access the `client_phone` field builder.
-    pub fn property_client_phone(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_client_phone(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("client_phone")
             .expect("ClientDetails1559.client_phone is statically defined in .baml and should always be present")
     }
 
     /// Access the `client_email` field builder.
-    pub fn property_client_email(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_client_email(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("client_email")
             .expect("ClientDetails1559.client_email is statically defined in .baml and should always be present")
     }
@@ -854,22 +854,22 @@ impl ClientDetails1559ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ComplexMemoryObjectClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ComplexMemoryObjectClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "ComplexMemoryObject is statically defined in .baml and should always have a type",
         )
@@ -880,27 +880,27 @@ impl ComplexMemoryObjectClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("id").expect(
             "ComplexMemoryObject.id is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("name").expect(
             "ComplexMemoryObject.name is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description")
             .expect("ComplexMemoryObject.description is statically defined in .baml and should always be present")
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadata")
             .expect("ComplexMemoryObject.metadata is statically defined in .baml and should always be present")
     }
@@ -912,22 +912,22 @@ impl ComplexMemoryObjectClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct CompoundBigNumbersClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl CompoundBigNumbersClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "CompoundBigNumbers is statically defined in .baml and should always have a type",
         )
@@ -938,20 +938,20 @@ impl CompoundBigNumbersClassBuilder {
     // =========================================================================
 
     /// Access the `big` field builder.
-    pub fn property_big(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_big(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("big").expect(
             "CompoundBigNumbers.big is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `big_nums` field builder.
-    pub fn property_big_nums(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_big_nums(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("big_nums")
             .expect("CompoundBigNumbers.big_nums is statically defined in .baml and should always be present")
     }
 
     /// Access the `another` field builder.
-    pub fn property_another(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_another(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("another")
             .expect("CompoundBigNumbers.another is statically defined in .baml and should always be present")
     }
@@ -963,22 +963,22 @@ impl CompoundBigNumbersClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ContactInfoClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ContactInfoClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ContactInfo is statically defined in .baml and should always have a type")
@@ -989,14 +989,14 @@ impl ContactInfoClassBuilder {
     // =========================================================================
 
     /// Access the `primary` field builder.
-    pub fn property_primary(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_primary(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("primary").expect(
             "ContactInfo.primary is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `secondary` field builder.
-    pub fn property_secondary(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_secondary(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("secondary").expect(
             "ContactInfo.secondary is statically defined in .baml and should always be present",
         )
@@ -1009,22 +1009,22 @@ impl ContactInfoClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct CustomStoryClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl CustomStoryClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("CustomStory is statically defined in .baml and should always have a type")
@@ -1035,21 +1035,21 @@ impl CustomStoryClassBuilder {
     // =========================================================================
 
     /// Access the `title` field builder.
-    pub fn property_title(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_title(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("title")
             .expect("CustomStory.title is statically defined in .baml and should always be present")
     }
 
     /// Access the `characters` field builder.
-    pub fn property_characters(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_characters(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("characters").expect(
             "CustomStory.characters is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `content` field builder.
-    pub fn property_content(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_content(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("content").expect(
             "CustomStory.content is statically defined in .baml and should always be present",
         )
@@ -1062,22 +1062,22 @@ impl CustomStoryClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct CustomTaskResultClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl CustomTaskResultClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("CustomTaskResult is statically defined in .baml and should always have a type")
@@ -1088,19 +1088,19 @@ impl CustomTaskResultClassBuilder {
     // =========================================================================
 
     /// Access the `bookOrder` field builder.
-    pub fn property_bookOrder(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_bookOrder(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("bookOrder")
             .expect("CustomTaskResult.bookOrder is statically defined in .baml and should always be present")
     }
 
     /// Access the `flightConfirmation` field builder.
-    pub fn property_flightConfirmation(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_flightConfirmation(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("flightConfirmation")
             .expect("CustomTaskResult.flightConfirmation is statically defined in .baml and should always be present")
     }
 
     /// Access the `groceryReceipt` field builder.
-    pub fn property_groceryReceipt(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_groceryReceipt(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("groceryReceipt")
             .expect("CustomTaskResult.groceryReceipt is statically defined in .baml and should always be present")
     }
@@ -1112,22 +1112,22 @@ impl CustomTaskResultClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct Document1559ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl Document1559ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Document1559 is statically defined in .baml and should always have a type")
@@ -1138,13 +1138,13 @@ impl Document1559ClassBuilder {
     // =========================================================================
 
     /// Access the `client_details` field builder.
-    pub fn property_client_details(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_client_details(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("client_details")
             .expect("Document1559.client_details is statically defined in .baml and should always be present")
     }
 
     /// Access the `notes` field builder.
-    pub fn property_notes(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_notes(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("notes").expect(
             "Document1559.notes is statically defined in .baml and should always be present",
         )
@@ -1157,22 +1157,22 @@ impl Document1559ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct DummyJsonTodoClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DummyJsonTodoClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DummyJsonTodo is statically defined in .baml and should always have a type")
@@ -1183,28 +1183,28 @@ impl DummyJsonTodoClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("DummyJsonTodo.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `todo` field builder.
-    pub fn property_todo(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_todo(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("todo").expect(
             "DummyJsonTodo.todo is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `completed` field builder.
-    pub fn property_completed(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_completed(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("completed").expect(
             "DummyJsonTodo.completed is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `userId` field builder.
-    pub fn property_userId(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_userId(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("userId").expect(
             "DummyJsonTodo.userId is statically defined in .baml and should always be present",
         )
@@ -1220,22 +1220,22 @@ impl DummyJsonTodoClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct DummyOutputClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DummyOutputClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DummyOutput is statically defined in .baml and should always have a type")
@@ -1245,8 +1245,8 @@ impl DummyOutputClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1255,14 +1255,14 @@ impl DummyOutputClassBuilder {
     // =========================================================================
 
     /// Access the `nonce` field builder.
-    pub fn property_nonce(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nonce(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("nonce")
             .expect("DummyOutput.nonce is statically defined in .baml and should always be present")
     }
 
     /// Access the `nonce2` field builder.
-    pub fn property_nonce2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nonce2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nonce2").expect(
             "DummyOutput.nonce2 is statically defined in .baml and should always be present",
         )
@@ -1278,22 +1278,22 @@ impl DummyOutputClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct DynInputOutputClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DynInputOutputClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DynInputOutput is statically defined in .baml and should always have a type")
@@ -1303,8 +1303,8 @@ impl DynInputOutputClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1313,7 +1313,7 @@ impl DynInputOutputClassBuilder {
     // =========================================================================
 
     /// Access the `testKey` field builder.
-    pub fn property_testKey(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_testKey(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("testKey").expect(
             "DynInputOutput.testKey is statically defined in .baml and should always be present",
         )
@@ -1329,22 +1329,22 @@ impl DynInputOutputClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct DynamicClassOneClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DynamicClassOneClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DynamicClassOne is statically defined in .baml and should always have a type")
@@ -1354,8 +1354,8 @@ impl DynamicClassOneClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1373,22 +1373,22 @@ impl DynamicClassOneClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct DynamicClassTwoClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DynamicClassTwoClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DynamicClassTwo is statically defined in .baml and should always have a type")
@@ -1398,8 +1398,8 @@ impl DynamicClassTwoClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1408,20 +1408,20 @@ impl DynamicClassTwoClassBuilder {
     // =========================================================================
 
     /// Access the `hi` field builder.
-    pub fn property_hi(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_hi(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("hi").expect(
             "DynamicClassTwo.hi is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `some_class` field builder.
-    pub fn property_some_class(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_some_class(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("some_class")
             .expect("DynamicClassTwo.some_class is statically defined in .baml and should always be present")
     }
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("status").expect(
             "DynamicClassTwo.status is statically defined in .baml and should always be present",
         )
@@ -1437,22 +1437,22 @@ impl DynamicClassTwoClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct DynamicOutputClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DynamicOutputClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DynamicOutput is statically defined in .baml and should always have a type")
@@ -1462,8 +1462,8 @@ impl DynamicOutputClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1481,22 +1481,22 @@ impl DynamicOutputClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct DynamicSchemaClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl DynamicSchemaClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DynamicSchema is statically defined in .baml and should always have a type")
@@ -1506,8 +1506,8 @@ impl DynamicSchemaClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -1522,22 +1522,22 @@ impl DynamicSchemaClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct EarthlingClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl EarthlingClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Earthling is statically defined in .baml and should always have a type")
@@ -1548,7 +1548,7 @@ impl EarthlingClassBuilder {
     // =========================================================================
 
     /// Access the `age` field builder.
-    pub fn property_age(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_age(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("age")
             .expect("Earthling.age is statically defined in .baml and should always be present")
@@ -1561,22 +1561,22 @@ impl EarthlingClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct EducationClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl EducationClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Education is statically defined in .baml and should always have a type")
@@ -1587,35 +1587,35 @@ impl EducationClassBuilder {
     // =========================================================================
 
     /// Access the `institution` field builder.
-    pub fn property_institution(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_institution(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("institution").expect(
             "Education.institution is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `location` field builder.
-    pub fn property_location(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_location(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("location").expect(
             "Education.location is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `degree` field builder.
-    pub fn property_degree(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_degree(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("degree")
             .expect("Education.degree is statically defined in .baml and should always be present")
     }
 
     /// Access the `major` field builder.
-    pub fn property_major(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_major(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("major")
             .expect("Education.major is statically defined in .baml and should always be present")
     }
 
     /// Access the `graduation_date` field builder.
-    pub fn property_graduation_date(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_graduation_date(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("graduation_date").expect(
             "Education.graduation_date is statically defined in .baml and should always be present",
         )
@@ -1628,22 +1628,22 @@ impl EducationClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct EmailClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl EmailClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Email is statically defined in .baml and should always have a type")
@@ -1654,21 +1654,21 @@ impl EmailClassBuilder {
     // =========================================================================
 
     /// Access the `subject` field builder.
-    pub fn property_subject(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_subject(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("subject")
             .expect("Email.subject is statically defined in .baml and should always be present")
     }
 
     /// Access the `body` field builder.
-    pub fn property_body(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_body(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("body")
             .expect("Email.body is statically defined in .baml and should always be present")
     }
 
     /// Access the `from_address` field builder.
-    pub fn property_from_address(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_from_address(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("from_address").expect(
             "Email.from_address is statically defined in .baml and should always be present",
         )
@@ -1681,22 +1681,22 @@ impl EmailClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct EmailAddressClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl EmailAddressClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("EmailAddress is statically defined in .baml and should always have a type")
@@ -1707,7 +1707,7 @@ impl EmailAddressClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value").expect(
             "EmailAddress.value is statically defined in .baml and should always be present",
         )
@@ -1720,22 +1720,22 @@ impl EmailAddressClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct EventClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl EventClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Event is statically defined in .baml and should always have a type")
@@ -1746,28 +1746,28 @@ impl EventClassBuilder {
     // =========================================================================
 
     /// Access the `title` field builder.
-    pub fn property_title(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_title(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("title")
             .expect("Event.title is statically defined in .baml and should always be present")
     }
 
     /// Access the `date` field builder.
-    pub fn property_date(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_date(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("date")
             .expect("Event.date is statically defined in .baml and should always be present")
     }
 
     /// Access the `location` field builder.
-    pub fn property_location(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_location(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("location")
             .expect("Event.location is statically defined in .baml and should always be present")
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("description")
             .expect("Event.description is statically defined in .baml and should always be present")
@@ -1780,22 +1780,22 @@ impl EventClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct FakeImageClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl FakeImageClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("FakeImage is statically defined in .baml and should always have a type")
@@ -1806,7 +1806,7 @@ impl FakeImageClassBuilder {
     // =========================================================================
 
     /// Access the `url` field builder.
-    pub fn property_url(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_url(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("url")
             .expect("FakeImage.url is statically defined in .baml and should always be present")
@@ -1819,22 +1819,22 @@ impl FakeImageClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct FlightConfirmationClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl FlightConfirmationClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "FlightConfirmation is statically defined in .baml and should always have a type",
         )
@@ -1845,31 +1845,31 @@ impl FlightConfirmationClassBuilder {
     // =========================================================================
 
     /// Access the `confirmationNumber` field builder.
-    pub fn property_confirmationNumber(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_confirmationNumber(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("confirmationNumber")
             .expect("FlightConfirmation.confirmationNumber is statically defined in .baml and should always be present")
     }
 
     /// Access the `flightNumber` field builder.
-    pub fn property_flightNumber(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_flightNumber(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("flightNumber")
             .expect("FlightConfirmation.flightNumber is statically defined in .baml and should always be present")
     }
 
     /// Access the `departureTime` field builder.
-    pub fn property_departureTime(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_departureTime(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("departureTime")
             .expect("FlightConfirmation.departureTime is statically defined in .baml and should always be present")
     }
 
     /// Access the `arrivalTime` field builder.
-    pub fn property_arrivalTime(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_arrivalTime(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("arrivalTime")
             .expect("FlightConfirmation.arrivalTime is statically defined in .baml and should always be present")
     }
 
     /// Access the `seatNumber` field builder.
-    pub fn property_seatNumber(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_seatNumber(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("seatNumber")
             .expect("FlightConfirmation.seatNumber is statically defined in .baml and should always be present")
     }
@@ -1881,22 +1881,22 @@ impl FlightConfirmationClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct FooAnyClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl FooAnyClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("FooAny is statically defined in .baml and should always have a type")
@@ -1907,21 +1907,21 @@ impl FooAnyClassBuilder {
     // =========================================================================
 
     /// Access the `planetary_age` field builder.
-    pub fn property_planetary_age(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_planetary_age(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("planetary_age").expect(
             "FooAny.planetary_age is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `certainty` field builder.
-    pub fn property_certainty(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_certainty(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("certainty")
             .expect("FooAny.certainty is statically defined in .baml and should always be present")
     }
 
     /// Access the `species` field builder.
-    pub fn property_species(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_species(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("species")
             .expect("FooAny.species is statically defined in .baml and should always be present")
@@ -1934,22 +1934,22 @@ impl FooAnyClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ForestClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ForestClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Forest is statically defined in .baml and should always have a type")
@@ -1960,7 +1960,7 @@ impl ForestClassBuilder {
     // =========================================================================
 
     /// Access the `trees` field builder.
-    pub fn property_trees(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_trees(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("trees")
             .expect("Forest.trees is statically defined in .baml and should always be present")
@@ -1973,22 +1973,22 @@ impl ForestClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct FormatterTest0ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl FormatterTest0ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("FormatterTest0 is statically defined in .baml and should always have a type")
@@ -1999,14 +1999,14 @@ impl FormatterTest0ClassBuilder {
     // =========================================================================
 
     /// Access the `lorem` field builder.
-    pub fn property_lorem(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_lorem(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("lorem").expect(
             "FormatterTest0.lorem is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `ipsum` field builder.
-    pub fn property_ipsum(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_ipsum(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("ipsum").expect(
             "FormatterTest0.ipsum is statically defined in .baml and should always be present",
         )
@@ -2019,22 +2019,22 @@ impl FormatterTest0ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct FormatterTest1ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl FormatterTest1ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("FormatterTest1 is statically defined in .baml and should always have a type")
@@ -2045,14 +2045,14 @@ impl FormatterTest1ClassBuilder {
     // =========================================================================
 
     /// Access the `lorem` field builder.
-    pub fn property_lorem(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_lorem(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("lorem").expect(
             "FormatterTest1.lorem is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `ipsum` field builder.
-    pub fn property_ipsum(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_ipsum(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("ipsum").expect(
             "FormatterTest1.ipsum is statically defined in .baml and should always be present",
         )
@@ -2065,22 +2065,22 @@ impl FormatterTest1ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct FormatterTest2ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl FormatterTest2ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("FormatterTest2 is statically defined in .baml and should always have a type")
@@ -2091,14 +2091,14 @@ impl FormatterTest2ClassBuilder {
     // =========================================================================
 
     /// Access the `lorem` field builder.
-    pub fn property_lorem(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_lorem(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("lorem").expect(
             "FormatterTest2.lorem is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `ipsum` field builder.
-    pub fn property_ipsum(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_ipsum(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("ipsum").expect(
             "FormatterTest2.ipsum is statically defined in .baml and should always be present",
         )
@@ -2111,22 +2111,22 @@ impl FormatterTest2ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct FormatterTest3ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl FormatterTest3ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("FormatterTest3 is statically defined in .baml and should always have a type")
@@ -2137,14 +2137,14 @@ impl FormatterTest3ClassBuilder {
     // =========================================================================
 
     /// Access the `lorem` field builder.
-    pub fn property_lorem(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_lorem(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("lorem").expect(
             "FormatterTest3.lorem is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `ipsum` field builder.
-    pub fn property_ipsum(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_ipsum(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("ipsum").expect(
             "FormatterTest3.ipsum is statically defined in .baml and should always be present",
         )
@@ -2157,22 +2157,22 @@ impl FormatterTest3ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct GroceryReceiptClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl GroceryReceiptClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("GroceryReceipt is statically defined in .baml and should always have a type")
@@ -2183,28 +2183,28 @@ impl GroceryReceiptClassBuilder {
     // =========================================================================
 
     /// Access the `receiptId` field builder.
-    pub fn property_receiptId(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_receiptId(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("receiptId").expect(
             "GroceryReceipt.receiptId is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `storeName` field builder.
-    pub fn property_storeName(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_storeName(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("storeName").expect(
             "GroceryReceipt.storeName is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `items` field builder.
-    pub fn property_items(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_items(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("items").expect(
             "GroceryReceipt.items is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `totalAmount` field builder.
-    pub fn property_totalAmount(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_totalAmount(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("totalAmount")
             .expect("GroceryReceipt.totalAmount is statically defined in .baml and should always be present")
     }
@@ -2216,22 +2216,22 @@ impl GroceryReceiptClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct HaikuClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl HaikuClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Haiku is statically defined in .baml and should always have a type")
@@ -2242,21 +2242,21 @@ impl HaikuClassBuilder {
     // =========================================================================
 
     /// Access the `line1` field builder.
-    pub fn property_line1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_line1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("line1")
             .expect("Haiku.line1 is statically defined in .baml and should always be present")
     }
 
     /// Access the `line2` field builder.
-    pub fn property_line2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_line2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("line2")
             .expect("Haiku.line2 is statically defined in .baml and should always be present")
     }
 
     /// Access the `line3` field builder.
-    pub fn property_line3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_line3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("line3")
             .expect("Haiku.line3 is statically defined in .baml and should always be present")
@@ -2269,22 +2269,22 @@ impl HaikuClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct InnerClassClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl InnerClassClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("InnerClass is statically defined in .baml and should always have a type")
@@ -2295,21 +2295,21 @@ impl InnerClassClassBuilder {
     // =========================================================================
 
     /// Access the `prop1` field builder.
-    pub fn property_prop1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop1")
             .expect("InnerClass.prop1 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop2` field builder.
-    pub fn property_prop2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop2")
             .expect("InnerClass.prop2 is statically defined in .baml and should always be present")
     }
 
     /// Access the `inner` field builder.
-    pub fn property_inner(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_inner(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("inner")
             .expect("InnerClass.inner is statically defined in .baml and should always be present")
@@ -2322,22 +2322,22 @@ impl InnerClassClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct InnerClass2ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl InnerClass2ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("InnerClass2 is statically defined in .baml and should always have a type")
@@ -2348,14 +2348,14 @@ impl InnerClass2ClassBuilder {
     // =========================================================================
 
     /// Access the `prop2` field builder.
-    pub fn property_prop2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop2")
             .expect("InnerClass2.prop2 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop3` field builder.
-    pub fn property_prop3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop3")
             .expect("InnerClass2.prop3 is statically defined in .baml and should always be present")
@@ -2368,22 +2368,22 @@ impl InnerClass2ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct InputClassClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl InputClassClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("InputClass is statically defined in .baml and should always have a type")
@@ -2394,14 +2394,14 @@ impl InputClassClassBuilder {
     // =========================================================================
 
     /// Access the `key` field builder.
-    pub fn property_key(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("key")
             .expect("InputClass.key is statically defined in .baml and should always be present")
     }
 
     /// Access the `key2` field builder.
-    pub fn property_key2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("key2")
             .expect("InputClass.key2 is statically defined in .baml and should always be present")
@@ -2414,22 +2414,22 @@ impl InputClassClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct InputClassNestedClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl InputClassNestedClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("InputClassNested is statically defined in .baml and should always have a type")
@@ -2440,14 +2440,14 @@ impl InputClassNestedClassBuilder {
     // =========================================================================
 
     /// Access the `key` field builder.
-    pub fn property_key(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("key").expect(
             "InputClassNested.key is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `nested` field builder.
-    pub fn property_nested(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nested(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nested").expect(
             "InputClassNested.nested is statically defined in .baml and should always be present",
         )
@@ -2460,22 +2460,22 @@ impl InputClassNestedClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct LinkedListClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl LinkedListClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("LinkedList is statically defined in .baml and should always have a type")
@@ -2486,14 +2486,14 @@ impl LinkedListClassBuilder {
     // =========================================================================
 
     /// Access the `head` field builder.
-    pub fn property_head(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_head(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("head")
             .expect("LinkedList.head is statically defined in .baml and should always be present")
     }
 
     /// Access the `len` field builder.
-    pub fn property_len(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_len(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("len")
             .expect("LinkedList.len is statically defined in .baml and should always be present")
@@ -2506,22 +2506,22 @@ impl LinkedListClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct LinkedListAliasNodeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl LinkedListAliasNodeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "LinkedListAliasNode is statically defined in .baml and should always have a type",
         )
@@ -2532,14 +2532,14 @@ impl LinkedListAliasNodeClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value").expect(
             "LinkedListAliasNode.value is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `next` field builder.
-    pub fn property_next(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_next(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("next").expect(
             "LinkedListAliasNode.next is statically defined in .baml and should always be present",
         )
@@ -2552,22 +2552,22 @@ impl LinkedListAliasNodeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct LiteralClassHelloClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl LiteralClassHelloClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "LiteralClassHello is statically defined in .baml and should always have a type",
         )
@@ -2578,7 +2578,7 @@ impl LiteralClassHelloClassBuilder {
     // =========================================================================
 
     /// Access the `prop` field builder.
-    pub fn property_prop(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop").expect(
             "LiteralClassHello.prop is statically defined in .baml and should always be present",
         )
@@ -2591,22 +2591,22 @@ impl LiteralClassHelloClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct LiteralClassOneClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl LiteralClassOneClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("LiteralClassOne is statically defined in .baml and should always have a type")
@@ -2617,7 +2617,7 @@ impl LiteralClassOneClassBuilder {
     // =========================================================================
 
     /// Access the `prop` field builder.
-    pub fn property_prop(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop").expect(
             "LiteralClassOne.prop is statically defined in .baml and should always be present",
         )
@@ -2630,22 +2630,22 @@ impl LiteralClassOneClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct LiteralClassTwoClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl LiteralClassTwoClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("LiteralClassTwo is statically defined in .baml and should always have a type")
@@ -2656,7 +2656,7 @@ impl LiteralClassTwoClassBuilder {
     // =========================================================================
 
     /// Access the `prop` field builder.
-    pub fn property_prop(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop").expect(
             "LiteralClassTwo.prop is statically defined in .baml and should always be present",
         )
@@ -2669,22 +2669,22 @@ impl LiteralClassTwoClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MaintainFieldOrderClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MaintainFieldOrderClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "MaintainFieldOrder is statically defined in .baml and should always have a type",
         )
@@ -2695,21 +2695,21 @@ impl MaintainFieldOrderClassBuilder {
     // =========================================================================
 
     /// Access the `c` field builder.
-    pub fn property_c(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_c(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("c").expect(
             "MaintainFieldOrder.c is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `b` field builder.
-    pub fn property_b(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_b(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("b").expect(
             "MaintainFieldOrder.b is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `a` field builder.
-    pub fn property_a(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_a(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("a").expect(
             "MaintainFieldOrder.a is statically defined in .baml and should always be present",
         )
@@ -2722,22 +2722,22 @@ impl MaintainFieldOrderClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MalformedConstraintsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MalformedConstraintsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "MalformedConstraints is statically defined in .baml and should always have a type",
         )
@@ -2748,7 +2748,7 @@ impl MalformedConstraintsClassBuilder {
     // =========================================================================
 
     /// Access the `foo` field builder.
-    pub fn property_foo(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_foo(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("foo").expect(
             "MalformedConstraints.foo is statically defined in .baml and should always be present",
         )
@@ -2761,22 +2761,22 @@ impl MalformedConstraintsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MalformedConstraints2ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MalformedConstraints2ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "MalformedConstraints2 is statically defined in .baml and should always have a type",
         )
@@ -2787,7 +2787,7 @@ impl MalformedConstraints2ClassBuilder {
     // =========================================================================
 
     /// Access the `foo` field builder.
-    pub fn property_foo(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_foo(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("foo").expect(
             "MalformedConstraints2.foo is statically defined in .baml and should always be present",
         )
@@ -2800,22 +2800,22 @@ impl MalformedConstraints2ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MartianClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MartianClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Martian is statically defined in .baml and should always have a type")
@@ -2826,7 +2826,7 @@ impl MartianClassBuilder {
     // =========================================================================
 
     /// Access the `age` field builder.
-    pub fn property_age(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_age(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("age")
             .expect("Martian.age is statically defined in .baml and should always be present")
@@ -2839,22 +2839,22 @@ impl MartianClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MemoryObjectClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MemoryObjectClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("MemoryObject is statically defined in .baml and should always have a type")
@@ -2865,21 +2865,21 @@ impl MemoryObjectClassBuilder {
     // =========================================================================
 
     /// Access the `id` field builder.
-    pub fn property_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("id")
             .expect("MemoryObject.id is statically defined in .baml and should always be present")
     }
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("MemoryObject.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description").expect(
             "MemoryObject.description is statically defined in .baml and should always be present",
         )
@@ -2892,22 +2892,22 @@ impl MemoryObjectClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct MergeAttrsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl MergeAttrsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("MergeAttrs is statically defined in .baml and should always have a type")
@@ -2918,7 +2918,7 @@ impl MergeAttrsClassBuilder {
     // =========================================================================
 
     /// Access the `amount` field builder.
-    pub fn property_amount(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_amount(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("amount")
             .expect("MergeAttrs.amount is statically defined in .baml and should always be present")
@@ -2931,22 +2931,22 @@ impl MergeAttrsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NamedArgsSingleClassClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NamedArgsSingleClassClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "NamedArgsSingleClass is statically defined in .baml and should always have a type",
         )
@@ -2957,20 +2957,20 @@ impl NamedArgsSingleClassClassBuilder {
     // =========================================================================
 
     /// Access the `key` field builder.
-    pub fn property_key(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("key").expect(
             "NamedArgsSingleClass.key is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `key_two` field builder.
-    pub fn property_key_two(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key_two(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("key_two")
             .expect("NamedArgsSingleClass.key_two is statically defined in .baml and should always be present")
     }
 
     /// Access the `key_three` field builder.
-    pub fn property_key_three(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key_three(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("key_three")
             .expect("NamedArgsSingleClass.key_three is statically defined in .baml and should always be present")
     }
@@ -2982,22 +2982,22 @@ impl NamedArgsSingleClassClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NestedClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NestedClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Nested is statically defined in .baml and should always have a type")
@@ -3008,21 +3008,21 @@ impl NestedClassBuilder {
     // =========================================================================
 
     /// Access the `prop3` field builder.
-    pub fn property_prop3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop3")
             .expect("Nested.prop3 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop4` field builder.
-    pub fn property_prop4(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop4(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop4")
             .expect("Nested.prop4 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop20` field builder.
-    pub fn property_prop20(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop20(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop20")
             .expect("Nested.prop20 is statically defined in .baml and should always be present")
@@ -3035,22 +3035,22 @@ impl NestedClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct Nested2ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl Nested2ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Nested2 is statically defined in .baml and should always have a type")
@@ -3061,14 +3061,14 @@ impl Nested2ClassBuilder {
     // =========================================================================
 
     /// Access the `prop11` field builder.
-    pub fn property_prop11(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop11(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop11")
             .expect("Nested2.prop11 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop12` field builder.
-    pub fn property_prop12(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop12(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop12")
             .expect("Nested2.prop12 is statically defined in .baml and should always be present")
@@ -3081,22 +3081,22 @@ impl Nested2ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NestedBlockConstraintClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NestedBlockConstraintClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "NestedBlockConstraint is statically defined in .baml and should always have a type",
         )
@@ -3107,7 +3107,7 @@ impl NestedBlockConstraintClassBuilder {
     // =========================================================================
 
     /// Access the `nbc` field builder.
-    pub fn property_nbc(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nbc(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nbc").expect(
             "NestedBlockConstraint.nbc is statically defined in .baml and should always be present",
         )
@@ -3120,22 +3120,22 @@ impl NestedBlockConstraintClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NestedBlockConstraintForParamClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NestedBlockConstraintForParamClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type()
             .expect("NestedBlockConstraintForParam is statically defined in .baml and should always have a type")
     }
@@ -3145,7 +3145,7 @@ impl NestedBlockConstraintForParamClassBuilder {
     // =========================================================================
 
     /// Access the `nbcfp` field builder.
-    pub fn property_nbcfp(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nbcfp(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nbcfp")
             .expect("NestedBlockConstraintForParam.nbcfp is statically defined in .baml and should always be present")
     }
@@ -3157,22 +3157,22 @@ impl NestedBlockConstraintForParamClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NodeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NodeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Node is statically defined in .baml and should always have a type")
@@ -3183,14 +3183,14 @@ impl NodeClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Node.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `next` field builder.
-    pub fn property_next(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_next(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("next")
             .expect("Node.next is statically defined in .baml and should always be present")
@@ -3203,22 +3203,22 @@ impl NodeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct NodeWithAliasIndirectionClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl NodeWithAliasIndirectionClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "NodeWithAliasIndirection is statically defined in .baml and should always have a type",
         )
@@ -3229,13 +3229,13 @@ impl NodeWithAliasIndirectionClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value")
             .expect("NodeWithAliasIndirection.value is statically defined in .baml and should always be present")
     }
 
     /// Access the `next` field builder.
-    pub fn property_next(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_next(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("next")
             .expect("NodeWithAliasIndirection.next is statically defined in .baml and should always be present")
     }
@@ -3247,22 +3247,22 @@ impl NodeWithAliasIndirectionClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct Note1599ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl Note1599ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Note1599 is statically defined in .baml and should always have a type")
@@ -3273,21 +3273,21 @@ impl Note1599ClassBuilder {
     // =========================================================================
 
     /// Access the `note_title` field builder.
-    pub fn property_note_title(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_note_title(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("note_title").expect(
             "Note1599.note_title is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `note_description` field builder.
-    pub fn property_note_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_note_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("note_description").expect(
             "Note1599.note_description is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `note_amount` field builder.
-    pub fn property_note_amount(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_note_amount(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("note_amount").expect(
             "Note1599.note_amount is statically defined in .baml and should always be present",
         )
@@ -3300,22 +3300,22 @@ impl Note1599ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OptionalListAndMapClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OptionalListAndMapClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "OptionalListAndMap is statically defined in .baml and should always have a type",
         )
@@ -3326,14 +3326,14 @@ impl OptionalListAndMapClassBuilder {
     // =========================================================================
 
     /// Access the `p` field builder.
-    pub fn property_p(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_p(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("p").expect(
             "OptionalListAndMap.p is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `q` field builder.
-    pub fn property_q(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_q(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("q").expect(
             "OptionalListAndMap.q is statically defined in .baml and should always be present",
         )
@@ -3346,22 +3346,22 @@ impl OptionalListAndMapClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OptionalTest_Prop1ClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OptionalTest_Prop1ClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "OptionalTest_Prop1 is statically defined in .baml and should always have a type",
         )
@@ -3372,13 +3372,13 @@ impl OptionalTest_Prop1ClassBuilder {
     // =========================================================================
 
     /// Access the `omega_a` field builder.
-    pub fn property_omega_a(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_omega_a(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("omega_a")
             .expect("OptionalTest_Prop1.omega_a is statically defined in .baml and should always be present")
     }
 
     /// Access the `omega_b` field builder.
-    pub fn property_omega_b(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_omega_b(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("omega_b")
             .expect("OptionalTest_Prop1.omega_b is statically defined in .baml and should always be present")
     }
@@ -3390,22 +3390,22 @@ impl OptionalTest_Prop1ClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OptionalTest_ReturnTypeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OptionalTest_ReturnTypeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "OptionalTest_ReturnType is statically defined in .baml and should always have a type",
         )
@@ -3416,19 +3416,19 @@ impl OptionalTest_ReturnTypeClassBuilder {
     // =========================================================================
 
     /// Access the `omega_1` field builder.
-    pub fn property_omega_1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_omega_1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("omega_1")
             .expect("OptionalTest_ReturnType.omega_1 is statically defined in .baml and should always be present")
     }
 
     /// Access the `omega_2` field builder.
-    pub fn property_omega_2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_omega_2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("omega_2")
             .expect("OptionalTest_ReturnType.omega_2 is statically defined in .baml and should always be present")
     }
 
     /// Access the `omega_3` field builder.
-    pub fn property_omega_3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_omega_3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("omega_3")
             .expect("OptionalTest_ReturnType.omega_3 is statically defined in .baml and should always be present")
     }
@@ -3440,22 +3440,22 @@ impl OptionalTest_ReturnTypeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OrderInfoClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OrderInfoClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("OrderInfo is statically defined in .baml and should always have a type")
@@ -3466,21 +3466,21 @@ impl OrderInfoClassBuilder {
     // =========================================================================
 
     /// Access the `order_status` field builder.
-    pub fn property_order_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_order_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("order_status").expect(
             "OrderInfo.order_status is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `tracking_number` field builder.
-    pub fn property_tracking_number(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tracking_number(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("tracking_number").expect(
             "OrderInfo.tracking_number is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `estimated_arrival_date` field builder.
-    pub fn property_estimated_arrival_date(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_estimated_arrival_date(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("estimated_arrival_date")
             .expect("OrderInfo.estimated_arrival_date is statically defined in .baml and should always be present")
     }
@@ -3492,22 +3492,22 @@ impl OrderInfoClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct OriginalAClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OriginalAClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("OriginalA is statically defined in .baml and should always have a type")
@@ -3518,7 +3518,7 @@ impl OriginalAClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("value")
             .expect("OriginalA.value is statically defined in .baml and should always be present")
@@ -3534,22 +3534,22 @@ impl OriginalAClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct OriginalBClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl OriginalBClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("OriginalB is statically defined in .baml and should always have a type")
@@ -3559,8 +3559,8 @@ impl OriginalBClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -3569,7 +3569,7 @@ impl OriginalBClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("value")
             .expect("OriginalB.value is statically defined in .baml and should always be present")
@@ -3585,22 +3585,22 @@ impl OriginalBClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct PersonClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PersonClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Person is statically defined in .baml and should always have a type")
@@ -3610,8 +3610,8 @@ impl PersonClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -3620,14 +3620,14 @@ impl PersonClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Person.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `hair_color` field builder.
-    pub fn property_hair_color(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_hair_color(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("hair_color")
             .expect("Person.hair_color is statically defined in .baml and should always be present")
@@ -3640,22 +3640,22 @@ impl PersonClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PersonWithMetaClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PersonWithMetaClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("PersonWithMeta is statically defined in .baml and should always have a type")
@@ -3666,28 +3666,28 @@ impl PersonWithMetaClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("name").expect(
             "PersonWithMeta.name is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `age` field builder.
-    pub fn property_age(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_age(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("age").expect(
             "PersonWithMeta.age is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `address` field builder.
-    pub fn property_address(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_address(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("address").expect(
             "PersonWithMeta.address is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("tags").expect(
             "PersonWithMeta.tags is statically defined in .baml and should always be present",
         )
@@ -3700,22 +3700,22 @@ impl PersonWithMetaClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct PhoneNumberClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl PhoneNumberClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("PhoneNumber is statically defined in .baml and should always have a type")
@@ -3726,7 +3726,7 @@ impl PhoneNumberClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("value")
             .expect("PhoneNumber.value is statically defined in .baml and should always be present")
@@ -3739,22 +3739,22 @@ impl PhoneNumberClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct QuantityClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl QuantityClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Quantity is statically defined in .baml and should always have a type")
@@ -3765,14 +3765,14 @@ impl QuantityClassBuilder {
     // =========================================================================
 
     /// Access the `amount` field builder.
-    pub fn property_amount(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_amount(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("amount")
             .expect("Quantity.amount is statically defined in .baml and should always be present")
     }
 
     /// Access the `unit` field builder.
-    pub fn property_unit(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_unit(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("unit")
             .expect("Quantity.unit is statically defined in .baml and should always be present")
@@ -3785,22 +3785,22 @@ impl QuantityClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct RaysDataClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RaysDataClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("RaysData is statically defined in .baml and should always have a type")
@@ -3811,14 +3811,14 @@ impl RaysDataClassBuilder {
     // =========================================================================
 
     /// Access the `dataType` field builder.
-    pub fn property_dataType(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_dataType(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("dataType")
             .expect("RaysData.dataType is statically defined in .baml and should always be present")
     }
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("value")
             .expect("RaysData.value is statically defined in .baml and should always be present")
@@ -3831,22 +3831,22 @@ impl RaysDataClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ReceiptInfoClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ReceiptInfoClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ReceiptInfo is statically defined in .baml and should always have a type")
@@ -3857,21 +3857,21 @@ impl ReceiptInfoClassBuilder {
     // =========================================================================
 
     /// Access the `items` field builder.
-    pub fn property_items(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_items(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("items")
             .expect("ReceiptInfo.items is statically defined in .baml and should always be present")
     }
 
     /// Access the `total_cost` field builder.
-    pub fn property_total_cost(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_total_cost(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("total_cost").expect(
             "ReceiptInfo.total_cost is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `venue` field builder.
-    pub fn property_venue(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_venue(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("venue")
             .expect("ReceiptInfo.venue is statically defined in .baml and should always be present")
@@ -3884,22 +3884,22 @@ impl ReceiptInfoClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ReceiptItemClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ReceiptItemClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("ReceiptItem is statically defined in .baml and should always have a type")
@@ -3910,28 +3910,28 @@ impl ReceiptItemClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("ReceiptItem.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description").expect(
             "ReceiptItem.description is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `quantity` field builder.
-    pub fn property_quantity(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_quantity(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("quantity").expect(
             "ReceiptItem.quantity is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `price` field builder.
-    pub fn property_price(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_price(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("price")
             .expect("ReceiptItem.price is statically defined in .baml and should always be present")
@@ -3944,22 +3944,22 @@ impl ReceiptItemClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct RecipeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RecipeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Recipe is statically defined in .baml and should always have a type")
@@ -3970,14 +3970,14 @@ impl RecipeClassBuilder {
     // =========================================================================
 
     /// Access the `ingredients` field builder.
-    pub fn property_ingredients(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_ingredients(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("ingredients").expect(
             "Recipe.ingredients is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `recipe_type` field builder.
-    pub fn property_recipe_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_recipe_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("recipe_type").expect(
             "Recipe.recipe_type is statically defined in .baml and should always be present",
         )
@@ -3990,22 +3990,22 @@ impl RecipeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct RecursiveAliasDependencyClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RecursiveAliasDependencyClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "RecursiveAliasDependency is statically defined in .baml and should always have a type",
         )
@@ -4016,7 +4016,7 @@ impl RecursiveAliasDependencyClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value")
             .expect("RecursiveAliasDependency.value is statically defined in .baml and should always be present")
     }
@@ -4031,22 +4031,22 @@ impl RecursiveAliasDependencyClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct RenderEnumInputClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RenderEnumInputClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("RenderEnumInput is statically defined in .baml and should always have a type")
@@ -4056,8 +4056,8 @@ impl RenderEnumInputClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -4066,7 +4066,7 @@ impl RenderEnumInputClassBuilder {
     // =========================================================================
 
     /// Access the `testKey` field builder.
-    pub fn property_testKey(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_testKey(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("testKey").expect(
             "RenderEnumInput.testKey is statically defined in .baml and should always be present",
         )
@@ -4082,22 +4082,22 @@ impl RenderEnumInputClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct RenderTestClassClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl RenderTestClassClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("RenderTestClass is statically defined in .baml and should always have a type")
@@ -4107,8 +4107,8 @@ impl RenderTestClassClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -4117,14 +4117,14 @@ impl RenderTestClassClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("name").expect(
             "RenderTestClass.name is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `status` field builder.
-    pub fn property_status(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_status(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("status").expect(
             "RenderTestClass.status is statically defined in .baml and should always be present",
         )
@@ -4137,22 +4137,22 @@ impl RenderTestClassClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct ResumeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl ResumeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Resume is statically defined in .baml and should always have a type")
@@ -4163,42 +4163,42 @@ impl ResumeClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("name")
             .expect("Resume.name is statically defined in .baml and should always be present")
     }
 
     /// Access the `email` field builder.
-    pub fn property_email(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_email(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("email")
             .expect("Resume.email is statically defined in .baml and should always be present")
     }
 
     /// Access the `phone` field builder.
-    pub fn property_phone(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_phone(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("phone")
             .expect("Resume.phone is statically defined in .baml and should always be present")
     }
 
     /// Access the `experience` field builder.
-    pub fn property_experience(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_experience(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("experience")
             .expect("Resume.experience is statically defined in .baml and should always be present")
     }
 
     /// Access the `education` field builder.
-    pub fn property_education(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_education(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("education")
             .expect("Resume.education is statically defined in .baml and should always be present")
     }
 
     /// Access the `skills` field builder.
-    pub fn property_skills(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_skills(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("skills")
             .expect("Resume.skills is statically defined in .baml and should always be present")
@@ -4211,22 +4211,22 @@ impl ResumeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SchemaClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SchemaClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Schema is statically defined in .baml and should always have a type")
@@ -4237,49 +4237,49 @@ impl SchemaClassBuilder {
     // =========================================================================
 
     /// Access the `prop1` field builder.
-    pub fn property_prop1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop1")
             .expect("Schema.prop1 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop2` field builder.
-    pub fn property_prop2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop2")
             .expect("Schema.prop2 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop5` field builder.
-    pub fn property_prop5(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop5(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop5")
             .expect("Schema.prop5 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop6` field builder.
-    pub fn property_prop6(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop6(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("prop6")
             .expect("Schema.prop6 is statically defined in .baml and should always be present")
     }
 
     /// Access the `nested_attrs` field builder.
-    pub fn property_nested_attrs(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_nested_attrs(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("nested_attrs").expect(
             "Schema.nested_attrs is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `parens` field builder.
-    pub fn property_parens(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_parens(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("parens")
             .expect("Schema.parens is statically defined in .baml and should always be present")
     }
 
     /// Access the `other_group` field builder.
-    pub fn property_other_group(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_other_group(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("other_group").expect(
             "Schema.other_group is statically defined in .baml and should always be present",
         )
@@ -4292,22 +4292,22 @@ impl SchemaClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SearchParamsClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SearchParamsClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SearchParams is statically defined in .baml and should always have a type")
@@ -4318,42 +4318,42 @@ impl SearchParamsClassBuilder {
     // =========================================================================
 
     /// Access the `dateRange` field builder.
-    pub fn property_dateRange(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_dateRange(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("dateRange").expect(
             "SearchParams.dateRange is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `location` field builder.
-    pub fn property_location(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_location(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("location").expect(
             "SearchParams.location is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `jobTitle` field builder.
-    pub fn property_jobTitle(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_jobTitle(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("jobTitle").expect(
             "SearchParams.jobTitle is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `company` field builder.
-    pub fn property_company(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_company(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("company").expect(
             "SearchParams.company is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description").expect(
             "SearchParams.description is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `tags` field builder.
-    pub fn property_tags(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_tags(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("tags")
             .expect("SearchParams.tags is statically defined in .baml and should always be present")
@@ -4366,22 +4366,22 @@ impl SearchParamsClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SemanticContainerClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SemanticContainerClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "SemanticContainer is statically defined in .baml and should always have a type",
         )
@@ -4392,51 +4392,51 @@ impl SemanticContainerClassBuilder {
     // =========================================================================
 
     /// Access the `sixteen_digit_number` field builder.
-    pub fn property_sixteen_digit_number(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_sixteen_digit_number(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("sixteen_digit_number")
             .expect("SemanticContainer.sixteen_digit_number is statically defined in .baml and should always be present")
     }
 
     /// Access the `string_with_twenty_words` field builder.
-    pub fn property_string_with_twenty_words(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_string_with_twenty_words(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("string_with_twenty_words")
             .expect("SemanticContainer.string_with_twenty_words is statically defined in .baml and should always be present")
     }
 
     /// Access the `class_1` field builder.
-    pub fn property_class_1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_class_1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("class_1").expect(
             "SemanticContainer.class_1 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `class_2` field builder.
-    pub fn property_class_2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_class_2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("class_2").expect(
             "SemanticContainer.class_2 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `class_done_needed` field builder.
-    pub fn property_class_done_needed(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_class_done_needed(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("class_done_needed")
             .expect("SemanticContainer.class_done_needed is statically defined in .baml and should always be present")
     }
 
     /// Access the `class_needed` field builder.
-    pub fn property_class_needed(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_class_needed(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("class_needed")
             .expect("SemanticContainer.class_needed is statically defined in .baml and should always be present")
     }
 
     /// Access the `three_small_things` field builder.
-    pub fn property_three_small_things(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_three_small_things(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("three_small_things")
             .expect("SemanticContainer.three_small_things is statically defined in .baml and should always be present")
     }
 
     /// Access the `final_string` field builder.
-    pub fn property_final_string(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_final_string(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("final_string")
             .expect("SemanticContainer.final_string is statically defined in .baml and should always be present")
     }
@@ -4448,22 +4448,22 @@ impl SemanticContainerClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SimpleTagClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SimpleTagClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SimpleTag is statically defined in .baml and should always have a type")
@@ -4474,7 +4474,7 @@ impl SimpleTagClassBuilder {
     // =========================================================================
 
     /// Access the `field` field builder.
-    pub fn property_field(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_field(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("field")
             .expect("SimpleTag.field is statically defined in .baml and should always be present")
@@ -4490,22 +4490,22 @@ impl SimpleTagClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct SkipDynamicClassClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SkipDynamicClassClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SkipDynamicClass is statically defined in .baml and should always have a type")
@@ -4515,8 +4515,8 @@ impl SkipDynamicClassClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -4525,14 +4525,14 @@ impl SkipDynamicClassClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value").expect(
             "SkipDynamicClass.value is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `internal_id` field builder.
-    pub fn property_internal_id(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_internal_id(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("internal_id")
             .expect("SkipDynamicClass.internal_id is statically defined in .baml and should always be present")
     }
@@ -4544,22 +4544,22 @@ impl SkipDynamicClassClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SkipNonDynamicClassClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SkipNonDynamicClassClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "SkipNonDynamicClass is statically defined in .baml and should always have a type",
         )
@@ -4570,20 +4570,20 @@ impl SkipNonDynamicClassClassBuilder {
     // =========================================================================
 
     /// Access the `name` field builder.
-    pub fn property_name(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_name(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("name").expect(
             "SkipNonDynamicClass.name is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `description` field builder.
-    pub fn property_description(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_description(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("description")
             .expect("SkipNonDynamicClass.description is statically defined in .baml and should always be present")
     }
 
     /// Access the `metadata` field builder.
-    pub fn property_metadata(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_metadata(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("metadata")
             .expect("SkipNonDynamicClass.metadata is statically defined in .baml and should always be present")
     }
@@ -4595,22 +4595,22 @@ impl SkipNonDynamicClassClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct SmallThingClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SmallThingClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("SmallThing is statically defined in .baml and should always have a type")
@@ -4621,14 +4621,14 @@ impl SmallThingClassBuilder {
     // =========================================================================
 
     /// Access the `i_16_digits` field builder.
-    pub fn property_i_16_digits(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_i_16_digits(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("i_16_digits").expect(
             "SmallThing.i_16_digits is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `i_8_digits` field builder.
-    pub fn property_i_8_digits(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_i_8_digits(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("i_8_digits").expect(
             "SmallThing.i_8_digits is statically defined in .baml and should always be present",
         )
@@ -4644,22 +4644,22 @@ impl SmallThingClassBuilder {
 /// This class is marked `@@dynamic` - you can add new properties at runtime.
 
 pub struct SomeClassNestedDynamicClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl SomeClassNestedDynamicClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "SomeClassNestedDynamic is statically defined in .baml and should always have a type",
         )
@@ -4669,8 +4669,8 @@ impl SomeClassNestedDynamicClassBuilder {
     pub fn add_property(
         &self,
         name: &str,
-        field_type: &baml::TypeDef,
-    ) -> Result<baml::ClassPropertyBuilder, baml::BamlError> {
+        field_type: &::baml::TypeDef,
+    ) -> ::std::result::Result<&mut Self, ::baml::BamlError> {
         self.inner.add_property(name, field_type)
     }
 
@@ -4679,7 +4679,7 @@ impl SomeClassNestedDynamicClassBuilder {
     // =========================================================================
 
     /// Access the `hi` field builder.
-    pub fn property_hi(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_hi(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("hi").expect(
             "SomeClassNestedDynamic.hi is statically defined in .baml and should always be present",
         )
@@ -4692,22 +4692,22 @@ impl SomeClassNestedDynamicClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct StringToClassEntryClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl StringToClassEntryClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "StringToClassEntry is statically defined in .baml and should always have a type",
         )
@@ -4718,7 +4718,7 @@ impl StringToClassEntryClassBuilder {
     // =========================================================================
 
     /// Access the `word` field builder.
-    pub fn property_word(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_word(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("word").expect(
             "StringToClassEntry.word is statically defined in .baml and should always be present",
         )
@@ -4731,22 +4731,22 @@ impl StringToClassEntryClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TestClassAliasClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TestClassAliasClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("TestClassAlias is statically defined in .baml and should always have a type")
@@ -4757,35 +4757,35 @@ impl TestClassAliasClassBuilder {
     // =========================================================================
 
     /// Access the `key` field builder.
-    pub fn property_key(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("key").expect(
             "TestClassAlias.key is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `key2` field builder.
-    pub fn property_key2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("key2").expect(
             "TestClassAlias.key2 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `key3` field builder.
-    pub fn property_key3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("key3").expect(
             "TestClassAlias.key3 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `key4` field builder.
-    pub fn property_key4(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key4(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("key4").expect(
             "TestClassAlias.key4 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `key5` field builder.
-    pub fn property_key5(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_key5(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("key5").expect(
             "TestClassAlias.key5 is statically defined in .baml and should always be present",
         )
@@ -4798,22 +4798,22 @@ impl TestClassAliasClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TestClassNestedClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TestClassNestedClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("TestClassNested is statically defined in .baml and should always have a type")
@@ -4824,14 +4824,14 @@ impl TestClassNestedClassBuilder {
     // =========================================================================
 
     /// Access the `prop1` field builder.
-    pub fn property_prop1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop1").expect(
             "TestClassNested.prop1 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `prop2` field builder.
-    pub fn property_prop2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop2").expect(
             "TestClassNested.prop2 is statically defined in .baml and should always be present",
         )
@@ -4844,22 +4844,22 @@ impl TestClassNestedClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TestClassWithEnumClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TestClassWithEnumClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "TestClassWithEnum is statically defined in .baml and should always have a type",
         )
@@ -4870,14 +4870,14 @@ impl TestClassWithEnumClassBuilder {
     // =========================================================================
 
     /// Access the `prop1` field builder.
-    pub fn property_prop1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop1").expect(
             "TestClassWithEnum.prop1 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `prop2` field builder.
-    pub fn property_prop2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop2").expect(
             "TestClassWithEnum.prop2 is statically defined in .baml and should always be present",
         )
@@ -4890,22 +4890,22 @@ impl TestClassWithEnumClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TestMemoryOutputClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TestMemoryOutputClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("TestMemoryOutput is statically defined in .baml and should always have a type")
@@ -4916,14 +4916,14 @@ impl TestMemoryOutputClassBuilder {
     // =========================================================================
 
     /// Access the `items` field builder.
-    pub fn property_items(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_items(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("items").expect(
             "TestMemoryOutput.items is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `more_items` field builder.
-    pub fn property_more_items(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_more_items(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("more_items")
             .expect("TestMemoryOutput.more_items is statically defined in .baml and should always be present")
     }
@@ -4935,22 +4935,22 @@ impl TestMemoryOutputClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TestOutputClassClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TestOutputClassClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("TestOutputClass is statically defined in .baml and should always have a type")
@@ -4961,14 +4961,14 @@ impl TestOutputClassClassBuilder {
     // =========================================================================
 
     /// Access the `prop1` field builder.
-    pub fn property_prop1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop1").expect(
             "TestOutputClass.prop1 is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `prop2` field builder.
-    pub fn property_prop2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop2").expect(
             "TestOutputClass.prop2 is statically defined in .baml and should always be present",
         )
@@ -4981,22 +4981,22 @@ impl TestOutputClassClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TodoMessageToUserClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TodoMessageToUserClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "TodoMessageToUser is statically defined in .baml and should always have a type",
         )
@@ -5007,14 +5007,14 @@ impl TodoMessageToUserClassBuilder {
     // =========================================================================
 
     /// Access the `r#type` field builder.
-    pub fn property_type(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_type(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("type").expect(
             "TodoMessageToUser.type is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `message` field builder.
-    pub fn property_message(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_message(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("message").expect(
             "TodoMessageToUser.message is statically defined in .baml and should always be present",
         )
@@ -5027,22 +5027,22 @@ impl TodoMessageToUserClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TreeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TreeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Tree is statically defined in .baml and should always have a type")
@@ -5053,14 +5053,14 @@ impl TreeClassBuilder {
     // =========================================================================
 
     /// Access the `data` field builder.
-    pub fn property_data(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_data(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("data")
             .expect("Tree.data is statically defined in .baml and should always be present")
     }
 
     /// Access the `children` field builder.
-    pub fn property_children(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_children(&self) -> ::baml::ClassPropertyBuilder {
         self.inner
             .get_property("children")
             .expect("Tree.children is statically defined in .baml and should always be present")
@@ -5073,22 +5073,22 @@ impl TreeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TwoStoriesOneTitleClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TwoStoriesOneTitleClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "TwoStoriesOneTitle is statically defined in .baml and should always have a type",
         )
@@ -5099,20 +5099,20 @@ impl TwoStoriesOneTitleClassBuilder {
     // =========================================================================
 
     /// Access the `title` field builder.
-    pub fn property_title(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_title(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("title").expect(
             "TwoStoriesOneTitle.title is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `story_a` field builder.
-    pub fn property_story_a(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_story_a(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("story_a")
             .expect("TwoStoriesOneTitle.story_a is statically defined in .baml and should always be present")
     }
 
     /// Access the `story_b` field builder.
-    pub fn property_story_b(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_story_b(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("story_b")
             .expect("TwoStoriesOneTitle.story_b is statically defined in .baml and should always be present")
     }
@@ -5124,22 +5124,22 @@ impl TwoStoriesOneTitleClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct TwoStoriesOneTitleCheckClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl TwoStoriesOneTitleCheckClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "TwoStoriesOneTitleCheck is statically defined in .baml and should always have a type",
         )
@@ -5150,19 +5150,19 @@ impl TwoStoriesOneTitleCheckClassBuilder {
     // =========================================================================
 
     /// Access the `title` field builder.
-    pub fn property_title(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_title(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("title")
             .expect("TwoStoriesOneTitleCheck.title is statically defined in .baml and should always be present")
     }
 
     /// Access the `story_a` field builder.
-    pub fn property_story_a(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_story_a(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("story_a")
             .expect("TwoStoriesOneTitleCheck.story_a is statically defined in .baml and should always be present")
     }
 
     /// Access the `story_b` field builder.
-    pub fn property_story_b(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_story_b(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("story_b")
             .expect("TwoStoriesOneTitleCheck.story_b is statically defined in .baml and should always be present")
     }
@@ -5174,22 +5174,22 @@ impl TwoStoriesOneTitleCheckClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UnionTest_ReturnTypeClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UnionTest_ReturnTypeClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "UnionTest_ReturnType is statically defined in .baml and should always have a type",
         )
@@ -5200,19 +5200,19 @@ impl UnionTest_ReturnTypeClassBuilder {
     // =========================================================================
 
     /// Access the `prop1` field builder.
-    pub fn property_prop1(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop1(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop1")
             .expect("UnionTest_ReturnType.prop1 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop2` field builder.
-    pub fn property_prop2(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop2(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop2")
             .expect("UnionTest_ReturnType.prop2 is statically defined in .baml and should always be present")
     }
 
     /// Access the `prop3` field builder.
-    pub fn property_prop3(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_prop3(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("prop3")
             .expect("UnionTest_ReturnType.prop3 is statically defined in .baml and should always be present")
     }
@@ -5224,22 +5224,22 @@ impl UnionTest_ReturnTypeClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UniverseQuestionClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UniverseQuestionClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("UniverseQuestion is statically defined in .baml and should always have a type")
@@ -5250,14 +5250,14 @@ impl UniverseQuestionClassBuilder {
     // =========================================================================
 
     /// Access the `question` field builder.
-    pub fn property_question(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_question(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("question").expect(
             "UniverseQuestion.question is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `answer` field builder.
-    pub fn property_answer(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_answer(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("answer").expect(
             "UniverseQuestion.answer is statically defined in .baml and should always be present",
         )
@@ -5270,22 +5270,22 @@ impl UniverseQuestionClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct UniverseQuestionInputClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl UniverseQuestionInputClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "UniverseQuestionInput is statically defined in .baml and should always have a type",
         )
@@ -5296,7 +5296,7 @@ impl UniverseQuestionInputClassBuilder {
     // =========================================================================
 
     /// Access the `question` field builder.
-    pub fn property_question(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_question(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("question")
             .expect("UniverseQuestionInput.question is statically defined in .baml and should always be present")
     }
@@ -5308,22 +5308,22 @@ impl UniverseQuestionInputClassBuilder {
 /// Access fields via methods: `builder.field_name()`
 
 pub struct WithReasoningClassBuilder {
-    inner: baml::ClassBuilder,
+    inner: ::baml::ClassBuilder,
 }
 
 impl WithReasoningClassBuilder {
     /// Create wrapper from runtime ClassBuilder.
-    pub(crate) fn new(inner: baml::ClassBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::ClassBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying ClassBuilder.
-    pub fn inner(&self) -> &baml::ClassBuilder {
+    pub fn inner(&self) -> &::baml::ClassBuilder {
         &self.inner
     }
 
     /// Get the class as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("WithReasoning is statically defined in .baml and should always have a type")
@@ -5334,14 +5334,14 @@ impl WithReasoningClassBuilder {
     // =========================================================================
 
     /// Access the `value` field builder.
-    pub fn property_value(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_value(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("value").expect(
             "WithReasoning.value is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `reasoning` field builder.
-    pub fn property_reasoning(&self) -> baml::ClassPropertyBuilder {
+    pub fn property_reasoning(&self) -> ::baml::ClassPropertyBuilder {
         self.inner.get_property("reasoning").expect(
             "WithReasoning.reasoning is statically defined in .baml and should always be present",
         )

--- a/integ-tests/rust/src/baml_client/type_builder/enums.rs
+++ b/integ-tests/rust/src/baml_client/type_builder/enums.rs
@@ -11,22 +11,22 @@
 /// Access values via methods: `builder.ValueName()`
 
 pub struct AliasedEnumEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl AliasedEnumEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("AliasedEnum is statically defined in .baml and should always have a type")
@@ -37,14 +37,14 @@ impl AliasedEnumEnumBuilder {
     // =========================================================================
 
     /// Access the `KEY_ONE` value builder.
-    pub fn value_KEY_ONE(&self) -> baml::EnumValueBuilder {
+    pub fn value_KEY_ONE(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("KEY_ONE").expect(
             "AliasedEnum.KEY_ONE is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `KEY_TWO` value builder.
-    pub fn value_KEY_TWO(&self) -> baml::EnumValueBuilder {
+    pub fn value_KEY_TWO(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("KEY_TWO").expect(
             "AliasedEnum.KEY_TWO is statically defined in .baml and should always be present",
         )
@@ -57,22 +57,22 @@ impl AliasedEnumEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct CategoryEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl CategoryEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Category is statically defined in .baml and should always have a type")
@@ -83,35 +83,35 @@ impl CategoryEnumBuilder {
     // =========================================================================
 
     /// Access the `Refund` value builder.
-    pub fn value_Refund(&self) -> baml::EnumValueBuilder {
+    pub fn value_Refund(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Refund")
             .expect("Category.Refund is statically defined in .baml and should always be present")
     }
 
     /// Access the `CancelOrder` value builder.
-    pub fn value_CancelOrder(&self) -> baml::EnumValueBuilder {
+    pub fn value_CancelOrder(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("CancelOrder").expect(
             "Category.CancelOrder is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `TechnicalSupport` value builder.
-    pub fn value_TechnicalSupport(&self) -> baml::EnumValueBuilder {
+    pub fn value_TechnicalSupport(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("TechnicalSupport").expect(
             "Category.TechnicalSupport is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `AccountIssue` value builder.
-    pub fn value_AccountIssue(&self) -> baml::EnumValueBuilder {
+    pub fn value_AccountIssue(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("AccountIssue").expect(
             "Category.AccountIssue is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `Question` value builder.
-    pub fn value_Question(&self) -> baml::EnumValueBuilder {
+    pub fn value_Question(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Question")
             .expect("Category.Question is statically defined in .baml and should always be present")
@@ -124,22 +124,22 @@ impl CategoryEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct Category2EnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl Category2EnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Category2 is statically defined in .baml and should always have a type")
@@ -150,34 +150,34 @@ impl Category2EnumBuilder {
     // =========================================================================
 
     /// Access the `Refund` value builder.
-    pub fn value_Refund(&self) -> baml::EnumValueBuilder {
+    pub fn value_Refund(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Refund")
             .expect("Category2.Refund is statically defined in .baml and should always be present")
     }
 
     /// Access the `CancelOrder` value builder.
-    pub fn value_CancelOrder(&self) -> baml::EnumValueBuilder {
+    pub fn value_CancelOrder(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("CancelOrder").expect(
             "Category2.CancelOrder is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `TechnicalSupport` value builder.
-    pub fn value_TechnicalSupport(&self) -> baml::EnumValueBuilder {
+    pub fn value_TechnicalSupport(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("TechnicalSupport")
             .expect("Category2.TechnicalSupport is statically defined in .baml and should always be present")
     }
 
     /// Access the `AccountIssue` value builder.
-    pub fn value_AccountIssue(&self) -> baml::EnumValueBuilder {
+    pub fn value_AccountIssue(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("AccountIssue").expect(
             "Category2.AccountIssue is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `Question` value builder.
-    pub fn value_Question(&self) -> baml::EnumValueBuilder {
+    pub fn value_Question(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("Question").expect(
             "Category2.Question is statically defined in .baml and should always be present",
         )
@@ -190,22 +190,22 @@ impl Category2EnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct Category3EnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl Category3EnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Category3 is statically defined in .baml and should always have a type")
@@ -216,34 +216,34 @@ impl Category3EnumBuilder {
     // =========================================================================
 
     /// Access the `Refund` value builder.
-    pub fn value_Refund(&self) -> baml::EnumValueBuilder {
+    pub fn value_Refund(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Refund")
             .expect("Category3.Refund is statically defined in .baml and should always be present")
     }
 
     /// Access the `CancelOrder` value builder.
-    pub fn value_CancelOrder(&self) -> baml::EnumValueBuilder {
+    pub fn value_CancelOrder(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("CancelOrder").expect(
             "Category3.CancelOrder is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `TechnicalSupport` value builder.
-    pub fn value_TechnicalSupport(&self) -> baml::EnumValueBuilder {
+    pub fn value_TechnicalSupport(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("TechnicalSupport")
             .expect("Category3.TechnicalSupport is statically defined in .baml and should always be present")
     }
 
     /// Access the `AccountIssue` value builder.
-    pub fn value_AccountIssue(&self) -> baml::EnumValueBuilder {
+    pub fn value_AccountIssue(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("AccountIssue").expect(
             "Category3.AccountIssue is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `Question` value builder.
-    pub fn value_Question(&self) -> baml::EnumValueBuilder {
+    pub fn value_Question(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("Question").expect(
             "Category3.Question is statically defined in .baml and should always be present",
         )
@@ -259,29 +259,32 @@ impl Category3EnumBuilder {
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 
 pub struct ColorEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl ColorEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Color is statically defined in .baml and should always have a type")
     }
 
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(
+        &self,
+        value: &str,
+    ) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -290,42 +293,42 @@ impl ColorEnumBuilder {
     // =========================================================================
 
     /// Access the `RED` value builder.
-    pub fn value_RED(&self) -> baml::EnumValueBuilder {
+    pub fn value_RED(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("RED")
             .expect("Color.RED is statically defined in .baml and should always be present")
     }
 
     /// Access the `BLUE` value builder.
-    pub fn value_BLUE(&self) -> baml::EnumValueBuilder {
+    pub fn value_BLUE(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("BLUE")
             .expect("Color.BLUE is statically defined in .baml and should always be present")
     }
 
     /// Access the `GREEN` value builder.
-    pub fn value_GREEN(&self) -> baml::EnumValueBuilder {
+    pub fn value_GREEN(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("GREEN")
             .expect("Color.GREEN is statically defined in .baml and should always be present")
     }
 
     /// Access the `YELLOW` value builder.
-    pub fn value_YELLOW(&self) -> baml::EnumValueBuilder {
+    pub fn value_YELLOW(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("YELLOW")
             .expect("Color.YELLOW is statically defined in .baml and should always be present")
     }
 
     /// Access the `BLACK` value builder.
-    pub fn value_BLACK(&self) -> baml::EnumValueBuilder {
+    pub fn value_BLACK(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("BLACK")
             .expect("Color.BLACK is statically defined in .baml and should always be present")
     }
 
     /// Access the `WHITE` value builder.
-    pub fn value_WHITE(&self) -> baml::EnumValueBuilder {
+    pub fn value_WHITE(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("WHITE")
             .expect("Color.WHITE is statically defined in .baml and should always be present")
@@ -338,22 +341,22 @@ impl ColorEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct DataTypeEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl DataTypeEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DataType is statically defined in .baml and should always have a type")
@@ -364,14 +367,14 @@ impl DataTypeEnumBuilder {
     // =========================================================================
 
     /// Access the `Resume` value builder.
-    pub fn value_Resume(&self) -> baml::EnumValueBuilder {
+    pub fn value_Resume(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Resume")
             .expect("DataType.Resume is statically defined in .baml and should always be present")
     }
 
     /// Access the `Event` value builder.
-    pub fn value_Event(&self) -> baml::EnumValueBuilder {
+    pub fn value_Event(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Event")
             .expect("DataType.Event is statically defined in .baml and should always be present")
@@ -387,29 +390,32 @@ impl DataTypeEnumBuilder {
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 
 pub struct DynEnumOneEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl DynEnumOneEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DynEnumOne is statically defined in .baml and should always have a type")
     }
 
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(
+        &self,
+        value: &str,
+    ) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -427,29 +433,32 @@ impl DynEnumOneEnumBuilder {
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 
 pub struct DynEnumThreeEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl DynEnumThreeEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DynEnumThree is statically defined in .baml and should always have a type")
     }
 
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(
+        &self,
+        value: &str,
+    ) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -458,14 +467,14 @@ impl DynEnumThreeEnumBuilder {
     // =========================================================================
 
     /// Access the `TRICYCLE` value builder.
-    pub fn value_TRICYCLE(&self) -> baml::EnumValueBuilder {
+    pub fn value_TRICYCLE(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("TRICYCLE").expect(
             "DynEnumThree.TRICYCLE is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `TRIANGLE` value builder.
-    pub fn value_TRIANGLE(&self) -> baml::EnumValueBuilder {
+    pub fn value_TRIANGLE(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("TRIANGLE").expect(
             "DynEnumThree.TRIANGLE is statically defined in .baml and should always be present",
         )
@@ -481,29 +490,32 @@ impl DynEnumThreeEnumBuilder {
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 
 pub struct DynEnumTwoEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl DynEnumTwoEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("DynEnumTwo is statically defined in .baml and should always have a type")
     }
 
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(
+        &self,
+        value: &str,
+    ) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -518,22 +530,22 @@ impl DynEnumTwoEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct EnumInClassEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl EnumInClassEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("EnumInClass is statically defined in .baml and should always have a type")
@@ -544,14 +556,14 @@ impl EnumInClassEnumBuilder {
     // =========================================================================
 
     /// Access the `ONE` value builder.
-    pub fn value_ONE(&self) -> baml::EnumValueBuilder {
+    pub fn value_ONE(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("ONE")
             .expect("EnumInClass.ONE is statically defined in .baml and should always be present")
     }
 
     /// Access the `TWO` value builder.
-    pub fn value_TWO(&self) -> baml::EnumValueBuilder {
+    pub fn value_TWO(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("TWO")
             .expect("EnumInClass.TWO is statically defined in .baml and should always be present")
@@ -564,22 +576,22 @@ impl EnumInClassEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct EnumOutputEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl EnumOutputEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("EnumOutput is statically defined in .baml and should always have a type")
@@ -590,21 +602,21 @@ impl EnumOutputEnumBuilder {
     // =========================================================================
 
     /// Access the `ONE` value builder.
-    pub fn value_ONE(&self) -> baml::EnumValueBuilder {
+    pub fn value_ONE(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("ONE")
             .expect("EnumOutput.ONE is statically defined in .baml and should always be present")
     }
 
     /// Access the `TWO` value builder.
-    pub fn value_TWO(&self) -> baml::EnumValueBuilder {
+    pub fn value_TWO(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("TWO")
             .expect("EnumOutput.TWO is statically defined in .baml and should always be present")
     }
 
     /// Access the `THREE` value builder.
-    pub fn value_THREE(&self) -> baml::EnumValueBuilder {
+    pub fn value_THREE(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("THREE")
             .expect("EnumOutput.THREE is statically defined in .baml and should always be present")
@@ -620,29 +632,32 @@ impl EnumOutputEnumBuilder {
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 
 pub struct HobbyEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl HobbyEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Hobby is statically defined in .baml and should always have a type")
     }
 
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(
+        &self,
+        value: &str,
+    ) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -651,21 +666,21 @@ impl HobbyEnumBuilder {
     // =========================================================================
 
     /// Access the `SPORTS` value builder.
-    pub fn value_SPORTS(&self) -> baml::EnumValueBuilder {
+    pub fn value_SPORTS(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("SPORTS")
             .expect("Hobby.SPORTS is statically defined in .baml and should always be present")
     }
 
     /// Access the `MUSIC` value builder.
-    pub fn value_MUSIC(&self) -> baml::EnumValueBuilder {
+    pub fn value_MUSIC(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("MUSIC")
             .expect("Hobby.MUSIC is statically defined in .baml and should always be present")
     }
 
     /// Access the `READING` value builder.
-    pub fn value_READING(&self) -> baml::EnumValueBuilder {
+    pub fn value_READING(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("READING")
             .expect("Hobby.READING is statically defined in .baml and should always be present")
@@ -678,22 +693,22 @@ impl HobbyEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct MapKeyEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl MapKeyEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("MapKey is statically defined in .baml and should always have a type")
@@ -704,21 +719,21 @@ impl MapKeyEnumBuilder {
     // =========================================================================
 
     /// Access the `A` value builder.
-    pub fn value_A(&self) -> baml::EnumValueBuilder {
+    pub fn value_A(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("A")
             .expect("MapKey.A is statically defined in .baml and should always be present")
     }
 
     /// Access the `B` value builder.
-    pub fn value_B(&self) -> baml::EnumValueBuilder {
+    pub fn value_B(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("B")
             .expect("MapKey.B is statically defined in .baml and should always be present")
     }
 
     /// Access the `C` value builder.
-    pub fn value_C(&self) -> baml::EnumValueBuilder {
+    pub fn value_C(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("C")
             .expect("MapKey.C is statically defined in .baml and should always be present")
@@ -731,22 +746,22 @@ impl MapKeyEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct NamedArgsSingleEnumEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl NamedArgsSingleEnumEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "NamedArgsSingleEnum is statically defined in .baml and should always have a type",
         )
@@ -757,14 +772,14 @@ impl NamedArgsSingleEnumEnumBuilder {
     // =========================================================================
 
     /// Access the `ONE` value builder.
-    pub fn value_ONE(&self) -> baml::EnumValueBuilder {
+    pub fn value_ONE(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("ONE").expect(
             "NamedArgsSingleEnum.ONE is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `TWO` value builder.
-    pub fn value_TWO(&self) -> baml::EnumValueBuilder {
+    pub fn value_TWO(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("TWO").expect(
             "NamedArgsSingleEnum.TWO is statically defined in .baml and should always be present",
         )
@@ -777,22 +792,22 @@ impl NamedArgsSingleEnumEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct NamedArgsSingleEnumListEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl NamedArgsSingleEnumListEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type().expect(
             "NamedArgsSingleEnumList is statically defined in .baml and should always have a type",
         )
@@ -803,13 +818,13 @@ impl NamedArgsSingleEnumListEnumBuilder {
     // =========================================================================
 
     /// Access the `ONE` value builder.
-    pub fn value_ONE(&self) -> baml::EnumValueBuilder {
+    pub fn value_ONE(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("ONE")
             .expect("NamedArgsSingleEnumList.ONE is statically defined in .baml and should always be present")
     }
 
     /// Access the `TWO` value builder.
-    pub fn value_TWO(&self) -> baml::EnumValueBuilder {
+    pub fn value_TWO(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("TWO")
             .expect("NamedArgsSingleEnumList.TWO is statically defined in .baml and should always be present")
     }
@@ -821,22 +836,22 @@ impl NamedArgsSingleEnumListEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct OptionalTest_CategoryTypeEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl OptionalTest_CategoryTypeEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner.as_type()
             .expect("OptionalTest_CategoryType is statically defined in .baml and should always have a type")
     }
@@ -846,19 +861,19 @@ impl OptionalTest_CategoryTypeEnumBuilder {
     // =========================================================================
 
     /// Access the `Aleph` value builder.
-    pub fn value_Aleph(&self) -> baml::EnumValueBuilder {
+    pub fn value_Aleph(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("Aleph")
             .expect("OptionalTest_CategoryType.Aleph is statically defined in .baml and should always be present")
     }
 
     /// Access the `Beta` value builder.
-    pub fn value_Beta(&self) -> baml::EnumValueBuilder {
+    pub fn value_Beta(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("Beta")
             .expect("OptionalTest_CategoryType.Beta is statically defined in .baml and should always be present")
     }
 
     /// Access the `Gamma` value builder.
-    pub fn value_Gamma(&self) -> baml::EnumValueBuilder {
+    pub fn value_Gamma(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("Gamma")
             .expect("OptionalTest_CategoryType.Gamma is statically defined in .baml and should always be present")
     }
@@ -870,22 +885,22 @@ impl OptionalTest_CategoryTypeEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct OrderStatusEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl OrderStatusEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("OrderStatus is statically defined in .baml and should always have a type")
@@ -896,28 +911,28 @@ impl OrderStatusEnumBuilder {
     // =========================================================================
 
     /// Access the `ORDERED` value builder.
-    pub fn value_ORDERED(&self) -> baml::EnumValueBuilder {
+    pub fn value_ORDERED(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("ORDERED").expect(
             "OrderStatus.ORDERED is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `SHIPPED` value builder.
-    pub fn value_SHIPPED(&self) -> baml::EnumValueBuilder {
+    pub fn value_SHIPPED(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("SHIPPED").expect(
             "OrderStatus.SHIPPED is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `DELIVERED` value builder.
-    pub fn value_DELIVERED(&self) -> baml::EnumValueBuilder {
+    pub fn value_DELIVERED(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("DELIVERED").expect(
             "OrderStatus.DELIVERED is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `CANCELLED` value builder.
-    pub fn value_CANCELLED(&self) -> baml::EnumValueBuilder {
+    pub fn value_CANCELLED(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("CANCELLED").expect(
             "OrderStatus.CANCELLED is statically defined in .baml and should always be present",
         )
@@ -933,29 +948,32 @@ impl OrderStatusEnumBuilder {
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 
 pub struct RenderStatusEnumEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl RenderStatusEnumEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("RenderStatusEnum is statically defined in .baml and should always have a type")
     }
 
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(
+        &self,
+        value: &str,
+    ) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -964,14 +982,14 @@ impl RenderStatusEnumEnumBuilder {
     // =========================================================================
 
     /// Access the `ACTIVE` value builder.
-    pub fn value_ACTIVE(&self) -> baml::EnumValueBuilder {
+    pub fn value_ACTIVE(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("ACTIVE").expect(
             "RenderStatusEnum.ACTIVE is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `INACTIVE` value builder.
-    pub fn value_INACTIVE(&self) -> baml::EnumValueBuilder {
+    pub fn value_INACTIVE(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("INACTIVE").expect(
             "RenderStatusEnum.INACTIVE is statically defined in .baml and should always be present",
         )
@@ -987,29 +1005,32 @@ impl RenderStatusEnumEnumBuilder {
 /// This enum is marked `@@dynamic` - you can add new values at runtime.
 
 pub struct RenderTestEnumEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl RenderTestEnumEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("RenderTestEnum is statically defined in .baml and should always have a type")
     }
 
     /// Add a new value to this dynamic enum.
-    pub fn add_value(&self, value: &str) -> Result<baml::EnumValueBuilder, baml::BamlError> {
+    pub fn add_value(
+        &self,
+        value: &str,
+    ) -> ::std::result::Result<::baml::EnumValueBuilder, ::baml::BamlError> {
         self.inner.add_value(value)
     }
 
@@ -1018,14 +1039,14 @@ impl RenderTestEnumEnumBuilder {
     // =========================================================================
 
     /// Access the `BIKE` value builder.
-    pub fn value_BIKE(&self) -> baml::EnumValueBuilder {
+    pub fn value_BIKE(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("BIKE").expect(
             "RenderTestEnum.BIKE is statically defined in .baml and should always be present",
         )
     }
 
     /// Access the `SCOOTER` value builder.
-    pub fn value_SCOOTER(&self) -> baml::EnumValueBuilder {
+    pub fn value_SCOOTER(&self) -> ::baml::EnumValueBuilder {
         self.inner.get_value("SCOOTER").expect(
             "RenderTestEnum.SCOOTER is statically defined in .baml and should always be present",
         )
@@ -1038,22 +1059,22 @@ impl RenderTestEnumEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct TagEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl TagEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("Tag is statically defined in .baml and should always have a type")
@@ -1064,21 +1085,21 @@ impl TagEnumBuilder {
     // =========================================================================
 
     /// Access the `Security` value builder.
-    pub fn value_Security(&self) -> baml::EnumValueBuilder {
+    pub fn value_Security(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Security")
             .expect("Tag.Security is statically defined in .baml and should always be present")
     }
 
     /// Access the `AI` value builder.
-    pub fn value_AI(&self) -> baml::EnumValueBuilder {
+    pub fn value_AI(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("AI")
             .expect("Tag.AI is statically defined in .baml and should always be present")
     }
 
     /// Access the `Blockchain` value builder.
-    pub fn value_Blockchain(&self) -> baml::EnumValueBuilder {
+    pub fn value_Blockchain(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("Blockchain")
             .expect("Tag.Blockchain is statically defined in .baml and should always be present")
@@ -1091,22 +1112,22 @@ impl TagEnumBuilder {
 /// Access values via methods: `builder.ValueName()`
 
 pub struct TestEnumEnumBuilder {
-    inner: baml::EnumBuilder,
+    inner: ::baml::EnumBuilder,
 }
 
 impl TestEnumEnumBuilder {
     /// Create wrapper from runtime EnumBuilder.
-    pub(crate) fn new(inner: baml::EnumBuilder) -> Self {
+    pub(crate) fn new(inner: ::baml::EnumBuilder) -> Self {
         Self { inner }
     }
 
     /// Get the underlying EnumBuilder.
-    pub fn inner(&self) -> &baml::EnumBuilder {
+    pub fn inner(&self) -> &::baml::EnumBuilder {
         &self.inner
     }
 
     /// Get the enum as a type definition.
-    pub fn r#type(&self) -> baml::TypeDef {
+    pub fn r#type(&self) -> ::baml::TypeDef {
         self.inner
             .as_type()
             .expect("TestEnum is statically defined in .baml and should always have a type")
@@ -1117,49 +1138,49 @@ impl TestEnumEnumBuilder {
     // =========================================================================
 
     /// Access the `A` value builder.
-    pub fn value_A(&self) -> baml::EnumValueBuilder {
+    pub fn value_A(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("A")
             .expect("TestEnum.A is statically defined in .baml and should always be present")
     }
 
     /// Access the `B` value builder.
-    pub fn value_B(&self) -> baml::EnumValueBuilder {
+    pub fn value_B(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("B")
             .expect("TestEnum.B is statically defined in .baml and should always be present")
     }
 
     /// Access the `C` value builder.
-    pub fn value_C(&self) -> baml::EnumValueBuilder {
+    pub fn value_C(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("C")
             .expect("TestEnum.C is statically defined in .baml and should always be present")
     }
 
     /// Access the `D` value builder.
-    pub fn value_D(&self) -> baml::EnumValueBuilder {
+    pub fn value_D(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("D")
             .expect("TestEnum.D is statically defined in .baml and should always be present")
     }
 
     /// Access the `E` value builder.
-    pub fn value_E(&self) -> baml::EnumValueBuilder {
+    pub fn value_E(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("E")
             .expect("TestEnum.E is statically defined in .baml and should always be present")
     }
 
     /// Access the `F` value builder.
-    pub fn value_F(&self) -> baml::EnumValueBuilder {
+    pub fn value_F(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("F")
             .expect("TestEnum.F is statically defined in .baml and should always be present")
     }
 
     /// Access the `G` value builder.
-    pub fn value_G(&self) -> baml::EnumValueBuilder {
+    pub fn value_G(&self) -> ::baml::EnumValueBuilder {
         self.inner
             .get_value("G")
             .expect("TestEnum.G is statically defined in .baml and should always be present")

--- a/integ-tests/rust/src/baml_client/type_builder/mod.rs
+++ b/integ-tests/rust/src/baml_client/type_builder/mod.rs
@@ -11,8 +11,6 @@ mod enums;
 pub use classes::*;
 pub use enums::*;
 
-use std::sync::Arc;
-
 /// TypeBuilder for dynamic type construction.
 ///
 /// This wrapper provides access to the BAML TypeBuilder for creating
@@ -23,7 +21,7 @@ use std::sync::Arc;
 /// - `tb.EnumName()` returns the enum builder
 #[derive(Clone)]
 pub struct TypeBuilder {
-    inner: Arc<baml::TypeBuilder>,
+    inner: ::std::sync::Arc<::baml::TypeBuilder>,
 }
 
 impl TypeBuilder {
@@ -37,12 +35,12 @@ impl TypeBuilder {
     /// ```
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(super::runtime::get_runtime().new_type_builder()),
+            inner: ::std::sync::Arc::new(super::runtime::get_runtime().new_type_builder()),
         }
     }
 
     /// Get reference to inner TypeBuilder for FFI calls.
-    pub(crate) fn inner(&self) -> &baml::TypeBuilder {
+    pub(crate) fn inner(&self) -> &::baml::TypeBuilder {
         &self.inner
     }
 
@@ -1220,27 +1218,27 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Get the string type.
-    pub fn string(&self) -> baml::TypeDef {
+    pub fn string(&self) -> ::baml::TypeDef {
         self.inner.string()
     }
 
     /// Get the int type.
-    pub fn int(&self) -> baml::TypeDef {
+    pub fn int(&self) -> ::baml::TypeDef {
         self.inner.int()
     }
 
     /// Get the float type.
-    pub fn float(&self) -> baml::TypeDef {
+    pub fn float(&self) -> ::baml::TypeDef {
         self.inner.float()
     }
 
     /// Get the bool type.
-    pub fn bool(&self) -> baml::TypeDef {
+    pub fn bool(&self) -> ::baml::TypeDef {
         self.inner.bool()
     }
 
     /// Get the null type.
-    pub fn null(&self) -> baml::TypeDef {
+    pub fn null(&self) -> ::baml::TypeDef {
         self.inner.null()
     }
 
@@ -1249,17 +1247,17 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a literal string type.
-    pub fn literal_string(&self, value: &str) -> baml::TypeDef {
+    pub fn literal_string(&self, value: &str) -> ::baml::TypeDef {
         self.inner.literal_string(value)
     }
 
     /// Create a literal int type.
-    pub fn literal_int(&self, value: i64) -> baml::TypeDef {
+    pub fn literal_int(&self, value: i64) -> ::baml::TypeDef {
         self.inner.literal_int(value)
     }
 
     /// Create a literal bool type.
-    pub fn literal_bool(&self, value: bool) -> baml::TypeDef {
+    pub fn literal_bool(&self, value: bool) -> ::baml::TypeDef {
         self.inner.literal_bool(value)
     }
 
@@ -1268,22 +1266,22 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Create a list type.
-    pub fn list(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn list(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.list(inner)
     }
 
     /// Create an optional type.
-    pub fn optional(&self, inner: &baml::TypeDef) -> baml::TypeDef {
+    pub fn optional(&self, inner: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.optional(inner)
     }
 
     /// Create a map type.
-    pub fn map(&self, key: &baml::TypeDef, value: &baml::TypeDef) -> baml::TypeDef {
+    pub fn map(&self, key: &::baml::TypeDef, value: &::baml::TypeDef) -> ::baml::TypeDef {
         self.inner.map(key, value)
     }
 
     /// Create a union type.
-    pub fn union(&self, types: &[&baml::TypeDef]) -> baml::TypeDef {
+    pub fn union(&self, types: &[&::baml::TypeDef]) -> ::baml::TypeDef {
         self.inner.union(types)
     }
 
@@ -1292,12 +1290,12 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add BAML schema definitions.
-    pub fn add_baml(&self, baml_source: &str) -> Result<(), baml::BamlError> {
+    pub fn add_baml(&self, baml_source: &str) -> ::std::result::Result<(), ::baml::BamlError> {
         self.inner.add_baml(baml_source)
     }
 
     /// Print the TypeBuilder state for debugging.
-    pub fn print(&self) -> String {
+    pub fn print(&self) -> ::std::string::String {
         self.inner.print()
     }
 
@@ -1306,17 +1304,20 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic enum.
-    pub fn add_enum(&self, name: &str) -> Result<baml::EnumBuilder, baml::BamlError> {
+    pub fn add_enum(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::EnumBuilder, ::baml::BamlError> {
         self.inner.add_enum(name)
     }
 
     /// Get an enum by name (returns None if not found).
-    pub fn get_enum(&self, name: &str) -> Option<baml::EnumBuilder> {
+    pub fn get_enum(&self, name: &str) -> ::std::option::Option<::baml::EnumBuilder> {
         self.inner.get_enum(name)
     }
 
     /// List all enums.
-    pub fn list_enums(&self) -> Vec<baml::EnumBuilder> {
+    pub fn list_enums(&self) -> ::std::vec::Vec<::baml::EnumBuilder> {
         self.inner.list_enums()
     }
 
@@ -1325,29 +1326,32 @@ impl TypeBuilder {
     // =========================================================================
 
     /// Add a new dynamic class.
-    pub fn add_class(&self, name: &str) -> Result<baml::ClassBuilder, baml::BamlError> {
+    pub fn add_class(
+        &self,
+        name: &str,
+    ) -> ::std::result::Result<::baml::ClassBuilder, ::baml::BamlError> {
         self.inner.add_class(name)
     }
 
     /// Get a class by name (returns None if not found).
-    pub fn get_class(&self, name: &str) -> Option<baml::ClassBuilder> {
+    pub fn get_class(&self, name: &str) -> ::std::option::Option<::baml::ClassBuilder> {
         self.inner.get_class(name)
     }
 
     /// List all classes.
-    pub fn list_classes(&self) -> Vec<baml::ClassBuilder> {
+    pub fn list_classes(&self) -> ::std::vec::Vec<::baml::ClassBuilder> {
         self.inner.list_classes()
     }
 }
 
-impl Default for TypeBuilder {
+impl ::std::default::Default for TypeBuilder {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl std::fmt::Debug for TypeBuilder {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Debug for TypeBuilder {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         f.debug_struct("TypeBuilder")
             .field("state", &self.print())
             .finish()

--- a/integ-tests/rust/src/baml_client/types/classes.rs
+++ b/integ-tests/rust/src/baml_client/types/classes.rs
@@ -203,7 +203,7 @@ impl ::std::convert::AsRef<ClassWithBlockDone> for ClassWithBlockDone {
 #[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithImage {
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_image")]
     pub myImage: Image,
     pub param2: String,
     pub fake_image: FakeImage,

--- a/integ-tests/rust/src/baml_client/types/classes.rs
+++ b/integ-tests/rust/src/baml_client/types/classes.rs
@@ -22,7 +22,7 @@ pub struct AddTodoItem {
     pub description: String,
 }
 
-impl AsRef<AddTodoItem> for AddTodoItem {
+impl ::std::convert::AsRef<AddTodoItem> for AddTodoItem {
     fn as_ref(&self) -> &AddTodoItem {
         self
     }
@@ -36,7 +36,7 @@ pub struct AddressWithMeta {
     pub zipcode: String,
 }
 
-impl AsRef<AddressWithMeta> for AddressWithMeta {
+impl ::std::convert::AsRef<AddressWithMeta> for AddressWithMeta {
     fn as_ref(&self) -> &AddressWithMeta {
         self
     }
@@ -50,7 +50,7 @@ pub struct AnotherObject {
     pub thingy3: String,
 }
 
-impl AsRef<AnotherObject> for AnotherObject {
+impl ::std::convert::AsRef<AnotherObject> for AnotherObject {
     fn as_ref(&self) -> &AnotherObject {
         self
     }
@@ -63,7 +63,7 @@ pub struct BigNumbers {
     pub b: f64,
 }
 
-impl AsRef<BigNumbers> for BigNumbers {
+impl ::std::convert::AsRef<BigNumbers> for BigNumbers {
     fn as_ref(&self) -> &BigNumbers {
         self
     }
@@ -77,7 +77,7 @@ pub struct BinaryNode {
     pub right: Option<Box<BinaryNode>>,
 }
 
-impl AsRef<BinaryNode> for BinaryNode {
+impl ::std::convert::AsRef<BinaryNode> for BinaryNode {
     fn as_ref(&self) -> &BinaryNode {
         self
     }
@@ -89,7 +89,7 @@ pub struct Blah {
     pub prop4: Option<String>,
 }
 
-impl AsRef<Blah> for Blah {
+impl ::std::convert::AsRef<Blah> for Blah {
     fn as_ref(&self) -> &Blah {
         self
     }
@@ -102,7 +102,7 @@ pub struct BlockConstraint {
     pub bar: String,
 }
 
-impl AsRef<BlockConstraint> for BlockConstraint {
+impl ::std::convert::AsRef<BlockConstraint> for BlockConstraint {
     fn as_ref(&self) -> &BlockConstraint {
         self
     }
@@ -115,7 +115,7 @@ pub struct BlockConstraintForParam {
     pub bcfp2: String,
 }
 
-impl AsRef<BlockConstraintForParam> for BlockConstraintForParam {
+impl ::std::convert::AsRef<BlockConstraintForParam> for BlockConstraintForParam {
     fn as_ref(&self) -> &BlockConstraintForParam {
         self
     }
@@ -130,7 +130,7 @@ pub struct BookOrder {
     pub price: f64,
 }
 
-impl AsRef<BookOrder> for BookOrder {
+impl ::std::convert::AsRef<BookOrder> for BookOrder {
     fn as_ref(&self) -> &BookOrder {
         self
     }
@@ -142,7 +142,7 @@ pub struct ClassForNullLiteral {
     pub a: String,
 }
 
-impl AsRef<ClassForNullLiteral> for ClassForNullLiteral {
+impl ::std::convert::AsRef<ClassForNullLiteral> for ClassForNullLiteral {
     fn as_ref(&self) -> &ClassForNullLiteral {
         self
     }
@@ -155,7 +155,7 @@ pub struct ClassOptionalOutput {
     pub prop2: String,
 }
 
-impl AsRef<ClassOptionalOutput> for ClassOptionalOutput {
+impl ::std::convert::AsRef<ClassOptionalOutput> for ClassOptionalOutput {
     fn as_ref(&self) -> &ClassOptionalOutput {
         self
     }
@@ -169,7 +169,7 @@ pub struct ClassOptionalOutput2 {
     pub prop3: Option<Blah>,
 }
 
-impl AsRef<ClassOptionalOutput2> for ClassOptionalOutput2 {
+impl ::std::convert::AsRef<ClassOptionalOutput2> for ClassOptionalOutput2 {
     fn as_ref(&self) -> &ClassOptionalOutput2 {
         self
     }
@@ -181,7 +181,7 @@ pub struct ClassToRecAlias {
     pub list: LinkedListAliasNode,
 }
 
-impl AsRef<ClassToRecAlias> for ClassToRecAlias {
+impl ::std::convert::AsRef<ClassToRecAlias> for ClassToRecAlias {
     fn as_ref(&self) -> &ClassToRecAlias {
         self
     }
@@ -194,7 +194,7 @@ pub struct ClassWithBlockDone {
     pub s_20_words: String,
 }
 
-impl AsRef<ClassWithBlockDone> for ClassWithBlockDone {
+impl ::std::convert::AsRef<ClassWithBlockDone> for ClassWithBlockDone {
     fn as_ref(&self) -> &ClassWithBlockDone {
         self
     }
@@ -203,12 +203,13 @@ impl AsRef<ClassWithBlockDone> for ClassWithBlockDone {
 #[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithImage {
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
     pub myImage: Image,
     pub param2: String,
     pub fake_image: FakeImage,
 }
 
-impl AsRef<ClassWithImage> for ClassWithImage {
+impl ::std::convert::AsRef<ClassWithImage> for ClassWithImage {
     fn as_ref(&self) -> &ClassWithImage {
         self
     }
@@ -221,7 +222,7 @@ pub struct ClassWithoutDone {
     pub s_20_words: String,
 }
 
-impl AsRef<ClassWithoutDone> for ClassWithoutDone {
+impl ::std::convert::AsRef<ClassWithoutDone> for ClassWithoutDone {
     fn as_ref(&self) -> &ClassWithoutDone {
         self
     }
@@ -239,7 +240,7 @@ pub struct ClientDetails1559 {
     pub client_email: Option<String>,
 }
 
-impl AsRef<ClientDetails1559> for ClientDetails1559 {
+impl ::std::convert::AsRef<ClientDetails1559> for ClientDetails1559 {
     fn as_ref(&self) -> &ClientDetails1559 {
         self
     }
@@ -254,7 +255,7 @@ pub struct ComplexMemoryObject {
     pub metadata: Vec<Union3FloatOrIntOrString>,
 }
 
-impl AsRef<ComplexMemoryObject> for ComplexMemoryObject {
+impl ::std::convert::AsRef<ComplexMemoryObject> for ComplexMemoryObject {
     fn as_ref(&self) -> &ComplexMemoryObject {
         self
     }
@@ -268,7 +269,7 @@ pub struct CompoundBigNumbers {
     pub another: BigNumbers,
 }
 
-impl AsRef<CompoundBigNumbers> for CompoundBigNumbers {
+impl ::std::convert::AsRef<CompoundBigNumbers> for CompoundBigNumbers {
     fn as_ref(&self) -> &CompoundBigNumbers {
         self
     }
@@ -281,7 +282,7 @@ pub struct ContactInfo {
     pub secondary: Option<Union2EmailAddressOrPhoneNumber>,
 }
 
-impl AsRef<ContactInfo> for ContactInfo {
+impl ::std::convert::AsRef<ContactInfo> for ContactInfo {
     fn as_ref(&self) -> &ContactInfo {
         self
     }
@@ -295,7 +296,7 @@ pub struct CustomStory {
     pub content: String,
 }
 
-impl AsRef<CustomStory> for CustomStory {
+impl ::std::convert::AsRef<CustomStory> for CustomStory {
     fn as_ref(&self) -> &CustomStory {
         self
     }
@@ -309,7 +310,7 @@ pub struct CustomTaskResult {
     pub groceryReceipt: Option<GroceryReceipt>,
 }
 
-impl AsRef<CustomTaskResult> for CustomTaskResult {
+impl ::std::convert::AsRef<CustomTaskResult> for CustomTaskResult {
     fn as_ref(&self) -> &CustomTaskResult {
         self
     }
@@ -322,7 +323,7 @@ pub struct Document1559 {
     pub notes: Vec<Note1599>,
 }
 
-impl AsRef<Document1559> for Document1559 {
+impl ::std::convert::AsRef<Document1559> for Document1559 {
     fn as_ref(&self) -> &Document1559 {
         self
     }
@@ -337,7 +338,7 @@ pub struct DummyJsonTodo {
     pub userId: i64,
 }
 
-impl AsRef<DummyJsonTodo> for DummyJsonTodo {
+impl ::std::convert::AsRef<DummyJsonTodo> for DummyJsonTodo {
     fn as_ref(&self) -> &DummyJsonTodo {
         self
     }
@@ -349,27 +350,26 @@ impl AsRef<DummyJsonTodo> for DummyJsonTodo {
 pub struct DummyOutput {
     pub nonce: String,
     pub nonce2: String,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DummyOutput {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -378,7 +378,9 @@ impl DummyOutput {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -390,7 +392,7 @@ impl DummyOutput {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -400,17 +402,17 @@ impl DummyOutput {
     }
 }
 
-impl Default for DummyOutput {
+impl ::std::default::Default for DummyOutput {
     fn default() -> Self {
         Self {
-            nonce: Default::default(),
-            nonce2: Default::default(),
-            __dynamic: std::collections::HashMap::new(),
+            nonce: ::std::default::Default::default(),
+            nonce2: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DummyOutput> for DummyOutput {
+impl ::std::convert::AsRef<DummyOutput> for DummyOutput {
     fn as_ref(&self) -> &DummyOutput {
         self
     }
@@ -421,27 +423,26 @@ impl AsRef<DummyOutput> for DummyOutput {
 #[serde(crate = "::baml::__internal::serde")]
 pub struct DynInputOutput {
     pub testKey: String,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynInputOutput {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -450,7 +451,9 @@ impl DynInputOutput {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -462,7 +465,7 @@ impl DynInputOutput {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -472,16 +475,16 @@ impl DynInputOutput {
     }
 }
 
-impl Default for DynInputOutput {
+impl ::std::default::Default for DynInputOutput {
     fn default() -> Self {
         Self {
-            testKey: Default::default(),
-            __dynamic: std::collections::HashMap::new(),
+            testKey: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynInputOutput> for DynInputOutput {
+impl ::std::convert::AsRef<DynInputOutput> for DynInputOutput {
     fn as_ref(&self) -> &DynInputOutput {
         self
     }
@@ -494,23 +497,23 @@ pub struct DynamicClassOne {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynamicClassOne {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -519,7 +522,9 @@ impl DynamicClassOne {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -531,7 +536,7 @@ impl DynamicClassOne {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -541,15 +546,15 @@ impl DynamicClassOne {
     }
 }
 
-impl Default for DynamicClassOne {
+impl ::std::default::Default for DynamicClassOne {
     fn default() -> Self {
         Self {
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynamicClassOne> for DynamicClassOne {
+impl ::std::convert::AsRef<DynamicClassOne> for DynamicClassOne {
     fn as_ref(&self) -> &DynamicClassOne {
         self
     }
@@ -562,27 +567,26 @@ pub struct DynamicClassTwo {
     pub hi: String,
     pub some_class: SomeClassNestedDynamic,
     pub status: DynEnumOne,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynamicClassTwo {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -591,7 +595,9 @@ impl DynamicClassTwo {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -603,7 +609,7 @@ impl DynamicClassTwo {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -613,18 +619,18 @@ impl DynamicClassTwo {
     }
 }
 
-impl Default for DynamicClassTwo {
+impl ::std::default::Default for DynamicClassTwo {
     fn default() -> Self {
         Self {
-            hi: Default::default(),
-            some_class: Default::default(),
-            status: Default::default(),
-            __dynamic: std::collections::HashMap::new(),
+            hi: ::std::default::Default::default(),
+            some_class: ::std::default::Default::default(),
+            status: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynamicClassTwo> for DynamicClassTwo {
+impl ::std::convert::AsRef<DynamicClassTwo> for DynamicClassTwo {
     fn as_ref(&self) -> &DynamicClassTwo {
         self
     }
@@ -637,23 +643,23 @@ pub struct DynamicOutput {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynamicOutput {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -662,7 +668,9 @@ impl DynamicOutput {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -674,7 +682,7 @@ impl DynamicOutput {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -684,15 +692,15 @@ impl DynamicOutput {
     }
 }
 
-impl Default for DynamicOutput {
+impl ::std::default::Default for DynamicOutput {
     fn default() -> Self {
         Self {
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynamicOutput> for DynamicOutput {
+impl ::std::convert::AsRef<DynamicOutput> for DynamicOutput {
     fn as_ref(&self) -> &DynamicOutput {
         self
     }
@@ -705,23 +713,23 @@ pub struct DynamicSchema {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl DynamicSchema {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -730,7 +738,9 @@ impl DynamicSchema {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -742,7 +752,7 @@ impl DynamicSchema {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -752,15 +762,15 @@ impl DynamicSchema {
     }
 }
 
-impl Default for DynamicSchema {
+impl ::std::default::Default for DynamicSchema {
     fn default() -> Self {
         Self {
-            __dynamic: std::collections::HashMap::new(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<DynamicSchema> for DynamicSchema {
+impl ::std::convert::AsRef<DynamicSchema> for DynamicSchema {
     fn as_ref(&self) -> &DynamicSchema {
         self
     }
@@ -772,7 +782,7 @@ pub struct Earthling {
     pub age: Checked<i64>,
 }
 
-impl AsRef<Earthling> for Earthling {
+impl ::std::convert::AsRef<Earthling> for Earthling {
     fn as_ref(&self) -> &Earthling {
         self
     }
@@ -788,7 +798,7 @@ pub struct Education {
     pub graduation_date: Option<String>,
 }
 
-impl AsRef<Education> for Education {
+impl ::std::convert::AsRef<Education> for Education {
     fn as_ref(&self) -> &Education {
         self
     }
@@ -802,7 +812,7 @@ pub struct Email {
     pub from_address: String,
 }
 
-impl AsRef<Email> for Email {
+impl ::std::convert::AsRef<Email> for Email {
     fn as_ref(&self) -> &Email {
         self
     }
@@ -814,7 +824,7 @@ pub struct EmailAddress {
     pub value: String,
 }
 
-impl AsRef<EmailAddress> for EmailAddress {
+impl ::std::convert::AsRef<EmailAddress> for EmailAddress {
     fn as_ref(&self) -> &EmailAddress {
         self
     }
@@ -829,7 +839,7 @@ pub struct Event {
     pub description: String,
 }
 
-impl AsRef<Event> for Event {
+impl ::std::convert::AsRef<Event> for Event {
     fn as_ref(&self) -> &Event {
         self
     }
@@ -841,7 +851,7 @@ pub struct FakeImage {
     pub url: String,
 }
 
-impl AsRef<FakeImage> for FakeImage {
+impl ::std::convert::AsRef<FakeImage> for FakeImage {
     fn as_ref(&self) -> &FakeImage {
         self
     }
@@ -857,7 +867,7 @@ pub struct FlightConfirmation {
     pub seatNumber: String,
 }
 
-impl AsRef<FlightConfirmation> for FlightConfirmation {
+impl ::std::convert::AsRef<FlightConfirmation> for FlightConfirmation {
     fn as_ref(&self) -> &FlightConfirmation {
         self
     }
@@ -871,7 +881,7 @@ pub struct FooAny {
     pub species: Checked<String>,
 }
 
-impl AsRef<FooAny> for FooAny {
+impl ::std::convert::AsRef<FooAny> for FooAny {
     fn as_ref(&self) -> &FooAny {
         self
     }
@@ -883,7 +893,7 @@ pub struct Forest {
     pub trees: Vec<Box<Tree>>,
 }
 
-impl AsRef<Forest> for Forest {
+impl ::std::convert::AsRef<Forest> for Forest {
     fn as_ref(&self) -> &Forest {
         self
     }
@@ -896,7 +906,7 @@ pub struct FormatterTest0 {
     pub ipsum: String,
 }
 
-impl AsRef<FormatterTest0> for FormatterTest0 {
+impl ::std::convert::AsRef<FormatterTest0> for FormatterTest0 {
     fn as_ref(&self) -> &FormatterTest0 {
         self
     }
@@ -909,7 +919,7 @@ pub struct FormatterTest1 {
     pub ipsum: String,
 }
 
-impl AsRef<FormatterTest1> for FormatterTest1 {
+impl ::std::convert::AsRef<FormatterTest1> for FormatterTest1 {
     fn as_ref(&self) -> &FormatterTest1 {
         self
     }
@@ -922,7 +932,7 @@ pub struct FormatterTest2 {
     pub ipsum: String,
 }
 
-impl AsRef<FormatterTest2> for FormatterTest2 {
+impl ::std::convert::AsRef<FormatterTest2> for FormatterTest2 {
     fn as_ref(&self) -> &FormatterTest2 {
         self
     }
@@ -935,7 +945,7 @@ pub struct FormatterTest3 {
     pub ipsum: String,
 }
 
-impl AsRef<FormatterTest3> for FormatterTest3 {
+impl ::std::convert::AsRef<FormatterTest3> for FormatterTest3 {
     fn as_ref(&self) -> &FormatterTest3 {
         self
     }
@@ -950,7 +960,7 @@ pub struct GroceryReceipt {
     pub totalAmount: f64,
 }
 
-impl AsRef<GroceryReceipt> for GroceryReceipt {
+impl ::std::convert::AsRef<GroceryReceipt> for GroceryReceipt {
     fn as_ref(&self) -> &GroceryReceipt {
         self
     }
@@ -964,7 +974,7 @@ pub struct Haiku {
     pub line3: String,
 }
 
-impl AsRef<Haiku> for Haiku {
+impl ::std::convert::AsRef<Haiku> for Haiku {
     fn as_ref(&self) -> &Haiku {
         self
     }
@@ -978,7 +988,7 @@ pub struct InnerClass {
     pub inner: InnerClass2,
 }
 
-impl AsRef<InnerClass> for InnerClass {
+impl ::std::convert::AsRef<InnerClass> for InnerClass {
     fn as_ref(&self) -> &InnerClass {
         self
     }
@@ -991,7 +1001,7 @@ pub struct InnerClass2 {
     pub prop3: f64,
 }
 
-impl AsRef<InnerClass2> for InnerClass2 {
+impl ::std::convert::AsRef<InnerClass2> for InnerClass2 {
     fn as_ref(&self) -> &InnerClass2 {
         self
     }
@@ -1004,7 +1014,7 @@ pub struct InputClass {
     pub key2: String,
 }
 
-impl AsRef<InputClass> for InputClass {
+impl ::std::convert::AsRef<InputClass> for InputClass {
     fn as_ref(&self) -> &InputClass {
         self
     }
@@ -1017,7 +1027,7 @@ pub struct InputClassNested {
     pub nested: InputClass,
 }
 
-impl AsRef<InputClassNested> for InputClassNested {
+impl ::std::convert::AsRef<InputClassNested> for InputClassNested {
     fn as_ref(&self) -> &InputClassNested {
         self
     }
@@ -1030,7 +1040,7 @@ pub struct LinkedList {
     pub len: i64,
 }
 
-impl AsRef<LinkedList> for LinkedList {
+impl ::std::convert::AsRef<LinkedList> for LinkedList {
     fn as_ref(&self) -> &LinkedList {
         self
     }
@@ -1043,7 +1053,7 @@ pub struct LinkedListAliasNode {
     pub next: Option<Box<LinkedListAliasNode>>,
 }
 
-impl AsRef<LinkedListAliasNode> for LinkedListAliasNode {
+impl ::std::convert::AsRef<LinkedListAliasNode> for LinkedListAliasNode {
     fn as_ref(&self) -> &LinkedListAliasNode {
         self
     }
@@ -1055,7 +1065,7 @@ pub struct LiteralClassHello {
     pub prop: String,
 }
 
-impl AsRef<LiteralClassHello> for LiteralClassHello {
+impl ::std::convert::AsRef<LiteralClassHello> for LiteralClassHello {
     fn as_ref(&self) -> &LiteralClassHello {
         self
     }
@@ -1067,7 +1077,7 @@ pub struct LiteralClassOne {
     pub prop: String,
 }
 
-impl AsRef<LiteralClassOne> for LiteralClassOne {
+impl ::std::convert::AsRef<LiteralClassOne> for LiteralClassOne {
     fn as_ref(&self) -> &LiteralClassOne {
         self
     }
@@ -1079,7 +1089,7 @@ pub struct LiteralClassTwo {
     pub prop: String,
 }
 
-impl AsRef<LiteralClassTwo> for LiteralClassTwo {
+impl ::std::convert::AsRef<LiteralClassTwo> for LiteralClassTwo {
     fn as_ref(&self) -> &LiteralClassTwo {
         self
     }
@@ -1093,7 +1103,7 @@ pub struct MaintainFieldOrder {
     pub a: String,
 }
 
-impl AsRef<MaintainFieldOrder> for MaintainFieldOrder {
+impl ::std::convert::AsRef<MaintainFieldOrder> for MaintainFieldOrder {
     fn as_ref(&self) -> &MaintainFieldOrder {
         self
     }
@@ -1105,7 +1115,7 @@ pub struct MalformedConstraints {
     pub foo: Checked<i64>,
 }
 
-impl AsRef<MalformedConstraints> for MalformedConstraints {
+impl ::std::convert::AsRef<MalformedConstraints> for MalformedConstraints {
     fn as_ref(&self) -> &MalformedConstraints {
         self
     }
@@ -1117,7 +1127,7 @@ pub struct MalformedConstraints2 {
     pub foo: i64,
 }
 
-impl AsRef<MalformedConstraints2> for MalformedConstraints2 {
+impl ::std::convert::AsRef<MalformedConstraints2> for MalformedConstraints2 {
     fn as_ref(&self) -> &MalformedConstraints2 {
         self
     }
@@ -1134,7 +1144,7 @@ pub struct Martian {
     pub age: Checked<i64>,
 }
 
-impl AsRef<Martian> for Martian {
+impl ::std::convert::AsRef<Martian> for Martian {
     fn as_ref(&self) -> &Martian {
         self
     }
@@ -1148,7 +1158,7 @@ pub struct MemoryObject {
     pub description: String,
 }
 
-impl AsRef<MemoryObject> for MemoryObject {
+impl ::std::convert::AsRef<MemoryObject> for MemoryObject {
     fn as_ref(&self) -> &MemoryObject {
         self
     }
@@ -1160,7 +1170,7 @@ pub struct MergeAttrs {
     pub amount: Checked<i64>,
 }
 
-impl AsRef<MergeAttrs> for MergeAttrs {
+impl ::std::convert::AsRef<MergeAttrs> for MergeAttrs {
     fn as_ref(&self) -> &MergeAttrs {
         self
     }
@@ -1174,7 +1184,7 @@ pub struct NamedArgsSingleClass {
     pub key_three: i64,
 }
 
-impl AsRef<NamedArgsSingleClass> for NamedArgsSingleClass {
+impl ::std::convert::AsRef<NamedArgsSingleClass> for NamedArgsSingleClass {
     fn as_ref(&self) -> &NamedArgsSingleClass {
         self
     }
@@ -1188,7 +1198,7 @@ pub struct Nested {
     pub prop20: Nested2,
 }
 
-impl AsRef<Nested> for Nested {
+impl ::std::convert::AsRef<Nested> for Nested {
     fn as_ref(&self) -> &Nested {
         self
     }
@@ -1201,7 +1211,7 @@ pub struct Nested2 {
     pub prop12: Option<String>,
 }
 
-impl AsRef<Nested2> for Nested2 {
+impl ::std::convert::AsRef<Nested2> for Nested2 {
     fn as_ref(&self) -> &Nested2 {
         self
     }
@@ -1213,7 +1223,7 @@ pub struct NestedBlockConstraint {
     pub nbc: Checked<BlockConstraint>,
 }
 
-impl AsRef<NestedBlockConstraint> for NestedBlockConstraint {
+impl ::std::convert::AsRef<NestedBlockConstraint> for NestedBlockConstraint {
     fn as_ref(&self) -> &NestedBlockConstraint {
         self
     }
@@ -1225,7 +1235,7 @@ pub struct NestedBlockConstraintForParam {
     pub nbcfp: BlockConstraintForParam,
 }
 
-impl AsRef<NestedBlockConstraintForParam> for NestedBlockConstraintForParam {
+impl ::std::convert::AsRef<NestedBlockConstraintForParam> for NestedBlockConstraintForParam {
     fn as_ref(&self) -> &NestedBlockConstraintForParam {
         self
     }
@@ -1238,7 +1248,7 @@ pub struct Node {
     pub next: Option<Box<Node>>,
 }
 
-impl AsRef<Node> for Node {
+impl ::std::convert::AsRef<Node> for Node {
     fn as_ref(&self) -> &Node {
         self
     }
@@ -1251,7 +1261,7 @@ pub struct NodeWithAliasIndirection {
     pub next: Option<Box<NodeWithAliasIndirection>>,
 }
 
-impl AsRef<NodeWithAliasIndirection> for NodeWithAliasIndirection {
+impl ::std::convert::AsRef<NodeWithAliasIndirection> for NodeWithAliasIndirection {
     fn as_ref(&self) -> &NodeWithAliasIndirection {
         self
     }
@@ -1265,7 +1275,7 @@ pub struct Note1599 {
     pub note_amount: Option<String>,
 }
 
-impl AsRef<Note1599> for Note1599 {
+impl ::std::convert::AsRef<Note1599> for Note1599 {
     fn as_ref(&self) -> &Note1599 {
         self
     }
@@ -1278,7 +1288,7 @@ pub struct OptionalListAndMap {
     pub q: Option<std::collections::HashMap<String, String>>,
 }
 
-impl AsRef<OptionalListAndMap> for OptionalListAndMap {
+impl ::std::convert::AsRef<OptionalListAndMap> for OptionalListAndMap {
     fn as_ref(&self) -> &OptionalListAndMap {
         self
     }
@@ -1291,7 +1301,7 @@ pub struct OptionalTest_Prop1 {
     pub omega_b: i64,
 }
 
-impl AsRef<OptionalTest_Prop1> for OptionalTest_Prop1 {
+impl ::std::convert::AsRef<OptionalTest_Prop1> for OptionalTest_Prop1 {
     fn as_ref(&self) -> &OptionalTest_Prop1 {
         self
     }
@@ -1305,7 +1315,7 @@ pub struct OptionalTest_ReturnType {
     pub omega_3: Vec<Option<OptionalTest_CategoryType>>,
 }
 
-impl AsRef<OptionalTest_ReturnType> for OptionalTest_ReturnType {
+impl ::std::convert::AsRef<OptionalTest_ReturnType> for OptionalTest_ReturnType {
     fn as_ref(&self) -> &OptionalTest_ReturnType {
         self
     }
@@ -1319,7 +1329,7 @@ pub struct OrderInfo {
     pub estimated_arrival_date: Option<String>,
 }
 
-impl AsRef<OrderInfo> for OrderInfo {
+impl ::std::convert::AsRef<OrderInfo> for OrderInfo {
     fn as_ref(&self) -> &OrderInfo {
         self
     }
@@ -1331,7 +1341,7 @@ pub struct OriginalA {
     pub value: i64,
 }
 
-impl AsRef<OriginalA> for OriginalA {
+impl ::std::convert::AsRef<OriginalA> for OriginalA {
     fn as_ref(&self) -> &OriginalA {
         self
     }
@@ -1342,27 +1352,26 @@ impl AsRef<OriginalA> for OriginalA {
 #[serde(crate = "::baml::__internal::serde")]
 pub struct OriginalB {
     pub value: i64,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl OriginalB {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1371,7 +1380,9 @@ impl OriginalB {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1383,7 +1394,7 @@ impl OriginalB {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1393,16 +1404,16 @@ impl OriginalB {
     }
 }
 
-impl Default for OriginalB {
+impl ::std::default::Default for OriginalB {
     fn default() -> Self {
         Self {
-            value: Default::default(),
-            __dynamic: std::collections::HashMap::new(),
+            value: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<OriginalB> for OriginalB {
+impl ::std::convert::AsRef<OriginalB> for OriginalB {
     fn as_ref(&self) -> &OriginalB {
         self
     }
@@ -1414,27 +1425,26 @@ impl AsRef<OriginalB> for OriginalB {
 pub struct Person {
     pub name: Option<String>,
     pub hair_color: Option<Color>,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl Person {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1443,7 +1453,9 @@ impl Person {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1455,7 +1467,7 @@ impl Person {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1465,17 +1477,17 @@ impl Person {
     }
 }
 
-impl Default for Person {
+impl ::std::default::Default for Person {
     fn default() -> Self {
         Self {
-            name: Default::default(),
-            hair_color: Default::default(),
-            __dynamic: std::collections::HashMap::new(),
+            name: ::std::default::Default::default(),
+            hair_color: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<Person> for Person {
+impl ::std::convert::AsRef<Person> for Person {
     fn as_ref(&self) -> &Person {
         self
     }
@@ -1490,7 +1502,7 @@ pub struct PersonWithMeta {
     pub tags: Vec<String>,
 }
 
-impl AsRef<PersonWithMeta> for PersonWithMeta {
+impl ::std::convert::AsRef<PersonWithMeta> for PersonWithMeta {
     fn as_ref(&self) -> &PersonWithMeta {
         self
     }
@@ -1502,7 +1514,7 @@ pub struct PhoneNumber {
     pub value: String,
 }
 
-impl AsRef<PhoneNumber> for PhoneNumber {
+impl ::std::convert::AsRef<PhoneNumber> for PhoneNumber {
     fn as_ref(&self) -> &PhoneNumber {
         self
     }
@@ -1515,7 +1527,7 @@ pub struct Quantity {
     pub unit: Option<String>,
 }
 
-impl AsRef<Quantity> for Quantity {
+impl ::std::convert::AsRef<Quantity> for Quantity {
     fn as_ref(&self) -> &Quantity {
         self
     }
@@ -1528,7 +1540,7 @@ pub struct RaysData {
     pub value: Union2EventOrResume,
 }
 
-impl AsRef<RaysData> for RaysData {
+impl ::std::convert::AsRef<RaysData> for RaysData {
     fn as_ref(&self) -> &RaysData {
         self
     }
@@ -1542,7 +1554,7 @@ pub struct ReceiptInfo {
     pub venue: Union2KbarisaOrKox_burger,
 }
 
-impl AsRef<ReceiptInfo> for ReceiptInfo {
+impl ::std::convert::AsRef<ReceiptInfo> for ReceiptInfo {
     fn as_ref(&self) -> &ReceiptInfo {
         self
     }
@@ -1557,7 +1569,7 @@ pub struct ReceiptItem {
     pub price: f64,
 }
 
-impl AsRef<ReceiptItem> for ReceiptItem {
+impl ::std::convert::AsRef<ReceiptItem> for ReceiptItem {
     fn as_ref(&self) -> &ReceiptItem {
         self
     }
@@ -1570,7 +1582,7 @@ pub struct Recipe {
     pub recipe_type: Union2KbreakfastOrKdinner,
 }
 
-impl AsRef<Recipe> for Recipe {
+impl ::std::convert::AsRef<Recipe> for Recipe {
     fn as_ref(&self) -> &Recipe {
         self
     }
@@ -1582,7 +1594,7 @@ pub struct RecursiveAliasDependency {
     pub value: JsonValue,
 }
 
-impl AsRef<RecursiveAliasDependency> for RecursiveAliasDependency {
+impl ::std::convert::AsRef<RecursiveAliasDependency> for RecursiveAliasDependency {
     fn as_ref(&self) -> &RecursiveAliasDependency {
         self
     }
@@ -1593,27 +1605,26 @@ impl AsRef<RecursiveAliasDependency> for RecursiveAliasDependency {
 #[serde(crate = "::baml::__internal::serde")]
 pub struct RenderEnumInput {
     pub testKey: String,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl RenderEnumInput {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1622,7 +1633,9 @@ impl RenderEnumInput {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1634,7 +1647,7 @@ impl RenderEnumInput {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1644,16 +1657,16 @@ impl RenderEnumInput {
     }
 }
 
-impl Default for RenderEnumInput {
+impl ::std::default::Default for RenderEnumInput {
     fn default() -> Self {
         Self {
-            testKey: Default::default(),
-            __dynamic: std::collections::HashMap::new(),
+            testKey: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<RenderEnumInput> for RenderEnumInput {
+impl ::std::convert::AsRef<RenderEnumInput> for RenderEnumInput {
     fn as_ref(&self) -> &RenderEnumInput {
         self
     }
@@ -1665,27 +1678,26 @@ impl AsRef<RenderEnumInput> for RenderEnumInput {
 pub struct RenderTestClass {
     pub name: String,
     pub status: RenderStatusEnum,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl RenderTestClass {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1694,7 +1706,9 @@ impl RenderTestClass {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1706,7 +1720,7 @@ impl RenderTestClass {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1716,17 +1730,17 @@ impl RenderTestClass {
     }
 }
 
-impl Default for RenderTestClass {
+impl ::std::default::Default for RenderTestClass {
     fn default() -> Self {
         Self {
-            name: Default::default(),
-            status: Default::default(),
-            __dynamic: std::collections::HashMap::new(),
+            name: ::std::default::Default::default(),
+            status: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<RenderTestClass> for RenderTestClass {
+impl ::std::convert::AsRef<RenderTestClass> for RenderTestClass {
     fn as_ref(&self) -> &RenderTestClass {
         self
     }
@@ -1743,7 +1757,7 @@ pub struct Resume {
     pub skills: Vec<String>,
 }
 
-impl AsRef<Resume> for Resume {
+impl ::std::convert::AsRef<Resume> for Resume {
     fn as_ref(&self) -> &Resume {
         self
     }
@@ -1761,7 +1775,7 @@ pub struct Schema {
     pub other_group: Union2IntOrString,
 }
 
-impl AsRef<Schema> for Schema {
+impl ::std::convert::AsRef<Schema> for Schema {
     fn as_ref(&self) -> &Schema {
         self
     }
@@ -1778,7 +1792,7 @@ pub struct SearchParams {
     pub tags: Vec<Union2StringOrTag>,
 }
 
-impl AsRef<SearchParams> for SearchParams {
+impl ::std::convert::AsRef<SearchParams> for SearchParams {
     fn as_ref(&self) -> &SearchParams {
         self
     }
@@ -1797,7 +1811,7 @@ pub struct SemanticContainer {
     pub final_string: String,
 }
 
-impl AsRef<SemanticContainer> for SemanticContainer {
+impl ::std::convert::AsRef<SemanticContainer> for SemanticContainer {
     fn as_ref(&self) -> &SemanticContainer {
         self
     }
@@ -1809,7 +1823,7 @@ pub struct SimpleTag {
     pub field: String,
 }
 
-impl AsRef<SimpleTag> for SimpleTag {
+impl ::std::convert::AsRef<SimpleTag> for SimpleTag {
     fn as_ref(&self) -> &SimpleTag {
         self
     }
@@ -1821,27 +1835,26 @@ impl AsRef<SimpleTag> for SimpleTag {
 pub struct SkipDynamicClass {
     pub value: String,
     pub internal_id: Option<String>,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl SkipDynamicClass {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1850,7 +1863,9 @@ impl SkipDynamicClass {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1862,7 +1877,7 @@ impl SkipDynamicClass {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1872,17 +1887,17 @@ impl SkipDynamicClass {
     }
 }
 
-impl Default for SkipDynamicClass {
+impl ::std::default::Default for SkipDynamicClass {
     fn default() -> Self {
         Self {
-            value: Default::default(),
-            internal_id: Default::default(),
-            __dynamic: std::collections::HashMap::new(),
+            value: ::std::default::Default::default(),
+            internal_id: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<SkipDynamicClass> for SkipDynamicClass {
+impl ::std::convert::AsRef<SkipDynamicClass> for SkipDynamicClass {
     fn as_ref(&self) -> &SkipDynamicClass {
         self
     }
@@ -1896,7 +1911,7 @@ pub struct SkipNonDynamicClass {
     pub metadata: Option<String>,
 }
 
-impl AsRef<SkipNonDynamicClass> for SkipNonDynamicClass {
+impl ::std::convert::AsRef<SkipNonDynamicClass> for SkipNonDynamicClass {
     fn as_ref(&self) -> &SkipNonDynamicClass {
         self
     }
@@ -1909,7 +1924,7 @@ pub struct SmallThing {
     pub i_8_digits: i64,
 }
 
-impl AsRef<SmallThing> for SmallThing {
+impl ::std::convert::AsRef<SmallThing> for SmallThing {
     fn as_ref(&self) -> &SmallThing {
         self
     }
@@ -1920,27 +1935,26 @@ impl AsRef<SmallThing> for SmallThing {
 #[serde(crate = "::baml::__internal::serde")]
 pub struct SomeClassNestedDynamic {
     pub hi: String,
-
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
     #[serde(flatten)]
-    pub __dynamic: std::collections::HashMap<
-        String,
-        baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    pub __dynamic: ::std::collections::HashMap<
+        ::std::string::String,
+        ::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
     >,
 }
 
 impl SomeClassNestedDynamic {
     /// Get a dynamic field by name and convert to the specified type.
-    pub fn get<V: baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
+    pub fn get<V: ::baml::FromBamlValue<super::Types, super::super::stream_types::StreamTypes>>(
         &self,
         field: &str,
-    ) -> Result<V, baml::BamlError> {
+    ) -> ::std::result::Result<V, ::baml::BamlError> {
         self.__dynamic
             .get(field)
             .cloned()
             .ok_or_else(|| {
-                baml::BamlError::internal(format!("dynamic field '{}' not found", field))
+                ::baml::BamlError::internal(format!("dynamic field '{}' not found", field))
             })
             .and_then(|v| v.get())
     }
@@ -1949,7 +1963,9 @@ impl SomeClassNestedDynamic {
     pub fn get_ref(
         &self,
         field: &str,
-    ) -> Option<&baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>> {
+    ) -> ::std::option::Option<
+        &::baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
+    > {
         self.__dynamic.get(field)
     }
 
@@ -1961,7 +1977,7 @@ impl SomeClassNestedDynamic {
     /// Iterate over all dynamic fields.
     pub fn dynamic_fields(
         &self,
-    ) -> impl Iterator<
+    ) -> impl ::std::iter::Iterator<
         Item = (
             &str,
             &baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1971,16 +1987,16 @@ impl SomeClassNestedDynamic {
     }
 }
 
-impl Default for SomeClassNestedDynamic {
+impl ::std::default::Default for SomeClassNestedDynamic {
     fn default() -> Self {
         Self {
-            hi: Default::default(),
-            __dynamic: std::collections::HashMap::new(),
+            hi: ::std::default::Default::default(),
+            __dynamic: ::std::collections::HashMap::new(),
         }
     }
 }
 
-impl AsRef<SomeClassNestedDynamic> for SomeClassNestedDynamic {
+impl ::std::convert::AsRef<SomeClassNestedDynamic> for SomeClassNestedDynamic {
     fn as_ref(&self) -> &SomeClassNestedDynamic {
         self
     }
@@ -1992,7 +2008,7 @@ pub struct StringToClassEntry {
     pub word: String,
 }
 
-impl AsRef<StringToClassEntry> for StringToClassEntry {
+impl ::std::convert::AsRef<StringToClassEntry> for StringToClassEntry {
     fn as_ref(&self) -> &StringToClassEntry {
         self
     }
@@ -2008,7 +2024,7 @@ pub struct TestClassAlias {
     pub key5: String,
 }
 
-impl AsRef<TestClassAlias> for TestClassAlias {
+impl ::std::convert::AsRef<TestClassAlias> for TestClassAlias {
     fn as_ref(&self) -> &TestClassAlias {
         self
     }
@@ -2021,7 +2037,7 @@ pub struct TestClassNested {
     pub prop2: InnerClass,
 }
 
-impl AsRef<TestClassNested> for TestClassNested {
+impl ::std::convert::AsRef<TestClassNested> for TestClassNested {
     fn as_ref(&self) -> &TestClassNested {
         self
     }
@@ -2034,7 +2050,7 @@ pub struct TestClassWithEnum {
     pub prop2: EnumInClass,
 }
 
-impl AsRef<TestClassWithEnum> for TestClassWithEnum {
+impl ::std::convert::AsRef<TestClassWithEnum> for TestClassWithEnum {
     fn as_ref(&self) -> &TestClassWithEnum {
         self
     }
@@ -2047,7 +2063,7 @@ pub struct TestMemoryOutput {
     pub more_items: Vec<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>,
 }
 
-impl AsRef<TestMemoryOutput> for TestMemoryOutput {
+impl ::std::convert::AsRef<TestMemoryOutput> for TestMemoryOutput {
     fn as_ref(&self) -> &TestMemoryOutput {
         self
     }
@@ -2060,7 +2076,7 @@ pub struct TestOutputClass {
     pub prop2: i64,
 }
 
-impl AsRef<TestOutputClass> for TestOutputClass {
+impl ::std::convert::AsRef<TestOutputClass> for TestOutputClass {
     fn as_ref(&self) -> &TestOutputClass {
         self
     }
@@ -2075,7 +2091,7 @@ pub struct TodoMessageToUser {
     pub message: String,
 }
 
-impl AsRef<TodoMessageToUser> for TodoMessageToUser {
+impl ::std::convert::AsRef<TodoMessageToUser> for TodoMessageToUser {
     fn as_ref(&self) -> &TodoMessageToUser {
         self
     }
@@ -2088,7 +2104,7 @@ pub struct Tree {
     pub children: Box<Forest>,
 }
 
-impl AsRef<Tree> for Tree {
+impl ::std::convert::AsRef<Tree> for Tree {
     fn as_ref(&self) -> &Tree {
         self
     }
@@ -2102,7 +2118,7 @@ pub struct TwoStoriesOneTitle {
     pub story_b: String,
 }
 
-impl AsRef<TwoStoriesOneTitle> for TwoStoriesOneTitle {
+impl ::std::convert::AsRef<TwoStoriesOneTitle> for TwoStoriesOneTitle {
     fn as_ref(&self) -> &TwoStoriesOneTitle {
         self
     }
@@ -2116,7 +2132,7 @@ pub struct TwoStoriesOneTitleCheck {
     pub story_b: Checked<String>,
 }
 
-impl AsRef<TwoStoriesOneTitleCheck> for TwoStoriesOneTitleCheck {
+impl ::std::convert::AsRef<TwoStoriesOneTitleCheck> for TwoStoriesOneTitleCheck {
     fn as_ref(&self) -> &TwoStoriesOneTitleCheck {
         self
     }
@@ -2130,7 +2146,7 @@ pub struct UnionTest_ReturnType {
     pub prop3: Union2ListBoolOrListInt,
 }
 
-impl AsRef<UnionTest_ReturnType> for UnionTest_ReturnType {
+impl ::std::convert::AsRef<UnionTest_ReturnType> for UnionTest_ReturnType {
     fn as_ref(&self) -> &UnionTest_ReturnType {
         self
     }
@@ -2145,7 +2161,7 @@ pub struct UniverseQuestion {
     pub answer: String,
 }
 
-impl AsRef<UniverseQuestion> for UniverseQuestion {
+impl ::std::convert::AsRef<UniverseQuestion> for UniverseQuestion {
     fn as_ref(&self) -> &UniverseQuestion {
         self
     }
@@ -2157,7 +2173,7 @@ pub struct UniverseQuestionInput {
     pub question: String,
 }
 
-impl AsRef<UniverseQuestionInput> for UniverseQuestionInput {
+impl ::std::convert::AsRef<UniverseQuestionInput> for UniverseQuestionInput {
     fn as_ref(&self) -> &UniverseQuestionInput {
         self
     }
@@ -2170,7 +2186,7 @@ pub struct WithReasoning {
     pub reasoning: String,
 }
 
-impl AsRef<WithReasoning> for WithReasoning {
+impl ::std::convert::AsRef<WithReasoning> for WithReasoning {
     fn as_ref(&self) -> &WithReasoning {
         self
     }

--- a/integ-tests/rust/src/baml_client/types/classes.rs
+++ b/integ-tests/rust/src/baml_client/types/classes.rs
@@ -6,18 +6,15 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{BamlDecode, BamlEncode, BamlSerde};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct AddTodoItem {
     #[baml(name = "type")]
     pub r#type: String,
-
     pub item: String,
-
     pub time: String,
-
+    pub a: Audio,
     pub description: String,
 }
 
@@ -27,13 +24,10 @@ impl AsRef<AddTodoItem> for AddTodoItem {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct AddressWithMeta {
     pub street: String,
-
     pub city: String,
-
     pub zipcode: String,
 }
 
@@ -43,13 +37,10 @@ impl AsRef<AddressWithMeta> for AddressWithMeta {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct AnotherObject {
     pub id: String,
-
     pub thingy2: String,
-
     pub thingy3: String,
 }
 
@@ -59,11 +50,9 @@ impl AsRef<AnotherObject> for AnotherObject {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct BigNumbers {
     pub a: i64,
-
     pub b: f64,
 }
 
@@ -73,13 +62,10 @@ impl AsRef<BigNumbers> for BigNumbers {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct BinaryNode {
     pub data: i64,
-
     pub left: Option<Box<BinaryNode>>,
-
     pub right: Option<Box<BinaryNode>>,
 }
 
@@ -89,8 +75,7 @@ impl AsRef<BinaryNode> for BinaryNode {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Blah {
     pub prop4: Option<String>,
 }
@@ -101,11 +86,9 @@ impl AsRef<Blah> for Blah {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct BlockConstraint {
     pub foo: i64,
-
     pub bar: String,
 }
 
@@ -115,11 +98,9 @@ impl AsRef<BlockConstraint> for BlockConstraint {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct BlockConstraintForParam {
     pub bcfp: i64,
-
     pub bcfp2: String,
 }
 
@@ -129,15 +110,11 @@ impl AsRef<BlockConstraintForParam> for BlockConstraintForParam {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct BookOrder {
     pub orderId: String,
-
     pub title: String,
-
     pub quantity: i64,
-
     pub price: f64,
 }
 
@@ -147,8 +124,7 @@ impl AsRef<BookOrder> for BookOrder {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ClassForNullLiteral {
     pub a: String,
 }
@@ -159,11 +135,9 @@ impl AsRef<ClassForNullLiteral> for ClassForNullLiteral {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ClassOptionalOutput {
     pub prop1: String,
-
     pub prop2: String,
 }
 
@@ -173,13 +147,10 @@ impl AsRef<ClassOptionalOutput> for ClassOptionalOutput {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ClassOptionalOutput2 {
     pub prop1: Option<String>,
-
     pub prop2: Option<String>,
-
     pub prop3: Option<Blah>,
 }
 
@@ -189,8 +160,7 @@ impl AsRef<ClassOptionalOutput2> for ClassOptionalOutput2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ClassToRecAlias {
     pub list: LinkedListAliasNode,
 }
@@ -201,11 +171,9 @@ impl AsRef<ClassToRecAlias> for ClassToRecAlias {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ClassWithBlockDone {
     pub i_16_digits: i64,
-
     pub s_20_words: String,
 }
 
@@ -215,13 +183,10 @@ impl AsRef<ClassWithBlockDone> for ClassWithBlockDone {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ClassWithImage {
     pub myImage: Image,
-
     pub param2: String,
-
     pub fake_image: FakeImage,
 }
 
@@ -231,11 +196,9 @@ impl AsRef<ClassWithImage> for ClassWithImage {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ClassWithoutDone {
     pub i_16_digits: i64,
-
     pub s_20_words: String,
 }
 
@@ -245,21 +208,14 @@ impl AsRef<ClassWithoutDone> for ClassWithoutDone {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ClientDetails1559 {
     pub client_name: Option<String>,
-
     pub client_address: Option<String>,
-
     pub client_postal_code: Option<String>,
-
     pub client_city: Option<String>,
-
     pub client_country: Option<String>,
-
     pub client_phone: Option<String>,
-
     pub client_email: Option<String>,
 }
 
@@ -269,15 +225,11 @@ impl AsRef<ClientDetails1559> for ClientDetails1559 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ComplexMemoryObject {
     pub id: String,
-
     pub name: String,
-
     pub description: String,
-
     pub metadata: Vec<Union3FloatOrIntOrString>,
 }
 
@@ -287,13 +239,10 @@ impl AsRef<ComplexMemoryObject> for ComplexMemoryObject {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct CompoundBigNumbers {
     pub big: BigNumbers,
-
     pub big_nums: Vec<BigNumbers>,
-
     pub another: BigNumbers,
 }
 
@@ -303,11 +252,9 @@ impl AsRef<CompoundBigNumbers> for CompoundBigNumbers {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ContactInfo {
     pub primary: Union2EmailAddressOrPhoneNumber,
-
     pub secondary: Option<Union2EmailAddressOrPhoneNumber>,
 }
 
@@ -317,13 +264,10 @@ impl AsRef<ContactInfo> for ContactInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct CustomStory {
     pub title: String,
-
     pub characters: Vec<String>,
-
     pub content: String,
 }
 
@@ -333,13 +277,10 @@ impl AsRef<CustomStory> for CustomStory {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct CustomTaskResult {
     pub bookOrder: Option<BookOrder>,
-
     pub flightConfirmation: Option<FlightConfirmation>,
-
     pub groceryReceipt: Option<GroceryReceipt>,
 }
 
@@ -349,11 +290,9 @@ impl AsRef<CustomTaskResult> for CustomTaskResult {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Document1559 {
     pub client_details: ClientDetails1559,
-
     pub notes: Vec<Note1599>,
 }
 
@@ -363,15 +302,11 @@ impl AsRef<Document1559> for Document1559 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct DummyJsonTodo {
     pub id: i64,
-
     pub todo: String,
-
     pub completed: bool,
-
     pub userId: i64,
 }
 
@@ -381,12 +316,10 @@ impl AsRef<DummyJsonTodo> for DummyJsonTodo {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct DummyOutput {
     pub nonce: String,
-
     pub nonce2: String,
 
     /// Dynamic fields added at runtime via TypeBuilder.
@@ -442,9 +375,7 @@ impl Default for DummyOutput {
     fn default() -> Self {
         Self {
             nonce: Default::default(),
-
             nonce2: Default::default(),
-
             __dynamic: std::collections::HashMap::new(),
         }
     }
@@ -456,9 +387,8 @@ impl AsRef<DummyOutput> for DummyOutput {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct DynInputOutput {
     pub testKey: String,
 
@@ -515,7 +445,6 @@ impl Default for DynInputOutput {
     fn default() -> Self {
         Self {
             testKey: Default::default(),
-
             __dynamic: std::collections::HashMap::new(),
         }
     }
@@ -527,9 +456,8 @@ impl AsRef<DynInputOutput> for DynInputOutput {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct DynamicClassOne {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
@@ -594,14 +522,11 @@ impl AsRef<DynamicClassOne> for DynamicClassOne {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct DynamicClassTwo {
     pub hi: String,
-
     pub some_class: SomeClassNestedDynamic,
-
     pub status: DynEnumOne,
 
     /// Dynamic fields added at runtime via TypeBuilder.
@@ -657,11 +582,8 @@ impl Default for DynamicClassTwo {
     fn default() -> Self {
         Self {
             hi: Default::default(),
-
             some_class: Default::default(),
-
             status: Default::default(),
-
             __dynamic: std::collections::HashMap::new(),
         }
     }
@@ -673,9 +595,8 @@ impl AsRef<DynamicClassTwo> for DynamicClassTwo {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct DynamicOutput {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
@@ -740,9 +661,8 @@ impl AsRef<DynamicOutput> for DynamicOutput {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct DynamicSchema {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
@@ -807,8 +727,7 @@ impl AsRef<DynamicSchema> for DynamicSchema {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Earthling {
     pub age: Checked<i64>,
 }
@@ -819,17 +738,12 @@ impl AsRef<Earthling> for Earthling {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Education {
     pub institution: String,
-
     pub location: String,
-
     pub degree: String,
-
     pub major: Vec<String>,
-
     pub graduation_date: Option<String>,
 }
 
@@ -839,13 +753,10 @@ impl AsRef<Education> for Education {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Email {
     pub subject: String,
-
     pub body: String,
-
     pub from_address: String,
 }
 
@@ -855,8 +766,7 @@ impl AsRef<Email> for Email {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct EmailAddress {
     pub value: String,
 }
@@ -867,15 +777,11 @@ impl AsRef<EmailAddress> for EmailAddress {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Event {
     pub title: String,
-
     pub date: String,
-
     pub location: String,
-
     pub description: String,
 }
 
@@ -885,8 +791,7 @@ impl AsRef<Event> for Event {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct FakeImage {
     pub url: String,
 }
@@ -897,17 +802,12 @@ impl AsRef<FakeImage> for FakeImage {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct FlightConfirmation {
     pub confirmationNumber: String,
-
     pub flightNumber: String,
-
     pub departureTime: String,
-
     pub arrivalTime: String,
-
     pub seatNumber: String,
 }
 
@@ -917,13 +817,10 @@ impl AsRef<FlightConfirmation> for FlightConfirmation {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct FooAny {
     pub planetary_age: Union2EarthlingOrMartian,
-
     pub certainty: Checked<i64>,
-
     pub species: Checked<String>,
 }
 
@@ -933,8 +830,7 @@ impl AsRef<FooAny> for FooAny {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Forest {
     pub trees: Vec<Box<Tree>>,
 }
@@ -945,11 +841,9 @@ impl AsRef<Forest> for Forest {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct FormatterTest0 {
     pub lorem: String,
-
     pub ipsum: String,
 }
 
@@ -959,11 +853,9 @@ impl AsRef<FormatterTest0> for FormatterTest0 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct FormatterTest1 {
     pub lorem: String,
-
     pub ipsum: String,
 }
 
@@ -973,11 +865,9 @@ impl AsRef<FormatterTest1> for FormatterTest1 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct FormatterTest2 {
     pub lorem: String,
-
     pub ipsum: String,
 }
 
@@ -987,11 +877,9 @@ impl AsRef<FormatterTest2> for FormatterTest2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct FormatterTest3 {
     pub lorem: String,
-
     pub ipsum: String,
 }
 
@@ -1001,15 +889,11 @@ impl AsRef<FormatterTest3> for FormatterTest3 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct GroceryReceipt {
     pub receiptId: String,
-
     pub storeName: String,
-
     pub items: Vec<Union3FloatOrIntOrString>,
-
     pub totalAmount: f64,
 }
 
@@ -1019,13 +903,10 @@ impl AsRef<GroceryReceipt> for GroceryReceipt {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Haiku {
     pub line1: String,
-
     pub line2: String,
-
     pub line3: String,
 }
 
@@ -1035,13 +916,10 @@ impl AsRef<Haiku> for Haiku {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct InnerClass {
     pub prop1: String,
-
     pub prop2: String,
-
     pub inner: InnerClass2,
 }
 
@@ -1051,11 +929,9 @@ impl AsRef<InnerClass> for InnerClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct InnerClass2 {
     pub prop2: i64,
-
     pub prop3: f64,
 }
 
@@ -1065,11 +941,9 @@ impl AsRef<InnerClass2> for InnerClass2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct InputClass {
     pub key: String,
-
     pub key2: String,
 }
 
@@ -1079,11 +953,9 @@ impl AsRef<InputClass> for InputClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct InputClassNested {
     pub key: String,
-
     pub nested: InputClass,
 }
 
@@ -1093,11 +965,9 @@ impl AsRef<InputClassNested> for InputClassNested {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct LinkedList {
     pub head: Option<Node>,
-
     pub len: i64,
 }
 
@@ -1107,11 +977,9 @@ impl AsRef<LinkedList> for LinkedList {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct LinkedListAliasNode {
     pub value: i64,
-
     pub next: Option<Box<LinkedListAliasNode>>,
 }
 
@@ -1121,8 +989,7 @@ impl AsRef<LinkedListAliasNode> for LinkedListAliasNode {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct LiteralClassHello {
     pub prop: String,
 }
@@ -1133,8 +1000,7 @@ impl AsRef<LiteralClassHello> for LiteralClassHello {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct LiteralClassOne {
     pub prop: String,
 }
@@ -1145,8 +1011,7 @@ impl AsRef<LiteralClassOne> for LiteralClassOne {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct LiteralClassTwo {
     pub prop: String,
 }
@@ -1157,13 +1022,10 @@ impl AsRef<LiteralClassTwo> for LiteralClassTwo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct MaintainFieldOrder {
     pub c: String,
-
     pub b: String,
-
     pub a: String,
 }
 
@@ -1173,8 +1035,7 @@ impl AsRef<MaintainFieldOrder> for MaintainFieldOrder {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct MalformedConstraints {
     pub foo: Checked<i64>,
 }
@@ -1185,8 +1046,7 @@ impl AsRef<MalformedConstraints> for MalformedConstraints {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct MalformedConstraints2 {
     pub foo: i64,
 }
@@ -1200,8 +1060,7 @@ impl AsRef<MalformedConstraints2> for MalformedConstraints2 {
 /// A Martian organism with an age.
 /// Such a nice type.
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Martian {
     /// The age of the Martian in Mars years.
     /// So many Mars years.
@@ -1214,13 +1073,10 @@ impl AsRef<Martian> for Martian {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct MemoryObject {
     pub id: String,
-
     pub name: String,
-
     pub description: String,
 }
 
@@ -1230,8 +1086,7 @@ impl AsRef<MemoryObject> for MemoryObject {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct MergeAttrs {
     pub amount: Checked<i64>,
 }
@@ -1242,13 +1097,10 @@ impl AsRef<MergeAttrs> for MergeAttrs {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct NamedArgsSingleClass {
     pub key: String,
-
     pub key_two: bool,
-
     pub key_three: i64,
 }
 
@@ -1258,13 +1110,10 @@ impl AsRef<NamedArgsSingleClass> for NamedArgsSingleClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Nested {
     pub prop3: Option<String>,
-
     pub prop4: Option<String>,
-
     pub prop20: Nested2,
 }
 
@@ -1274,11 +1123,9 @@ impl AsRef<Nested> for Nested {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Nested2 {
     pub prop11: Option<String>,
-
     pub prop12: Option<String>,
 }
 
@@ -1288,8 +1135,7 @@ impl AsRef<Nested2> for Nested2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct NestedBlockConstraint {
     pub nbc: Checked<BlockConstraint>,
 }
@@ -1300,8 +1146,7 @@ impl AsRef<NestedBlockConstraint> for NestedBlockConstraint {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct NestedBlockConstraintForParam {
     pub nbcfp: BlockConstraintForParam,
 }
@@ -1312,11 +1157,9 @@ impl AsRef<NestedBlockConstraintForParam> for NestedBlockConstraintForParam {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Node {
     pub data: i64,
-
     pub next: Option<Box<Node>>,
 }
 
@@ -1326,11 +1169,9 @@ impl AsRef<Node> for Node {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct NodeWithAliasIndirection {
     pub value: i64,
-
     pub next: Option<Box<NodeWithAliasIndirection>>,
 }
 
@@ -1340,13 +1181,10 @@ impl AsRef<NodeWithAliasIndirection> for NodeWithAliasIndirection {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Note1599 {
     pub note_title: String,
-
     pub note_description: Option<String>,
-
     pub note_amount: Option<String>,
 }
 
@@ -1356,11 +1194,9 @@ impl AsRef<Note1599> for Note1599 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct OptionalListAndMap {
     pub p: Option<Vec<String>>,
-
     pub q: Option<std::collections::HashMap<String, String>>,
 }
 
@@ -1370,11 +1206,9 @@ impl AsRef<OptionalListAndMap> for OptionalListAndMap {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct OptionalTest_Prop1 {
     pub omega_a: String,
-
     pub omega_b: i64,
 }
 
@@ -1384,13 +1218,10 @@ impl AsRef<OptionalTest_Prop1> for OptionalTest_Prop1 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct OptionalTest_ReturnType {
     pub omega_1: Option<OptionalTest_Prop1>,
-
     pub omega_2: Option<String>,
-
     pub omega_3: Vec<Option<OptionalTest_CategoryType>>,
 }
 
@@ -1400,13 +1231,10 @@ impl AsRef<OptionalTest_ReturnType> for OptionalTest_ReturnType {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct OrderInfo {
     pub order_status: OrderStatus,
-
     pub tracking_number: Option<String>,
-
     pub estimated_arrival_date: Option<String>,
 }
 
@@ -1416,8 +1244,7 @@ impl AsRef<OrderInfo> for OrderInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct OriginalA {
     pub value: i64,
 }
@@ -1428,9 +1255,8 @@ impl AsRef<OriginalA> for OriginalA {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct OriginalB {
     pub value: i64,
 
@@ -1487,7 +1313,6 @@ impl Default for OriginalB {
     fn default() -> Self {
         Self {
             value: Default::default(),
-
             __dynamic: std::collections::HashMap::new(),
         }
     }
@@ -1499,12 +1324,10 @@ impl AsRef<OriginalB> for OriginalB {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct Person {
     pub name: Option<String>,
-
     pub hair_color: Option<Color>,
 
     /// Dynamic fields added at runtime via TypeBuilder.
@@ -1560,9 +1383,7 @@ impl Default for Person {
     fn default() -> Self {
         Self {
             name: Default::default(),
-
             hair_color: Default::default(),
-
             __dynamic: std::collections::HashMap::new(),
         }
     }
@@ -1574,15 +1395,11 @@ impl AsRef<Person> for Person {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct PersonWithMeta {
     pub name: String,
-
     pub age: i64,
-
     pub address: AddressWithMeta,
-
     pub tags: Vec<String>,
 }
 
@@ -1592,8 +1409,7 @@ impl AsRef<PersonWithMeta> for PersonWithMeta {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct PhoneNumber {
     pub value: String,
 }
@@ -1604,11 +1420,9 @@ impl AsRef<PhoneNumber> for PhoneNumber {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Quantity {
     pub amount: Union2FloatOrInt,
-
     pub unit: Option<String>,
 }
 
@@ -1618,11 +1432,9 @@ impl AsRef<Quantity> for Quantity {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct RaysData {
     pub dataType: DataType,
-
     pub value: Union2EventOrResume,
 }
 
@@ -1632,13 +1444,10 @@ impl AsRef<RaysData> for RaysData {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ReceiptInfo {
     pub items: Vec<ReceiptItem>,
-
     pub total_cost: Option<f64>,
-
     pub venue: Union2KbarisaOrKox_burger,
 }
 
@@ -1648,15 +1457,11 @@ impl AsRef<ReceiptInfo> for ReceiptInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct ReceiptItem {
     pub name: String,
-
     pub description: Option<String>,
-
     pub quantity: i64,
-
     pub price: f64,
 }
 
@@ -1666,11 +1471,9 @@ impl AsRef<ReceiptItem> for ReceiptItem {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Recipe {
     pub ingredients: std::collections::HashMap<String, Quantity>,
-
     pub recipe_type: Union2KbreakfastOrKdinner,
 }
 
@@ -1680,8 +1483,7 @@ impl AsRef<Recipe> for Recipe {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct RecursiveAliasDependency {
     pub value: JsonValue,
 }
@@ -1692,9 +1494,8 @@ impl AsRef<RecursiveAliasDependency> for RecursiveAliasDependency {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct RenderEnumInput {
     pub testKey: String,
 
@@ -1751,7 +1552,6 @@ impl Default for RenderEnumInput {
     fn default() -> Self {
         Self {
             testKey: Default::default(),
-
             __dynamic: std::collections::HashMap::new(),
         }
     }
@@ -1763,12 +1563,10 @@ impl AsRef<RenderEnumInput> for RenderEnumInput {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct RenderTestClass {
     pub name: String,
-
     pub status: RenderStatusEnum,
 
     /// Dynamic fields added at runtime via TypeBuilder.
@@ -1824,9 +1622,7 @@ impl Default for RenderTestClass {
     fn default() -> Self {
         Self {
             name: Default::default(),
-
             status: Default::default(),
-
             __dynamic: std::collections::HashMap::new(),
         }
     }
@@ -1838,19 +1634,13 @@ impl AsRef<RenderTestClass> for RenderTestClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Resume {
     pub name: String,
-
     pub email: String,
-
     pub phone: String,
-
     pub experience: Vec<String>,
-
     pub education: Vec<Education>,
-
     pub skills: Vec<String>,
 }
 
@@ -1860,21 +1650,14 @@ impl AsRef<Resume> for Resume {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Schema {
     pub prop1: Option<String>,
-
     pub prop2: Union2NestedOrString,
-
     pub prop5: Vec<Option<String>>,
-
     pub prop6: Union2ListNestedOrString,
-
     pub nested_attrs: Vec<Option<Union2NestedOrString>>,
-
     pub parens: Option<String>,
-
     pub other_group: Union2IntOrString,
 }
 
@@ -1884,19 +1667,13 @@ impl AsRef<Schema> for Schema {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct SearchParams {
     pub dateRange: Option<i64>,
-
     pub location: Vec<String>,
-
     pub jobTitle: Option<WithReasoning>,
-
     pub company: Option<WithReasoning>,
-
     pub description: Vec<WithReasoning>,
-
     pub tags: Vec<Union2StringOrTag>,
 }
 
@@ -1906,23 +1683,15 @@ impl AsRef<SearchParams> for SearchParams {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct SemanticContainer {
     pub sixteen_digit_number: i64,
-
     pub string_with_twenty_words: String,
-
     pub class_1: ClassWithoutDone,
-
     pub class_2: ClassWithBlockDone,
-
     pub class_done_needed: ClassWithBlockDone,
-
     pub class_needed: ClassWithoutDone,
-
     pub three_small_things: Vec<SmallThing>,
-
     pub final_string: String,
 }
 
@@ -1932,8 +1701,7 @@ impl AsRef<SemanticContainer> for SemanticContainer {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct SimpleTag {
     pub field: String,
 }
@@ -1944,12 +1712,10 @@ impl AsRef<SimpleTag> for SimpleTag {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct SkipDynamicClass {
     pub value: String,
-
     pub internal_id: Option<String>,
 
     /// Dynamic fields added at runtime via TypeBuilder.
@@ -2005,9 +1771,7 @@ impl Default for SkipDynamicClass {
     fn default() -> Self {
         Self {
             value: Default::default(),
-
             internal_id: Default::default(),
-
             __dynamic: std::collections::HashMap::new(),
         }
     }
@@ -2019,13 +1783,10 @@ impl AsRef<SkipDynamicClass> for SkipDynamicClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct SkipNonDynamicClass {
     pub name: String,
-
     pub description: Option<String>,
-
     pub metadata: Option<String>,
 }
 
@@ -2035,11 +1796,9 @@ impl AsRef<SkipNonDynamicClass> for SkipNonDynamicClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct SmallThing {
     pub i_16_digits: i64,
-
     pub i_8_digits: i64,
 }
 
@@ -2049,9 +1808,8 @@ impl AsRef<SmallThing> for SmallThing {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
-
 pub struct SomeClassNestedDynamic {
     pub hi: String,
 
@@ -2108,7 +1866,6 @@ impl Default for SomeClassNestedDynamic {
     fn default() -> Self {
         Self {
             hi: Default::default(),
-
             __dynamic: std::collections::HashMap::new(),
         }
     }
@@ -2120,8 +1877,7 @@ impl AsRef<SomeClassNestedDynamic> for SomeClassNestedDynamic {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct StringToClassEntry {
     pub word: String,
 }
@@ -2132,17 +1888,12 @@ impl AsRef<StringToClassEntry> for StringToClassEntry {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct TestClassAlias {
     pub key: String,
-
     pub key2: String,
-
     pub key3: String,
-
     pub key4: String,
-
     pub key5: String,
 }
 
@@ -2152,11 +1903,9 @@ impl AsRef<TestClassAlias> for TestClassAlias {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct TestClassNested {
     pub prop1: String,
-
     pub prop2: InnerClass,
 }
 
@@ -2166,11 +1915,9 @@ impl AsRef<TestClassNested> for TestClassNested {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct TestClassWithEnum {
     pub prop1: String,
-
     pub prop2: EnumInClass,
 }
 
@@ -2180,11 +1927,9 @@ impl AsRef<TestClassWithEnum> for TestClassWithEnum {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct TestMemoryOutput {
     pub items: Vec<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>,
-
     pub more_items: Vec<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>,
 }
 
@@ -2194,11 +1939,9 @@ impl AsRef<TestMemoryOutput> for TestMemoryOutput {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct TestOutputClass {
     pub prop1: String,
-
     pub prop2: i64,
 }
 
@@ -2208,12 +1951,10 @@ impl AsRef<TestOutputClass> for TestOutputClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct TodoMessageToUser {
     #[baml(name = "type")]
     pub r#type: String,
-
     pub message: String,
 }
 
@@ -2223,11 +1964,9 @@ impl AsRef<TodoMessageToUser> for TodoMessageToUser {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct Tree {
     pub data: i64,
-
     pub children: Box<Forest>,
 }
 
@@ -2237,13 +1976,10 @@ impl AsRef<Tree> for Tree {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct TwoStoriesOneTitle {
     pub title: String,
-
     pub story_a: String,
-
     pub story_b: String,
 }
 
@@ -2253,13 +1989,10 @@ impl AsRef<TwoStoriesOneTitle> for TwoStoriesOneTitle {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct TwoStoriesOneTitleCheck {
     pub title: String,
-
     pub story_a: Checked<String>,
-
     pub story_b: Checked<String>,
 }
 
@@ -2269,13 +2002,10 @@ impl AsRef<TwoStoriesOneTitleCheck> for TwoStoriesOneTitleCheck {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct UnionTest_ReturnType {
     pub prop1: Union2BoolOrString,
-
     pub prop2: Vec<Union2BoolOrFloat>,
-
     pub prop3: Union2ListBoolOrListInt,
 }
 
@@ -2287,11 +2017,9 @@ impl AsRef<UnionTest_ReturnType> for UnionTest_ReturnType {
 
 /// my docs
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct UniverseQuestion {
     pub question: String,
-
     pub answer: String,
 }
 
@@ -2301,8 +2029,7 @@ impl AsRef<UniverseQuestion> for UniverseQuestion {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct UniverseQuestionInput {
     pub question: String,
 }
@@ -2313,11 +2040,9 @@ impl AsRef<UniverseQuestionInput> for UniverseQuestionInput {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode)]
-
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
 pub struct WithReasoning {
     pub value: String,
-
     pub reasoning: String,
 }
 

--- a/integ-tests/rust/src/baml_client/types/classes.rs
+++ b/integ-tests/rust/src/baml_client/types/classes.rs
@@ -6,15 +6,19 @@
 //! Generated class types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode, BamlSerde};
+use baml::{
+    __internal::serde::{Deserialize, Serialize},
+    BamlDecode, BamlEncode,
+};
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AddTodoItem {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
     pub item: String,
     pub time: String,
-    pub a: Audio,
     pub description: String,
 }
 
@@ -24,7 +28,8 @@ impl AsRef<AddTodoItem> for AddTodoItem {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AddressWithMeta {
     pub street: String,
     pub city: String,
@@ -37,7 +42,8 @@ impl AsRef<AddressWithMeta> for AddressWithMeta {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct AnotherObject {
     pub id: String,
     pub thingy2: String,
@@ -50,7 +56,8 @@ impl AsRef<AnotherObject> for AnotherObject {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BigNumbers {
     pub a: i64,
     pub b: f64,
@@ -62,7 +69,8 @@ impl AsRef<BigNumbers> for BigNumbers {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BinaryNode {
     pub data: i64,
     pub left: Option<Box<BinaryNode>>,
@@ -75,7 +83,8 @@ impl AsRef<BinaryNode> for BinaryNode {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Blah {
     pub prop4: Option<String>,
 }
@@ -86,7 +95,8 @@ impl AsRef<Blah> for Blah {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BlockConstraint {
     pub foo: i64,
     pub bar: String,
@@ -98,7 +108,8 @@ impl AsRef<BlockConstraint> for BlockConstraint {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BlockConstraintForParam {
     pub bcfp: i64,
     pub bcfp2: String,
@@ -110,7 +121,8 @@ impl AsRef<BlockConstraintForParam> for BlockConstraintForParam {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct BookOrder {
     pub orderId: String,
     pub title: String,
@@ -124,7 +136,8 @@ impl AsRef<BookOrder> for BookOrder {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassForNullLiteral {
     pub a: String,
 }
@@ -135,7 +148,8 @@ impl AsRef<ClassForNullLiteral> for ClassForNullLiteral {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassOptionalOutput {
     pub prop1: String,
     pub prop2: String,
@@ -147,7 +161,8 @@ impl AsRef<ClassOptionalOutput> for ClassOptionalOutput {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassOptionalOutput2 {
     pub prop1: Option<String>,
     pub prop2: Option<String>,
@@ -160,7 +175,8 @@ impl AsRef<ClassOptionalOutput2> for ClassOptionalOutput2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassToRecAlias {
     pub list: LinkedListAliasNode,
 }
@@ -171,7 +187,8 @@ impl AsRef<ClassToRecAlias> for ClassToRecAlias {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithBlockDone {
     pub i_16_digits: i64,
     pub s_20_words: String,
@@ -183,7 +200,8 @@ impl AsRef<ClassWithBlockDone> for ClassWithBlockDone {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithImage {
     pub myImage: Image,
     pub param2: String,
@@ -196,7 +214,8 @@ impl AsRef<ClassWithImage> for ClassWithImage {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClassWithoutDone {
     pub i_16_digits: i64,
     pub s_20_words: String,
@@ -208,7 +227,8 @@ impl AsRef<ClassWithoutDone> for ClassWithoutDone {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ClientDetails1559 {
     pub client_name: Option<String>,
     pub client_address: Option<String>,
@@ -225,7 +245,8 @@ impl AsRef<ClientDetails1559> for ClientDetails1559 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ComplexMemoryObject {
     pub id: String,
     pub name: String,
@@ -239,7 +260,8 @@ impl AsRef<ComplexMemoryObject> for ComplexMemoryObject {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CompoundBigNumbers {
     pub big: BigNumbers,
     pub big_nums: Vec<BigNumbers>,
@@ -252,7 +274,8 @@ impl AsRef<CompoundBigNumbers> for CompoundBigNumbers {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ContactInfo {
     pub primary: Union2EmailAddressOrPhoneNumber,
     pub secondary: Option<Union2EmailAddressOrPhoneNumber>,
@@ -264,7 +287,8 @@ impl AsRef<ContactInfo> for ContactInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CustomStory {
     pub title: String,
     pub characters: Vec<String>,
@@ -277,7 +301,8 @@ impl AsRef<CustomStory> for CustomStory {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct CustomTaskResult {
     pub bookOrder: Option<BookOrder>,
     pub flightConfirmation: Option<FlightConfirmation>,
@@ -290,7 +315,8 @@ impl AsRef<CustomTaskResult> for CustomTaskResult {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Document1559 {
     pub client_details: ClientDetails1559,
     pub notes: Vec<Note1599>,
@@ -302,7 +328,8 @@ impl AsRef<Document1559> for Document1559 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DummyJsonTodo {
     pub id: i64,
     pub todo: String,
@@ -316,14 +343,16 @@ impl AsRef<DummyJsonTodo> for DummyJsonTodo {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DummyOutput {
     pub nonce: String,
     pub nonce2: String,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -387,13 +416,15 @@ impl AsRef<DummyOutput> for DummyOutput {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynInputOutput {
     pub testKey: String,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -456,11 +487,13 @@ impl AsRef<DynInputOutput> for DynInputOutput {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynamicClassOne {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -522,8 +555,9 @@ impl AsRef<DynamicClassOne> for DynamicClassOne {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynamicClassTwo {
     pub hi: String,
     pub some_class: SomeClassNestedDynamic,
@@ -531,6 +565,7 @@ pub struct DynamicClassTwo {
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -595,11 +630,13 @@ impl AsRef<DynamicClassTwo> for DynamicClassTwo {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynamicOutput {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -661,11 +698,13 @@ impl AsRef<DynamicOutput> for DynamicOutput {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct DynamicSchema {
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -727,7 +766,8 @@ impl AsRef<DynamicSchema> for DynamicSchema {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Earthling {
     pub age: Checked<i64>,
 }
@@ -738,7 +778,8 @@ impl AsRef<Earthling> for Earthling {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Education {
     pub institution: String,
     pub location: String,
@@ -753,7 +794,8 @@ impl AsRef<Education> for Education {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Email {
     pub subject: String,
     pub body: String,
@@ -766,7 +808,8 @@ impl AsRef<Email> for Email {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct EmailAddress {
     pub value: String,
 }
@@ -777,7 +820,8 @@ impl AsRef<EmailAddress> for EmailAddress {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Event {
     pub title: String,
     pub date: String,
@@ -791,7 +835,8 @@ impl AsRef<Event> for Event {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FakeImage {
     pub url: String,
 }
@@ -802,7 +847,8 @@ impl AsRef<FakeImage> for FakeImage {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FlightConfirmation {
     pub confirmationNumber: String,
     pub flightNumber: String,
@@ -817,7 +863,8 @@ impl AsRef<FlightConfirmation> for FlightConfirmation {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FooAny {
     pub planetary_age: Union2EarthlingOrMartian,
     pub certainty: Checked<i64>,
@@ -830,7 +877,8 @@ impl AsRef<FooAny> for FooAny {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Forest {
     pub trees: Vec<Box<Tree>>,
 }
@@ -841,7 +889,8 @@ impl AsRef<Forest> for Forest {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FormatterTest0 {
     pub lorem: String,
     pub ipsum: String,
@@ -853,7 +902,8 @@ impl AsRef<FormatterTest0> for FormatterTest0 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FormatterTest1 {
     pub lorem: String,
     pub ipsum: String,
@@ -865,7 +915,8 @@ impl AsRef<FormatterTest1> for FormatterTest1 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FormatterTest2 {
     pub lorem: String,
     pub ipsum: String,
@@ -877,7 +928,8 @@ impl AsRef<FormatterTest2> for FormatterTest2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct FormatterTest3 {
     pub lorem: String,
     pub ipsum: String,
@@ -889,7 +941,8 @@ impl AsRef<FormatterTest3> for FormatterTest3 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct GroceryReceipt {
     pub receiptId: String,
     pub storeName: String,
@@ -903,7 +956,8 @@ impl AsRef<GroceryReceipt> for GroceryReceipt {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Haiku {
     pub line1: String,
     pub line2: String,
@@ -916,7 +970,8 @@ impl AsRef<Haiku> for Haiku {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InnerClass {
     pub prop1: String,
     pub prop2: String,
@@ -929,7 +984,8 @@ impl AsRef<InnerClass> for InnerClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InnerClass2 {
     pub prop2: i64,
     pub prop3: f64,
@@ -941,7 +997,8 @@ impl AsRef<InnerClass2> for InnerClass2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InputClass {
     pub key: String,
     pub key2: String,
@@ -953,7 +1010,8 @@ impl AsRef<InputClass> for InputClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct InputClassNested {
     pub key: String,
     pub nested: InputClass,
@@ -965,7 +1023,8 @@ impl AsRef<InputClassNested> for InputClassNested {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LinkedList {
     pub head: Option<Node>,
     pub len: i64,
@@ -977,7 +1036,8 @@ impl AsRef<LinkedList> for LinkedList {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LinkedListAliasNode {
     pub value: i64,
     pub next: Option<Box<LinkedListAliasNode>>,
@@ -989,7 +1049,8 @@ impl AsRef<LinkedListAliasNode> for LinkedListAliasNode {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LiteralClassHello {
     pub prop: String,
 }
@@ -1000,7 +1061,8 @@ impl AsRef<LiteralClassHello> for LiteralClassHello {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LiteralClassOne {
     pub prop: String,
 }
@@ -1011,7 +1073,8 @@ impl AsRef<LiteralClassOne> for LiteralClassOne {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct LiteralClassTwo {
     pub prop: String,
 }
@@ -1022,7 +1085,8 @@ impl AsRef<LiteralClassTwo> for LiteralClassTwo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MaintainFieldOrder {
     pub c: String,
     pub b: String,
@@ -1035,7 +1099,8 @@ impl AsRef<MaintainFieldOrder> for MaintainFieldOrder {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MalformedConstraints {
     pub foo: Checked<i64>,
 }
@@ -1046,7 +1111,8 @@ impl AsRef<MalformedConstraints> for MalformedConstraints {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MalformedConstraints2 {
     pub foo: i64,
 }
@@ -1060,7 +1126,8 @@ impl AsRef<MalformedConstraints2> for MalformedConstraints2 {
 /// A Martian organism with an age.
 /// Such a nice type.
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Martian {
     /// The age of the Martian in Mars years.
     /// So many Mars years.
@@ -1073,7 +1140,8 @@ impl AsRef<Martian> for Martian {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MemoryObject {
     pub id: String,
     pub name: String,
@@ -1086,7 +1154,8 @@ impl AsRef<MemoryObject> for MemoryObject {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct MergeAttrs {
     pub amount: Checked<i64>,
 }
@@ -1097,7 +1166,8 @@ impl AsRef<MergeAttrs> for MergeAttrs {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NamedArgsSingleClass {
     pub key: String,
     pub key_two: bool,
@@ -1110,7 +1180,8 @@ impl AsRef<NamedArgsSingleClass> for NamedArgsSingleClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Nested {
     pub prop3: Option<String>,
     pub prop4: Option<String>,
@@ -1123,7 +1194,8 @@ impl AsRef<Nested> for Nested {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Nested2 {
     pub prop11: Option<String>,
     pub prop12: Option<String>,
@@ -1135,7 +1207,8 @@ impl AsRef<Nested2> for Nested2 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedBlockConstraint {
     pub nbc: Checked<BlockConstraint>,
 }
@@ -1146,7 +1219,8 @@ impl AsRef<NestedBlockConstraint> for NestedBlockConstraint {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NestedBlockConstraintForParam {
     pub nbcfp: BlockConstraintForParam,
 }
@@ -1157,7 +1231,8 @@ impl AsRef<NestedBlockConstraintForParam> for NestedBlockConstraintForParam {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Node {
     pub data: i64,
     pub next: Option<Box<Node>>,
@@ -1169,7 +1244,8 @@ impl AsRef<Node> for Node {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct NodeWithAliasIndirection {
     pub value: i64,
     pub next: Option<Box<NodeWithAliasIndirection>>,
@@ -1181,7 +1257,8 @@ impl AsRef<NodeWithAliasIndirection> for NodeWithAliasIndirection {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Note1599 {
     pub note_title: String,
     pub note_description: Option<String>,
@@ -1194,7 +1271,8 @@ impl AsRef<Note1599> for Note1599 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalListAndMap {
     pub p: Option<Vec<String>>,
     pub q: Option<std::collections::HashMap<String, String>>,
@@ -1206,7 +1284,8 @@ impl AsRef<OptionalListAndMap> for OptionalListAndMap {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalTest_Prop1 {
     pub omega_a: String,
     pub omega_b: i64,
@@ -1218,7 +1297,8 @@ impl AsRef<OptionalTest_Prop1> for OptionalTest_Prop1 {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OptionalTest_ReturnType {
     pub omega_1: Option<OptionalTest_Prop1>,
     pub omega_2: Option<String>,
@@ -1231,7 +1311,8 @@ impl AsRef<OptionalTest_ReturnType> for OptionalTest_ReturnType {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OrderInfo {
     pub order_status: OrderStatus,
     pub tracking_number: Option<String>,
@@ -1244,7 +1325,8 @@ impl AsRef<OrderInfo> for OrderInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OriginalA {
     pub value: i64,
 }
@@ -1255,13 +1337,15 @@ impl AsRef<OriginalA> for OriginalA {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct OriginalB {
     pub value: i64,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1324,14 +1408,16 @@ impl AsRef<OriginalB> for OriginalB {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Person {
     pub name: Option<String>,
     pub hair_color: Option<Color>,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1395,7 +1481,8 @@ impl AsRef<Person> for Person {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PersonWithMeta {
     pub name: String,
     pub age: i64,
@@ -1409,7 +1496,8 @@ impl AsRef<PersonWithMeta> for PersonWithMeta {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct PhoneNumber {
     pub value: String,
 }
@@ -1420,7 +1508,8 @@ impl AsRef<PhoneNumber> for PhoneNumber {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Quantity {
     pub amount: Union2FloatOrInt,
     pub unit: Option<String>,
@@ -1432,7 +1521,8 @@ impl AsRef<Quantity> for Quantity {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RaysData {
     pub dataType: DataType,
     pub value: Union2EventOrResume,
@@ -1444,7 +1534,8 @@ impl AsRef<RaysData> for RaysData {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ReceiptInfo {
     pub items: Vec<ReceiptItem>,
     pub total_cost: Option<f64>,
@@ -1457,7 +1548,8 @@ impl AsRef<ReceiptInfo> for ReceiptInfo {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct ReceiptItem {
     pub name: String,
     pub description: Option<String>,
@@ -1471,7 +1563,8 @@ impl AsRef<ReceiptItem> for ReceiptItem {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Recipe {
     pub ingredients: std::collections::HashMap<String, Quantity>,
     pub recipe_type: Union2KbreakfastOrKdinner,
@@ -1483,7 +1576,8 @@ impl AsRef<Recipe> for Recipe {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RecursiveAliasDependency {
     pub value: JsonValue,
 }
@@ -1494,13 +1588,15 @@ impl AsRef<RecursiveAliasDependency> for RecursiveAliasDependency {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RenderEnumInput {
     pub testKey: String,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1563,14 +1659,16 @@ impl AsRef<RenderEnumInput> for RenderEnumInput {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct RenderTestClass {
     pub name: String,
     pub status: RenderStatusEnum,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1634,7 +1732,8 @@ impl AsRef<RenderTestClass> for RenderTestClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Resume {
     pub name: String,
     pub email: String,
@@ -1650,7 +1749,8 @@ impl AsRef<Resume> for Resume {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Schema {
     pub prop1: Option<String>,
     pub prop2: Union2NestedOrString,
@@ -1667,7 +1767,8 @@ impl AsRef<Schema> for Schema {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SearchParams {
     pub dateRange: Option<i64>,
     pub location: Vec<String>,
@@ -1683,7 +1784,8 @@ impl AsRef<SearchParams> for SearchParams {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SemanticContainer {
     pub sixteen_digit_number: i64,
     pub string_with_twenty_words: String,
@@ -1701,7 +1803,8 @@ impl AsRef<SemanticContainer> for SemanticContainer {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SimpleTag {
     pub field: String,
 }
@@ -1712,14 +1815,16 @@ impl AsRef<SimpleTag> for SimpleTag {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SkipDynamicClass {
     pub value: String,
     pub internal_id: Option<String>,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1783,7 +1888,8 @@ impl AsRef<SkipDynamicClass> for SkipDynamicClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SkipNonDynamicClass {
     pub name: String,
     pub description: Option<String>,
@@ -1796,7 +1902,8 @@ impl AsRef<SkipNonDynamicClass> for SkipNonDynamicClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SmallThing {
     pub i_16_digits: i64,
     pub i_8_digits: i64,
@@ -1808,13 +1915,15 @@ impl AsRef<SmallThing> for SmallThing {
     }
 }
 
-#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct SomeClassNestedDynamic {
     pub hi: String,
 
     /// Dynamic fields added at runtime via TypeBuilder.
     #[baml(dynamic_fields)]
+    #[serde(flatten)]
     pub __dynamic: std::collections::HashMap<
         String,
         baml::BamlValue<super::Types, super::super::stream_types::StreamTypes>,
@@ -1877,7 +1986,8 @@ impl AsRef<SomeClassNestedDynamic> for SomeClassNestedDynamic {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct StringToClassEntry {
     pub word: String,
 }
@@ -1888,7 +1998,8 @@ impl AsRef<StringToClassEntry> for StringToClassEntry {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestClassAlias {
     pub key: String,
     pub key2: String,
@@ -1903,7 +2014,8 @@ impl AsRef<TestClassAlias> for TestClassAlias {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestClassNested {
     pub prop1: String,
     pub prop2: InnerClass,
@@ -1915,7 +2027,8 @@ impl AsRef<TestClassNested> for TestClassNested {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestClassWithEnum {
     pub prop1: String,
     pub prop2: EnumInClass,
@@ -1927,7 +2040,8 @@ impl AsRef<TestClassWithEnum> for TestClassWithEnum {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestMemoryOutput {
     pub items: Vec<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>,
     pub more_items: Vec<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>,
@@ -1939,7 +2053,8 @@ impl AsRef<TestMemoryOutput> for TestMemoryOutput {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TestOutputClass {
     pub prop1: String,
     pub prop2: i64,
@@ -1951,9 +2066,11 @@ impl AsRef<TestOutputClass> for TestOutputClass {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TodoMessageToUser {
     #[baml(name = "type")]
+    #[serde(rename = "type")]
     pub r#type: String,
     pub message: String,
 }
@@ -1964,7 +2081,8 @@ impl AsRef<TodoMessageToUser> for TodoMessageToUser {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct Tree {
     pub data: i64,
     pub children: Box<Forest>,
@@ -1976,7 +2094,8 @@ impl AsRef<Tree> for Tree {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TwoStoriesOneTitle {
     pub title: String,
     pub story_a: String,
@@ -1989,7 +2108,8 @@ impl AsRef<TwoStoriesOneTitle> for TwoStoriesOneTitle {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct TwoStoriesOneTitleCheck {
     pub title: String,
     pub story_a: Checked<String>,
@@ -2002,7 +2122,8 @@ impl AsRef<TwoStoriesOneTitleCheck> for TwoStoriesOneTitleCheck {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UnionTest_ReturnType {
     pub prop1: Union2BoolOrString,
     pub prop2: Vec<Union2BoolOrFloat>,
@@ -2017,7 +2138,8 @@ impl AsRef<UnionTest_ReturnType> for UnionTest_ReturnType {
 
 /// my docs
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UniverseQuestion {
     pub question: String,
     pub answer: String,
@@ -2029,7 +2151,8 @@ impl AsRef<UniverseQuestion> for UniverseQuestion {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct UniverseQuestionInput {
     pub question: String,
 }
@@ -2040,7 +2163,8 @@ impl AsRef<UniverseQuestionInput> for UniverseQuestionInput {
     }
 }
 
-#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, Default, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub struct WithReasoning {
     pub value: String,
     pub reasoning: String,

--- a/integ-tests/rust/src/baml_client/types/enums.rs
+++ b/integ-tests/rust/src/baml_client/types/enums.rs
@@ -95,15 +95,15 @@ impl ::std::str::FromStr for Category {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Refund" => ::std::result::Result::Ok(Self::REFUND),
+            "Refund" => ::std::result::Result::Ok(Self::Refund),
 
-            "CancelOrder" => ::std::result::Result::Ok(Self::CANCELORDER),
+            "CancelOrder" => ::std::result::Result::Ok(Self::CancelOrder),
 
-            "TechnicalSupport" => ::std::result::Result::Ok(Self::TECHNICALSUPPORT),
+            "TechnicalSupport" => ::std::result::Result::Ok(Self::TechnicalSupport),
 
-            "AccountIssue" => ::std::result::Result::Ok(Self::ACCOUNTISSUE),
+            "AccountIssue" => ::std::result::Result::Ok(Self::AccountIssue),
 
-            "Question" => ::std::result::Result::Ok(Self::QUESTION),
+            "Question" => ::std::result::Result::Ok(Self::Question),
 
             _ => ::std::result::Result::Err(()),
         }
@@ -157,15 +157,15 @@ impl ::std::str::FromStr for Category2 {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Refund" => ::std::result::Result::Ok(Self::REFUND),
+            "Refund" => ::std::result::Result::Ok(Self::Refund),
 
-            "CancelOrder" => ::std::result::Result::Ok(Self::CANCELORDER),
+            "CancelOrder" => ::std::result::Result::Ok(Self::CancelOrder),
 
-            "TechnicalSupport" => ::std::result::Result::Ok(Self::TECHNICALSUPPORT),
+            "TechnicalSupport" => ::std::result::Result::Ok(Self::TechnicalSupport),
 
-            "AccountIssue" => ::std::result::Result::Ok(Self::ACCOUNTISSUE),
+            "AccountIssue" => ::std::result::Result::Ok(Self::AccountIssue),
 
-            "Question" => ::std::result::Result::Ok(Self::QUESTION),
+            "Question" => ::std::result::Result::Ok(Self::Question),
 
             _ => ::std::result::Result::Err(()),
         }
@@ -219,15 +219,15 @@ impl ::std::str::FromStr for Category3 {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Refund" => ::std::result::Result::Ok(Self::REFUND),
+            "Refund" => ::std::result::Result::Ok(Self::Refund),
 
-            "CancelOrder" => ::std::result::Result::Ok(Self::CANCELORDER),
+            "CancelOrder" => ::std::result::Result::Ok(Self::CancelOrder),
 
-            "TechnicalSupport" => ::std::result::Result::Ok(Self::TECHNICALSUPPORT),
+            "TechnicalSupport" => ::std::result::Result::Ok(Self::TechnicalSupport),
 
-            "AccountIssue" => ::std::result::Result::Ok(Self::ACCOUNTISSUE),
+            "AccountIssue" => ::std::result::Result::Ok(Self::AccountIssue),
 
-            "Question" => ::std::result::Result::Ok(Self::QUESTION),
+            "Question" => ::std::result::Result::Ok(Self::Question),
 
             _ => ::std::result::Result::Err(()),
         }
@@ -345,9 +345,9 @@ impl ::std::str::FromStr for DataType {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Resume" => ::std::result::Result::Ok(Self::RESUME),
+            "Resume" => ::std::result::Result::Ok(Self::Resume),
 
-            "Event" => ::std::result::Result::Ok(Self::EVENT),
+            "Event" => ::std::result::Result::Ok(Self::Event),
 
             _ => ::std::result::Result::Err(()),
         }
@@ -824,11 +824,11 @@ impl ::std::str::FromStr for OptionalTest_CategoryType {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Aleph" => ::std::result::Result::Ok(Self::ALEPH),
+            "Aleph" => ::std::result::Result::Ok(Self::Aleph),
 
-            "Beta" => ::std::result::Result::Ok(Self::BETA),
+            "Beta" => ::std::result::Result::Ok(Self::Beta),
 
-            "Gamma" => ::std::result::Result::Ok(Self::GAMMA),
+            "Gamma" => ::std::result::Result::Ok(Self::Gamma),
 
             _ => ::std::result::Result::Err(()),
         }
@@ -1034,11 +1034,11 @@ impl ::std::str::FromStr for Tag {
 
     fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Security" => ::std::result::Result::Ok(Self::SECURITY),
+            "Security" => ::std::result::Result::Ok(Self::Security),
 
             "AI" => ::std::result::Result::Ok(Self::AI),
 
-            "Blockchain" => ::std::result::Result::Ok(Self::BLOCKCHAIN),
+            "Blockchain" => ::std::result::Result::Ok(Self::Blockchain),
 
             _ => ::std::result::Result::Err(()),
         }

--- a/integ-tests/rust/src/baml_client/types/enums.rs
+++ b/integ-tests/rust/src/baml_client/types/enums.rs
@@ -18,14 +18,14 @@ pub enum AliasedEnum {
     KEY_TWO,
 }
 
-impl Default for AliasedEnum {
+impl ::std::default::Default for AliasedEnum {
     fn default() -> Self {
         Self::KEY_ONE
     }
 }
 
-impl std::fmt::Display for AliasedEnum {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for AliasedEnum {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::KEY_ONE => write!(f, "KEY_ONE"),
 
@@ -34,21 +34,21 @@ impl std::fmt::Display for AliasedEnum {
     }
 }
 
-impl std::str::FromStr for AliasedEnum {
+impl ::std::str::FromStr for AliasedEnum {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "KEY_ONE" => Ok(Self::KEY_ONE),
+            "KEY_ONE" => ::std::result::Result::Ok(Self::KEY_ONE),
 
-            "KEY_TWO" => Ok(Self::KEY_TWO),
+            "KEY_TWO" => ::std::result::Result::Ok(Self::KEY_TWO),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<AliasedEnum> for AliasedEnum {
+impl ::std::convert::AsRef<AliasedEnum> for AliasedEnum {
     fn as_ref(&self) -> &AliasedEnum {
         self
     }
@@ -68,14 +68,14 @@ pub enum Category {
     Question,
 }
 
-impl Default for Category {
+impl ::std::default::Default for Category {
     fn default() -> Self {
         Self::Refund
     }
 }
 
-impl std::fmt::Display for Category {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Category {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::Refund => write!(f, "Refund"),
 
@@ -90,27 +90,27 @@ impl std::fmt::Display for Category {
     }
 }
 
-impl std::str::FromStr for Category {
+impl ::std::str::FromStr for Category {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Refund" => Ok(Self::Refund),
+            "Refund" => ::std::result::Result::Ok(Self::REFUND),
 
-            "CancelOrder" => Ok(Self::CancelOrder),
+            "CancelOrder" => ::std::result::Result::Ok(Self::CANCELORDER),
 
-            "TechnicalSupport" => Ok(Self::TechnicalSupport),
+            "TechnicalSupport" => ::std::result::Result::Ok(Self::TECHNICALSUPPORT),
 
-            "AccountIssue" => Ok(Self::AccountIssue),
+            "AccountIssue" => ::std::result::Result::Ok(Self::ACCOUNTISSUE),
 
-            "Question" => Ok(Self::Question),
+            "Question" => ::std::result::Result::Ok(Self::QUESTION),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<Category> for Category {
+impl ::std::convert::AsRef<Category> for Category {
     fn as_ref(&self) -> &Category {
         self
     }
@@ -130,14 +130,14 @@ pub enum Category2 {
     Question,
 }
 
-impl Default for Category2 {
+impl ::std::default::Default for Category2 {
     fn default() -> Self {
         Self::Refund
     }
 }
 
-impl std::fmt::Display for Category2 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Category2 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::Refund => write!(f, "Refund"),
 
@@ -152,27 +152,27 @@ impl std::fmt::Display for Category2 {
     }
 }
 
-impl std::str::FromStr for Category2 {
+impl ::std::str::FromStr for Category2 {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Refund" => Ok(Self::Refund),
+            "Refund" => ::std::result::Result::Ok(Self::REFUND),
 
-            "CancelOrder" => Ok(Self::CancelOrder),
+            "CancelOrder" => ::std::result::Result::Ok(Self::CANCELORDER),
 
-            "TechnicalSupport" => Ok(Self::TechnicalSupport),
+            "TechnicalSupport" => ::std::result::Result::Ok(Self::TECHNICALSUPPORT),
 
-            "AccountIssue" => Ok(Self::AccountIssue),
+            "AccountIssue" => ::std::result::Result::Ok(Self::ACCOUNTISSUE),
 
-            "Question" => Ok(Self::Question),
+            "Question" => ::std::result::Result::Ok(Self::QUESTION),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<Category2> for Category2 {
+impl ::std::convert::AsRef<Category2> for Category2 {
     fn as_ref(&self) -> &Category2 {
         self
     }
@@ -192,14 +192,14 @@ pub enum Category3 {
     Question,
 }
 
-impl Default for Category3 {
+impl ::std::default::Default for Category3 {
     fn default() -> Self {
         Self::Refund
     }
 }
 
-impl std::fmt::Display for Category3 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Category3 {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::Refund => write!(f, "Refund"),
 
@@ -214,27 +214,27 @@ impl std::fmt::Display for Category3 {
     }
 }
 
-impl std::str::FromStr for Category3 {
+impl ::std::str::FromStr for Category3 {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Refund" => Ok(Self::Refund),
+            "Refund" => ::std::result::Result::Ok(Self::REFUND),
 
-            "CancelOrder" => Ok(Self::CancelOrder),
+            "CancelOrder" => ::std::result::Result::Ok(Self::CANCELORDER),
 
-            "TechnicalSupport" => Ok(Self::TechnicalSupport),
+            "TechnicalSupport" => ::std::result::Result::Ok(Self::TECHNICALSUPPORT),
 
-            "AccountIssue" => Ok(Self::AccountIssue),
+            "AccountIssue" => ::std::result::Result::Ok(Self::ACCOUNTISSUE),
 
-            "Question" => Ok(Self::Question),
+            "Question" => ::std::result::Result::Ok(Self::QUESTION),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<Category3> for Category3 {
+impl ::std::convert::AsRef<Category3> for Category3 {
     fn as_ref(&self) -> &Category3 {
         self
     }
@@ -259,17 +259,17 @@ pub enum Color {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
     #[serde(untagged)]
-    _Dynamic(String),
+    _Dynamic(::std::string::String),
 }
 
-impl Default for Color {
+impl ::std::default::Default for Color {
     fn default() -> Self {
         Self::RED
     }
 }
 
-impl std::fmt::Display for Color {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Color {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::RED => write!(f, "RED"),
 
@@ -288,29 +288,29 @@ impl std::fmt::Display for Color {
     }
 }
 
-impl std::str::FromStr for Color {
+impl ::std::str::FromStr for Color {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "RED" => Ok(Self::RED),
+            "RED" => ::std::result::Result::Ok(Self::RED),
 
-            "BLUE" => Ok(Self::BLUE),
+            "BLUE" => ::std::result::Result::Ok(Self::BLUE),
 
-            "GREEN" => Ok(Self::GREEN),
+            "GREEN" => ::std::result::Result::Ok(Self::GREEN),
 
-            "YELLOW" => Ok(Self::YELLOW),
+            "YELLOW" => ::std::result::Result::Ok(Self::YELLOW),
 
-            "BLACK" => Ok(Self::BLACK),
+            "BLACK" => ::std::result::Result::Ok(Self::BLACK),
 
-            "WHITE" => Ok(Self::WHITE),
+            "WHITE" => ::std::result::Result::Ok(Self::WHITE),
 
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
     }
 }
 
-impl AsRef<Color> for Color {
+impl ::std::convert::AsRef<Color> for Color {
     fn as_ref(&self) -> &Color {
         self
     }
@@ -324,14 +324,14 @@ pub enum DataType {
     Event,
 }
 
-impl Default for DataType {
+impl ::std::default::Default for DataType {
     fn default() -> Self {
         Self::Resume
     }
 }
 
-impl std::fmt::Display for DataType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for DataType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::Resume => write!(f, "Resume"),
 
@@ -340,21 +340,21 @@ impl std::fmt::Display for DataType {
     }
 }
 
-impl std::str::FromStr for DataType {
+impl ::std::str::FromStr for DataType {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Resume" => Ok(Self::Resume),
+            "Resume" => ::std::result::Result::Ok(Self::RESUME),
 
-            "Event" => Ok(Self::Event),
+            "Event" => ::std::result::Result::Ok(Self::EVENT),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<DataType> for DataType {
+impl ::std::convert::AsRef<DataType> for DataType {
     fn as_ref(&self) -> &DataType {
         self
     }
@@ -367,10 +367,10 @@ pub enum DynEnumOne {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
     #[serde(untagged)]
-    _Dynamic(String),
+    _Dynamic(::std::string::String),
 }
 
-impl Default for DynEnumOne {
+impl ::std::default::Default for DynEnumOne {
     fn default() -> Self {
         // Eventually, we will remove the default trait for enums with no values
         // But as a temporary solution, we will panic if the enum has no values
@@ -378,25 +378,25 @@ impl Default for DynEnumOne {
     }
 }
 
-impl std::fmt::Display for DynEnumOne {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for DynEnumOne {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::_Dynamic(s) => write!(f, "{}", s),
         }
     }
 }
 
-impl std::str::FromStr for DynEnumOne {
+impl ::std::str::FromStr for DynEnumOne {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
     }
 }
 
-impl AsRef<DynEnumOne> for DynEnumOne {
+impl ::std::convert::AsRef<DynEnumOne> for DynEnumOne {
     fn as_ref(&self) -> &DynEnumOne {
         self
     }
@@ -413,17 +413,17 @@ pub enum DynEnumThree {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
     #[serde(untagged)]
-    _Dynamic(String),
+    _Dynamic(::std::string::String),
 }
 
-impl Default for DynEnumThree {
+impl ::std::default::Default for DynEnumThree {
     fn default() -> Self {
         Self::TRICYCLE
     }
 }
 
-impl std::fmt::Display for DynEnumThree {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for DynEnumThree {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::TRICYCLE => write!(f, "TRICYCLE"),
 
@@ -434,21 +434,21 @@ impl std::fmt::Display for DynEnumThree {
     }
 }
 
-impl std::str::FromStr for DynEnumThree {
+impl ::std::str::FromStr for DynEnumThree {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "TRICYCLE" => Ok(Self::TRICYCLE),
+            "TRICYCLE" => ::std::result::Result::Ok(Self::TRICYCLE),
 
-            "TRIANGLE" => Ok(Self::TRIANGLE),
+            "TRIANGLE" => ::std::result::Result::Ok(Self::TRIANGLE),
 
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
     }
 }
 
-impl AsRef<DynEnumThree> for DynEnumThree {
+impl ::std::convert::AsRef<DynEnumThree> for DynEnumThree {
     fn as_ref(&self) -> &DynEnumThree {
         self
     }
@@ -461,10 +461,10 @@ pub enum DynEnumTwo {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
     #[serde(untagged)]
-    _Dynamic(String),
+    _Dynamic(::std::string::String),
 }
 
-impl Default for DynEnumTwo {
+impl ::std::default::Default for DynEnumTwo {
     fn default() -> Self {
         // Eventually, we will remove the default trait for enums with no values
         // But as a temporary solution, we will panic if the enum has no values
@@ -472,25 +472,25 @@ impl Default for DynEnumTwo {
     }
 }
 
-impl std::fmt::Display for DynEnumTwo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for DynEnumTwo {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::_Dynamic(s) => write!(f, "{}", s),
         }
     }
 }
 
-impl std::str::FromStr for DynEnumTwo {
+impl ::std::str::FromStr for DynEnumTwo {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
     }
 }
 
-impl AsRef<DynEnumTwo> for DynEnumTwo {
+impl ::std::convert::AsRef<DynEnumTwo> for DynEnumTwo {
     fn as_ref(&self) -> &DynEnumTwo {
         self
     }
@@ -504,14 +504,14 @@ pub enum EnumInClass {
     TWO,
 }
 
-impl Default for EnumInClass {
+impl ::std::default::Default for EnumInClass {
     fn default() -> Self {
         Self::ONE
     }
 }
 
-impl std::fmt::Display for EnumInClass {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for EnumInClass {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::ONE => write!(f, "ONE"),
 
@@ -520,21 +520,21 @@ impl std::fmt::Display for EnumInClass {
     }
 }
 
-impl std::str::FromStr for EnumInClass {
+impl ::std::str::FromStr for EnumInClass {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "ONE" => Ok(Self::ONE),
+            "ONE" => ::std::result::Result::Ok(Self::ONE),
 
-            "TWO" => Ok(Self::TWO),
+            "TWO" => ::std::result::Result::Ok(Self::TWO),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<EnumInClass> for EnumInClass {
+impl ::std::convert::AsRef<EnumInClass> for EnumInClass {
     fn as_ref(&self) -> &EnumInClass {
         self
     }
@@ -555,14 +555,14 @@ pub enum EnumOutput {
     THREE,
 }
 
-impl Default for EnumOutput {
+impl ::std::default::Default for EnumOutput {
     fn default() -> Self {
         Self::ONE
     }
 }
 
-impl std::fmt::Display for EnumOutput {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for EnumOutput {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::ONE => write!(f, "ONE"),
 
@@ -573,23 +573,23 @@ impl std::fmt::Display for EnumOutput {
     }
 }
 
-impl std::str::FromStr for EnumOutput {
+impl ::std::str::FromStr for EnumOutput {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "ONE" => Ok(Self::ONE),
+            "ONE" => ::std::result::Result::Ok(Self::ONE),
 
-            "TWO" => Ok(Self::TWO),
+            "TWO" => ::std::result::Result::Ok(Self::TWO),
 
-            "THREE" => Ok(Self::THREE),
+            "THREE" => ::std::result::Result::Ok(Self::THREE),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<EnumOutput> for EnumOutput {
+impl ::std::convert::AsRef<EnumOutput> for EnumOutput {
     fn as_ref(&self) -> &EnumOutput {
         self
     }
@@ -608,17 +608,17 @@ pub enum Hobby {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
     #[serde(untagged)]
-    _Dynamic(String),
+    _Dynamic(::std::string::String),
 }
 
-impl Default for Hobby {
+impl ::std::default::Default for Hobby {
     fn default() -> Self {
         Self::SPORTS
     }
 }
 
-impl std::fmt::Display for Hobby {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Hobby {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::SPORTS => write!(f, "SPORTS"),
 
@@ -631,23 +631,23 @@ impl std::fmt::Display for Hobby {
     }
 }
 
-impl std::str::FromStr for Hobby {
+impl ::std::str::FromStr for Hobby {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "SPORTS" => Ok(Self::SPORTS),
+            "SPORTS" => ::std::result::Result::Ok(Self::SPORTS),
 
-            "MUSIC" => Ok(Self::MUSIC),
+            "MUSIC" => ::std::result::Result::Ok(Self::MUSIC),
 
-            "READING" => Ok(Self::READING),
+            "READING" => ::std::result::Result::Ok(Self::READING),
 
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
     }
 }
 
-impl AsRef<Hobby> for Hobby {
+impl ::std::convert::AsRef<Hobby> for Hobby {
     fn as_ref(&self) -> &Hobby {
         self
     }
@@ -663,14 +663,14 @@ pub enum MapKey {
     C,
 }
 
-impl Default for MapKey {
+impl ::std::default::Default for MapKey {
     fn default() -> Self {
         Self::A
     }
 }
 
-impl std::fmt::Display for MapKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for MapKey {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::A => write!(f, "A"),
 
@@ -681,23 +681,23 @@ impl std::fmt::Display for MapKey {
     }
 }
 
-impl std::str::FromStr for MapKey {
+impl ::std::str::FromStr for MapKey {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "A" => Ok(Self::A),
+            "A" => ::std::result::Result::Ok(Self::A),
 
-            "B" => Ok(Self::B),
+            "B" => ::std::result::Result::Ok(Self::B),
 
-            "C" => Ok(Self::C),
+            "C" => ::std::result::Result::Ok(Self::C),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<MapKey> for MapKey {
+impl ::std::convert::AsRef<MapKey> for MapKey {
     fn as_ref(&self) -> &MapKey {
         self
     }
@@ -711,14 +711,14 @@ pub enum NamedArgsSingleEnum {
     TWO,
 }
 
-impl Default for NamedArgsSingleEnum {
+impl ::std::default::Default for NamedArgsSingleEnum {
     fn default() -> Self {
         Self::ONE
     }
 }
 
-impl std::fmt::Display for NamedArgsSingleEnum {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for NamedArgsSingleEnum {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::ONE => write!(f, "ONE"),
 
@@ -727,21 +727,21 @@ impl std::fmt::Display for NamedArgsSingleEnum {
     }
 }
 
-impl std::str::FromStr for NamedArgsSingleEnum {
+impl ::std::str::FromStr for NamedArgsSingleEnum {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "ONE" => Ok(Self::ONE),
+            "ONE" => ::std::result::Result::Ok(Self::ONE),
 
-            "TWO" => Ok(Self::TWO),
+            "TWO" => ::std::result::Result::Ok(Self::TWO),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<NamedArgsSingleEnum> for NamedArgsSingleEnum {
+impl ::std::convert::AsRef<NamedArgsSingleEnum> for NamedArgsSingleEnum {
     fn as_ref(&self) -> &NamedArgsSingleEnum {
         self
     }
@@ -755,14 +755,14 @@ pub enum NamedArgsSingleEnumList {
     TWO,
 }
 
-impl Default for NamedArgsSingleEnumList {
+impl ::std::default::Default for NamedArgsSingleEnumList {
     fn default() -> Self {
         Self::ONE
     }
 }
 
-impl std::fmt::Display for NamedArgsSingleEnumList {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for NamedArgsSingleEnumList {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::ONE => write!(f, "ONE"),
 
@@ -771,21 +771,21 @@ impl std::fmt::Display for NamedArgsSingleEnumList {
     }
 }
 
-impl std::str::FromStr for NamedArgsSingleEnumList {
+impl ::std::str::FromStr for NamedArgsSingleEnumList {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "ONE" => Ok(Self::ONE),
+            "ONE" => ::std::result::Result::Ok(Self::ONE),
 
-            "TWO" => Ok(Self::TWO),
+            "TWO" => ::std::result::Result::Ok(Self::TWO),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<NamedArgsSingleEnumList> for NamedArgsSingleEnumList {
+impl ::std::convert::AsRef<NamedArgsSingleEnumList> for NamedArgsSingleEnumList {
     fn as_ref(&self) -> &NamedArgsSingleEnumList {
         self
     }
@@ -801,14 +801,14 @@ pub enum OptionalTest_CategoryType {
     Gamma,
 }
 
-impl Default for OptionalTest_CategoryType {
+impl ::std::default::Default for OptionalTest_CategoryType {
     fn default() -> Self {
         Self::Aleph
     }
 }
 
-impl std::fmt::Display for OptionalTest_CategoryType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for OptionalTest_CategoryType {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::Aleph => write!(f, "Aleph"),
 
@@ -819,23 +819,23 @@ impl std::fmt::Display for OptionalTest_CategoryType {
     }
 }
 
-impl std::str::FromStr for OptionalTest_CategoryType {
+impl ::std::str::FromStr for OptionalTest_CategoryType {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Aleph" => Ok(Self::Aleph),
+            "Aleph" => ::std::result::Result::Ok(Self::ALEPH),
 
-            "Beta" => Ok(Self::Beta),
+            "Beta" => ::std::result::Result::Ok(Self::BETA),
 
-            "Gamma" => Ok(Self::Gamma),
+            "Gamma" => ::std::result::Result::Ok(Self::GAMMA),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<OptionalTest_CategoryType> for OptionalTest_CategoryType {
+impl ::std::convert::AsRef<OptionalTest_CategoryType> for OptionalTest_CategoryType {
     fn as_ref(&self) -> &OptionalTest_CategoryType {
         self
     }
@@ -853,14 +853,14 @@ pub enum OrderStatus {
     CANCELLED,
 }
 
-impl Default for OrderStatus {
+impl ::std::default::Default for OrderStatus {
     fn default() -> Self {
         Self::ORDERED
     }
 }
 
-impl std::fmt::Display for OrderStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for OrderStatus {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::ORDERED => write!(f, "ORDERED"),
 
@@ -873,25 +873,25 @@ impl std::fmt::Display for OrderStatus {
     }
 }
 
-impl std::str::FromStr for OrderStatus {
+impl ::std::str::FromStr for OrderStatus {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "ORDERED" => Ok(Self::ORDERED),
+            "ORDERED" => ::std::result::Result::Ok(Self::ORDERED),
 
-            "SHIPPED" => Ok(Self::SHIPPED),
+            "SHIPPED" => ::std::result::Result::Ok(Self::SHIPPED),
 
-            "DELIVERED" => Ok(Self::DELIVERED),
+            "DELIVERED" => ::std::result::Result::Ok(Self::DELIVERED),
 
-            "CANCELLED" => Ok(Self::CANCELLED),
+            "CANCELLED" => ::std::result::Result::Ok(Self::CANCELLED),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<OrderStatus> for OrderStatus {
+impl ::std::convert::AsRef<OrderStatus> for OrderStatus {
     fn as_ref(&self) -> &OrderStatus {
         self
     }
@@ -908,17 +908,17 @@ pub enum RenderStatusEnum {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
     #[serde(untagged)]
-    _Dynamic(String),
+    _Dynamic(::std::string::String),
 }
 
-impl Default for RenderStatusEnum {
+impl ::std::default::Default for RenderStatusEnum {
     fn default() -> Self {
         Self::ACTIVE
     }
 }
 
-impl std::fmt::Display for RenderStatusEnum {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for RenderStatusEnum {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::ACTIVE => write!(f, "ACTIVE"),
 
@@ -929,21 +929,21 @@ impl std::fmt::Display for RenderStatusEnum {
     }
 }
 
-impl std::str::FromStr for RenderStatusEnum {
+impl ::std::str::FromStr for RenderStatusEnum {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "ACTIVE" => Ok(Self::ACTIVE),
+            "ACTIVE" => ::std::result::Result::Ok(Self::ACTIVE),
 
-            "INACTIVE" => Ok(Self::INACTIVE),
+            "INACTIVE" => ::std::result::Result::Ok(Self::INACTIVE),
 
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
     }
 }
 
-impl AsRef<RenderStatusEnum> for RenderStatusEnum {
+impl ::std::convert::AsRef<RenderStatusEnum> for RenderStatusEnum {
     fn as_ref(&self) -> &RenderStatusEnum {
         self
     }
@@ -960,17 +960,17 @@ pub enum RenderTestEnum {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
     #[serde(untagged)]
-    _Dynamic(String),
+    _Dynamic(::std::string::String),
 }
 
-impl Default for RenderTestEnum {
+impl ::std::default::Default for RenderTestEnum {
     fn default() -> Self {
         Self::BIKE
     }
 }
 
-impl std::fmt::Display for RenderTestEnum {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for RenderTestEnum {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::BIKE => write!(f, "BIKE"),
 
@@ -981,21 +981,21 @@ impl std::fmt::Display for RenderTestEnum {
     }
 }
 
-impl std::str::FromStr for RenderTestEnum {
+impl ::std::str::FromStr for RenderTestEnum {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "BIKE" => Ok(Self::BIKE),
+            "BIKE" => ::std::result::Result::Ok(Self::BIKE),
 
-            "SCOOTER" => Ok(Self::SCOOTER),
+            "SCOOTER" => ::std::result::Result::Ok(Self::SCOOTER),
 
-            other => Ok(Self::_Dynamic(other.to_string())),
+            other => ::std::result::Result::Ok(Self::_Dynamic(other.to_string())),
         }
     }
 }
 
-impl AsRef<RenderTestEnum> for RenderTestEnum {
+impl ::std::convert::AsRef<RenderTestEnum> for RenderTestEnum {
     fn as_ref(&self) -> &RenderTestEnum {
         self
     }
@@ -1011,14 +1011,14 @@ pub enum Tag {
     Blockchain,
 }
 
-impl Default for Tag {
+impl ::std::default::Default for Tag {
     fn default() -> Self {
         Self::Security
     }
 }
 
-impl std::fmt::Display for Tag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for Tag {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::Security => write!(f, "Security"),
 
@@ -1029,23 +1029,23 @@ impl std::fmt::Display for Tag {
     }
 }
 
-impl std::str::FromStr for Tag {
+impl ::std::str::FromStr for Tag {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "Security" => Ok(Self::Security),
+            "Security" => ::std::result::Result::Ok(Self::SECURITY),
 
-            "AI" => Ok(Self::AI),
+            "AI" => ::std::result::Result::Ok(Self::AI),
 
-            "Blockchain" => Ok(Self::Blockchain),
+            "Blockchain" => ::std::result::Result::Ok(Self::BLOCKCHAIN),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<Tag> for Tag {
+impl ::std::convert::AsRef<Tag> for Tag {
     fn as_ref(&self) -> &Tag {
         self
     }
@@ -1069,14 +1069,14 @@ pub enum TestEnum {
     G,
 }
 
-impl Default for TestEnum {
+impl ::std::default::Default for TestEnum {
     fn default() -> Self {
         Self::A
     }
 }
 
-impl std::fmt::Display for TestEnum {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl ::std::fmt::Display for TestEnum {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match self {
             Self::A => write!(f, "A"),
 
@@ -1095,31 +1095,31 @@ impl std::fmt::Display for TestEnum {
     }
 }
 
-impl std::str::FromStr for TestEnum {
+impl ::std::str::FromStr for TestEnum {
     type Err = ();
 
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
+    fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
         match s {
-            "A" => Ok(Self::A),
+            "A" => ::std::result::Result::Ok(Self::A),
 
-            "B" => Ok(Self::B),
+            "B" => ::std::result::Result::Ok(Self::B),
 
-            "C" => Ok(Self::C),
+            "C" => ::std::result::Result::Ok(Self::C),
 
-            "D" => Ok(Self::D),
+            "D" => ::std::result::Result::Ok(Self::D),
 
-            "E" => Ok(Self::E),
+            "E" => ::std::result::Result::Ok(Self::E),
 
-            "F" => Ok(Self::F),
+            "F" => ::std::result::Result::Ok(Self::F),
 
-            "G" => Ok(Self::G),
+            "G" => ::std::result::Result::Ok(Self::G),
 
-            _ => Err(()),
+            _ => ::std::result::Result::Err(()),
         }
     }
 }
 
-impl AsRef<TestEnum> for TestEnum {
+impl ::std::convert::AsRef<TestEnum> for TestEnum {
     fn as_ref(&self) -> &TestEnum {
         self
     }

--- a/integ-tests/rust/src/baml_client/types/enums.rs
+++ b/integ-tests/rust/src/baml_client/types/enums.rs
@@ -5,10 +5,13 @@
 
 //! Generated enum types.
 
-use baml::{BamlDecode, BamlEncode, BamlSerde};
+use baml::{
+    __internal::serde::{Deserialize, Serialize},
+    BamlDecode, BamlEncode,
+};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum AliasedEnum {
     KEY_ONE,
 
@@ -51,8 +54,8 @@ impl AsRef<AliasedEnum> for AliasedEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Category {
     Refund,
 
@@ -113,8 +116,8 @@ impl AsRef<Category> for Category {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Category2 {
     Refund,
 
@@ -175,8 +178,8 @@ impl AsRef<Category2> for Category2 {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Category3 {
     Refund,
 
@@ -237,9 +240,9 @@ impl AsRef<Category3> for Category3 {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Color {
     RED,
 
@@ -255,6 +258,7 @@ pub enum Color {
 
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
+    #[serde(untagged)]
     _Dynamic(String),
 }
 
@@ -312,8 +316,8 @@ impl AsRef<Color> for Color {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum DataType {
     Resume,
 
@@ -356,12 +360,13 @@ impl AsRef<DataType> for DataType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub enum DynEnumOne {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
+    #[serde(untagged)]
     _Dynamic(String),
 }
 
@@ -397,9 +402,9 @@ impl AsRef<DynEnumOne> for DynEnumOne {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub enum DynEnumThree {
     TRICYCLE,
 
@@ -407,6 +412,7 @@ pub enum DynEnumThree {
 
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
+    #[serde(untagged)]
     _Dynamic(String),
 }
 
@@ -448,12 +454,13 @@ impl AsRef<DynEnumThree> for DynEnumThree {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub enum DynEnumTwo {
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
+    #[serde(untagged)]
     _Dynamic(String),
 }
 
@@ -489,8 +496,8 @@ impl AsRef<DynEnumTwo> for DynEnumTwo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum EnumInClass {
     ONE,
 
@@ -536,8 +543,8 @@ impl AsRef<EnumInClass> for EnumInClass {
 /// An enum with three values,
 /// ONE, TWO and THREE.
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum EnumOutput {
     /// The first enum.
     ONE,
@@ -588,9 +595,9 @@ impl AsRef<EnumOutput> for EnumOutput {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Hobby {
     SPORTS,
 
@@ -600,6 +607,7 @@ pub enum Hobby {
 
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
+    #[serde(untagged)]
     _Dynamic(String),
 }
 
@@ -645,8 +653,8 @@ impl AsRef<Hobby> for Hobby {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum MapKey {
     A,
 
@@ -695,8 +703,8 @@ impl AsRef<MapKey> for MapKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum NamedArgsSingleEnum {
     ONE,
 
@@ -739,8 +747,8 @@ impl AsRef<NamedArgsSingleEnum> for NamedArgsSingleEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum NamedArgsSingleEnumList {
     ONE,
 
@@ -783,8 +791,8 @@ impl AsRef<NamedArgsSingleEnumList> for NamedArgsSingleEnumList {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum OptionalTest_CategoryType {
     Aleph,
 
@@ -833,8 +841,8 @@ impl AsRef<OptionalTest_CategoryType> for OptionalTest_CategoryType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum OrderStatus {
     ORDERED,
 
@@ -889,9 +897,9 @@ impl AsRef<OrderStatus> for OrderStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub enum RenderStatusEnum {
     ACTIVE,
 
@@ -899,6 +907,7 @@ pub enum RenderStatusEnum {
 
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
+    #[serde(untagged)]
     _Dynamic(String),
 }
 
@@ -940,9 +949,9 @@ impl AsRef<RenderStatusEnum> for RenderStatusEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
 #[baml(dynamic)]
-
+#[serde(crate = "::baml::__internal::serde")]
 pub enum RenderTestEnum {
     BIKE,
 
@@ -950,6 +959,7 @@ pub enum RenderTestEnum {
 
     /// Dynamic variant for runtime-added enum values.
     #[baml(dynamic_variant)]
+    #[serde(untagged)]
     _Dynamic(String),
 }
 
@@ -991,8 +1001,8 @@ impl AsRef<RenderTestEnum> for RenderTestEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum Tag {
     Security,
 
@@ -1041,8 +1051,8 @@ impl AsRef<Tag> for Tag {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
-
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde")]
 pub enum TestEnum {
     A,
 

--- a/integ-tests/rust/src/baml_client/types/enums.rs
+++ b/integ-tests/rust/src/baml_client/types/enums.rs
@@ -5,9 +5,9 @@
 
 //! Generated enum types.
 
-use baml::{BamlDecode, BamlEncode};
+use baml::{BamlDecode, BamlEncode, BamlSerde};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum AliasedEnum {
     KEY_ONE,
@@ -51,7 +51,7 @@ impl AsRef<AliasedEnum> for AliasedEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum Category {
     Refund,
@@ -113,7 +113,7 @@ impl AsRef<Category> for Category {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum Category2 {
     Refund,
@@ -175,7 +175,7 @@ impl AsRef<Category2> for Category2 {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum Category3 {
     Refund,
@@ -237,7 +237,7 @@ impl AsRef<Category3> for Category3 {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
 
 pub enum Color {
@@ -312,7 +312,7 @@ impl AsRef<Color> for Color {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum DataType {
     Resume,
@@ -356,7 +356,7 @@ impl AsRef<DataType> for DataType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
 
 pub enum DynEnumOne {
@@ -397,7 +397,7 @@ impl AsRef<DynEnumOne> for DynEnumOne {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
 
 pub enum DynEnumThree {
@@ -448,7 +448,7 @@ impl AsRef<DynEnumThree> for DynEnumThree {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
 
 pub enum DynEnumTwo {
@@ -489,7 +489,7 @@ impl AsRef<DynEnumTwo> for DynEnumTwo {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum EnumInClass {
     ONE,
@@ -536,7 +536,7 @@ impl AsRef<EnumInClass> for EnumInClass {
 /// An enum with three values,
 /// ONE, TWO and THREE.
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum EnumOutput {
     /// The first enum.
@@ -588,7 +588,7 @@ impl AsRef<EnumOutput> for EnumOutput {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
 
 pub enum Hobby {
@@ -645,7 +645,7 @@ impl AsRef<Hobby> for Hobby {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum MapKey {
     A,
@@ -695,7 +695,7 @@ impl AsRef<MapKey> for MapKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum NamedArgsSingleEnum {
     ONE,
@@ -739,7 +739,7 @@ impl AsRef<NamedArgsSingleEnum> for NamedArgsSingleEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum NamedArgsSingleEnumList {
     ONE,
@@ -783,7 +783,7 @@ impl AsRef<NamedArgsSingleEnumList> for NamedArgsSingleEnumList {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum OptionalTest_CategoryType {
     Aleph,
@@ -833,7 +833,7 @@ impl AsRef<OptionalTest_CategoryType> for OptionalTest_CategoryType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum OrderStatus {
     ORDERED,
@@ -889,7 +889,7 @@ impl AsRef<OrderStatus> for OrderStatus {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
 
 pub enum RenderStatusEnum {
@@ -940,7 +940,7 @@ impl AsRef<RenderStatusEnum> for RenderStatusEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 #[baml(dynamic)]
 
 pub enum RenderTestEnum {
@@ -991,7 +991,7 @@ impl AsRef<RenderTestEnum> for RenderTestEnum {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum Tag {
     Security,
@@ -1041,7 +1041,7 @@ impl AsRef<Tag> for Tag {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, BamlEncode, BamlDecode, BamlSerde)]
 
 pub enum TestEnum {
     A,

--- a/integ-tests/rust/src/baml_client/types/mod.rs
+++ b/integ-tests/rust/src/baml_client/types/mod.rs
@@ -348,340 +348,338 @@ pub enum Types {
     ),
 }
 
-impl baml::KnownTypes for Types {
+impl ::baml::KnownTypes for Types {
     fn as_any(&self) -> &dyn ::std::any::Any {
         self
     }
 
     fn type_name(&self) -> &'static str {
         match self {
-            Types::AddTodoItem(_) => "AddTodoItem",
+            Self::AddTodoItem(_) => "AddTodoItem",
 
-            Types::AddressWithMeta(_) => "AddressWithMeta",
+            Self::AddressWithMeta(_) => "AddressWithMeta",
 
-            Types::AnotherObject(_) => "AnotherObject",
+            Self::AnotherObject(_) => "AnotherObject",
 
-            Types::BigNumbers(_) => "BigNumbers",
+            Self::BigNumbers(_) => "BigNumbers",
 
-            Types::BinaryNode(_) => "BinaryNode",
+            Self::BinaryNode(_) => "BinaryNode",
 
-            Types::Blah(_) => "Blah",
+            Self::Blah(_) => "Blah",
 
-            Types::BlockConstraint(_) => "BlockConstraint",
+            Self::BlockConstraint(_) => "BlockConstraint",
 
-            Types::BlockConstraintForParam(_) => "BlockConstraintForParam",
+            Self::BlockConstraintForParam(_) => "BlockConstraintForParam",
 
-            Types::BookOrder(_) => "BookOrder",
+            Self::BookOrder(_) => "BookOrder",
 
-            Types::ClassForNullLiteral(_) => "ClassForNullLiteral",
+            Self::ClassForNullLiteral(_) => "ClassForNullLiteral",
 
-            Types::ClassOptionalOutput(_) => "ClassOptionalOutput",
+            Self::ClassOptionalOutput(_) => "ClassOptionalOutput",
 
-            Types::ClassOptionalOutput2(_) => "ClassOptionalOutput2",
+            Self::ClassOptionalOutput2(_) => "ClassOptionalOutput2",
 
-            Types::ClassToRecAlias(_) => "ClassToRecAlias",
+            Self::ClassToRecAlias(_) => "ClassToRecAlias",
 
-            Types::ClassWithBlockDone(_) => "ClassWithBlockDone",
+            Self::ClassWithBlockDone(_) => "ClassWithBlockDone",
 
-            Types::ClassWithImage(_) => "ClassWithImage",
+            Self::ClassWithImage(_) => "ClassWithImage",
 
-            Types::ClassWithoutDone(_) => "ClassWithoutDone",
+            Self::ClassWithoutDone(_) => "ClassWithoutDone",
 
-            Types::ClientDetails1559(_) => "ClientDetails1559",
+            Self::ClientDetails1559(_) => "ClientDetails1559",
 
-            Types::ComplexMemoryObject(_) => "ComplexMemoryObject",
+            Self::ComplexMemoryObject(_) => "ComplexMemoryObject",
 
-            Types::CompoundBigNumbers(_) => "CompoundBigNumbers",
+            Self::CompoundBigNumbers(_) => "CompoundBigNumbers",
 
-            Types::ContactInfo(_) => "ContactInfo",
+            Self::ContactInfo(_) => "ContactInfo",
 
-            Types::CustomStory(_) => "CustomStory",
+            Self::CustomStory(_) => "CustomStory",
 
-            Types::CustomTaskResult(_) => "CustomTaskResult",
+            Self::CustomTaskResult(_) => "CustomTaskResult",
 
-            Types::Document1559(_) => "Document1559",
+            Self::Document1559(_) => "Document1559",
 
-            Types::DummyJsonTodo(_) => "DummyJsonTodo",
+            Self::DummyJsonTodo(_) => "DummyJsonTodo",
 
-            Types::DummyOutput(_) => "DummyOutput",
+            Self::DummyOutput(_) => "DummyOutput",
 
-            Types::DynInputOutput(_) => "DynInputOutput",
+            Self::DynInputOutput(_) => "DynInputOutput",
 
-            Types::DynamicClassOne(_) => "DynamicClassOne",
+            Self::DynamicClassOne(_) => "DynamicClassOne",
 
-            Types::DynamicClassTwo(_) => "DynamicClassTwo",
+            Self::DynamicClassTwo(_) => "DynamicClassTwo",
 
-            Types::DynamicOutput(_) => "DynamicOutput",
+            Self::DynamicOutput(_) => "DynamicOutput",
 
-            Types::DynamicSchema(_) => "DynamicSchema",
+            Self::DynamicSchema(_) => "DynamicSchema",
 
-            Types::Earthling(_) => "Earthling",
+            Self::Earthling(_) => "Earthling",
 
-            Types::Education(_) => "Education",
+            Self::Education(_) => "Education",
 
-            Types::Email(_) => "Email",
+            Self::Email(_) => "Email",
 
-            Types::EmailAddress(_) => "EmailAddress",
+            Self::EmailAddress(_) => "EmailAddress",
 
-            Types::Event(_) => "Event",
+            Self::Event(_) => "Event",
 
-            Types::FakeImage(_) => "FakeImage",
+            Self::FakeImage(_) => "FakeImage",
 
-            Types::FlightConfirmation(_) => "FlightConfirmation",
+            Self::FlightConfirmation(_) => "FlightConfirmation",
 
-            Types::FooAny(_) => "FooAny",
+            Self::FooAny(_) => "FooAny",
 
-            Types::Forest(_) => "Forest",
+            Self::Forest(_) => "Forest",
 
-            Types::FormatterTest0(_) => "FormatterTest0",
+            Self::FormatterTest0(_) => "FormatterTest0",
 
-            Types::FormatterTest1(_) => "FormatterTest1",
+            Self::FormatterTest1(_) => "FormatterTest1",
 
-            Types::FormatterTest2(_) => "FormatterTest2",
+            Self::FormatterTest2(_) => "FormatterTest2",
 
-            Types::FormatterTest3(_) => "FormatterTest3",
+            Self::FormatterTest3(_) => "FormatterTest3",
 
-            Types::GroceryReceipt(_) => "GroceryReceipt",
+            Self::GroceryReceipt(_) => "GroceryReceipt",
 
-            Types::Haiku(_) => "Haiku",
+            Self::Haiku(_) => "Haiku",
 
-            Types::InnerClass(_) => "InnerClass",
+            Self::InnerClass(_) => "InnerClass",
 
-            Types::InnerClass2(_) => "InnerClass2",
+            Self::InnerClass2(_) => "InnerClass2",
 
-            Types::InputClass(_) => "InputClass",
+            Self::InputClass(_) => "InputClass",
 
-            Types::InputClassNested(_) => "InputClassNested",
+            Self::InputClassNested(_) => "InputClassNested",
 
-            Types::LinkedList(_) => "LinkedList",
+            Self::LinkedList(_) => "LinkedList",
 
-            Types::LinkedListAliasNode(_) => "LinkedListAliasNode",
+            Self::LinkedListAliasNode(_) => "LinkedListAliasNode",
 
-            Types::LiteralClassHello(_) => "LiteralClassHello",
+            Self::LiteralClassHello(_) => "LiteralClassHello",
 
-            Types::LiteralClassOne(_) => "LiteralClassOne",
+            Self::LiteralClassOne(_) => "LiteralClassOne",
 
-            Types::LiteralClassTwo(_) => "LiteralClassTwo",
+            Self::LiteralClassTwo(_) => "LiteralClassTwo",
 
-            Types::MaintainFieldOrder(_) => "MaintainFieldOrder",
+            Self::MaintainFieldOrder(_) => "MaintainFieldOrder",
 
-            Types::MalformedConstraints(_) => "MalformedConstraints",
+            Self::MalformedConstraints(_) => "MalformedConstraints",
 
-            Types::MalformedConstraints2(_) => "MalformedConstraints2",
+            Self::MalformedConstraints2(_) => "MalformedConstraints2",
 
-            Types::Martian(_) => "Martian",
+            Self::Martian(_) => "Martian",
 
-            Types::MemoryObject(_) => "MemoryObject",
+            Self::MemoryObject(_) => "MemoryObject",
 
-            Types::MergeAttrs(_) => "MergeAttrs",
+            Self::MergeAttrs(_) => "MergeAttrs",
 
-            Types::NamedArgsSingleClass(_) => "NamedArgsSingleClass",
+            Self::NamedArgsSingleClass(_) => "NamedArgsSingleClass",
 
-            Types::Nested(_) => "Nested",
+            Self::Nested(_) => "Nested",
 
-            Types::Nested2(_) => "Nested2",
+            Self::Nested2(_) => "Nested2",
 
-            Types::NestedBlockConstraint(_) => "NestedBlockConstraint",
+            Self::NestedBlockConstraint(_) => "NestedBlockConstraint",
 
-            Types::NestedBlockConstraintForParam(_) => "NestedBlockConstraintForParam",
+            Self::NestedBlockConstraintForParam(_) => "NestedBlockConstraintForParam",
 
-            Types::Node(_) => "Node",
+            Self::Node(_) => "Node",
 
-            Types::NodeWithAliasIndirection(_) => "NodeWithAliasIndirection",
+            Self::NodeWithAliasIndirection(_) => "NodeWithAliasIndirection",
 
-            Types::Note1599(_) => "Note1599",
+            Self::Note1599(_) => "Note1599",
 
-            Types::OptionalListAndMap(_) => "OptionalListAndMap",
+            Self::OptionalListAndMap(_) => "OptionalListAndMap",
 
-            Types::OptionalTest_Prop1(_) => "OptionalTest_Prop1",
+            Self::OptionalTest_Prop1(_) => "OptionalTest_Prop1",
 
-            Types::OptionalTest_ReturnType(_) => "OptionalTest_ReturnType",
+            Self::OptionalTest_ReturnType(_) => "OptionalTest_ReturnType",
 
-            Types::OrderInfo(_) => "OrderInfo",
+            Self::OrderInfo(_) => "OrderInfo",
 
-            Types::OriginalA(_) => "OriginalA",
+            Self::OriginalA(_) => "OriginalA",
 
-            Types::OriginalB(_) => "OriginalB",
+            Self::OriginalB(_) => "OriginalB",
 
-            Types::Person(_) => "Person",
+            Self::Person(_) => "Person",
 
-            Types::PersonWithMeta(_) => "PersonWithMeta",
+            Self::PersonWithMeta(_) => "PersonWithMeta",
 
-            Types::PhoneNumber(_) => "PhoneNumber",
+            Self::PhoneNumber(_) => "PhoneNumber",
 
-            Types::Quantity(_) => "Quantity",
+            Self::Quantity(_) => "Quantity",
 
-            Types::RaysData(_) => "RaysData",
+            Self::RaysData(_) => "RaysData",
 
-            Types::ReceiptInfo(_) => "ReceiptInfo",
+            Self::ReceiptInfo(_) => "ReceiptInfo",
 
-            Types::ReceiptItem(_) => "ReceiptItem",
+            Self::ReceiptItem(_) => "ReceiptItem",
 
-            Types::Recipe(_) => "Recipe",
+            Self::Recipe(_) => "Recipe",
 
-            Types::RecursiveAliasDependency(_) => "RecursiveAliasDependency",
+            Self::RecursiveAliasDependency(_) => "RecursiveAliasDependency",
 
-            Types::RenderEnumInput(_) => "RenderEnumInput",
+            Self::RenderEnumInput(_) => "RenderEnumInput",
 
-            Types::RenderTestClass(_) => "RenderTestClass",
+            Self::RenderTestClass(_) => "RenderTestClass",
 
-            Types::Resume(_) => "Resume",
+            Self::Resume(_) => "Resume",
 
-            Types::Schema(_) => "Schema",
+            Self::Schema(_) => "Schema",
 
-            Types::SearchParams(_) => "SearchParams",
+            Self::SearchParams(_) => "SearchParams",
 
-            Types::SemanticContainer(_) => "SemanticContainer",
+            Self::SemanticContainer(_) => "SemanticContainer",
 
-            Types::SimpleTag(_) => "SimpleTag",
+            Self::SimpleTag(_) => "SimpleTag",
 
-            Types::SkipDynamicClass(_) => "SkipDynamicClass",
+            Self::SkipDynamicClass(_) => "SkipDynamicClass",
 
-            Types::SkipNonDynamicClass(_) => "SkipNonDynamicClass",
+            Self::SkipNonDynamicClass(_) => "SkipNonDynamicClass",
 
-            Types::SmallThing(_) => "SmallThing",
+            Self::SmallThing(_) => "SmallThing",
 
-            Types::SomeClassNestedDynamic(_) => "SomeClassNestedDynamic",
+            Self::SomeClassNestedDynamic(_) => "SomeClassNestedDynamic",
 
-            Types::StringToClassEntry(_) => "StringToClassEntry",
+            Self::StringToClassEntry(_) => "StringToClassEntry",
 
-            Types::TestClassAlias(_) => "TestClassAlias",
+            Self::TestClassAlias(_) => "TestClassAlias",
 
-            Types::TestClassNested(_) => "TestClassNested",
+            Self::TestClassNested(_) => "TestClassNested",
 
-            Types::TestClassWithEnum(_) => "TestClassWithEnum",
+            Self::TestClassWithEnum(_) => "TestClassWithEnum",
 
-            Types::TestMemoryOutput(_) => "TestMemoryOutput",
+            Self::TestMemoryOutput(_) => "TestMemoryOutput",
 
-            Types::TestOutputClass(_) => "TestOutputClass",
+            Self::TestOutputClass(_) => "TestOutputClass",
 
-            Types::TodoMessageToUser(_) => "TodoMessageToUser",
+            Self::TodoMessageToUser(_) => "TodoMessageToUser",
 
-            Types::Tree(_) => "Tree",
+            Self::Tree(_) => "Tree",
 
-            Types::TwoStoriesOneTitle(_) => "TwoStoriesOneTitle",
+            Self::TwoStoriesOneTitle(_) => "TwoStoriesOneTitle",
 
-            Types::TwoStoriesOneTitleCheck(_) => "TwoStoriesOneTitleCheck",
+            Self::TwoStoriesOneTitleCheck(_) => "TwoStoriesOneTitleCheck",
 
-            Types::UnionTest_ReturnType(_) => "UnionTest_ReturnType",
+            Self::UnionTest_ReturnType(_) => "UnionTest_ReturnType",
 
-            Types::UniverseQuestion(_) => "UniverseQuestion",
+            Self::UniverseQuestion(_) => "UniverseQuestion",
 
-            Types::UniverseQuestionInput(_) => "UniverseQuestionInput",
+            Self::UniverseQuestionInput(_) => "UniverseQuestionInput",
 
-            Types::WithReasoning(_) => "WithReasoning",
+            Self::WithReasoning(_) => "WithReasoning",
 
-            Types::AliasedEnum(_) => "AliasedEnum",
+            Self::AliasedEnum(_) => "AliasedEnum",
 
-            Types::Category(_) => "Category",
+            Self::Category(_) => "Category",
 
-            Types::Category2(_) => "Category2",
+            Self::Category2(_) => "Category2",
 
-            Types::Category3(_) => "Category3",
+            Self::Category3(_) => "Category3",
 
-            Types::Color(_) => "Color",
+            Self::Color(_) => "Color",
 
-            Types::DataType(_) => "DataType",
+            Self::DataType(_) => "DataType",
 
-            Types::DynEnumOne(_) => "DynEnumOne",
+            Self::DynEnumOne(_) => "DynEnumOne",
 
-            Types::DynEnumThree(_) => "DynEnumThree",
+            Self::DynEnumThree(_) => "DynEnumThree",
 
-            Types::DynEnumTwo(_) => "DynEnumTwo",
+            Self::DynEnumTwo(_) => "DynEnumTwo",
 
-            Types::EnumInClass(_) => "EnumInClass",
+            Self::EnumInClass(_) => "EnumInClass",
 
-            Types::EnumOutput(_) => "EnumOutput",
+            Self::EnumOutput(_) => "EnumOutput",
 
-            Types::Hobby(_) => "Hobby",
+            Self::Hobby(_) => "Hobby",
 
-            Types::MapKey(_) => "MapKey",
+            Self::MapKey(_) => "MapKey",
 
-            Types::NamedArgsSingleEnum(_) => "NamedArgsSingleEnum",
+            Self::NamedArgsSingleEnum(_) => "NamedArgsSingleEnum",
 
-            Types::NamedArgsSingleEnumList(_) => "NamedArgsSingleEnumList",
+            Self::NamedArgsSingleEnumList(_) => "NamedArgsSingleEnumList",
 
-            Types::OptionalTest_CategoryType(_) => "OptionalTest_CategoryType",
+            Self::OptionalTest_CategoryType(_) => "OptionalTest_CategoryType",
 
-            Types::OrderStatus(_) => "OrderStatus",
+            Self::OrderStatus(_) => "OrderStatus",
 
-            Types::RenderStatusEnum(_) => "RenderStatusEnum",
+            Self::RenderStatusEnum(_) => "RenderStatusEnum",
 
-            Types::RenderTestEnum(_) => "RenderTestEnum",
+            Self::RenderTestEnum(_) => "RenderTestEnum",
 
-            Types::Tag(_) => "Tag",
+            Self::Tag(_) => "Tag",
 
-            Types::TestEnum(_) => "TestEnum",
+            Self::TestEnum(_) => "TestEnum",
 
-            Types::Union2AddTodoItemOrTodoMessageToUser(_) => {
-                "Union2AddTodoItemOrTodoMessageToUser"
-            }
+            Self::Union2AddTodoItemOrTodoMessageToUser(_) => "Union2AddTodoItemOrTodoMessageToUser",
 
-            Types::Union2BoolOrFloat(_) => "Union2BoolOrFloat",
+            Self::Union2BoolOrFloat(_) => "Union2BoolOrFloat",
 
-            Types::Union2BoolOrString(_) => "Union2BoolOrString",
+            Self::Union2BoolOrString(_) => "Union2BoolOrString",
 
-            Types::Union2EarthlingOrMartian(_) => "Union2EarthlingOrMartian",
+            Self::Union2EarthlingOrMartian(_) => "Union2EarthlingOrMartian",
 
-            Types::Union2EmailAddressOrPhoneNumber(_) => "Union2EmailAddressOrPhoneNumber",
+            Self::Union2EmailAddressOrPhoneNumber(_) => "Union2EmailAddressOrPhoneNumber",
 
-            Types::Union2EventOrResume(_) => "Union2EventOrResume",
+            Self::Union2EventOrResume(_) => "Union2EventOrResume",
 
-            Types::Union2FloatOrInt(_) => "Union2FloatOrInt",
+            Self::Union2FloatOrInt(_) => "Union2FloatOrInt",
 
-            Types::Union2IntOrString(_) => "Union2IntOrString",
+            Self::Union2IntOrString(_) => "Union2IntOrString",
 
-            Types::Union2JsonTemplateOrSimpleTag(_) => "Union2JsonTemplateOrSimpleTag",
+            Self::Union2JsonTemplateOrSimpleTag(_) => "Union2JsonTemplateOrSimpleTag",
 
-            Types::Union2KbarisaOrKox_burger(_) => "Union2KbarisaOrKox_burger",
+            Self::Union2KbarisaOrKox_burger(_) => "Union2KbarisaOrKox_burger",
 
-            Types::Union2KbreakfastOrKdinner(_) => "Union2KbreakfastOrKdinner",
+            Self::Union2KbreakfastOrKdinner(_) => "Union2KbreakfastOrKdinner",
 
-            Types::Union2KcuriosityOrKpersonal_finance(_) => "Union2KcuriosityOrKpersonal_finance",
+            Self::Union2KcuriosityOrKpersonal_finance(_) => "Union2KcuriosityOrKpersonal_finance",
 
-            Types::Union2ListBoolOrListInt(_) => "Union2ListBoolOrListInt",
+            Self::Union2ListBoolOrListInt(_) => "Union2ListBoolOrListInt",
 
-            Types::Union2ListNestedOrString(_) => "Union2ListNestedOrString",
+            Self::Union2ListNestedOrString(_) => "Union2ListNestedOrString",
 
-            Types::Union2LiteralClassOneOrLiteralClassTwo(_) => {
+            Self::Union2LiteralClassOneOrLiteralClassTwo(_) => {
                 "Union2LiteralClassOneOrLiteralClassTwo"
             }
 
-            Types::Union2MapStringKeyRecursiveUnionValueOrString(_) => {
+            Self::Union2MapStringKeyRecursiveUnionValueOrString(_) => {
                 "Union2MapStringKeyRecursiveUnionValueOrString"
             }
 
-            Types::Union2NestedOrString(_) => "Union2NestedOrString",
+            Self::Union2NestedOrString(_) => "Union2NestedOrString",
 
-            Types::Union2OriginalAOrOriginalB(_) => "Union2OriginalAOrOriginalB",
+            Self::Union2OriginalAOrOriginalB(_) => "Union2OriginalAOrOriginalB",
 
-            Types::Union2StringOrTag(_) => "Union2StringOrTag",
+            Self::Union2StringOrTag(_) => "Union2StringOrTag",
 
-            Types::Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject(_) => {
+            Self::Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject(_) => {
                 "Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject"
             }
 
-            Types::Union3BookOrderOrFlightConfirmationOrGroceryReceipt(_) => {
+            Self::Union3BookOrderOrFlightConfirmationOrGroceryReceipt(_) => {
                 "Union3BookOrderOrFlightConfirmationOrGroceryReceipt"
             }
 
-            Types::Union3BoolKTrueOrIntK1OrKstring_output(_) => {
+            Self::Union3BoolKTrueOrIntK1OrKstring_output(_) => {
                 "Union3BoolKTrueOrIntK1OrKstring_output"
             }
 
-            Types::Union3FloatOrIntOrString(_) => "Union3FloatOrIntOrString",
+            Self::Union3FloatOrIntOrString(_) => "Union3FloatOrIntOrString",
 
-            Types::Union4AudioOrImageOrPDFOrString(_) => "Union4AudioOrImageOrPDFOrString",
+            Self::Union4AudioOrImageOrPDFOrString(_) => "Union4AudioOrImageOrPDFOrString",
 
-            Types::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
+            Self::Union4BoolOrFloatOrIntOrString(_) => "Union4BoolOrFloatOrIntOrString",
 
-            Types::Union4KfourOrKoneOrKthreeOrKtwo(_) => "Union4KfourOrKoneOrKthreeOrKtwo",
+            Self::Union4KfourOrKoneOrKthreeOrKtwo(_) => "Union4KfourOrKoneOrKthreeOrKtwo",
 
-            Types::Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString(_) => {
+            Self::Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString(_) => {
                 "Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString"
             }
 
-            Types::Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString(_) => {
+            Self::Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString(_) => {
                 "Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString"
             }
         }

--- a/integ-tests/rust/src/baml_client/types/mod.rs
+++ b/integ-tests/rust/src/baml_client/types/mod.rs
@@ -16,12 +16,14 @@ pub use type_aliases::*;
 pub use unions::*;
 
 // Re-export types from baml runtime
+use baml::__internal::serde;
 pub use baml::{Audio, Image, Pdf, Video};
 pub use baml::{Checked, StreamState};
 
 /// All known types in this BAML project.
 /// Serves as the compile-time type registry for BamlValue.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Types {
     AddTodoItem(AddTodoItem),
 
@@ -683,5 +685,13 @@ impl baml::KnownTypes for Types {
                 "Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString"
             }
         }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Types {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Err(serde::de::Error::custom(
+            "Types is not deserializable, as we cannot disambiguate the type.",
+        ))
     }
 }

--- a/integ-tests/rust/src/baml_client/types/mod.rs
+++ b/integ-tests/rust/src/baml_client/types/mod.rs
@@ -349,7 +349,7 @@ pub enum Types {
 }
 
 impl baml::KnownTypes for Types {
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn ::std::any::Any {
         self
     }
 
@@ -689,8 +689,10 @@ impl baml::KnownTypes for Types {
 }
 
 impl<'de> serde::Deserialize<'de> for Types {
-    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Err(serde::de::Error::custom(
+    fn deserialize<D: serde::Deserializer<'de>>(
+        _deserializer: D,
+    ) -> ::std::result::Result<Self, D::Error> {
+        ::std::result::Result::Err(serde::de::Error::custom(
             "Types is not deserializable, as we cannot disambiguate the type.",
         ))
     }

--- a/integ-tests/rust/src/baml_client/types/unions.rs
+++ b/integ-tests/rust/src/baml_client/types/unions.rs
@@ -616,18 +616,18 @@ impl ::std::default::Default for Union3FloatOrIntOrString {
 #[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4AudioOrImageOrPDFOrString {
     #[baml(name = "image")]
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_image")]
     Image(Image),
 
     #[baml(name = "string")]
     String(String),
 
     #[baml(name = "pdf")]
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_pdf")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_pdf")]
     PDF(Pdf),
 
     #[baml(name = "audio")]
-    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_audio")]
+    #[serde(deserialize_with = "super::super::runtime::__internal_media_serde::deserialize_audio")]
     Audio(Audio),
 }
 

--- a/integ-tests/rust/src/baml_client/types/unions.rs
+++ b/integ-tests/rust/src/baml_client/types/unions.rs
@@ -6,10 +6,14 @@
 //! Generated union types.
 
 use super::*;
-use baml::{BamlDecode, BamlEncode};
+use baml::{
+    __internal::serde::{Deserialize, Serialize},
+    BamlDecode, BamlEncode,
+};
 
 /// Generated from: (AddTodoItem | TodoMessageToUser)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2AddTodoItemOrTodoMessageToUser {
     #[baml(name = "AddTodoItem")]
@@ -32,7 +36,8 @@ impl Default for Union2AddTodoItemOrTodoMessageToUser {
 }
 
 /// Generated from: (float | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2BoolOrFloat {
     #[baml(name = "float")]
@@ -55,7 +60,8 @@ impl Default for Union2BoolOrFloat {
 }
 
 /// Generated from: (string | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2BoolOrString {
     #[baml(name = "string")]
@@ -78,7 +84,8 @@ impl Default for Union2BoolOrString {
 }
 
 /// Generated from: (Martian | Earthling)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2EarthlingOrMartian {
     #[baml(name = "Martian")]
@@ -101,7 +108,8 @@ impl Default for Union2EarthlingOrMartian {
 }
 
 /// Generated from: (PhoneNumber | EmailAddress)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2EmailAddressOrPhoneNumber {
     #[baml(name = "PhoneNumber")]
@@ -124,7 +132,8 @@ impl Default for Union2EmailAddressOrPhoneNumber {
 }
 
 /// Generated from: (Resume | Event)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2EventOrResume {
     #[baml(name = "Resume")]
@@ -147,7 +156,8 @@ impl Default for Union2EventOrResume {
 }
 
 /// Generated from: (int | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2FloatOrInt {
     #[baml(name = "int")]
@@ -170,7 +180,8 @@ impl Default for Union2FloatOrInt {
 }
 
 /// Generated from: (string | int)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2IntOrString {
     #[baml(name = "string")]
@@ -193,7 +204,8 @@ impl Default for Union2IntOrString {
 }
 
 /// Generated from: (SimpleTag | JsonTemplate)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2JsonTemplateOrSimpleTag {
     #[baml(name = "SimpleTag")]
@@ -216,7 +228,8 @@ impl Default for Union2JsonTemplateOrSimpleTag {
 }
 
 /// Generated from: ("barisa" | "ox_burger")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2KbarisaOrKox_burger {
     #[baml(name = "string_barisa", literal_string = "barisa")]
@@ -239,7 +252,8 @@ impl Default for Union2KbarisaOrKox_burger {
 }
 
 /// Generated from: ("breakfast" | "dinner")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2KbreakfastOrKdinner {
     #[baml(name = "string_breakfast", literal_string = "breakfast")]
@@ -262,7 +276,8 @@ impl Default for Union2KbreakfastOrKdinner {
 }
 
 /// Generated from: ("curiosity" | "personal_finance")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2KcuriosityOrKpersonal_finance {
     #[baml(name = "string_curiosity", literal_string = "curiosity")]
@@ -285,7 +300,8 @@ impl Default for Union2KcuriosityOrKpersonal_finance {
 }
 
 /// Generated from: (bool[] | int[])
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2ListBoolOrListInt {
     #[baml(name = "List__bool")]
@@ -308,7 +324,8 @@ impl Default for Union2ListBoolOrListInt {
 }
 
 /// Generated from: (string | Nested[])
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2ListNestedOrString {
     #[baml(name = "string")]
@@ -331,7 +348,8 @@ impl Default for Union2ListNestedOrString {
 }
 
 /// Generated from: (LiteralClassOne | LiteralClassTwo)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2LiteralClassOneOrLiteralClassTwo {
     #[baml(name = "LiteralClassOne")]
@@ -354,7 +372,8 @@ impl Default for Union2LiteralClassOneOrLiteralClassTwo {
 }
 
 /// Generated from: (string | map<string, RecursiveUnion>)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2MapStringKeyRecursiveUnionValueOrString {
     #[baml(name = "string")]
@@ -379,7 +398,8 @@ impl Default for Union2MapStringKeyRecursiveUnionValueOrString {
 }
 
 /// Generated from: (Nested | string)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2NestedOrString {
     #[baml(name = "Nested")]
@@ -402,7 +422,8 @@ impl Default for Union2NestedOrString {
 }
 
 /// Generated from: (OriginalA | OriginalB)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2OriginalAOrOriginalB {
     #[baml(name = "OriginalA")]
@@ -425,7 +446,8 @@ impl Default for Union2OriginalAOrOriginalB {
 }
 
 /// Generated from: (Tag | string)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union2StringOrTag {
     #[baml(name = "Tag")]
@@ -448,7 +470,8 @@ impl Default for Union2StringOrTag {
 }
 
 /// Generated from: (MemoryObject | ComplexMemoryObject | AnotherObject)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
     #[baml(name = "MemoryObject")]
@@ -476,7 +499,8 @@ impl Default for Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
 }
 
 /// Generated from: (BookOrder | FlightConfirmation | GroceryReceipt)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
     #[baml(name = "BookOrder")]
@@ -504,7 +528,8 @@ impl Default for Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
 }
 
 /// Generated from: (1 | true | "string output")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union3BoolKTrueOrIntK1OrKstring_output {
     #[baml(name = "int_1", literal_int = 1)]
@@ -530,7 +555,8 @@ impl Default for Union3BoolKTrueOrIntK1OrKstring_output {
 }
 
 /// Generated from: (string | int | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union3FloatOrIntOrString {
     #[baml(name = "string")]
@@ -556,7 +582,8 @@ impl Default for Union3FloatOrIntOrString {
 }
 
 /// Generated from: (image | string | pdf | audio)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union4AudioOrImageOrPDFOrString {
     #[baml(name = "image")]
@@ -585,7 +612,8 @@ impl Default for Union4AudioOrImageOrPDFOrString {
 }
 
 /// Generated from: (int | string | bool | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union4BoolOrFloatOrIntOrString {
     #[baml(name = "int")]
@@ -614,7 +642,8 @@ impl Default for Union4BoolOrFloatOrIntOrString {
 }
 
 /// Generated from: ("one" | "two" | "three" | "four")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union4KfourOrKoneOrKthreeOrKtwo {
     #[baml(name = "string_one", literal_string = "one")]
@@ -643,7 +672,8 @@ impl Default for Union4KfourOrKoneOrKthreeOrKtwo {
 }
 
 /// Generated from: (int | string | bool | float | JsonObject | JsonArray)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
     #[baml(name = "int")]
@@ -680,7 +710,8 @@ impl Default for Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
 }
 
 /// Generated from: (int | string | bool | float | string[] | map<string, string[]>)
-#[derive(Debug, Clone, BamlEncode, BamlDecode)]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
+#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
 #[baml(union)]
 pub enum Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString {
     #[baml(name = "int")]

--- a/integ-tests/rust/src/baml_client/types/unions.rs
+++ b/integ-tests/rust/src/baml_client/types/unions.rs
@@ -23,15 +23,17 @@ pub enum Union2AddTodoItemOrTodoMessageToUser {
     TodoMessageToUser(TodoMessageToUser),
 }
 
-impl AsRef<Union2AddTodoItemOrTodoMessageToUser> for Union2AddTodoItemOrTodoMessageToUser {
+impl ::std::convert::AsRef<Union2AddTodoItemOrTodoMessageToUser>
+    for Union2AddTodoItemOrTodoMessageToUser
+{
     fn as_ref(&self) -> &Union2AddTodoItemOrTodoMessageToUser {
         self
     }
 }
 
-impl Default for Union2AddTodoItemOrTodoMessageToUser {
+impl ::std::default::Default for Union2AddTodoItemOrTodoMessageToUser {
     fn default() -> Self {
-        Self::AddTodoItem(Default::default())
+        Self::AddTodoItem(::std::default::Default::default())
     }
 }
 
@@ -47,15 +49,15 @@ pub enum Union2BoolOrFloat {
     Bool(bool),
 }
 
-impl AsRef<Union2BoolOrFloat> for Union2BoolOrFloat {
+impl ::std::convert::AsRef<Union2BoolOrFloat> for Union2BoolOrFloat {
     fn as_ref(&self) -> &Union2BoolOrFloat {
         self
     }
 }
 
-impl Default for Union2BoolOrFloat {
+impl ::std::default::Default for Union2BoolOrFloat {
     fn default() -> Self {
-        Self::Float(Default::default())
+        Self::Float(::std::default::Default::default())
     }
 }
 
@@ -71,15 +73,15 @@ pub enum Union2BoolOrString {
     Bool(bool),
 }
 
-impl AsRef<Union2BoolOrString> for Union2BoolOrString {
+impl ::std::convert::AsRef<Union2BoolOrString> for Union2BoolOrString {
     fn as_ref(&self) -> &Union2BoolOrString {
         self
     }
 }
 
-impl Default for Union2BoolOrString {
+impl ::std::default::Default for Union2BoolOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
@@ -95,15 +97,15 @@ pub enum Union2EarthlingOrMartian {
     Earthling(Earthling),
 }
 
-impl AsRef<Union2EarthlingOrMartian> for Union2EarthlingOrMartian {
+impl ::std::convert::AsRef<Union2EarthlingOrMartian> for Union2EarthlingOrMartian {
     fn as_ref(&self) -> &Union2EarthlingOrMartian {
         self
     }
 }
 
-impl Default for Union2EarthlingOrMartian {
+impl ::std::default::Default for Union2EarthlingOrMartian {
     fn default() -> Self {
-        Self::Martian(Default::default())
+        Self::Martian(::std::default::Default::default())
     }
 }
 
@@ -119,15 +121,15 @@ pub enum Union2EmailAddressOrPhoneNumber {
     EmailAddress(EmailAddress),
 }
 
-impl AsRef<Union2EmailAddressOrPhoneNumber> for Union2EmailAddressOrPhoneNumber {
+impl ::std::convert::AsRef<Union2EmailAddressOrPhoneNumber> for Union2EmailAddressOrPhoneNumber {
     fn as_ref(&self) -> &Union2EmailAddressOrPhoneNumber {
         self
     }
 }
 
-impl Default for Union2EmailAddressOrPhoneNumber {
+impl ::std::default::Default for Union2EmailAddressOrPhoneNumber {
     fn default() -> Self {
-        Self::PhoneNumber(Default::default())
+        Self::PhoneNumber(::std::default::Default::default())
     }
 }
 
@@ -143,15 +145,15 @@ pub enum Union2EventOrResume {
     Event(Event),
 }
 
-impl AsRef<Union2EventOrResume> for Union2EventOrResume {
+impl ::std::convert::AsRef<Union2EventOrResume> for Union2EventOrResume {
     fn as_ref(&self) -> &Union2EventOrResume {
         self
     }
 }
 
-impl Default for Union2EventOrResume {
+impl ::std::default::Default for Union2EventOrResume {
     fn default() -> Self {
-        Self::Resume(Default::default())
+        Self::Resume(::std::default::Default::default())
     }
 }
 
@@ -167,15 +169,15 @@ pub enum Union2FloatOrInt {
     Float(f64),
 }
 
-impl AsRef<Union2FloatOrInt> for Union2FloatOrInt {
+impl ::std::convert::AsRef<Union2FloatOrInt> for Union2FloatOrInt {
     fn as_ref(&self) -> &Union2FloatOrInt {
         self
     }
 }
 
-impl Default for Union2FloatOrInt {
+impl ::std::default::Default for Union2FloatOrInt {
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }
 
@@ -191,15 +193,15 @@ pub enum Union2IntOrString {
     Int(i64),
 }
 
-impl AsRef<Union2IntOrString> for Union2IntOrString {
+impl ::std::convert::AsRef<Union2IntOrString> for Union2IntOrString {
     fn as_ref(&self) -> &Union2IntOrString {
         self
     }
 }
 
-impl Default for Union2IntOrString {
+impl ::std::default::Default for Union2IntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
@@ -215,15 +217,15 @@ pub enum Union2JsonTemplateOrSimpleTag {
     JsonTemplate(JsonTemplate),
 }
 
-impl AsRef<Union2JsonTemplateOrSimpleTag> for Union2JsonTemplateOrSimpleTag {
+impl ::std::convert::AsRef<Union2JsonTemplateOrSimpleTag> for Union2JsonTemplateOrSimpleTag {
     fn as_ref(&self) -> &Union2JsonTemplateOrSimpleTag {
         self
     }
 }
 
-impl Default for Union2JsonTemplateOrSimpleTag {
+impl ::std::default::Default for Union2JsonTemplateOrSimpleTag {
     fn default() -> Self {
-        Self::SimpleTag(Default::default())
+        Self::SimpleTag(::std::default::Default::default())
     }
 }
 
@@ -243,13 +245,13 @@ pub enum Union2KbarisaOrKox_burger {
     Kox_burger,
 }
 
-impl AsRef<Union2KbarisaOrKox_burger> for Union2KbarisaOrKox_burger {
+impl ::std::convert::AsRef<Union2KbarisaOrKox_burger> for Union2KbarisaOrKox_burger {
     fn as_ref(&self) -> &Union2KbarisaOrKox_burger {
         self
     }
 }
 
-impl Default for Union2KbarisaOrKox_burger {
+impl ::std::default::Default for Union2KbarisaOrKox_burger {
     fn default() -> Self {
         Self::Kbarisa
     }
@@ -271,13 +273,13 @@ pub enum Union2KbreakfastOrKdinner {
     Kdinner,
 }
 
-impl AsRef<Union2KbreakfastOrKdinner> for Union2KbreakfastOrKdinner {
+impl ::std::convert::AsRef<Union2KbreakfastOrKdinner> for Union2KbreakfastOrKdinner {
     fn as_ref(&self) -> &Union2KbreakfastOrKdinner {
         self
     }
 }
 
-impl Default for Union2KbreakfastOrKdinner {
+impl ::std::default::Default for Union2KbreakfastOrKdinner {
     fn default() -> Self {
         Self::Kbreakfast
     }
@@ -301,13 +303,15 @@ pub enum Union2KcuriosityOrKpersonal_finance {
     Kpersonal_finance,
 }
 
-impl AsRef<Union2KcuriosityOrKpersonal_finance> for Union2KcuriosityOrKpersonal_finance {
+impl ::std::convert::AsRef<Union2KcuriosityOrKpersonal_finance>
+    for Union2KcuriosityOrKpersonal_finance
+{
     fn as_ref(&self) -> &Union2KcuriosityOrKpersonal_finance {
         self
     }
 }
 
-impl Default for Union2KcuriosityOrKpersonal_finance {
+impl ::std::default::Default for Union2KcuriosityOrKpersonal_finance {
     fn default() -> Self {
         Self::Kcuriosity
     }
@@ -325,15 +329,15 @@ pub enum Union2ListBoolOrListInt {
     ListInt(Vec<i64>),
 }
 
-impl AsRef<Union2ListBoolOrListInt> for Union2ListBoolOrListInt {
+impl ::std::convert::AsRef<Union2ListBoolOrListInt> for Union2ListBoolOrListInt {
     fn as_ref(&self) -> &Union2ListBoolOrListInt {
         self
     }
 }
 
-impl Default for Union2ListBoolOrListInt {
+impl ::std::default::Default for Union2ListBoolOrListInt {
     fn default() -> Self {
-        Self::ListBool(Default::default())
+        Self::ListBool(::std::default::Default::default())
     }
 }
 
@@ -349,15 +353,15 @@ pub enum Union2ListNestedOrString {
     ListNested(Vec<Nested>),
 }
 
-impl AsRef<Union2ListNestedOrString> for Union2ListNestedOrString {
+impl ::std::convert::AsRef<Union2ListNestedOrString> for Union2ListNestedOrString {
     fn as_ref(&self) -> &Union2ListNestedOrString {
         self
     }
 }
 
-impl Default for Union2ListNestedOrString {
+impl ::std::default::Default for Union2ListNestedOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
@@ -373,15 +377,17 @@ pub enum Union2LiteralClassOneOrLiteralClassTwo {
     LiteralClassTwo(LiteralClassTwo),
 }
 
-impl AsRef<Union2LiteralClassOneOrLiteralClassTwo> for Union2LiteralClassOneOrLiteralClassTwo {
+impl ::std::convert::AsRef<Union2LiteralClassOneOrLiteralClassTwo>
+    for Union2LiteralClassOneOrLiteralClassTwo
+{
     fn as_ref(&self) -> &Union2LiteralClassOneOrLiteralClassTwo {
         self
     }
 }
 
-impl Default for Union2LiteralClassOneOrLiteralClassTwo {
+impl ::std::default::Default for Union2LiteralClassOneOrLiteralClassTwo {
     fn default() -> Self {
-        Self::LiteralClassOne(Default::default())
+        Self::LiteralClassOne(::std::default::Default::default())
     }
 }
 
@@ -397,7 +403,7 @@ pub enum Union2MapStringKeyRecursiveUnionValueOrString {
     MapStringKeyRecursiveUnionValue(std::collections::HashMap<String, RecursiveUnion>),
 }
 
-impl AsRef<Union2MapStringKeyRecursiveUnionValueOrString>
+impl ::std::convert::AsRef<Union2MapStringKeyRecursiveUnionValueOrString>
     for Union2MapStringKeyRecursiveUnionValueOrString
 {
     fn as_ref(&self) -> &Union2MapStringKeyRecursiveUnionValueOrString {
@@ -405,9 +411,9 @@ impl AsRef<Union2MapStringKeyRecursiveUnionValueOrString>
     }
 }
 
-impl Default for Union2MapStringKeyRecursiveUnionValueOrString {
+impl ::std::default::Default for Union2MapStringKeyRecursiveUnionValueOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
@@ -423,15 +429,15 @@ pub enum Union2NestedOrString {
     String(String),
 }
 
-impl AsRef<Union2NestedOrString> for Union2NestedOrString {
+impl ::std::convert::AsRef<Union2NestedOrString> for Union2NestedOrString {
     fn as_ref(&self) -> &Union2NestedOrString {
         self
     }
 }
 
-impl Default for Union2NestedOrString {
+impl ::std::default::Default for Union2NestedOrString {
     fn default() -> Self {
-        Self::Nested(Default::default())
+        Self::Nested(::std::default::Default::default())
     }
 }
 
@@ -447,15 +453,15 @@ pub enum Union2OriginalAOrOriginalB {
     OriginalB(OriginalB),
 }
 
-impl AsRef<Union2OriginalAOrOriginalB> for Union2OriginalAOrOriginalB {
+impl ::std::convert::AsRef<Union2OriginalAOrOriginalB> for Union2OriginalAOrOriginalB {
     fn as_ref(&self) -> &Union2OriginalAOrOriginalB {
         self
     }
 }
 
-impl Default for Union2OriginalAOrOriginalB {
+impl ::std::default::Default for Union2OriginalAOrOriginalB {
     fn default() -> Self {
-        Self::OriginalA(Default::default())
+        Self::OriginalA(::std::default::Default::default())
     }
 }
 
@@ -471,15 +477,15 @@ pub enum Union2StringOrTag {
     String(String),
 }
 
-impl AsRef<Union2StringOrTag> for Union2StringOrTag {
+impl ::std::convert::AsRef<Union2StringOrTag> for Union2StringOrTag {
     fn as_ref(&self) -> &Union2StringOrTag {
         self
     }
 }
 
-impl Default for Union2StringOrTag {
+impl ::std::default::Default for Union2StringOrTag {
     fn default() -> Self {
-        Self::Tag(Default::default())
+        Self::Tag(::std::default::Default::default())
     }
 }
 
@@ -498,7 +504,7 @@ pub enum Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
     AnotherObject(AnotherObject),
 }
 
-impl AsRef<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>
+impl ::std::convert::AsRef<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>
     for Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject
 {
     fn as_ref(&self) -> &Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
@@ -506,9 +512,9 @@ impl AsRef<Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject>
     }
 }
 
-impl Default for Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
+impl ::std::default::Default for Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
     fn default() -> Self {
-        Self::MemoryObject(Default::default())
+        Self::MemoryObject(::std::default::Default::default())
     }
 }
 
@@ -527,7 +533,7 @@ pub enum Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
     GroceryReceipt(GroceryReceipt),
 }
 
-impl AsRef<Union3BookOrderOrFlightConfirmationOrGroceryReceipt>
+impl ::std::convert::AsRef<Union3BookOrderOrFlightConfirmationOrGroceryReceipt>
     for Union3BookOrderOrFlightConfirmationOrGroceryReceipt
 {
     fn as_ref(&self) -> &Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
@@ -535,9 +541,9 @@ impl AsRef<Union3BookOrderOrFlightConfirmationOrGroceryReceipt>
     }
 }
 
-impl Default for Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
+impl ::std::default::Default for Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
     fn default() -> Self {
-        Self::BookOrder(Default::default())
+        Self::BookOrder(::std::default::Default::default())
     }
 }
 
@@ -563,13 +569,15 @@ pub enum Union3BoolKTrueOrIntK1OrKstring_output {
     Kstring_output,
 }
 
-impl AsRef<Union3BoolKTrueOrIntK1OrKstring_output> for Union3BoolKTrueOrIntK1OrKstring_output {
+impl ::std::convert::AsRef<Union3BoolKTrueOrIntK1OrKstring_output>
+    for Union3BoolKTrueOrIntK1OrKstring_output
+{
     fn as_ref(&self) -> &Union3BoolKTrueOrIntK1OrKstring_output {
         self
     }
 }
 
-impl Default for Union3BoolKTrueOrIntK1OrKstring_output {
+impl ::std::default::Default for Union3BoolKTrueOrIntK1OrKstring_output {
     fn default() -> Self {
         Self::IntK1
     }
@@ -590,15 +598,15 @@ pub enum Union3FloatOrIntOrString {
     Float(f64),
 }
 
-impl AsRef<Union3FloatOrIntOrString> for Union3FloatOrIntOrString {
+impl ::std::convert::AsRef<Union3FloatOrIntOrString> for Union3FloatOrIntOrString {
     fn as_ref(&self) -> &Union3FloatOrIntOrString {
         self
     }
 }
 
-impl Default for Union3FloatOrIntOrString {
+impl ::std::default::Default for Union3FloatOrIntOrString {
     fn default() -> Self {
-        Self::String(Default::default())
+        Self::String(::std::default::Default::default())
     }
 }
 
@@ -608,27 +616,30 @@ impl Default for Union3FloatOrIntOrString {
 #[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4AudioOrImageOrPDFOrString {
     #[baml(name = "image")]
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_image")]
     Image(Image),
 
     #[baml(name = "string")]
     String(String),
 
     #[baml(name = "pdf")]
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_pdf")]
     PDF(Pdf),
 
     #[baml(name = "audio")]
+    #[serde(deserialize_with = "super::__internal_media_serde::deserialize_audio")]
     Audio(Audio),
 }
 
-impl AsRef<Union4AudioOrImageOrPDFOrString> for Union4AudioOrImageOrPDFOrString {
+impl ::std::convert::AsRef<Union4AudioOrImageOrPDFOrString> for Union4AudioOrImageOrPDFOrString {
     fn as_ref(&self) -> &Union4AudioOrImageOrPDFOrString {
         self
     }
 }
 
-impl Default for Union4AudioOrImageOrPDFOrString {
+impl ::std::default::Default for Union4AudioOrImageOrPDFOrString {
     fn default() -> Self {
-        Self::Image(Default::default())
+        Self::Image(::std::default::Default::default())
     }
 }
 
@@ -650,15 +661,15 @@ pub enum Union4BoolOrFloatOrIntOrString {
     Float(f64),
 }
 
-impl AsRef<Union4BoolOrFloatOrIntOrString> for Union4BoolOrFloatOrIntOrString {
+impl ::std::convert::AsRef<Union4BoolOrFloatOrIntOrString> for Union4BoolOrFloatOrIntOrString {
     fn as_ref(&self) -> &Union4BoolOrFloatOrIntOrString {
         self
     }
 }
 
-impl Default for Union4BoolOrFloatOrIntOrString {
+impl ::std::default::Default for Union4BoolOrFloatOrIntOrString {
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }
 
@@ -686,13 +697,13 @@ pub enum Union4KfourOrKoneOrKthreeOrKtwo {
     Kfour,
 }
 
-impl AsRef<Union4KfourOrKoneOrKthreeOrKtwo> for Union4KfourOrKoneOrKthreeOrKtwo {
+impl ::std::convert::AsRef<Union4KfourOrKoneOrKthreeOrKtwo> for Union4KfourOrKoneOrKthreeOrKtwo {
     fn as_ref(&self) -> &Union4KfourOrKoneOrKthreeOrKtwo {
         self
     }
 }
 
-impl Default for Union4KfourOrKoneOrKthreeOrKtwo {
+impl ::std::default::Default for Union4KfourOrKoneOrKthreeOrKtwo {
     fn default() -> Self {
         Self::Kone
     }
@@ -722,7 +733,7 @@ pub enum Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
     JsonArray(JsonArray),
 }
 
-impl AsRef<Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString>
+impl ::std::convert::AsRef<Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString>
     for Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString
 {
     fn as_ref(&self) -> &Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
@@ -730,9 +741,9 @@ impl AsRef<Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString>
     }
 }
 
-impl Default for Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
+impl ::std::default::Default for Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }
 
@@ -760,7 +771,7 @@ pub enum Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString
     MapStringKeyListStringValue(std::collections::HashMap<String, Vec<String>>),
 }
 
-impl AsRef<Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString>
+impl ::std::convert::AsRef<Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString>
     for Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString
 {
     fn as_ref(&self) -> &Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString {
@@ -768,8 +779,10 @@ impl AsRef<Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrStri
     }
 }
 
-impl Default for Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString {
+impl ::std::default::Default
+    for Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString
+{
     fn default() -> Self {
-        Self::Int(Default::default())
+        Self::Int(::std::default::Default::default())
     }
 }

--- a/integ-tests/rust/src/baml_client/types/unions.rs
+++ b/integ-tests/rust/src/baml_client/types/unions.rs
@@ -8,13 +8,13 @@
 use super::*;
 use baml::{
     __internal::serde::{Deserialize, Serialize},
-    BamlDecode, BamlEncode,
+    BamlDecode, BamlEncode, BamlSerde,
 };
 
 /// Generated from: (AddTodoItem | TodoMessageToUser)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2AddTodoItemOrTodoMessageToUser {
     #[baml(name = "AddTodoItem")]
     AddTodoItem(AddTodoItem),
@@ -36,9 +36,9 @@ impl Default for Union2AddTodoItemOrTodoMessageToUser {
 }
 
 /// Generated from: (float | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2BoolOrFloat {
     #[baml(name = "float")]
     Float(f64),
@@ -60,9 +60,9 @@ impl Default for Union2BoolOrFloat {
 }
 
 /// Generated from: (string | bool)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2BoolOrString {
     #[baml(name = "string")]
     String(String),
@@ -84,9 +84,9 @@ impl Default for Union2BoolOrString {
 }
 
 /// Generated from: (Martian | Earthling)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2EarthlingOrMartian {
     #[baml(name = "Martian")]
     Martian(Martian),
@@ -108,9 +108,9 @@ impl Default for Union2EarthlingOrMartian {
 }
 
 /// Generated from: (PhoneNumber | EmailAddress)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2EmailAddressOrPhoneNumber {
     #[baml(name = "PhoneNumber")]
     PhoneNumber(PhoneNumber),
@@ -132,9 +132,9 @@ impl Default for Union2EmailAddressOrPhoneNumber {
 }
 
 /// Generated from: (Resume | Event)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2EventOrResume {
     #[baml(name = "Resume")]
     Resume(Resume),
@@ -156,9 +156,9 @@ impl Default for Union2EventOrResume {
 }
 
 /// Generated from: (int | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2FloatOrInt {
     #[baml(name = "int")]
     Int(i64),
@@ -180,9 +180,9 @@ impl Default for Union2FloatOrInt {
 }
 
 /// Generated from: (string | int)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2IntOrString {
     #[baml(name = "string")]
     String(String),
@@ -204,9 +204,9 @@ impl Default for Union2IntOrString {
 }
 
 /// Generated from: (SimpleTag | JsonTemplate)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2JsonTemplateOrSimpleTag {
     #[baml(name = "SimpleTag")]
     SimpleTag(SimpleTag),
@@ -228,14 +228,18 @@ impl Default for Union2JsonTemplateOrSimpleTag {
 }
 
 /// Generated from: ("barisa" | "ox_burger")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2KbarisaOrKox_burger {
     #[baml(name = "string_barisa", literal_string = "barisa")]
+    #[serde(with = "__baml_serde_union_literal_Union2KbarisaOrKox_burger::Kbarisa")]
     Kbarisa,
 
     #[baml(name = "string_ox_burger", literal_string = "ox_burger")]
+    #[serde(with = "__baml_serde_union_literal_Union2KbarisaOrKox_burger::Kox_burger")]
     Kox_burger,
 }
 
@@ -252,14 +256,18 @@ impl Default for Union2KbarisaOrKox_burger {
 }
 
 /// Generated from: ("breakfast" | "dinner")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2KbreakfastOrKdinner {
     #[baml(name = "string_breakfast", literal_string = "breakfast")]
+    #[serde(with = "__baml_serde_union_literal_Union2KbreakfastOrKdinner::Kbreakfast")]
     Kbreakfast,
 
     #[baml(name = "string_dinner", literal_string = "dinner")]
+    #[serde(with = "__baml_serde_union_literal_Union2KbreakfastOrKdinner::Kdinner")]
     Kdinner,
 }
 
@@ -276,14 +284,20 @@ impl Default for Union2KbreakfastOrKdinner {
 }
 
 /// Generated from: ("curiosity" | "personal_finance")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2KcuriosityOrKpersonal_finance {
     #[baml(name = "string_curiosity", literal_string = "curiosity")]
+    #[serde(with = "__baml_serde_union_literal_Union2KcuriosityOrKpersonal_finance::Kcuriosity")]
     Kcuriosity,
 
     #[baml(name = "string_personal_finance", literal_string = "personal_finance")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union2KcuriosityOrKpersonal_finance::Kpersonal_finance"
+    )]
     Kpersonal_finance,
 }
 
@@ -300,9 +314,9 @@ impl Default for Union2KcuriosityOrKpersonal_finance {
 }
 
 /// Generated from: (bool[] | int[])
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ListBoolOrListInt {
     #[baml(name = "List__bool")]
     ListBool(Vec<bool>),
@@ -324,9 +338,9 @@ impl Default for Union2ListBoolOrListInt {
 }
 
 /// Generated from: (string | Nested[])
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2ListNestedOrString {
     #[baml(name = "string")]
     String(String),
@@ -348,9 +362,9 @@ impl Default for Union2ListNestedOrString {
 }
 
 /// Generated from: (LiteralClassOne | LiteralClassTwo)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2LiteralClassOneOrLiteralClassTwo {
     #[baml(name = "LiteralClassOne")]
     LiteralClassOne(LiteralClassOne),
@@ -372,9 +386,9 @@ impl Default for Union2LiteralClassOneOrLiteralClassTwo {
 }
 
 /// Generated from: (string | map<string, RecursiveUnion>)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2MapStringKeyRecursiveUnionValueOrString {
     #[baml(name = "string")]
     String(String),
@@ -398,9 +412,9 @@ impl Default for Union2MapStringKeyRecursiveUnionValueOrString {
 }
 
 /// Generated from: (Nested | string)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2NestedOrString {
     #[baml(name = "Nested")]
     Nested(Nested),
@@ -422,9 +436,9 @@ impl Default for Union2NestedOrString {
 }
 
 /// Generated from: (OriginalA | OriginalB)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2OriginalAOrOriginalB {
     #[baml(name = "OriginalA")]
     OriginalA(OriginalA),
@@ -446,9 +460,9 @@ impl Default for Union2OriginalAOrOriginalB {
 }
 
 /// Generated from: (Tag | string)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union2StringOrTag {
     #[baml(name = "Tag")]
     Tag(Tag),
@@ -470,9 +484,9 @@ impl Default for Union2StringOrTag {
 }
 
 /// Generated from: (MemoryObject | ComplexMemoryObject | AnotherObject)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
     #[baml(name = "MemoryObject")]
     MemoryObject(MemoryObject),
@@ -499,9 +513,9 @@ impl Default for Union3AnotherObjectOrComplexMemoryObjectOrMemoryObject {
 }
 
 /// Generated from: (BookOrder | FlightConfirmation | GroceryReceipt)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
     #[baml(name = "BookOrder")]
     BookOrder(BookOrder),
@@ -528,17 +542,24 @@ impl Default for Union3BookOrderOrFlightConfirmationOrGroceryReceipt {
 }
 
 /// Generated from: (1 | true | "string output")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3BoolKTrueOrIntK1OrKstring_output {
     #[baml(name = "int_1", literal_int = 1)]
+    #[serde(with = "__baml_serde_union_literal_Union3BoolKTrueOrIntK1OrKstring_output::IntK1")]
     IntK1,
 
     #[baml(name = "bool_true", literal_bool = true)]
+    #[serde(with = "__baml_serde_union_literal_Union3BoolKTrueOrIntK1OrKstring_output::BoolKTrue")]
     BoolKTrue,
 
     #[baml(name = "string_string_output", literal_string = "string output")]
+    #[serde(
+        with = "__baml_serde_union_literal_Union3BoolKTrueOrIntK1OrKstring_output::Kstring_output"
+    )]
     Kstring_output,
 }
 
@@ -555,9 +576,9 @@ impl Default for Union3BoolKTrueOrIntK1OrKstring_output {
 }
 
 /// Generated from: (string | int | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union3FloatOrIntOrString {
     #[baml(name = "string")]
     String(String),
@@ -582,9 +603,9 @@ impl Default for Union3FloatOrIntOrString {
 }
 
 /// Generated from: (image | string | pdf | audio)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4AudioOrImageOrPDFOrString {
     #[baml(name = "image")]
     Image(Image),
@@ -612,9 +633,9 @@ impl Default for Union4AudioOrImageOrPDFOrString {
 }
 
 /// Generated from: (int | string | bool | float)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4BoolOrFloatOrIntOrString {
     #[baml(name = "int")]
     Int(i64),
@@ -642,20 +663,26 @@ impl Default for Union4BoolOrFloatOrIntOrString {
 }
 
 /// Generated from: ("one" | "two" | "three" | "four")
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(
+    Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize, PartialEq, Eq, Hash,
+)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union4KfourOrKoneOrKthreeOrKtwo {
     #[baml(name = "string_one", literal_string = "one")]
+    #[serde(with = "__baml_serde_union_literal_Union4KfourOrKoneOrKthreeOrKtwo::Kone")]
     Kone,
 
     #[baml(name = "string_two", literal_string = "two")]
+    #[serde(with = "__baml_serde_union_literal_Union4KfourOrKoneOrKthreeOrKtwo::Ktwo")]
     Ktwo,
 
     #[baml(name = "string_three", literal_string = "three")]
+    #[serde(with = "__baml_serde_union_literal_Union4KfourOrKoneOrKthreeOrKtwo::Kthree")]
     Kthree,
 
     #[baml(name = "string_four", literal_string = "four")]
+    #[serde(with = "__baml_serde_union_literal_Union4KfourOrKoneOrKthreeOrKtwo::Kfour")]
     Kfour,
 }
 
@@ -672,9 +699,9 @@ impl Default for Union4KfourOrKoneOrKthreeOrKtwo {
 }
 
 /// Generated from: (int | string | bool | float | JsonObject | JsonArray)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
     #[baml(name = "int")]
     Int(i64),
@@ -710,9 +737,9 @@ impl Default for Union6BoolOrFloatOrIntOrJsonArrayOrJsonObjectOrString {
 }
 
 /// Generated from: (int | string | bool | float | string[] | map<string, string[]>)
-#[derive(Debug, Clone, BamlEncode, BamlDecode, Serialize, Deserialize)]
-#[serde(crate = "::baml::__internal::serde", tag = "_baml_type")]
+#[derive(Debug, Clone, BamlEncode, BamlDecode, BamlSerde, Serialize, Deserialize)]
 #[baml(union)]
+#[serde(crate = "::baml::__internal::serde", untagged)]
 pub enum Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString {
     #[baml(name = "int")]
     Int(i64),

--- a/integ-tests/rust/tests/test_serde.rs
+++ b/integ-tests/rust/tests/test_serde.rs
@@ -1,0 +1,1573 @@
+use rust::baml_client::types::*;
+use std::collections::HashMap;
+
+// =============================================================================
+// Primitive / simple class serialization + deserialization
+// =============================================================================
+
+#[test]
+fn test_simple_class_roundtrip() {
+    let a = BigNumbers { a: 42, b: 13.37 };
+    let json = serde_json::to_string(&a).unwrap();
+    assert_eq!(json, r#"{"a":42,"b":13.37}"#);
+    let b: BigNumbers = serde_json::from_str(&json).unwrap();
+    assert_eq!(b.a, 42);
+    assert_eq!(b.b, 13.37);
+}
+
+#[test]
+fn test_class_with_optional_fields() {
+    let full = Blah {
+        prop4: Some("hello".into()),
+    };
+    let json = serde_json::to_string(&full).unwrap();
+    assert_eq!(json, r#"{"prop4":"hello"}"#);
+    let rt: Blah = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.prop4, Some("hello".into()));
+
+    let empty = Blah { prop4: None };
+    let json = serde_json::to_string(&empty).unwrap();
+    assert_eq!(json, r#"{"prop4":null}"#);
+    let rt: Blah = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.prop4, None);
+}
+
+#[test]
+fn test_class_with_renamed_field() {
+    let item = AddTodoItem {
+        r#type: "add".into(),
+        item: "milk".into(),
+        time: "now".into(),
+        description: "buy milk".into(),
+    };
+    let json = serde_json::to_string(&item).unwrap();
+    // The field should be serialized as "type", not "r#type"
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["type"], "add");
+    assert_eq!(v["item"], "milk");
+
+    let rt: AddTodoItem = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.r#type, "add");
+}
+
+#[test]
+fn test_nested_classes() {
+    let nested = Nested {
+        prop3: Some("a".into()),
+        prop4: None,
+        prop20: Nested2 {
+            prop11: Some("b".into()),
+            prop12: None,
+        },
+    };
+    let json = serde_json::to_string(&nested).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["prop3"], "a");
+    assert!(v["prop4"].is_null());
+    assert_eq!(v["prop20"]["prop11"], "b");
+    assert!(v["prop20"]["prop12"].is_null());
+
+    let rt: Nested = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.prop3, Some("a".into()));
+    assert_eq!(rt.prop4, None);
+    assert_eq!(rt.prop20.prop11, Some("b".into()));
+}
+
+#[test]
+fn test_recursive_class() {
+    let tree = BinaryNode {
+        data: 1,
+        left: Some(Box::new(BinaryNode {
+            data: 2,
+            left: None,
+            right: None,
+        })),
+        right: Some(Box::new(BinaryNode {
+            data: 3,
+            left: None,
+            right: Some(Box::new(BinaryNode {
+                data: 4,
+                left: None,
+                right: None,
+            })),
+        })),
+    };
+    let json = serde_json::to_string(&tree).unwrap();
+    let rt: BinaryNode = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.data, 1);
+    assert_eq!(rt.left.as_ref().unwrap().data, 2);
+    assert_eq!(rt.right.as_ref().unwrap().data, 3);
+    assert_eq!(
+        rt.right.as_ref().unwrap().right.as_ref().unwrap().data,
+        4
+    );
+    assert!(rt.left.as_ref().unwrap().left.is_none());
+}
+
+#[test]
+fn test_class_with_list_fields() {
+    let resume = Resume {
+        name: "Alice".into(),
+        email: "a@b.com".into(),
+        phone: "555-1234".into(),
+        experience: vec!["job1".into(), "job2".into()],
+        education: vec![Education {
+            institution: "MIT".into(),
+            location: "Cambridge".into(),
+            degree: "BS".into(),
+            major: vec!["CS".into()],
+            graduation_date: Some("2020".into()),
+        }],
+        skills: vec!["rust".into(), "python".into()],
+    };
+    let json = serde_json::to_string(&resume).unwrap();
+    let rt: Resume = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.name, "Alice");
+    assert_eq!(rt.experience.len(), 2);
+    assert_eq!(rt.education[0].institution, "MIT");
+    assert_eq!(rt.education[0].major, vec!["CS"]);
+    assert_eq!(rt.education[0].graduation_date, Some("2020".into()));
+    assert_eq!(rt.skills, vec!["rust", "python"]);
+}
+
+// =============================================================================
+// Enum serialization + deserialization
+// =============================================================================
+
+#[test]
+fn test_normal_enum_serialize() {
+    assert_eq!(
+        serde_json::to_string(&Category::Refund).unwrap(),
+        r#""Refund""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Category::TechnicalSupport).unwrap(),
+        r#""TechnicalSupport""#
+    );
+}
+
+#[test]
+fn test_normal_enum_deserialize() {
+    let c: Category = serde_json::from_str(r#""CancelOrder""#).unwrap();
+    assert_eq!(c, Category::CancelOrder);
+
+    let c: Category = serde_json::from_str(r#""Question""#).unwrap();
+    assert_eq!(c, Category::Question);
+}
+
+#[test]
+fn test_normal_enum_unknown_variant_fails() {
+    let result = serde_json::from_str::<Category>(r#""SomethingElse""#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_normal_enum_roundtrip_all_variants() {
+    for variant in [
+        Category::Refund,
+        Category::CancelOrder,
+        Category::TechnicalSupport,
+        Category::AccountIssue,
+        Category::Question,
+    ] {
+        let json = serde_json::to_string(&variant).unwrap();
+        let rt: Category = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt, variant);
+    }
+}
+
+// =============================================================================
+// Dynamic enum serialization + deserialization
+// =============================================================================
+
+#[test]
+fn test_dynamic_enum_known_variant_roundtrip() {
+    let c = Color::RED;
+    let json = serde_json::to_string(&c).unwrap();
+    assert_eq!(json, r#""RED""#);
+    let rt: Color = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt, Color::RED);
+}
+
+#[test]
+fn test_dynamic_enum_all_known_variants() {
+    for (variant, expected) in [
+        (Color::RED, "RED"),
+        (Color::BLUE, "BLUE"),
+        (Color::GREEN, "GREEN"),
+        (Color::YELLOW, "YELLOW"),
+        (Color::BLACK, "BLACK"),
+        (Color::WHITE, "WHITE"),
+    ] {
+        let json = serde_json::to_string(&variant).unwrap();
+        assert_eq!(json, format!(r#""{}""#, expected));
+        let rt: Color = serde_json::from_str(&json).unwrap();
+        assert_eq!(rt, variant);
+    }
+}
+
+#[test]
+fn test_dynamic_enum_dynamic_variant_serialize() {
+    let c = Color::_Dynamic("MAGENTA".into());
+    let json = serde_json::to_string(&c).unwrap();
+    assert_eq!(json, r#""MAGENTA""#);
+}
+
+#[test]
+fn test_dynamic_enum_dynamic_variant_deserialize() {
+    // Unknown string values should deserialize to _Dynamic
+    let c: Color = serde_json::from_str(r#""MAGENTA""#).unwrap();
+    assert_eq!(c, Color::_Dynamic("MAGENTA".into()));
+
+    let c: Color = serde_json::from_str(r#""PURPLE""#).unwrap();
+    assert_eq!(c, Color::_Dynamic("PURPLE".into()));
+}
+
+#[test]
+fn test_fully_dynamic_enum_serialize() {
+    let e = DynEnumOne::_Dynamic("anything".into());
+    let json = serde_json::to_string(&e).unwrap();
+    assert_eq!(json, r#""anything""#);
+}
+
+#[test]
+fn test_fully_dynamic_enum_deserialize() {
+    let e: DynEnumOne = serde_json::from_str(r#""hello""#).unwrap();
+    assert_eq!(e, DynEnumOne::_Dynamic("hello".into()));
+}
+
+#[test]
+fn test_dynamic_enum_with_known_variants() {
+    // Known variant roundtrip
+    let e = DynEnumThree::TRICYCLE;
+    let json = serde_json::to_string(&e).unwrap();
+    assert_eq!(json, r#""TRICYCLE""#);
+    let rt: DynEnumThree = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt, DynEnumThree::TRICYCLE);
+
+    // Unknown becomes _Dynamic
+    let e: DynEnumThree = serde_json::from_str(r#""SQUARE""#).unwrap();
+    assert_eq!(e, DynEnumThree::_Dynamic("SQUARE".into()));
+}
+
+// =============================================================================
+// Union serialization + deserialization
+// =============================================================================
+
+#[test]
+fn test_primitive_union_int_or_string() {
+    // String variant
+    let u = Union2IntOrString::String("hello".into());
+    let json = serde_json::to_string(&u).unwrap();
+    assert_eq!(json, r#""hello""#);
+
+    // Int variant
+    let u = Union2IntOrString::Int(42);
+    let json = serde_json::to_string(&u).unwrap();
+    assert_eq!(json, "42");
+}
+
+#[test]
+fn test_primitive_union_deserialize_prefers_first_matching_variant() {
+    // Union2IntOrString has String first, then Int.
+    // A string should deserialize as String variant
+    let u: Union2IntOrString = serde_json::from_str(r#""hello""#).unwrap();
+    assert!(matches!(u, Union2IntOrString::String(s) if s == "hello"));
+
+    // An integer should deserialize as Int (doesn't match String)
+    let u: Union2IntOrString = serde_json::from_str("42").unwrap();
+    assert!(matches!(u, Union2IntOrString::Int(42)));
+}
+
+#[test]
+fn test_union_bool_or_float() {
+    // Union2BoolOrFloat: Float first, then Bool
+    let u = Union2BoolOrFloat::Float(3.14);
+    let json = serde_json::to_string(&u).unwrap();
+    assert_eq!(json, "3.14");
+
+    let u = Union2BoolOrFloat::Bool(true);
+    let json = serde_json::to_string(&u).unwrap();
+    assert_eq!(json, "true");
+
+    let rt: Union2BoolOrFloat = serde_json::from_str("true").unwrap();
+    assert!(matches!(rt, Union2BoolOrFloat::Bool(true)));
+}
+
+#[test]
+fn test_union_bool_or_string() {
+    let u = Union2BoolOrString::String("yes".into());
+    let json = serde_json::to_string(&u).unwrap();
+    assert_eq!(json, r#""yes""#);
+
+    let u = Union2BoolOrString::Bool(false);
+    let json = serde_json::to_string(&u).unwrap();
+    assert_eq!(json, "false");
+
+    let rt: Union2BoolOrString = serde_json::from_str("false").unwrap();
+    assert!(matches!(rt, Union2BoolOrString::Bool(false)));
+
+    let rt: Union2BoolOrString = serde_json::from_str(r#""test""#).unwrap();
+    assert!(matches!(rt, Union2BoolOrString::String(s) if s == "test"));
+}
+
+#[test]
+fn test_union_int_or_float_lossy_deserialization() {
+    // Union2FloatOrInt: Int first, then Float
+    // Serializing Int gives "42", serializing Float gives "3.14"
+    let u = Union2FloatOrInt::Int(42);
+    let json = serde_json::to_string(&u).unwrap();
+    assert_eq!(json, "42");
+
+    let u = Union2FloatOrInt::Float(3.14);
+    let json = serde_json::to_string(&u).unwrap();
+    assert_eq!(json, "3.14");
+
+    // Deserializing "42" - since Int is listed first, serde will try Int first
+    let rt: Union2FloatOrInt = serde_json::from_str("42").unwrap();
+    assert!(matches!(rt, Union2FloatOrInt::Int(42)));
+
+    // 3.14 can only match Float
+    let rt: Union2FloatOrInt = serde_json::from_str("3.14").unwrap();
+    assert!(matches!(rt, Union2FloatOrInt::Float(f) if (f - 3.14).abs() < 1e-10));
+}
+
+#[test]
+fn test_union_of_classes() {
+    let phone = Union2EmailAddressOrPhoneNumber::PhoneNumber(PhoneNumber {
+        value: "555-1234".into(),
+    });
+    let json = serde_json::to_string(&phone).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["value"], "555-1234");
+
+    let email = Union2EmailAddressOrPhoneNumber::EmailAddress(EmailAddress {
+        value: "a@b.com".into(),
+    });
+    let json = serde_json::to_string(&email).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["value"], "a@b.com");
+
+    // Since both PhoneNumber and EmailAddress have the same shape {value: string},
+    // deserialization will always pick the first variant (PhoneNumber) - this is
+    // the expected lossy behavior for untagged unions.
+    let rt: Union2EmailAddressOrPhoneNumber =
+        serde_json::from_str(r#"{"value":"anything"}"#).unwrap();
+    assert!(matches!(
+        rt,
+        Union2EmailAddressOrPhoneNumber::PhoneNumber(_)
+    ));
+}
+
+#[test]
+fn test_union_of_distinguishable_classes() {
+    // BookOrder and FlightConfirmation have different field sets, so we can
+    // distinguish them on deserialization.
+    let book = Union3BookOrderOrFlightConfirmationOrGroceryReceipt::BookOrder(BookOrder {
+        orderId: "123".into(),
+        title: "Rust Book".into(),
+        quantity: 2,
+        price: 29.99,
+    });
+    let json = serde_json::to_string(&book).unwrap();
+    let rt: Union3BookOrderOrFlightConfirmationOrGroceryReceipt =
+        serde_json::from_str(&json).unwrap();
+    assert!(matches!(
+        rt,
+        Union3BookOrderOrFlightConfirmationOrGroceryReceipt::BookOrder(b) if b.orderId == "123"
+    ));
+
+    let flight =
+        Union3BookOrderOrFlightConfirmationOrGroceryReceipt::FlightConfirmation(
+            FlightConfirmation {
+                confirmationNumber: "ABC".into(),
+                flightNumber: "UA100".into(),
+                departureTime: "08:00".into(),
+                arrivalTime: "12:00".into(),
+                seatNumber: "14A".into(),
+            },
+        );
+    let json = serde_json::to_string(&flight).unwrap();
+    let rt: Union3BookOrderOrFlightConfirmationOrGroceryReceipt =
+        serde_json::from_str(&json).unwrap();
+    assert!(matches!(
+        rt,
+        Union3BookOrderOrFlightConfirmationOrGroceryReceipt::FlightConfirmation(f) if f.flightNumber == "UA100"
+    ));
+}
+
+#[test]
+fn test_union_with_list_variant() {
+    // Union2ListNestedOrString: String first, then ListNested
+    let s = Union2ListNestedOrString::String("plain".into());
+    let json = serde_json::to_string(&s).unwrap();
+    assert_eq!(json, r#""plain""#);
+
+    let list = Union2ListNestedOrString::ListNested(vec![Nested {
+        prop3: Some("x".into()),
+        prop4: None,
+        prop20: Nested2 {
+            prop11: None,
+            prop12: None,
+        },
+    }]);
+    let json = serde_json::to_string(&list).unwrap();
+    let rt: Union2ListNestedOrString = serde_json::from_str(&json).unwrap();
+    assert!(matches!(rt, Union2ListNestedOrString::ListNested(v) if v.len() == 1));
+
+    let rt: Union2ListNestedOrString = serde_json::from_str(r#""text""#).unwrap();
+    assert!(matches!(rt, Union2ListNestedOrString::String(s) if s == "text"));
+}
+
+#[test]
+fn test_union_with_map_variant() {
+    // Union2MapStringKeyRecursiveUnionValueOrString
+    let s = Union2MapStringKeyRecursiveUnionValueOrString::String("simple".into());
+    let json = serde_json::to_string(&s).unwrap();
+    assert_eq!(json, r#""simple""#);
+
+    let mut map = HashMap::new();
+    map.insert(
+        "key1".to_string(),
+        Union2MapStringKeyRecursiveUnionValueOrString::String("leaf".into()),
+    );
+    let u = Union2MapStringKeyRecursiveUnionValueOrString::MapStringKeyRecursiveUnionValue(map);
+    let json = serde_json::to_string(&u).unwrap();
+    let rt: Union2MapStringKeyRecursiveUnionValueOrString =
+        serde_json::from_str(&json).unwrap();
+    assert!(matches!(
+        rt,
+        Union2MapStringKeyRecursiveUnionValueOrString::MapStringKeyRecursiveUnionValue(_)
+    ));
+}
+
+// =============================================================================
+// Literal unions
+// =============================================================================
+
+#[test]
+fn test_string_literal_union_serialize() {
+    assert_eq!(
+        serde_json::to_string(&Union4KfourOrKoneOrKthreeOrKtwo::Kone).unwrap(),
+        r#""one""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Union4KfourOrKoneOrKthreeOrKtwo::Ktwo).unwrap(),
+        r#""two""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Union4KfourOrKoneOrKthreeOrKtwo::Kthree).unwrap(),
+        r#""three""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Union4KfourOrKoneOrKthreeOrKtwo::Kfour).unwrap(),
+        r#""four""#
+    );
+}
+
+#[test]
+fn test_string_literal_union_deserialize() {
+    let v: Union4KfourOrKoneOrKthreeOrKtwo = serde_json::from_str(r#""one""#).unwrap();
+    assert_eq!(v, Union4KfourOrKoneOrKthreeOrKtwo::Kone);
+
+    let v: Union4KfourOrKoneOrKthreeOrKtwo = serde_json::from_str(r#""four""#).unwrap();
+    assert_eq!(v, Union4KfourOrKoneOrKthreeOrKtwo::Kfour);
+
+    let result = serde_json::from_str::<Union4KfourOrKoneOrKthreeOrKtwo>(r#""five""#);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_mixed_literal_union() {
+    // Union3BoolKTrueOrIntK1OrKstring_output: int 1, bool true, string "string output"
+    assert_eq!(
+        serde_json::to_string(&Union3BoolKTrueOrIntK1OrKstring_output::IntK1).unwrap(),
+        "1"
+    );
+    assert_eq!(
+        serde_json::to_string(&Union3BoolKTrueOrIntK1OrKstring_output::BoolKTrue).unwrap(),
+        "true"
+    );
+    assert_eq!(
+        serde_json::to_string(&Union3BoolKTrueOrIntK1OrKstring_output::Kstring_output).unwrap(),
+        r#""string output""#
+    );
+
+    // Deserialize
+    let v: Union3BoolKTrueOrIntK1OrKstring_output = serde_json::from_str("1").unwrap();
+    assert_eq!(v, Union3BoolKTrueOrIntK1OrKstring_output::IntK1);
+
+    let v: Union3BoolKTrueOrIntK1OrKstring_output = serde_json::from_str("true").unwrap();
+    assert_eq!(v, Union3BoolKTrueOrIntK1OrKstring_output::BoolKTrue);
+
+    let v: Union3BoolKTrueOrIntK1OrKstring_output =
+        serde_json::from_str(r#""string output""#).unwrap();
+    assert_eq!(v, Union3BoolKTrueOrIntK1OrKstring_output::Kstring_output);
+}
+
+#[test]
+fn test_two_string_literal_union() {
+    assert_eq!(
+        serde_json::to_string(&Union2KbarisaOrKox_burger::Kbarisa).unwrap(),
+        r#""barisa""#
+    );
+    assert_eq!(
+        serde_json::to_string(&Union2KbarisaOrKox_burger::Kox_burger).unwrap(),
+        r#""ox_burger""#
+    );
+
+    let v: Union2KbarisaOrKox_burger = serde_json::from_str(r#""barisa""#).unwrap();
+    assert_eq!(v, Union2KbarisaOrKox_burger::Kbarisa);
+
+    let v: Union2KbarisaOrKox_burger = serde_json::from_str(r#""ox_burger""#).unwrap();
+    assert_eq!(v, Union2KbarisaOrKox_burger::Kox_burger);
+}
+
+// =============================================================================
+// Union with container types (list, map)
+// =============================================================================
+
+#[test]
+fn test_union_with_list_bool_or_list_int() {
+    let bools = Union2ListBoolOrListInt::ListBool(vec![true, false, true]);
+    let json = serde_json::to_string(&bools).unwrap();
+    assert_eq!(json, "[true,false,true]");
+
+    let ints = Union2ListBoolOrListInt::ListInt(vec![1, 2, 3]);
+    let json = serde_json::to_string(&ints).unwrap();
+    assert_eq!(json, "[1,2,3]");
+
+    // Deserializing bools: ListBool is listed first, so bools match
+    let rt: Union2ListBoolOrListInt = serde_json::from_str("[true,false]").unwrap();
+    assert!(matches!(rt, Union2ListBoolOrListInt::ListBool(_)));
+
+    // Deserializing ints: ListBool can't match, so ListInt
+    let rt: Union2ListBoolOrListInt = serde_json::from_str("[1,2,3]").unwrap();
+    assert!(matches!(rt, Union2ListBoolOrListInt::ListInt(_)));
+
+    // Empty list: ambiguous, picks the first variant
+    let rt: Union2ListBoolOrListInt = serde_json::from_str("[]").unwrap();
+    assert!(matches!(rt, Union2ListBoolOrListInt::ListBool(v) if v.is_empty()));
+}
+
+#[test]
+fn test_complex_union_with_lists_and_maps() {
+    // Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString
+    type BigUnion = Union6BoolOrFloatOrIntOrListStringOrMapStringKeyListStringValueOrString;
+
+    let int_val = BigUnion::Int(42);
+    assert_eq!(serde_json::to_string(&int_val).unwrap(), "42");
+
+    let str_val = BigUnion::String("hello".into());
+    assert_eq!(serde_json::to_string(&str_val).unwrap(), r#""hello""#);
+
+    let bool_val = BigUnion::Bool(true);
+    assert_eq!(serde_json::to_string(&bool_val).unwrap(), "true");
+
+    let list_val = BigUnion::ListString(vec!["a".into(), "b".into()]);
+    let json = serde_json::to_string(&list_val).unwrap();
+    assert_eq!(json, r#"["a","b"]"#);
+
+    let mut map = HashMap::new();
+    map.insert("k".to_string(), vec!["v1".to_string(), "v2".to_string()]);
+    let map_val = BigUnion::MapStringKeyListStringValue(map);
+    let json = serde_json::to_string(&map_val).unwrap();
+    let rt: BigUnion = serde_json::from_str(&json).unwrap();
+    assert!(matches!(rt, BigUnion::MapStringKeyListStringValue(_)));
+}
+
+// =============================================================================
+// Dynamic class serialization + deserialization
+// =============================================================================
+
+#[test]
+fn test_dynamic_class_with_static_fields_only() {
+    let d = DummyOutput {
+        nonce: "abc".into(),
+        nonce2: "def".into(),
+        __dynamic: HashMap::new(),
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["nonce"], "abc");
+    assert_eq!(v["nonce2"], "def");
+    // No extra fields since __dynamic is empty
+    assert_eq!(v.as_object().unwrap().len(), 2);
+
+    let rt: DummyOutput = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.nonce, "abc");
+    assert_eq!(rt.nonce2, "def");
+    assert!(rt.__dynamic.is_empty());
+}
+
+#[test]
+fn test_dynamic_class_with_dynamic_string_field() {
+    let mut dynamic = HashMap::new();
+    dynamic.insert("extra".into(), baml::BamlValue::String("val".into()));
+    let d = DummyOutput {
+        nonce: "abc".into(),
+        nonce2: "def".into(),
+        __dynamic: dynamic,
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["nonce"], "abc");
+    assert_eq!(v["extra"], "val");
+
+    let rt: DummyOutput = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.nonce, "abc");
+    assert!(rt.__dynamic.contains_key("extra"));
+}
+
+#[test]
+fn test_dynamic_class_with_dynamic_int_field() {
+    let mut dynamic = HashMap::new();
+    dynamic.insert("count".into(), baml::BamlValue::Int(42));
+    let d = DynInputOutput {
+        testKey: "key".into(),
+        __dynamic: dynamic,
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["testKey"], "key");
+    assert_eq!(v["count"], 42);
+
+    let rt: DynInputOutput = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.testKey, "key");
+    assert!(rt.__dynamic.contains_key("count"));
+}
+
+#[test]
+fn test_dynamic_class_with_dynamic_list_field() {
+    let mut dynamic = HashMap::new();
+    dynamic.insert(
+        "tags".into(),
+        baml::BamlValue::List(vec![
+            baml::BamlValue::String("a".into()),
+            baml::BamlValue::String("b".into()),
+        ]),
+    );
+    let d = DynInputOutput {
+        testKey: "k".into(),
+        __dynamic: dynamic,
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["tags"], serde_json::json!(["a", "b"]));
+
+    let rt: DynInputOutput = serde_json::from_str(&json).unwrap();
+    assert!(rt.__dynamic.contains_key("tags"));
+}
+
+#[test]
+fn test_dynamic_class_with_dynamic_map_field() {
+    let mut inner_map = HashMap::new();
+    inner_map.insert("nested_key".into(), baml::BamlValue::Bool(true));
+    let mut dynamic = HashMap::new();
+    dynamic.insert("metadata".into(), baml::BamlValue::Map(inner_map));
+    let d = DynInputOutput {
+        testKey: "k".into(),
+        __dynamic: dynamic,
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["metadata"]["nested_key"], true);
+
+    let rt: DynInputOutput = serde_json::from_str(&json).unwrap();
+    assert!(rt.__dynamic.contains_key("metadata"));
+}
+
+#[test]
+fn test_dynamic_class_with_dynamic_null_field() {
+    let mut dynamic = HashMap::new();
+    dynamic.insert("optional".into(), baml::BamlValue::Null);
+    let d = DynInputOutput {
+        testKey: "k".into(),
+        __dynamic: dynamic,
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(v["optional"].is_null());
+
+    let rt: DynInputOutput = serde_json::from_str(&json).unwrap();
+    assert!(rt.__dynamic.contains_key("optional"));
+}
+
+#[test]
+fn test_fully_dynamic_class_no_static_fields() {
+    let mut dynamic = HashMap::new();
+    dynamic.insert("a".into(), baml::BamlValue::String("x".into()));
+    dynamic.insert("b".into(), baml::BamlValue::Int(1));
+    let d = DynamicClassOne {
+        __dynamic: dynamic,
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["a"], "x");
+    assert_eq!(v["b"], 1);
+
+    let rt: DynamicClassOne = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.__dynamic.len(), 2);
+}
+
+#[test]
+fn test_dynamic_class_with_nested_dynamic_and_enum() {
+    let d = DynamicClassTwo {
+        hi: "hello".into(),
+        some_class: SomeClassNestedDynamic {
+            hi: "inner".into(),
+            __dynamic: HashMap::new(),
+        },
+        status: DynEnumOne::_Dynamic("active".into()),
+        __dynamic: HashMap::new(),
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["hi"], "hello");
+    assert_eq!(v["some_class"]["hi"], "inner");
+    assert_eq!(v["status"], "active");
+
+    let rt: DynamicClassTwo = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.hi, "hello");
+    assert_eq!(rt.some_class.hi, "inner");
+    assert_eq!(rt.status, DynEnumOne::_Dynamic("active".into()));
+}
+
+#[test]
+fn test_dynamic_class_with_optional_and_dynamic_fields() {
+    let mut dynamic = HashMap::new();
+    dynamic.insert("age".into(), baml::BamlValue::Int(30));
+    let p = Person {
+        name: Some("Alice".into()),
+        hair_color: Some(Color::RED),
+        __dynamic: dynamic,
+    };
+    let json = serde_json::to_string(&p).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["name"], "Alice");
+    assert_eq!(v["hair_color"], "RED");
+    assert_eq!(v["age"], 30);
+
+    let rt: Person = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.name, Some("Alice".into()));
+    assert_eq!(rt.hair_color, Some(Color::RED));
+    assert!(rt.__dynamic.contains_key("age"));
+}
+
+#[test]
+fn test_dynamic_class_with_none_optional() {
+    let p = Person {
+        name: None,
+        hair_color: None,
+        __dynamic: HashMap::new(),
+    };
+    let json = serde_json::to_string(&p).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert!(v["name"].is_null());
+    assert!(v["hair_color"].is_null());
+
+    let rt: Person = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.name, None);
+    assert_eq!(rt.hair_color, None);
+}
+
+#[test]
+fn test_dynamic_class_deserialization_unknown_fields_into_dynamic() {
+    // JSON with both known and unknown fields
+    let json = r#"{"value":"hello","internal_id":"abc","extra_field":"dynamic_val","count":5}"#;
+    let rt: SkipDynamicClass = serde_json::from_str(json).unwrap();
+    assert_eq!(rt.value, "hello");
+    assert_eq!(rt.internal_id, Some("abc".into()));
+    assert!(rt.__dynamic.contains_key("extra_field"));
+    assert!(rt.__dynamic.contains_key("count"));
+}
+
+// =============================================================================
+// Dynamic class with OriginalB (dynamic with one static field)
+// =============================================================================
+
+#[test]
+fn test_original_b_dynamic_class() {
+    let mut dynamic = HashMap::new();
+    dynamic.insert("extra".into(), baml::BamlValue::String("bonus".into()));
+    let b = OriginalB {
+        value: 42,
+        __dynamic: dynamic,
+    };
+    let json = serde_json::to_string(&b).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["value"], 42);
+    assert_eq!(v["extra"], "bonus");
+
+    let rt: OriginalB = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.value, 42);
+    assert!(rt.__dynamic.contains_key("extra"));
+}
+
+// =============================================================================
+// Union of classes with dynamic class
+// =============================================================================
+
+#[test]
+fn test_union_with_dynamic_class_variant() {
+    // Union2OriginalAOrOriginalB: OriginalA first, then OriginalB (dynamic)
+    let a = Union2OriginalAOrOriginalB::OriginalA(OriginalA { value: 10 });
+    let json = serde_json::to_string(&a).unwrap();
+    assert_eq!(json, r#"{"value":10}"#);
+
+    // OriginalA and OriginalB share {value: int} so deserialization is ambiguous
+    // and will pick the first variant (OriginalA)
+    let rt: Union2OriginalAOrOriginalB = serde_json::from_str(r#"{"value":10}"#).unwrap();
+    assert!(matches!(rt, Union2OriginalAOrOriginalB::OriginalA(_)));
+
+    // But OriginalB with extra dynamic fields should still match OriginalB
+    // because OriginalA (non-dynamic) won't accept unknown fields.
+    // Actually, serde with deny_unknown_fields would help here, but without it,
+    // OriginalA will just ignore extra fields. Let's test what actually happens:
+    let rt: Union2OriginalAOrOriginalB =
+        serde_json::from_str(r#"{"value":10,"extra":"stuff"}"#).unwrap();
+    // Due to untagged union behavior, the first matching variant wins.
+    // OriginalA will match (ignoring extra fields), OR might fail depending on strictness.
+    // The actual behavior depends on whether OriginalA accepts extra fields.
+    // Let's just verify it doesn't error:
+    assert!(matches!(
+        rt,
+        Union2OriginalAOrOriginalB::OriginalA(_)
+            | Union2OriginalAOrOriginalB::OriginalB(_)
+    ));
+}
+
+// =============================================================================
+// Checked<T> serialization + deserialization
+// =============================================================================
+
+#[test]
+fn test_checked_type_serialize() {
+    let checked = Checked {
+        value: 42i64,
+        checks: {
+            let mut m = HashMap::new();
+            m.insert(
+                "age_check".to_string(),
+                baml::Check {
+                    name: "age_check".into(),
+                    expression: "age > 0".into(),
+                    status: baml::CheckStatus::Succeeded,
+                },
+            );
+            m
+        },
+    };
+    let json = serde_json::to_string(&checked).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["value"], 42);
+    assert_eq!(v["checks"]["age_check"]["status"], "succeeded");
+    assert_eq!(v["checks"]["age_check"]["name"], "age_check");
+}
+
+#[test]
+fn test_checked_type_deserialize() {
+    let json = r#"{"value":42,"checks":{"my_check":{"name":"my_check","expression":"x > 0","status":"succeeded"}}}"#;
+    let rt: Checked<i64> = serde_json::from_str(json).unwrap();
+    assert_eq!(rt.value, 42);
+    assert!(rt.checks.contains_key("my_check"));
+    assert_eq!(
+        rt.checks["my_check"].status,
+        baml::CheckStatus::Succeeded
+    );
+}
+
+#[test]
+fn test_checked_type_with_failed_check() {
+    let json = r#"{"value":-5,"checks":{"positive":{"name":"positive","expression":"x > 0","status":"failed"}}}"#;
+    let rt: Checked<i64> = serde_json::from_str(json).unwrap();
+    assert_eq!(rt.value, -5);
+    assert_eq!(rt.checks["positive"].status, baml::CheckStatus::Failed);
+    assert!(rt.any_failed());
+    assert!(!rt.all_passed());
+}
+
+#[test]
+fn test_class_with_checked_field() {
+    let m = Martian {
+        age: Checked {
+            value: 100,
+            checks: HashMap::new(),
+        },
+    };
+    let json = serde_json::to_string(&m).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["age"]["value"], 100);
+    assert!(v["age"]["checks"].is_object());
+
+    let rt: Martian = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.age.value, 100);
+}
+
+// =============================================================================
+// StreamState<T> serialization + deserialization
+// =============================================================================
+
+#[test]
+fn test_stream_state_serialize() {
+    let ss = StreamState {
+        value: 42i64,
+        state: baml::StreamingState::Pending,
+    };
+    let json = serde_json::to_string(&ss).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["value"], 42);
+    assert_eq!(v["state"], "pending");
+}
+
+#[test]
+fn test_stream_state_all_states() {
+    for (state, expected_str) in [
+        (baml::StreamingState::Pending, "pending"),
+        (baml::StreamingState::Started, "started"),
+        (baml::StreamingState::Done, "done"),
+    ] {
+        let ss = StreamState {
+            value: "hello".to_string(),
+            state,
+        };
+        let json = serde_json::to_string(&ss).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["state"], expected_str);
+    }
+}
+
+#[test]
+fn test_stream_state_deserialize() {
+    let json = r#"{"value":"hello","state":"done"}"#;
+    let rt: StreamState<String> = serde_json::from_str(json).unwrap();
+    assert_eq!(rt.value, "hello");
+    assert_eq!(rt.state, baml::StreamingState::Done);
+}
+
+// =============================================================================
+// BamlValue serialization + deserialization
+// =============================================================================
+
+type TestBamlValue = baml::BamlValue<Types, rust::baml_client::stream_types::StreamTypes>;
+
+#[test]
+fn test_baml_value_primitives_serialize() {
+    let s: TestBamlValue = baml::BamlValue::String("hello".into());
+    assert_eq!(serde_json::to_string(&s).unwrap(), r#""hello""#);
+
+    let i: TestBamlValue = baml::BamlValue::Int(42);
+    assert_eq!(serde_json::to_string(&i).unwrap(), "42");
+
+    let f: TestBamlValue = baml::BamlValue::Float(3.14);
+    assert_eq!(serde_json::to_string(&f).unwrap(), "3.14");
+
+    let b: TestBamlValue = baml::BamlValue::Bool(true);
+    assert_eq!(serde_json::to_string(&b).unwrap(), "true");
+
+    let n: TestBamlValue = baml::BamlValue::Null;
+    assert_eq!(serde_json::to_string(&n).unwrap(), "null");
+}
+
+#[test]
+fn test_baml_value_list_serialize() {
+    let list: TestBamlValue = baml::BamlValue::List(vec![
+        baml::BamlValue::Int(1),
+        baml::BamlValue::Int(2),
+        baml::BamlValue::Int(3),
+    ]);
+    assert_eq!(serde_json::to_string(&list).unwrap(), "[1,2,3]");
+}
+
+#[test]
+fn test_baml_value_map_serialize() {
+    // Use a single-entry map for deterministic output
+    let mut map = HashMap::new();
+    map.insert("key".into(), baml::BamlValue::String("value".into()));
+    let val: TestBamlValue = baml::BamlValue::Map(map);
+    assert_eq!(serde_json::to_string(&val).unwrap(), r#"{"key":"value"}"#);
+}
+
+#[test]
+fn test_baml_value_deserialize_primitives() {
+    let s: TestBamlValue = serde_json::from_str(r#""hello""#).unwrap();
+    assert!(matches!(s, baml::BamlValue::String(ref v) if v == "hello"));
+
+    let i: TestBamlValue = serde_json::from_str("42").unwrap();
+    assert!(matches!(i, baml::BamlValue::Int(42)));
+
+    let neg: TestBamlValue = serde_json::from_str("-42").unwrap();
+    assert!(matches!(neg, baml::BamlValue::Int(-42)));
+
+    let f: TestBamlValue = serde_json::from_str("3.14").unwrap();
+    assert!(matches!(f, baml::BamlValue::Float(v) if (v - 3.14).abs() < 1e-10));
+
+    let b: TestBamlValue = serde_json::from_str("true").unwrap();
+    assert!(matches!(b, baml::BamlValue::Bool(true)));
+
+    let n: TestBamlValue = serde_json::from_str("null").unwrap();
+    assert!(matches!(n, baml::BamlValue::Null));
+}
+
+#[test]
+fn test_baml_value_deserialize_list() {
+    let list: TestBamlValue = serde_json::from_str("[1, 2, 3]").unwrap();
+    match list {
+        baml::BamlValue::List(items) => {
+            assert_eq!(items.len(), 3);
+            assert!(matches!(items[0], baml::BamlValue::Int(1)));
+            assert!(matches!(items[1], baml::BamlValue::Int(2)));
+            assert!(matches!(items[2], baml::BamlValue::Int(3)));
+        }
+        other => panic!("expected List, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_baml_value_deserialize_map() {
+    let map: TestBamlValue = serde_json::from_str(r#"{"a": 1, "b": "two"}"#).unwrap();
+    match map {
+        baml::BamlValue::Map(m) => {
+            assert_eq!(m.len(), 2);
+            assert!(matches!(m["a"], baml::BamlValue::Int(1)));
+            assert!(matches!(m["b"], baml::BamlValue::String(ref s) if s == "two"));
+        }
+        other => panic!("expected Map, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_baml_value_deserialize_is_lossy_for_objects() {
+    // Objects (classes) deserialize as Map, not as Known types.
+    // This is the documented lossy behavior.
+    let json = r#"{"a": 42, "b": 13.37}"#;
+    let val: TestBamlValue = serde_json::from_str(json).unwrap();
+    // Even though this looks like BigNumbers, it will be Map not Known
+    assert!(matches!(val, baml::BamlValue::Map(_)));
+}
+
+#[test]
+fn test_baml_value_deserialize_nested() {
+    let json = r#"{"users": [{"name": "Alice"}, {"name": "Bob"}], "count": 2}"#;
+    let val: TestBamlValue = serde_json::from_str(json).unwrap();
+    match val {
+        baml::BamlValue::Map(m) => {
+            assert!(matches!(m["count"], baml::BamlValue::Int(2)));
+            match &m["users"] {
+                baml::BamlValue::List(users) => {
+                    assert_eq!(users.len(), 2);
+                }
+                other => panic!("expected List, got {:?}", other),
+            }
+        }
+        other => panic!("expected Map, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_baml_value_known_type_serialize() {
+    let known: TestBamlValue =
+        baml::BamlValue::Known(Types::BigNumbers(BigNumbers { a: 1, b: 2.0 }));
+    let json = serde_json::to_string(&known).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["a"], 1);
+    assert_eq!(v["b"], 2.0);
+}
+
+#[test]
+fn test_baml_value_dynamic_enum_serialize() {
+    let de: TestBamlValue = baml::BamlValue::DynamicEnum(baml::DynamicEnum {
+        name: "Sentiment".into(),
+        value: "happy".into(),
+    });
+    let json = serde_json::to_string(&de).unwrap();
+    assert_eq!(json, r#""happy""#);
+}
+
+#[test]
+fn test_baml_value_dynamic_class_serialize() {
+    let mut fields = HashMap::new();
+    fields.insert("x".into(), baml::BamlValue::Int(10));
+    fields.insert("y".into(), baml::BamlValue::String("hello".into()));
+    let dc: TestBamlValue =
+        baml::BamlValue::DynamicClass(baml::DynamicClass::with_fields("Point".into(), fields));
+    let json = serde_json::to_string(&dc).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["x"], 10);
+    assert_eq!(v["y"], "hello");
+}
+
+#[test]
+fn test_baml_value_dynamic_union_serialize() {
+    let du: TestBamlValue = baml::BamlValue::DynamicUnion(baml::DynamicUnion {
+        name: "FooOrBar".into(),
+        variant_name: "Foo".into(),
+        value: Box::new(baml::BamlValue::String("foo_value".into())),
+    });
+    let json = serde_json::to_string(&du).unwrap();
+    // DynamicUnion serializes the inner value directly
+    assert_eq!(json, r#""foo_value""#);
+}
+
+// =============================================================================
+// Types / StreamTypes cannot be deserialized
+// =============================================================================
+
+#[test]
+fn test_types_enum_cannot_deserialize() {
+    let result = serde_json::from_str::<Types>(r#"{"a":1,"b":2.0}"#);
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("not deserializable"));
+}
+
+#[test]
+fn test_stream_types_cannot_deserialize() {
+    let result =
+        serde_json::from_str::<rust::baml_client::stream_types::StreamTypes>(r#"{"a":1}"#);
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("not deserializable"));
+}
+
+#[test]
+fn test_types_enum_can_serialize() {
+    let t = Types::BigNumbers(BigNumbers { a: 1, b: 2.0 });
+    let json = serde_json::to_string(&t).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["a"], 1);
+    assert_eq!(v["b"], 2.0);
+}
+
+// =============================================================================
+// Streaming types: serialize only, no deserialize
+// =============================================================================
+
+#[test]
+fn test_stream_class_serialize_only() {
+    let s = rust::baml_client::stream_types::BigNumbers {
+        a: Some(42),
+        b: None,
+    };
+    let json = serde_json::to_string(&s).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["a"], 42);
+    assert!(v["b"].is_null());
+}
+
+#[test]
+fn test_stream_class_cannot_deserialize() {
+    // Stream types only derive Serialize, not Deserialize
+    // We can't test this with serde_json::from_str since it won't compile.
+    // Instead, we verify by attempting to serialize and confirming it works.
+    let s = rust::baml_client::stream_types::AddressWithMeta {
+        street: Some("123 Main".into()),
+        city: None,
+        zipcode: Some("12345".into()),
+    };
+    let json = serde_json::to_string(&s).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["street"], "123 Main");
+    assert!(v["city"].is_null());
+    assert_eq!(v["zipcode"], "12345");
+}
+
+// =============================================================================
+// Media types: serialize only (deserialize errors)
+// =============================================================================
+
+#[test]
+fn test_media_repr_serialize_url() {
+    use baml::__internal::{BamlMediaRepr, BamlMediaReprContent};
+    let repr = BamlMediaRepr {
+        mime_type: Some("image/png".into()),
+        content: BamlMediaReprContent::Url {
+            url: "https://example.com/img.png".into(),
+        },
+    };
+    let json = serde_json::to_string(&repr).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["media_type"], "image/png");
+    assert_eq!(v["url"], "https://example.com/img.png");
+}
+
+#[test]
+fn test_media_repr_serialize_base64() {
+    use baml::__internal::{BamlMediaRepr, BamlMediaReprContent};
+    let repr = BamlMediaRepr {
+        mime_type: None,
+        content: BamlMediaReprContent::Base64 {
+            base64: "SGVsbG8=".into(),
+        },
+    };
+    let json = serde_json::to_string(&repr).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    // mime_type should be absent (skip_serializing_if)
+    assert!(v.get("media_type").is_none());
+    assert_eq!(v["base64"], "SGVsbG8=");
+}
+
+#[test]
+fn test_media_repr_deserialize_url() {
+    use baml::__internal::{BamlMediaRepr, BamlMediaReprContent};
+    let json = r#"{"media_type":"image/jpeg","url":"https://example.com/photo.jpg"}"#;
+    let repr: BamlMediaRepr = serde_json::from_str(json).unwrap();
+    assert_eq!(repr.mime_type, Some("image/jpeg".into()));
+    assert!(matches!(
+        repr.content,
+        BamlMediaReprContent::Url { ref url } if url == "https://example.com/photo.jpg"
+    ));
+}
+
+#[test]
+fn test_media_repr_deserialize_base64() {
+    use baml::__internal::{BamlMediaRepr, BamlMediaReprContent};
+    let json = r#"{"base64":"AQID"}"#;
+    let repr: BamlMediaRepr = serde_json::from_str(json).unwrap();
+    assert_eq!(repr.mime_type, None);
+    assert!(
+        matches!(repr.content, BamlMediaReprContent::Base64 { ref base64 } if base64 == "AQID")
+    );
+}
+
+#[test]
+fn test_image_cannot_deserialize_directly() {
+    let result = serde_json::from_str::<Image>(r#"{"url":"https://example.com/img.png"}"#);
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Cannot deserialize Image directly"));
+}
+
+#[test]
+fn test_audio_cannot_deserialize_directly() {
+    let result = serde_json::from_str::<Audio>(r#"{"url":"https://example.com/audio.mp3"}"#);
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Cannot deserialize Audio directly"));
+}
+
+#[test]
+fn test_pdf_cannot_deserialize_directly() {
+    let result = serde_json::from_str::<Pdf>(r#"{"url":"https://example.com/doc.pdf"}"#);
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("Cannot deserialize Pdf directly"));
+}
+
+// =============================================================================
+// DynamicClass / DynamicEnum / DynamicUnion cannot be deserialized
+// =============================================================================
+
+#[test]
+fn test_dynamic_class_standalone_cannot_deserialize() {
+    let result = serde_json::from_str::<baml::DynamicClass<Types, rust::baml_client::stream_types::StreamTypes>>(
+        r#"{"x": 1}"#,
+    );
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("DynamicClass cannot be deserialized"));
+}
+
+#[test]
+fn test_dynamic_enum_standalone_cannot_deserialize() {
+    let result = serde_json::from_str::<baml::DynamicEnum>(r#""happy""#);
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("DynamicEnum cannot be deserialized"));
+}
+
+#[test]
+fn test_dynamic_union_standalone_cannot_deserialize() {
+    let result = serde_json::from_str::<baml::DynamicUnion<Types, rust::baml_client::stream_types::StreamTypes>>(
+        r#""value""#,
+    );
+    assert!(result.is_err());
+    assert!(result
+        .unwrap_err()
+        .to_string()
+        .contains("DynamicUnion cannot be deserialized"));
+}
+
+// =============================================================================
+// Class containing enum fields
+// =============================================================================
+
+#[test]
+fn test_class_with_enum_field_roundtrip() {
+    // DynamicClassTwo has a DynEnumOne field
+    let d = DynamicClassTwo {
+        hi: "greetings".into(),
+        some_class: SomeClassNestedDynamic {
+            hi: "nested".into(),
+            __dynamic: HashMap::new(),
+        },
+        status: DynEnumOne::_Dynamic("PENDING".into()),
+        __dynamic: HashMap::new(),
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let rt: DynamicClassTwo = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.hi, "greetings");
+    assert_eq!(rt.status, DynEnumOne::_Dynamic("PENDING".into()));
+}
+
+// =============================================================================
+// Union of class and string
+// =============================================================================
+
+#[test]
+fn test_union_class_or_string() {
+    // Union2NestedOrString: Nested first, then String
+    let nested = Union2NestedOrString::Nested(Nested {
+        prop3: Some("val".into()),
+        prop4: None,
+        prop20: Nested2 {
+            prop11: None,
+            prop12: None,
+        },
+    });
+    let json = serde_json::to_string(&nested).unwrap();
+    let rt: Union2NestedOrString = serde_json::from_str(&json).unwrap();
+    assert!(matches!(rt, Union2NestedOrString::Nested(_)));
+
+    let s = Union2NestedOrString::String("plain text".into());
+    let json = serde_json::to_string(&s).unwrap();
+    assert_eq!(json, r#""plain text""#);
+    let rt: Union2NestedOrString = serde_json::from_str(&json).unwrap();
+    assert!(matches!(rt, Union2NestedOrString::String(s) if s == "plain text"));
+}
+
+// =============================================================================
+// Multi-primitive union (4 types)
+// =============================================================================
+
+#[test]
+fn test_four_primitive_union() {
+    // Union4BoolOrFloatOrIntOrString: Int, String, Bool, Float
+    let cases: Vec<(Union4BoolOrFloatOrIntOrString, &str)> = vec![
+        (Union4BoolOrFloatOrIntOrString::Int(10), "10"),
+        (
+            Union4BoolOrFloatOrIntOrString::String("hi".into()),
+            r#""hi""#,
+        ),
+        (Union4BoolOrFloatOrIntOrString::Bool(true), "true"),
+        (Union4BoolOrFloatOrIntOrString::Float(1.5), "1.5"),
+    ];
+    for (val, expected_json) in cases {
+        let json = serde_json::to_string(&val).unwrap();
+        assert_eq!(json, expected_json);
+    }
+
+    // Deserialize
+    let rt: Union4BoolOrFloatOrIntOrString = serde_json::from_str("10").unwrap();
+    assert!(matches!(rt, Union4BoolOrFloatOrIntOrString::Int(10)));
+
+    let rt: Union4BoolOrFloatOrIntOrString = serde_json::from_str(r#""hi""#).unwrap();
+    assert!(matches!(rt, Union4BoolOrFloatOrIntOrString::String(s) if s == "hi"));
+
+    let rt: Union4BoolOrFloatOrIntOrString = serde_json::from_str("true").unwrap();
+    assert!(matches!(rt, Union4BoolOrFloatOrIntOrString::Bool(true)));
+
+    let rt: Union4BoolOrFloatOrIntOrString = serde_json::from_str("1.5").unwrap();
+    assert!(matches!(rt, Union4BoolOrFloatOrIntOrString::Float(_)));
+}
+
+// =============================================================================
+// Three-primitive union
+// =============================================================================
+
+#[test]
+fn test_three_primitive_union() {
+    // Union3FloatOrIntOrString: String, Int, Float
+    let s = Union3FloatOrIntOrString::String("hello".into());
+    assert_eq!(serde_json::to_string(&s).unwrap(), r#""hello""#);
+
+    let i = Union3FloatOrIntOrString::Int(7);
+    assert_eq!(serde_json::to_string(&i).unwrap(), "7");
+
+    let f = Union3FloatOrIntOrString::Float(2.5);
+    assert_eq!(serde_json::to_string(&f).unwrap(), "2.5");
+
+    // Roundtrip
+    let rt: Union3FloatOrIntOrString = serde_json::from_str(r#""world""#).unwrap();
+    assert!(matches!(rt, Union3FloatOrIntOrString::String(s) if s == "world"));
+
+    let rt: Union3FloatOrIntOrString = serde_json::from_str("7").unwrap();
+    assert!(matches!(rt, Union3FloatOrIntOrString::Int(7)));
+}
+
+// =============================================================================
+// Class with union field
+// =============================================================================
+
+#[test]
+fn test_class_with_union_field() {
+    let obj = ComplexMemoryObject {
+        id: "mem1".into(),
+        name: "test".into(),
+        description: "desc".into(),
+        metadata: vec![
+            Union3FloatOrIntOrString::String("tag".into()),
+            Union3FloatOrIntOrString::Int(42),
+        ],
+    };
+    let json = serde_json::to_string(&obj).unwrap();
+    let rt: ComplexMemoryObject = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.id, "mem1");
+    assert_eq!(rt.metadata.len(), 2);
+}
+
+// =============================================================================
+// Edge cases
+// =============================================================================
+
+#[test]
+fn test_empty_string_fields() {
+    let bn = BigNumbers { a: 0, b: 0.0 };
+    let json = serde_json::to_string(&bn).unwrap();
+    assert_eq!(json, r#"{"a":0,"b":0.0}"#);
+    let rt: BigNumbers = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.a, 0);
+    assert_eq!(rt.b, 0.0);
+}
+
+#[test]
+fn test_large_numbers() {
+    let bn = BigNumbers {
+        a: i64::MAX,
+        b: f64::MAX,
+    };
+    let json = serde_json::to_string(&bn).unwrap();
+    let rt: BigNumbers = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.a, i64::MAX);
+    // f64::MAX roundtrip should be exact
+    assert_eq!(rt.b, f64::MAX);
+}
+
+#[test]
+fn test_negative_numbers() {
+    let bn = BigNumbers {
+        a: -999,
+        b: -0.001,
+    };
+    let json = serde_json::to_string(&bn).unwrap();
+    let rt: BigNumbers = serde_json::from_str(&json).unwrap();
+    assert_eq!(rt.a, -999);
+    assert!((rt.b - (-0.001)).abs() < 1e-10);
+}
+
+#[test]
+fn test_dynamic_class_empty() {
+    let d = DynamicClassOne {
+        __dynamic: HashMap::new(),
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    assert_eq!(json, "{}");
+    let rt: DynamicClassOne = serde_json::from_str(&json).unwrap();
+    assert!(rt.__dynamic.is_empty());
+}
+
+#[test]
+fn test_baml_value_mixed_list_serialize() {
+    let list: TestBamlValue = baml::BamlValue::List(vec![
+        baml::BamlValue::String("hello".into()),
+        baml::BamlValue::Int(42),
+        baml::BamlValue::Bool(true),
+        baml::BamlValue::Null,
+    ]);
+    let json = serde_json::to_string(&list).unwrap();
+    assert_eq!(json, r#"["hello",42,true,null]"#);
+}
+
+#[test]
+fn test_baml_value_mixed_list_deserialize() {
+    let json = r#"["hello",42,true,null]"#;
+    let rt: TestBamlValue = serde_json::from_str(json).unwrap();
+    match rt {
+        baml::BamlValue::List(items) => {
+            assert_eq!(items.len(), 4);
+            assert!(matches!(items[0], baml::BamlValue::String(ref s) if s == "hello"));
+            assert!(matches!(items[1], baml::BamlValue::Int(42)));
+            assert!(matches!(items[2], baml::BamlValue::Bool(true)));
+            assert!(matches!(items[3], baml::BamlValue::Null));
+        }
+        other => panic!("expected List, got {:?}", other),
+    }
+}
+
+#[test]
+fn test_union_enum_or_string_with_tag() {
+    // Union2StringOrTag: Tag (enum) first, then String
+    let tag = Union2StringOrTag::Tag(Tag::Security);
+    let json = serde_json::to_string(&tag).unwrap();
+    assert_eq!(json, r#""Security""#);
+
+    // Deserialization of a known Tag variant
+    let rt: Union2StringOrTag = serde_json::from_str(r#""Security""#).unwrap();
+    // Since Tag is first and "Security" is a valid Tag variant, it matches Tag
+    assert!(matches!(rt, Union2StringOrTag::Tag(Tag::Security)));
+
+    let s = Union2StringOrTag::String("just a string".into());
+    let json = serde_json::to_string(&s).unwrap();
+    assert_eq!(json, r#""just a string""#);
+
+    // An unknown string should fall through to String variant
+    // (since Tag won't match it)
+    let rt: Union2StringOrTag = serde_json::from_str(r#""random text""#).unwrap();
+    // With untagged unions, Tag tries first. "random text" isn't a valid Tag variant,
+    // so it falls through to String.
+    assert!(matches!(rt, Union2StringOrTag::String(s) if s == "random text"));
+}
+
+#[test]
+fn test_dynamic_class_multiple_dynamic_value_types_serialize() {
+    // Serialization works for all BamlValue types
+    let mut dynamic = HashMap::new();
+    dynamic.insert("str_field".into(), baml::BamlValue::String("val".into()));
+    dynamic.insert("int_field".into(), baml::BamlValue::Int(99));
+    dynamic.insert("float_field".into(), baml::BamlValue::Float(1.5));
+    dynamic.insert("bool_field".into(), baml::BamlValue::Bool(false));
+    dynamic.insert("null_field".into(), baml::BamlValue::Null);
+    dynamic.insert(
+        "list_field".into(),
+        baml::BamlValue::List(vec![baml::BamlValue::String("x".into())]),
+    );
+
+    let d = DynamicClassOne {
+        __dynamic: dynamic,
+    };
+    let json = serde_json::to_string(&d).unwrap();
+    let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(v["str_field"], "val");
+    assert_eq!(v["int_field"], 99);
+    assert_eq!(v["float_field"], 1.5);
+    assert_eq!(v["bool_field"], false);
+    assert!(v["null_field"].is_null());
+    assert_eq!(v["list_field"], serde_json::json!(["x"]));
+}
+
+#[test]
+fn test_dynamic_class_multiple_dynamic_value_types_deserialize() {
+    let json = r#"{"str_field":"val","int_field":99,"float_field":1.5,"bool_field":false,"null_field":null,"list_field":["x"]}"#;
+    let rt: DynamicClassOne = serde_json::from_str(json).unwrap();
+    assert_eq!(rt.__dynamic.len(), 6);
+    assert!(rt.__dynamic.contains_key("str_field"));
+    assert!(rt.__dynamic.contains_key("int_field"));
+    assert!(rt.__dynamic.contains_key("float_field"));
+    assert!(rt.__dynamic.contains_key("bool_field"));
+    assert!(rt.__dynamic.contains_key("null_field"));
+    assert!(rt.__dynamic.contains_key("list_field"));
+}

--- a/integ-tests/rust/tests/test_serde.rs
+++ b/integ-tests/rust/tests/test_serde.rs
@@ -97,10 +97,7 @@ fn test_recursive_class() {
     assert_eq!(rt.data, 1);
     assert_eq!(rt.left.as_ref().unwrap().data, 2);
     assert_eq!(rt.right.as_ref().unwrap().data, 3);
-    assert_eq!(
-        rt.right.as_ref().unwrap().right.as_ref().unwrap().data,
-        4
-    );
+    assert_eq!(rt.right.as_ref().unwrap().right.as_ref().unwrap().data, 4);
     assert!(rt.left.as_ref().unwrap().left.is_none());
 }
 
@@ -377,16 +374,15 @@ fn test_union_of_distinguishable_classes() {
         Union3BookOrderOrFlightConfirmationOrGroceryReceipt::BookOrder(b) if b.orderId == "123"
     ));
 
-    let flight =
-        Union3BookOrderOrFlightConfirmationOrGroceryReceipt::FlightConfirmation(
-            FlightConfirmation {
-                confirmationNumber: "ABC".into(),
-                flightNumber: "UA100".into(),
-                departureTime: "08:00".into(),
-                arrivalTime: "12:00".into(),
-                seatNumber: "14A".into(),
-            },
-        );
+    let flight = Union3BookOrderOrFlightConfirmationOrGroceryReceipt::FlightConfirmation(
+        FlightConfirmation {
+            confirmationNumber: "ABC".into(),
+            flightNumber: "UA100".into(),
+            departureTime: "08:00".into(),
+            arrivalTime: "12:00".into(),
+            seatNumber: "14A".into(),
+        },
+    );
     let json = serde_json::to_string(&flight).unwrap();
     let rt: Union3BookOrderOrFlightConfirmationOrGroceryReceipt =
         serde_json::from_str(&json).unwrap();
@@ -433,8 +429,7 @@ fn test_union_with_map_variant() {
     );
     let u = Union2MapStringKeyRecursiveUnionValueOrString::MapStringKeyRecursiveUnionValue(map);
     let json = serde_json::to_string(&u).unwrap();
-    let rt: Union2MapStringKeyRecursiveUnionValueOrString =
-        serde_json::from_str(&json).unwrap();
+    let rt: Union2MapStringKeyRecursiveUnionValueOrString = serde_json::from_str(&json).unwrap();
     assert!(matches!(
         rt,
         Union2MapStringKeyRecursiveUnionValueOrString::MapStringKeyRecursiveUnionValue(_)
@@ -698,9 +693,7 @@ fn test_fully_dynamic_class_no_static_fields() {
     let mut dynamic = HashMap::new();
     dynamic.insert("a".into(), baml::BamlValue::String("x".into()));
     dynamic.insert("b".into(), baml::BamlValue::Int(1));
-    let d = DynamicClassOne {
-        __dynamic: dynamic,
-    };
+    let d = DynamicClassOne { __dynamic: dynamic };
     let json = serde_json::to_string(&d).unwrap();
     let v: serde_json::Value = serde_json::from_str(&json).unwrap();
     assert_eq!(v["a"], "x");
@@ -832,8 +825,7 @@ fn test_union_with_dynamic_class_variant() {
     // Let's just verify it doesn't error:
     assert!(matches!(
         rt,
-        Union2OriginalAOrOriginalB::OriginalA(_)
-            | Union2OriginalAOrOriginalB::OriginalB(_)
+        Union2OriginalAOrOriginalB::OriginalA(_) | Union2OriginalAOrOriginalB::OriginalB(_)
     ));
 }
 
@@ -871,10 +863,7 @@ fn test_checked_type_deserialize() {
     let rt: Checked<i64> = serde_json::from_str(json).unwrap();
     assert_eq!(rt.value, 42);
     assert!(rt.checks.contains_key("my_check"));
-    assert_eq!(
-        rt.checks["my_check"].status,
-        baml::CheckStatus::Succeeded
-    );
+    assert_eq!(rt.checks["my_check"].status, baml::CheckStatus::Succeeded);
 }
 
 #[test]
@@ -1117,21 +1106,24 @@ fn test_baml_value_dynamic_union_serialize() {
 fn test_types_enum_cannot_deserialize() {
     let result = serde_json::from_str::<Types>(r#"{"a":1,"b":2.0}"#);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("not deserializable"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("not deserializable")
+    );
 }
 
 #[test]
 fn test_stream_types_cannot_deserialize() {
-    let result =
-        serde_json::from_str::<rust::baml_client::stream_types::StreamTypes>(r#"{"a":1}"#);
+    let result = serde_json::from_str::<rust::baml_client::stream_types::StreamTypes>(r#"{"a":1}"#);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("not deserializable"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("not deserializable")
+    );
 }
 
 #[test]
@@ -1238,30 +1230,36 @@ fn test_media_repr_deserialize_base64() {
 fn test_image_cannot_deserialize_directly() {
     let result = serde_json::from_str::<Image>(r#"{"url":"https://example.com/img.png"}"#);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("Cannot deserialize Image directly"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot deserialize Image directly")
+    );
 }
 
 #[test]
 fn test_audio_cannot_deserialize_directly() {
     let result = serde_json::from_str::<Audio>(r#"{"url":"https://example.com/audio.mp3"}"#);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("Cannot deserialize Audio directly"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot deserialize Audio directly")
+    );
 }
 
 #[test]
 fn test_pdf_cannot_deserialize_directly() {
     let result = serde_json::from_str::<Pdf>(r#"{"url":"https://example.com/doc.pdf"}"#);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("Cannot deserialize Pdf directly"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Cannot deserialize Pdf directly")
+    );
 }
 
 // =============================================================================
@@ -1270,36 +1268,42 @@ fn test_pdf_cannot_deserialize_directly() {
 
 #[test]
 fn test_dynamic_class_standalone_cannot_deserialize() {
-    let result = serde_json::from_str::<baml::DynamicClass<Types, rust::baml_client::stream_types::StreamTypes>>(
-        r#"{"x": 1}"#,
-    );
+    let result = serde_json::from_str::<
+        baml::DynamicClass<Types, rust::baml_client::stream_types::StreamTypes>,
+    >(r#"{"x": 1}"#);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("DynamicClass cannot be deserialized"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("DynamicClass cannot be deserialized")
+    );
 }
 
 #[test]
 fn test_dynamic_enum_standalone_cannot_deserialize() {
     let result = serde_json::from_str::<baml::DynamicEnum>(r#""happy""#);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("DynamicEnum cannot be deserialized"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("DynamicEnum cannot be deserialized")
+    );
 }
 
 #[test]
 fn test_dynamic_union_standalone_cannot_deserialize() {
-    let result = serde_json::from_str::<baml::DynamicUnion<Types, rust::baml_client::stream_types::StreamTypes>>(
-        r#""value""#,
-    );
+    let result = serde_json::from_str::<
+        baml::DynamicUnion<Types, rust::baml_client::stream_types::StreamTypes>,
+    >(r#""value""#);
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("DynamicUnion cannot be deserialized"));
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("DynamicUnion cannot be deserialized")
+    );
 }
 
 // =============================================================================
@@ -1459,10 +1463,7 @@ fn test_large_numbers() {
 
 #[test]
 fn test_negative_numbers() {
-    let bn = BigNumbers {
-        a: -999,
-        b: -0.001,
-    };
+    let bn = BigNumbers { a: -999, b: -0.001 };
     let json = serde_json::to_string(&bn).unwrap();
     let rt: BigNumbers = serde_json::from_str(&json).unwrap();
     assert_eq!(rt.a, -999);
@@ -1546,9 +1547,7 @@ fn test_dynamic_class_multiple_dynamic_value_types_serialize() {
         baml::BamlValue::List(vec![baml::BamlValue::String("x".into())]),
     );
 
-    let d = DynamicClassOne {
-        __dynamic: dynamic,
-    };
+    let d = DynamicClassOne { __dynamic: dynamic };
     let json = serde_json::to_string(&d).unwrap();
     let v: serde_json::Value = serde_json::from_str(&json).unwrap();
     assert_eq!(v["str_field"], "val");

--- a/languages/rust/Cargo.lock
+++ b/languages/rust/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.216.0"
+version = "0.219.0"
 dependencies = [
  "async-channel",
  "baml-macros",
@@ -48,14 +48,14 @@ dependencies = [
 
 [[package]]
 name = "baml-cli"
-version = "0.216.0"
+version = "0.219.0"
 dependencies = [
  "baml",
 ]
 
 [[package]]
 name = "baml-macros"
-version = "0.216.0"
+version = "0.219.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "baml-sys"
-version = "0.216.0"
+version = "0.219.0"
 dependencies = [
  "hex",
  "libc",

--- a/languages/rust/baml-macros/src/baml_serde.rs
+++ b/languages/rust/baml-macros/src/baml_serde.rs
@@ -37,6 +37,7 @@ fn derive_serde_union(data: &DataEnum, ident: &Ident) -> Result<TokenStream> {
 
         if let Some(ref literal_string) = variant_attrs.literal_string {
             literal_serde.push(quote! {
+                #[allow(non_snake_case)]
                 pub mod #variant_ident {
                     use ::baml::__internal::serde;
                     pub fn serialize<S: serde::Serializer>(serializer: S) -> Result<S::Ok, S::Error> {

--- a/languages/rust/baml-macros/src/baml_serde.rs
+++ b/languages/rust/baml-macros/src/baml_serde.rs
@@ -1,19 +1,24 @@
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use syn::{Data, DataEnum, DataStruct, DeriveInput, Ident, Result};
+use syn::{Data, DataEnum, DeriveInput, Ident, Result};
 
-use crate::shared::{ContainerAttrs, FieldAttrs, VariantAttrs};
+use crate::shared::{ContainerAttrs, VariantAttrs};
 
 pub(crate) fn derive_serde(input: &DeriveInput) -> Result<TokenStream> {
     let container_attrs = ContainerAttrs::from_attrs(&input.attrs)?;
 
     match &input.data {
-        Data::Struct(data_struct) => derive_serde_struct(data_struct, &input.ident),
-        Data::Enum(..) if container_attrs.union => Err(syn::Error::new(
+        Data::Struct(..) => Err(syn::Error::new(
             Span::call_site(),
-            "BAML unions should use the inner-tagged default serde implementation.",
+            "BamlSerde cannot be derived for structs, use `#[serde(flatten)]` on dynamic instead.",
         )),
-        Data::Enum(data_enum) => derive_serde_enum(data_enum, &input.ident),
+        Data::Enum(data_enum) if container_attrs.union => {
+            derive_serde_union(data_enum, &input.ident)
+        }
+        Data::Enum(..) => Err(syn::Error::new(
+            Span::call_site(),
+            "BamlSerde cannot be derived for enums, use `#[serde(untagged)]` on dynamic instead.",
+        )),
         Data::Union(..) => Err(syn::Error::new(
             Span::call_site(),
             "Rust unions are not supported for this derive macro.",
@@ -21,197 +26,81 @@ pub(crate) fn derive_serde(input: &DeriveInput) -> Result<TokenStream> {
     }
 }
 
-fn derive_serde_struct(data: &DataStruct, ident: &Ident) -> Result<TokenStream> {
-    let mut dynamic_field = None;
-    let mut field_idents = Vec::new();
-    let mut field_names = Vec::new();
-    let mut ser_fields = Vec::new();
-    let mut de_field_match_arms = Vec::new();
-    for field in &data.fields {
-        let field_attrs = FieldAttrs::from_attrs(&field.attrs)?;
-        if field_attrs.skip {
-            continue;
-        }
-        if field_attrs.dynamic_fields {
-            if dynamic_field.is_some() {
-                return Err(syn::Error::new(
-                    Span::call_site(),
-                    "Only one dynamic field is allowed per struct.",
-                ));
-            }
-            dynamic_field = Some(field);
-            continue;
-        }
-        let field_ident = field
-            .ident
-            .as_ref()
-            .expect("Struct fields must have a name.");
-        field_idents.push(field_ident);
-        let field_name = field_attrs.name.unwrap_or_else(|| field_ident.to_string());
-        ser_fields.push(quote! {
-            map.serialize_entry(#field_name, &self.#field_ident)?;
-        });
-        de_field_match_arms.push(quote! {
-            #field_name => {
-                #field_ident = Some(map.next_value()?);
-            }
-        });
-        field_names.push(field_name);
-    }
-    let dynamic_ident = dynamic_field.as_ref().map(|field| {
-        field
-            .ident
-            .as_ref()
-            .expect("Struct fields must have a name.")
-    });
-    let ser_fields = ser_fields.as_slice();
-
-    let ser_dynamic_field = dynamic_ident.map(|dynamic_ident| {
-        quote! {
-            for (k, v) in self.#dynamic_ident.iter() {
-                map.serialize_entry(k, v)?;
-            }
-        }
-    });
-    let de_dynamic_hashmap = dynamic_ident.map(|dynamic_ident| {
-        quote! {
-            let mut #dynamic_ident = ::std::collections::HashMap::new();
-        }
-    });
-    let de_catchall_match_arm = match dynamic_ident {
-        Some(dynamic_ident) => quote! {
-            other => {
-                #dynamic_ident.insert(other.to_string(), map.next_value()?);
-            }
-        },
-        None => quote! {
-            other => {
-                return Err(::baml::__internal::serde::de::Error::invalid_value(::baml::__internal::serde::de::Unexpected::Other(&other), &self));
-            }
-        },
-    };
-    let de_dynamic_hashmap_field = dynamic_ident.map(|dynamic_ident| {
-        quote! { #dynamic_ident, }
-    });
-
-    let impls = quote! {
-        impl ::baml::__internal::serde::Serialize for #ident {
-            fn serialize<S: ::baml::__internal::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-                use ::baml::__internal::serde::ser::SerializeMap;
-                let mut map = serializer.serialize_map(::std::option::Option::None)?;
-                #(#ser_fields)*
-                #ser_dynamic_field
-                map.end()
-            }
-        }
-        impl<'de> ::baml::__internal::serde::Deserialize<'de> for #ident {
-            fn deserialize<D: ::baml::__internal::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-                struct Visitor;
-                impl<'v> ::baml::__internal::serde::de::Visitor<'v> for Visitor {
-                    type Value = #ident;
-                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                        formatter.write_str("BAML class")
-                    }
-                    fn visit_map<A: ::baml::__internal::serde::de::MapAccess<'v>>(self, mut map: A) -> Result<Self::Value, A::Error> {
-                        #(let mut #field_idents = None;)*
-                        #de_dynamic_hashmap
-
-                        while let Some(key) = map.next_key()? {
-                            match key {
-                                #(#de_field_match_arms)*
-                                #de_catchall_match_arm
-                            }
-                        }
-
-                        Ok(#ident {
-                            #(#field_idents: #field_idents.ok_or_else(|| ::baml::__internal::serde::de::Error::missing_field(#field_names))?,)*
-                            #de_dynamic_hashmap_field
-                        })
-                    }
-                }
-                deserializer.deserialize_map(Visitor)
-            }
-        }
-    };
-    Ok(impls)
-}
-
-fn derive_serde_enum(data: &DataEnum, ident: &Ident) -> Result<TokenStream> {
+fn derive_serde_union(data: &DataEnum, ident: &Ident) -> Result<TokenStream> {
     let name = ident.to_string();
 
-    let mut ser_variant_arms = Vec::new();
-    let mut de_variant_arms = Vec::new();
-    let mut dynamic_variant = None;
+    let mut literal_serde = Vec::new();
+
     for variant in &data.variants {
         let variant_attrs = VariantAttrs::from_attrs(&variant.attrs)?;
-        if variant_attrs.dynamic_variant {
-            if dynamic_variant.is_some() {
-                return Err(syn::Error::new(
-                    Span::call_site(),
-                    "Only one dynamic variant is allowed per enum.",
-                ));
-            }
-            dynamic_variant = Some(variant);
-            continue;
-        }
-        if !variant.fields.is_empty() {
-            return Err(syn::Error::new(
-                Span::call_site(),
-                "Enum variants must be unit.",
-            ));
-        }
         let variant_ident = &variant.ident;
-        let variant_name = variant_attrs
-            .name
-            .unwrap_or_else(|| variant_ident.to_string());
 
-        ser_variant_arms.push(quote! {
-            Self::#variant_ident => serializer.serialize_str(#variant_name),
-        });
-        de_variant_arms.push(quote! {
-            #variant_name => Ok(Self::Value::#variant_ident),
-        });
-    }
-    if let Some(dynamic_variant) = dynamic_variant {
-        let dynamic_variant_ident = &dynamic_variant.ident;
-        ser_variant_arms.push(quote! {
-            Self::#dynamic_variant_ident(v) => serializer.serialize_str(v),
-        });
-        de_variant_arms.push(quote! {
-            other => Ok(Self::Value::#dynamic_variant_ident(other.to_string())),
-        });
-    } else {
-        de_variant_arms.push(quote! {
-            other => Err(::baml::__internal::serde::de::Error::invalid_value(::baml::__internal::serde::de::Unexpected::Other(&other), &self)),
-        });
-    }
-
-    let impls = quote! {
-        impl ::baml::__internal::serde::Serialize for #ident {
-            fn serialize<S: ::baml::__internal::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-                match self {
-                    #(#ser_variant_arms)*
-                }
-            }
-        }
-        impl<'de> ::baml::__internal::serde::Deserialize<'de> for #ident {
-            fn deserialize<D: ::baml::__internal::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-                struct Visitor;
-                impl<'v> ::baml::__internal::serde::de::Visitor<'v> for Visitor {
-                    type Value = #ident;
-                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
-                        format!("BAML enum {} variant (string)", #name)
+        if let Some(ref literal_string) = variant_attrs.literal_string {
+            literal_serde.push(quote! {
+                pub mod #variant_ident {
+                    use ::baml::__internal::serde;
+                    pub fn serialize<S: serde::Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+                        serializer.serialize_str(#literal_string)
                     }
-                    fn visit_str<E: ::baml::__internal::serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
-                        match v {
-                            #(#de_variant_arms)*
-                            _ => Err(::baml::__internal::serde::de::Error::invalid_value(::baml::__internal::serde::de::Unexpected::Str(v), &self)),
+                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<(), D::Error> {
+                        let __value: String = serde::Deserialize::deserialize(deserializer)?;
+                        if __value == #literal_string {
+                            Ok(())
+                        } else {
+                            Err(serde::de::Error::custom("invalid literal"))
                         }
                     }
-                };
-            }
+                }
+            });
+        } else if let Some(literal_int) = variant_attrs.literal_int {
+            literal_serde.push(quote! {
+                pub mod #variant_ident {
+                    use ::baml::__internal::serde;
+                    pub fn serialize<S: serde::Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+                        serializer.serialize_i64(#literal_int)
+                    }
+                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<(), D::Error> {
+                        let __value: i64 = serde::Deserialize::deserialize(deserializer)?;
+                        if __value == #literal_int {
+                            Ok(())
+                        } else {
+                            Err(serde::de::Error::custom("invalid literal"))
+                        }
+                    }
+                }
+            });
+        } else if let Some(literal_bool) = variant_attrs.literal_bool {
+            literal_serde.push(quote! {
+                pub mod #variant_ident {
+                    use ::baml::__internal::serde;
+                    pub fn serialize<S: serde::Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+                        serializer.serialize_bool(#literal_bool)
+                        }
+                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<(), D::Error> {
+                        let __value: bool = serde::Deserialize::deserialize(deserializer)?;
+                        if __value == #literal_bool {
+                            Ok(())
+                        } else {
+                            Err(serde::de::Error::custom("invalid literal"))
+                        }
+                    }
+                }
+            });
         }
-    };
+    }
 
-    Ok(impls)
+    if literal_serde.is_empty() {
+        return Ok(TokenStream::new());
+    }
+
+    let module_ident = syn::Ident::new(
+        &format!("__baml_serde_union_literal_{}", name),
+        ident.span(),
+    );
+
+    Ok(quote! {
+        mod #module_ident {
+            #(#literal_serde)*
+        }
+    })
 }

--- a/languages/rust/baml-macros/src/baml_serde.rs
+++ b/languages/rust/baml-macros/src/baml_serde.rs
@@ -1,0 +1,217 @@
+use proc_macro2::{Span, TokenStream};
+use quote::quote;
+use syn::{Data, DataEnum, DataStruct, DeriveInput, Ident, Result};
+
+use crate::shared::{ContainerAttrs, FieldAttrs, VariantAttrs};
+
+pub(crate) fn derive_serde(input: &DeriveInput) -> Result<TokenStream> {
+    let container_attrs = ContainerAttrs::from_attrs(&input.attrs)?;
+
+    match &input.data {
+        Data::Struct(data_struct) => derive_serde_struct(data_struct, &input.ident),
+        Data::Enum(..) if container_attrs.union => Err(syn::Error::new(
+            Span::call_site(),
+            "BAML unions should use the inner-tagged default serde implementation.",
+        )),
+        Data::Enum(data_enum) => derive_serde_enum(data_enum, &input.ident),
+        Data::Union(..) => Err(syn::Error::new(
+            Span::call_site(),
+            "Rust unions are not supported for this derive macro.",
+        )),
+    }
+}
+
+fn derive_serde_struct(data: &DataStruct, ident: &Ident) -> Result<TokenStream> {
+    let mut dynamic_field = None;
+    let mut field_idents = Vec::new();
+    let mut field_names = Vec::new();
+    let mut ser_fields = Vec::new();
+    let mut de_field_match_arms = Vec::new();
+    for field in &data.fields {
+        let field_attrs = FieldAttrs::from_attrs(&field.attrs)?;
+        if field_attrs.skip {
+            continue;
+        }
+        if field_attrs.dynamic_fields {
+            if dynamic_field.is_some() {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    "Only one dynamic field is allowed per struct.",
+                ));
+            }
+            dynamic_field = Some(field);
+            continue;
+        }
+        let field_ident = field
+            .ident
+            .as_ref()
+            .expect("Struct fields must have a name.");
+        field_idents.push(field_ident);
+        let field_name = field_attrs.name.unwrap_or_else(|| field_ident.to_string());
+        ser_fields.push(quote! {
+            map.serialize_entry(#field_name, &self.#field_ident)?;
+        });
+        de_field_match_arms.push(quote! {
+            #field_name => {
+                #field_ident = Some(map.next_value()?);
+            }
+        });
+        field_names.push(field_name);
+    }
+    let dynamic_ident = dynamic_field.as_ref().map(|field| {
+        field
+            .ident
+            .as_ref()
+            .expect("Struct fields must have a name.")
+    });
+    let ser_fields = ser_fields.as_slice();
+
+    let ser_dynamic_field = dynamic_ident.map(|dynamic_ident| {
+        quote! {
+            for (k, v) in self.#dynamic_ident.iter() {
+                map.serialize_entry(k, v)?;
+            }
+        }
+    });
+    let de_dynamic_hashmap = dynamic_ident.map(|dynamic_ident| {
+        quote! {
+            let mut #dynamic_ident = ::std::collections::HashMap::new();
+        }
+    });
+    let de_catchall_match_arm = match dynamic_ident {
+        Some(dynamic_ident) => quote! {
+            other => {
+                #dynamic_ident.insert(other.to_string(), map.next_value()?);
+            }
+        },
+        None => quote! {
+            other => {
+                return Err(::baml::__internal::serde::de::Error::invalid_value(::baml::__internal::serde::de::Unexpected::Other(&other), &self));
+            }
+        },
+    };
+    let de_dynamic_hashmap_field = dynamic_ident.map(|dynamic_ident| {
+        quote! { #dynamic_ident, }
+    });
+
+    let impls = quote! {
+        impl ::baml::__internal::serde::Serialize for #ident {
+            fn serialize<S: ::baml::__internal::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                use ::baml::__internal::serde::ser::SerializeMap;
+                let mut map = serializer.serialize_map(::std::option::Option::None)?;
+                #(#ser_fields)*
+                #ser_dynamic_field
+                map.end()
+            }
+        }
+        impl<'de> ::baml::__internal::serde::Deserialize<'de> for #ident {
+            fn deserialize<D: ::baml::__internal::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                struct Visitor;
+                impl<'v> ::baml::__internal::serde::de::Visitor<'v> for Visitor {
+                    type Value = #ident;
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                        formatter.write_str("BAML class")
+                    }
+                    fn visit_map<A: ::baml::__internal::serde::de::MapAccess<'v>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                        #(let mut #field_idents = None;)*
+                        #de_dynamic_hashmap
+
+                        while let Some(key) = map.next_key()? {
+                            match key {
+                                #(#de_field_match_arms)*
+                                #de_catchall_match_arm
+                            }
+                        }
+
+                        Ok(#ident {
+                            #(#field_idents: #field_idents.ok_or_else(|| ::baml::__internal::serde::de::Error::missing_field(#field_names))?,)*
+                            #de_dynamic_hashmap_field
+                        })
+                    }
+                }
+                deserializer.deserialize_map(Visitor)
+            }
+        }
+    };
+    Ok(impls)
+}
+
+fn derive_serde_enum(data: &DataEnum, ident: &Ident) -> Result<TokenStream> {
+    let name = ident.to_string();
+
+    let mut ser_variant_arms = Vec::new();
+    let mut de_variant_arms = Vec::new();
+    let mut dynamic_variant = None;
+    for variant in &data.variants {
+        let variant_attrs = VariantAttrs::from_attrs(&variant.attrs)?;
+        if variant_attrs.dynamic_variant {
+            if dynamic_variant.is_some() {
+                return Err(syn::Error::new(
+                    Span::call_site(),
+                    "Only one dynamic variant is allowed per enum.",
+                ));
+            }
+            dynamic_variant = Some(variant);
+            continue;
+        }
+        if !variant.fields.is_empty() {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "Enum variants must be unit.",
+            ));
+        }
+        let variant_ident = &variant.ident;
+        let variant_name = variant_attrs
+            .name
+            .unwrap_or_else(|| variant_ident.to_string());
+
+        ser_variant_arms.push(quote! {
+            Self::#variant_ident => serializer.serialize_str(#variant_name),
+        });
+        de_variant_arms.push(quote! {
+            #variant_name => Ok(Self::Value::#variant_ident),
+        });
+    }
+    if let Some(dynamic_variant) = dynamic_variant {
+        let dynamic_variant_ident = &dynamic_variant.ident;
+        ser_variant_arms.push(quote! {
+            Self::#dynamic_variant_ident(v) => serializer.serialize_str(v),
+        });
+        de_variant_arms.push(quote! {
+            other => Ok(Self::Value::#dynamic_variant_ident(other.to_string())),
+        });
+    } else {
+        de_variant_arms.push(quote! {
+            other => Err(::baml::__internal::serde::de::Error::invalid_value(::baml::__internal::serde::de::Unexpected::Other(&other), &self)),
+        });
+    }
+
+    let impls = quote! {
+        impl ::baml::__internal::serde::Serialize for #ident {
+            fn serialize<S: ::baml::__internal::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                match self {
+                    #(#ser_variant_arms)*
+                }
+            }
+        }
+        impl<'de> ::baml::__internal::serde::Deserialize<'de> for #ident {
+            fn deserialize<D: ::baml::__internal::serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                struct Visitor;
+                impl<'v> ::baml::__internal::serde::de::Visitor<'v> for Visitor {
+                    type Value = #ident;
+                    fn expecting(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+                        format!("BAML enum {} variant (string)", #name)
+                    }
+                    fn visit_str<E: ::baml::__internal::serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                        match v {
+                            #(#de_variant_arms)*
+                            _ => Err(::baml::__internal::serde::de::Error::invalid_value(::baml::__internal::serde::de::Unexpected::Str(v), &self)),
+                        }
+                    }
+                };
+            }
+        }
+    };
+
+    Ok(impls)
+}

--- a/languages/rust/baml-macros/src/baml_serde.rs
+++ b/languages/rust/baml-macros/src/baml_serde.rs
@@ -42,12 +42,12 @@ fn derive_serde_union(data: &DataEnum, ident: &Ident) -> Result<TokenStream> {
                     pub fn serialize<S: serde::Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
                         serializer.serialize_str(#literal_string)
                     }
-                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<(), D::Error> {
+                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> ::std::result::Result<(), D::Error> {
                         let __value: String = serde::Deserialize::deserialize(deserializer)?;
                         if __value == #literal_string {
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         } else {
-                            Err(serde::de::Error::custom("invalid literal"))
+                            ::std::result::Result::Err(serde::de::Error::custom("invalid literal"))
                         }
                     }
                 }
@@ -56,15 +56,15 @@ fn derive_serde_union(data: &DataEnum, ident: &Ident) -> Result<TokenStream> {
             literal_serde.push(quote! {
                 pub mod #variant_ident {
                     use ::baml::__internal::serde;
-                    pub fn serialize<S: serde::Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+                    pub fn serialize<S: serde::Serializer>(serializer: S) -> ::std::result::Result<S::Ok, S::Error> {
                         serializer.serialize_i64(#literal_int)
                     }
-                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<(), D::Error> {
+                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> ::std::result::Result<(), D::Error> {
                         let __value: i64 = serde::Deserialize::deserialize(deserializer)?;
                         if __value == #literal_int {
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         } else {
-                            Err(serde::de::Error::custom("invalid literal"))
+                            ::std::result::Result::Err(serde::de::Error::custom("invalid literal"))
                         }
                     }
                 }
@@ -73,15 +73,15 @@ fn derive_serde_union(data: &DataEnum, ident: &Ident) -> Result<TokenStream> {
             literal_serde.push(quote! {
                 pub mod #variant_ident {
                     use ::baml::__internal::serde;
-                    pub fn serialize<S: serde::Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
+                    pub fn serialize<S: serde::Serializer>(serializer: S) -> ::std::result::Result<S::Ok, S::Error> {
                         serializer.serialize_bool(#literal_bool)
                         }
-                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<(), D::Error> {
+                    pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> ::std::result::Result<(), D::Error> {
                         let __value: bool = serde::Deserialize::deserialize(deserializer)?;
                         if __value == #literal_bool {
-                            Ok(())
+                            ::std::result::Result::Ok(())
                         } else {
-                            Err(serde::de::Error::custom("invalid literal"))
+                            ::std::result::Result::Err(serde::de::Error::custom("invalid literal"))
                         }
                     }
                 }

--- a/languages/rust/baml-macros/src/lib.rs
+++ b/languages/rust/baml-macros/src/lib.rs
@@ -97,8 +97,9 @@ pub fn derive_baml_decode(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Implements [`serde::Serialize`] and [`serde::Deserialize`]
-/// for baml-generated types.
+/// Helper for serde support.
+/// 
+/// Currently only adds helpers for deserializing unions with literal values.
 #[proc_macro_derive(BamlSerde, attributes(baml))]
 pub fn derive_baml_serde(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/languages/rust/baml-macros/src/lib.rs
+++ b/languages/rust/baml-macros/src/lib.rs
@@ -32,6 +32,7 @@
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
+mod baml_serde;
 mod decode;
 mod encode;
 mod shared;
@@ -92,6 +93,16 @@ pub fn derive_baml_encode(input: TokenStream) -> TokenStream {
 pub fn derive_baml_decode(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     decode::derive_decode(&input)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Implements [`serde::Serialize`] and [`serde::Deserialize`]
+/// for baml-generated types.
+#[proc_macro_derive(BamlSerde, attributes(baml))]
+pub fn derive_baml_serde(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    baml_serde::derive_serde(&input)
         .unwrap_or_else(|e| e.to_compile_error())
         .into()
 }

--- a/languages/rust/baml/src/codec/baml_value.rs
+++ b/languages/rust/baml/src/codec/baml_value.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 
+use serde::ser::SerializeMap as _;
+
 use super::{
     dynamic_types::{DynamicClass, DynamicEnum, DynamicUnion},
     from_baml_value::FromBamlValue,
@@ -327,5 +329,125 @@ impl<T: KnownTypes, S: KnownTypes> BamlDecode for BamlValue<T, S> {
                 ))
             }
         }
+    }
+}
+
+impl<T: KnownTypes + serde::Serialize, S: KnownTypes + serde::Serialize> serde::Serialize
+    for BamlValue<T, S>
+{
+    fn serialize<Ser: serde::Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
+        match self {
+            BamlValue::Null => serializer.serialize_none(),
+            BamlValue::String(s) => serializer.serialize_str(s),
+            BamlValue::Int(i) => serializer.serialize_i64(*i),
+            BamlValue::Float(f) => serializer.serialize_f64(*f),
+            BamlValue::Bool(b) => serializer.serialize_bool(*b),
+            BamlValue::List(items) => items.serialize(serializer),
+            BamlValue::Map(map) => map.serialize(serializer),
+            BamlValue::DynamicClass(dc) => dc.fields.serialize(serializer),
+            BamlValue::DynamicEnum(de) => serializer.serialize_str(&de.value),
+            BamlValue::DynamicUnion(du) => {
+                // externally tagged union
+                let mut map = serializer.serialize_map(Some(1))?;
+                map.serialize_entry(&du.variant_name, &*du.value)?;
+                map.end()
+            }
+            BamlValue::Known(known) => known.serialize(serializer),
+            BamlValue::StreamKnown(known) => known.serialize(serializer),
+            BamlValue::Checked(c) => c.serialize(serializer),
+            BamlValue::StreamState(ss) => ss.serialize(serializer),
+        }
+    }
+}
+
+impl<'de, T: KnownTypes + serde::Deserialize<'de>, S: KnownTypes + serde::Deserialize<'de>>
+    serde::Deserialize<'de> for BamlValue<T, S>
+{
+    /// BamlValue deserialization is currently lossy:
+    /// Everything is deserialized as scalars, maps, and arrays.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        struct Visitor<'de, T, S>(std::marker::PhantomData<(&'de (), T, S)>)
+        where
+            T: KnownTypes + serde::Deserialize<'de>,
+            S: KnownTypes + serde::Deserialize<'de>;
+
+        impl<'de, T, S> serde::de::Visitor<'de> for Visitor<'de, T, S>
+        where
+            T: KnownTypes + serde::Deserialize<'de>,
+            S: KnownTypes + serde::Deserialize<'de>,
+        {
+            type Value = BamlValue<T, S>;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("BAML value")
+            }
+
+            fn visit_none<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(BamlValue::Null)
+            }
+
+            fn visit_some<D: serde::Deserializer<'de>>(
+                self,
+                deserializer: D,
+            ) -> Result<Self::Value, D::Error> {
+                deserializer.deserialize_any(Visitor(std::marker::PhantomData))
+            }
+
+            fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+                Ok(BamlValue::Null)
+            }
+
+            fn visit_seq<A: serde::de::SeqAccess<'de>>(
+                self,
+                mut seq: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut list = Vec::new();
+                while let Some(value) = seq.next_element()? {
+                    list.push(value);
+                }
+                Ok(BamlValue::List(list))
+            }
+
+            fn visit_map<A: serde::de::MapAccess<'de>>(
+                self,
+                mut map: A,
+            ) -> Result<Self::Value, A::Error> {
+                let mut hashmap: HashMap<String, BamlValue<T, S>> = HashMap::new();
+                while let Some((key, value)) = map.next_entry()? {
+                    hashmap.insert(key, value);
+                }
+                Ok(BamlValue::Map(hashmap))
+            }
+
+            fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+                Ok(BamlValue::String(v.to_string()))
+            }
+
+            fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+                Ok(Self::Value::Int(v))
+            }
+
+            fn visit_u32<E: serde::de::Error>(self, v: u32) -> Result<Self::Value, E> {
+                Ok(Self::Value::Int(v as i64))
+            }
+
+            fn visit_u16<E: serde::de::Error>(self, v: u16) -> Result<Self::Value, E> {
+                Ok(Self::Value::Int(v as i64))
+            }
+
+            fn visit_u8<E: serde::de::Error>(self, v: u8) -> Result<Self::Value, E> {
+                Ok(Self::Value::Int(v as i64))
+            }
+
+            fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Self::Value, E> {
+                Ok(Self::Value::Bool(v))
+            }
+
+            fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Self::Value, E> {
+                Ok(Self::Value::Float(v))
+            }
+        }
+
+        deserializer.deserialize_any(Visitor(std::marker::PhantomData))
     }
 }

--- a/languages/rust/baml/src/codec/baml_value.rs
+++ b/languages/rust/baml/src/codec/baml_value.rs
@@ -2,8 +2,6 @@
 
 use std::collections::HashMap;
 
-use serde::ser::SerializeMap as _;
-
 use super::{
     dynamic_types::{DynamicClass, DynamicEnum, DynamicUnion},
     from_baml_value::FromBamlValue,
@@ -422,16 +420,14 @@ impl<'de, T: KnownTypes + serde::Deserialize<'de>, S: KnownTypes + serde::Deseri
                 Ok(Self::Value::Int(v))
             }
 
-            fn visit_u32<E: serde::de::Error>(self, v: u32) -> Result<Self::Value, E> {
-                Ok(Self::Value::Int(v as i64))
-            }
-
-            fn visit_u16<E: serde::de::Error>(self, v: u16) -> Result<Self::Value, E> {
-                Ok(Self::Value::Int(v as i64))
-            }
-
-            fn visit_u8<E: serde::de::Error>(self, v: u8) -> Result<Self::Value, E> {
-                Ok(Self::Value::Int(v as i64))
+            fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+                let v = i64::try_from(v).map_err(|_| {
+                    E::invalid_value(
+                        serde::de::Unexpected::Unsigned(v),
+                        &"a value fitting in an i64",
+                    )
+                })?;
+                Ok(Self::Value::Int(v))
             }
 
             fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Self::Value, E> {

--- a/languages/rust/baml/src/codec/baml_value.rs
+++ b/languages/rust/baml/src/codec/baml_value.rs
@@ -346,12 +346,7 @@ impl<T: KnownTypes + serde::Serialize, S: KnownTypes + serde::Serialize> serde::
             BamlValue::Map(map) => map.serialize(serializer),
             BamlValue::DynamicClass(dc) => dc.fields.serialize(serializer),
             BamlValue::DynamicEnum(de) => serializer.serialize_str(&de.value),
-            BamlValue::DynamicUnion(du) => {
-                // externally tagged union
-                let mut map = serializer.serialize_map(Some(1))?;
-                map.serialize_entry(&du.variant_name, &*du.value)?;
-                map.end()
-            }
+            BamlValue::DynamicUnion(du) => du.serialize(serializer),
             BamlValue::Known(known) => known.serialize(serializer),
             BamlValue::StreamKnown(known) => known.serialize(serializer),
             BamlValue::Checked(c) => c.serialize(serializer),

--- a/languages/rust/baml/src/codec/dynamic_types.rs
+++ b/languages/rust/baml/src/codec/dynamic_types.rs
@@ -151,10 +151,7 @@ impl<T: KnownTypes + serde::Serialize, S: KnownTypes + serde::Serialize> serde::
     for DynamicUnion<T, S>
 {
     fn serialize<Ser: serde::Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
-        // Using externally tagged union
-        let mut map = serializer.serialize_map(Some(1))?;
-        map.serialize_entry(&self.variant_name, &self.value)?;
-        map.end()
+        self.value.serialize(serializer)
     }
 }
 

--- a/languages/rust/baml/src/codec/dynamic_types.rs
+++ b/languages/rust/baml/src/codec/dynamic_types.rs
@@ -2,6 +2,9 @@
 
 use std::collections::HashMap;
 
+use serde::ser::SerializeMap as _;
+use serde::Serialize;
+
 use super::{
     baml_value::BamlValue, from_baml_value::FromBamlValue, from_baml_value_ref::FromBamlValueRef,
     known_types::KnownTypes,
@@ -84,6 +87,23 @@ impl<T: KnownTypes, S: KnownTypes> DynamicClass<T, S> {
     }
 }
 
+impl<T: KnownTypes + serde::Serialize, S: KnownTypes + serde::Serialize> serde::Serialize
+    for DynamicClass<T, S>
+{
+    fn serialize<Ser: serde::Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
+        self.fields.serialize(serializer)
+    }
+}
+impl<'de, T: KnownTypes + serde::Deserialize<'de>, S: KnownTypes + serde::Deserialize<'de>>
+    serde::Deserialize<'de> for DynamicClass<T, S>
+{
+    fn deserialize<D: serde::Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
+        Err(serde::de::Error::custom(
+            "DynamicClass cannot be deserialized as the class name is not known",
+        ))
+    }
+}
+
 /// A dynamic enum - name and value as strings
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DynamicEnum {
@@ -95,6 +115,20 @@ impl DynamicEnum {
     /// Get the enum name (e.g., "Sentiment", "Status").
     pub fn name(&self) -> &str {
         &self.name
+    }
+}
+
+impl Serialize for DynamicEnum {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.value)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for DynamicEnum {
+    fn deserialize<D: serde::Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
+        Err(serde::de::Error::custom(
+            "DynamicEnum cannot be deserialized as the enum name is not known",
+        ))
     }
 }
 
@@ -110,6 +144,27 @@ impl<T: KnownTypes, S: KnownTypes> DynamicUnion<T, S> {
     /// Get the union name (e.g., "`FooOrBar`", "`ResultOrError`").
     pub fn name(&self) -> &str {
         &self.name
+    }
+}
+
+impl<T: KnownTypes + serde::Serialize, S: KnownTypes + serde::Serialize> serde::Serialize
+    for DynamicUnion<T, S>
+{
+    fn serialize<Ser: serde::Serializer>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error> {
+        // Using externally tagged union
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry(&self.variant_name, &self.value)?;
+        map.end()
+    }
+}
+
+impl<'de, T: KnownTypes + serde::Deserialize<'de>, S: KnownTypes + serde::Deserialize<'de>>
+    serde::Deserialize<'de> for DynamicUnion<T, S>
+{
+    fn deserialize<D: serde::Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
+        Err(serde::de::Error::custom(
+            "DynamicUnion cannot be deserialized as the union name is not known",
+        ))
     }
 }
 

--- a/languages/rust/baml/src/lib.rs
+++ b/languages/rust/baml/src/lib.rs
@@ -103,7 +103,7 @@ pub mod __internal {
     pub use crate::{ffi::callbacks, proto::baml_cffi_v1::*};
     /// re-export
     pub use serde;
-
+    
     /// Decode a class from a `CffiValueHolder`.
     /// Used by derive macros to implement `BamlDecode` for structs.
     pub fn decode_class<T: BamlClass>(holder: &CffiValueHolder) -> Result<T, BamlError> {

--- a/languages/rust/baml/src/lib.rs
+++ b/languages/rust/baml/src/lib.rs
@@ -49,7 +49,7 @@ pub use args::{CancellationToken, FunctionArgs};
 // New dynamic type exports
 pub use async_stream::AsyncStreamingCall;
 // Re-export derive macros
-pub use baml_macros::{BamlDecode, BamlEncode};
+pub use baml_macros::{BamlDecode, BamlEncode, BamlSerde};
 pub use client_registry::ClientRegistry;
 pub use codec::{
     decode_enum, decode_field, encode_class, encode_class_dynamic, encode_enum, BamlClass,
@@ -101,6 +101,8 @@ pub use types::{Check, CheckStatus, Checked, StreamState, StreamingState};
 pub mod __internal {
     use crate::{codec::traits::BamlClass, error::BamlError};
     pub use crate::{ffi::callbacks, proto::baml_cffi_v1::*};
+    /// re-export
+    pub use serde;
 
     /// Decode a class from a `CffiValueHolder`.
     /// Used by derive macros to implement `BamlDecode` for structs.

--- a/languages/rust/baml/src/lib.rs
+++ b/languages/rust/baml/src/lib.rs
@@ -100,10 +100,14 @@ pub use types::{Check, CheckStatus, Checked, StreamState, StreamingState};
 #[doc(hidden)]
 pub mod __internal {
     use crate::{codec::traits::BamlClass, error::BamlError};
-    pub use crate::{ffi::callbacks, proto::baml_cffi_v1::*};
+    pub use crate::{
+        ffi::callbacks,
+        proto::baml_cffi_v1::*,
+        raw_objects::{BamlMediaRepr, BamlMediaReprContent},
+    };
     /// re-export
     pub use serde;
-    
+
     /// Decode a class from a `CffiValueHolder`.
     /// Used by derive macros to implement `BamlDecode` for structs.
     pub fn decode_class<T: BamlClass>(holder: &CffiValueHolder) -> Result<T, BamlError> {

--- a/languages/rust/baml/src/raw_objects/media.rs
+++ b/languages/rust/baml/src/raw_objects/media.rs
@@ -97,6 +97,17 @@ macro_rules! define_media_type {
                 ))
             }
         }
+
+        impl serde::Serialize for $name {
+            fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
+                Err(serde::ser::Error::custom(format!("Cannot serialize {}", stringify!($name))))
+            }
+        }
+        impl<'de> serde::Deserialize<'de> for $name {
+            fn deserialize<D: serde::Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
+                Err(serde::de::Error::custom(format!("Cannot deserialize {}", stringify!($name))))
+            }
+        }
     };
 }
 

--- a/languages/rust/baml/src/raw_objects/media.rs
+++ b/languages/rust/baml/src/raw_objects/media.rs
@@ -6,6 +6,7 @@ use std::ffi::c_void;
 
 use super::{RawObject, RawObjectTrait};
 use crate::{baml_unreachable, proto::baml_cffi_v1::BamlObjectType};
+use serde::{Deserialize, Serialize};
 
 // =============================================================================
 // Media type macro - generates Image, Audio, Pdf, Video
@@ -98,14 +99,32 @@ macro_rules! define_media_type {
             }
         }
 
+        impl From<&$name> for BamlMediaRepr {
+            fn from(media: &$name) -> Self {
+                let content = if let Some(base64) = media.as_base64() {
+                        BamlMediaReprContent::Base64 { base64 }
+                    } else if let Some(url) = media.as_url() {
+                        BamlMediaReprContent::Url { url }
+                    } else {
+                        panic!("Media cannot be serialized: was not URL or Base64");
+                    };
+                BamlMediaRepr {
+                    mime_type: media.mime_type(),
+                    content,
+                }
+            }
+        }
         impl serde::Serialize for $name {
-            fn serialize<S: serde::Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
-                Err(serde::ser::Error::custom(format!("Cannot serialize {}", stringify!($name))))
+            /// See https://github.com/BoundaryML/baml/blob/canary/engine/language_client_python/src/types/media_repr.rs
+            fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                let repr: BamlMediaRepr = self.into();
+                repr.serialize(serializer)
             }
         }
         impl<'de> serde::Deserialize<'de> for $name {
             fn deserialize<D: serde::Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
-                Err(serde::de::Error::custom(format!("Cannot deserialize {}", stringify!($name))))
+                // we don't have access to the runtime here
+                Err(serde::de::Error::custom(format!("Cannot deserialize {} directly", stringify!($name))))
             }
         }
     };
@@ -133,4 +152,23 @@ define_media_type! {
 define_media_type! {
     /// Video media type
     Video => ObjectMediaVideo
+}
+
+/// Used for serializing BAML media types in serde
+///
+/// See https://github.com/BoundaryML/baml/blob/canary/engine/language_client_python/src/types/media_repr.rs
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BamlMediaRepr {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "media_type")]
+    pub mime_type: Option<String>,
+    #[serde(flatten)]
+    pub content: BamlMediaReprContent,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BamlMediaReprContent {
+    Url { url: String },
+    Base64 { base64: String },
 }

--- a/languages/rust/baml/src/raw_objects/media.rs
+++ b/languages/rust/baml/src/raw_objects/media.rs
@@ -99,26 +99,23 @@ macro_rules! define_media_type {
             }
         }
 
-        impl From<&$name> for BamlMediaRepr {
-            fn from(media: &$name) -> Self {
-                let content = if let Some(base64) = media.as_base64() {
-                        BamlMediaReprContent::Base64 { base64 }
-                    } else if let Some(url) = media.as_url() {
-                        BamlMediaReprContent::Url { url }
-                    } else {
-                        panic!("Media cannot be serialized: was not URL or Base64");
-                    };
-                BamlMediaRepr {
-                    mime_type: media.mime_type(),
-                    content,
-                }
-            }
-        }
         impl serde::Serialize for $name {
             /// See https://github.com/BoundaryML/baml/blob/canary/engine/language_client_python/src/types/media_repr.rs
             fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-                let repr: BamlMediaRepr = self.into();
-                repr.serialize(serializer)
+                let content = if let Some(base64) = self.as_base64() {
+                    BamlMediaReprContent::Base64 { base64 }
+                } else if let Some(url) = self.as_url() {
+                    BamlMediaReprContent::Url { url }
+                } else {
+                    return Err(serde::ser::Error::custom(
+                        "media cannot be serialized: was not URL or base64",
+                    ));
+                };
+                BamlMediaRepr {
+                    mime_type: self.mime_type(),
+                    content,
+                }
+                .serialize(serializer)
             }
         }
         impl<'de> serde::Deserialize<'de> for $name {

--- a/languages/rust/baml/src/raw_objects/mod.rs
+++ b/languages/rust/baml/src/raw_objects/mod.rs
@@ -119,7 +119,7 @@ use std::{ffi::c_void, sync::Arc};
 pub use collector::{Collector, FunctionLog, LogType, StreamTiming, Timing, Usage};
 pub use http::{HTTPBody, HTTPRequest, HTTPResponse, SSEResponse};
 pub use llm_call::{LLMCall, LLMCallKind, LLMStreamCall};
-pub use media::{Audio, Image, Pdf, Video};
+pub use media::{Audio, Image, Pdf, Video, BamlMediaRepr, BamlMediaReprContent};
 use prost::Message;
 pub use type_builder::{
     ClassBuilder, ClassPropertyBuilder, EnumBuilder, EnumValueBuilder, TypeBuilder, TypeDef,

--- a/languages/rust/baml/src/types.rs
+++ b/languages/rust/baml/src/types.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::{
     codec::{BamlDecode, BamlEncode},
     error::BamlError,
@@ -7,7 +9,7 @@ use crate::{
 };
 
 /// Result of a @check constraint
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Checked<T> {
     pub value: T,
     pub checks: HashMap<String, Check>,
@@ -23,7 +25,7 @@ impl<T: Default> Default for Checked<T> {
 }
 
 /// Individual check result
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Check {
     pub name: String,
@@ -32,7 +34,7 @@ pub struct Check {
 }
 
 /// Status of a check constraint
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum CheckStatus {
     Succeeded,
@@ -113,14 +115,14 @@ impl<T> Checked<T> {
 }
 
 /// Streaming state wrapper for @`stream.with_state`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StreamState<T> {
     pub value: T,
     pub state: StreamingState,
 }
 
 /// Current streaming state
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StreamingState {
     Pending,


### PR DESCRIPTION
Added serde implementations to generated types for the Rust SDK, based on the JSON layout used in other SDKs:
- Classes are laid out normal objects, with dynamic fields at the same level (using `#[serde(flatten)]`
- Enums are represented as strings, including dynamic variants (using `#[serde(untagged)]` on the dynamic variant)
- Unions are represented un-tagged (using `#[serde(untagged)]` on the rust enum). This means that serialization+deserialization may be lossy, as the implementation will select the first valid variant for deserialization.

Some types cause errors if you try to deserialize:
- Streaming types cannot be deserialized, similar to how they do not have `BamlEncode` implemented.
- `Types` and `StreamTypes`, the two top-level enumerations of all generated types, cannot be deserialized due to too much ambiguity as to which variant to make: it will almost always be incorrect.
- `DynamicClass`, `DynamicEnum`, and `DynamicUnion` which are the fallback "fully dynamic" versions of these structures. Due to not knowing the associated `name`, we cannot deserialize to these types. Since these only seem to be used in `BamlValue`, and (as noted later) we never deserialize `BamlValue` to a variant containing any of these types, this should not be an issue unless a user directly tries to use one of these types.
- If you try to _directly_ deserialize media types they will error (since the `Deserialize` implementations in the `baml` crate cannot access the runtime directly). However, any time they appear as a field or union variant, we override the field/variant's deserializer to correctly deserialize the media (note: media deserialization could cause funny behavior if we are deserializing a union with multiple media types, where an image could be deserialized as an audio file, for example, due to lack of union disambiguation. Directly deserializing the types would not fix this).

While `BamlValue` does have `Deserialize` implemented, it will map all types into scalars, arrays, and maps. This means that dynamic types will often be typed incorrectly. However, since we do not have any type information on the dynamic types during deserialization, this is the best we can do here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated Rust types (classes, enums, unions, value containers, streams) now support broad JSON serialization and many deserialization paths.
  * Media objects (image, audio, PDF, video) accept URL or Base64 payloads and deserialize via runtime-backed handlers.
  * Dynamic fields are serialized/deserialized inline (flattened); streaming types gain serialization with explicit guards for ambiguous deserialization.

* **Tests**
  * Added extensive integration tests covering serde (de)serialization and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->