### PR TITLE
Propagate @stream.done to union variants for atomic list-item streaming

### DIFF
--- a/engine/baml-lib/baml-types/src/ir_type/converters/streaming.rs
+++ b/engine/baml-lib/baml-types/src/ir_type/converters/streaming.rs
@@ -123,6 +123,12 @@ pub fn from_type_ir(r#type: &TypeIR, lookup: &impl TypeLookups) -> TypeStreaming
                 let variants = union_type.iter_skip_null();
                 let variants = variants.into_iter().cloned().map(|mut t| {
                     t.meta_mut().streaming_behavior.needed = true;
+                    // If @stream.done is on the union, propagate it to variants.
+                    // This ensures variant classes use NonStreaming mode, preventing
+                    // incomplete objects from being coerced during streaming.
+                    if done {
+                        t.meta_mut().streaming_behavior.done = true;
+                    }
                     from_type_ir(&t, lookup)
                 });
 

--- a/engine/baml-lib/jsonish/src/tests/test_streaming.rs
+++ b/engine/baml-lib/jsonish/src/tests/test_streaming.rs
@@ -642,3 +642,118 @@ test_partial_deserializer_streaming!(
     TypeIR::class("Response"),
     {"content": "test value with {"}
 );
+
+// Regression test for Discord bug report: (T @stream.done)[] with union types
+// When using `(OutputItem @stream.done)[]` where OutputItem is a union of classes,
+// incomplete list items should be filtered out during streaming. Items should
+// only appear once they're fully complete.
+const UNION_STREAM_DONE_LIST: &str = r#"
+class ToolCall {
+  name string
+  parameters string
+}
+
+class ExampleMessage {
+  role string
+  content string
+}
+
+type OutputItem = ToolCall | ExampleMessage
+"#;
+
+// Test: An incomplete object in the list should be filtered out because the
+// union element type has @stream.done.
+test_partial_deserializer_streaming!(
+    test_union_stream_done_list_incomplete_item,
+    UNION_STREAM_DONE_LIST,
+    // First object complete, second object incomplete (no closing brace, missing field)
+    r#"[{"name": "get_weather", "parameters": "{}"}, {"name": "add_reminder"#,
+    {
+        let inner = {
+            let mut u = TypeIR::union(vec![
+                TypeIR::class("ToolCall"),
+                TypeIR::class("ExampleMessage"),
+            ]);
+            u.meta_mut().streaming_behavior.done = true;
+            u
+        };
+        TypeIR::List(Box::new(inner), Default::default())
+    },
+    // Only the first (complete) item should appear.
+    // The second item is incomplete and should be filtered out by @stream.done.
+    [{"name": "get_weather", "parameters": "{}"}]
+);
+
+// Test: A single incomplete object should result in an empty list.
+test_partial_deserializer_streaming!(
+    test_union_stream_done_list_all_incomplete,
+    UNION_STREAM_DONE_LIST,
+    // Single object, incomplete
+    r#"[{"name": "get_weather"#,
+    {
+        let inner = {
+            let mut u = TypeIR::union(vec![
+                TypeIR::class("ToolCall"),
+                TypeIR::class("ExampleMessage"),
+            ]);
+            u.meta_mut().streaming_behavior.done = true;
+            u
+        };
+        TypeIR::List(Box::new(inner), Default::default())
+    },
+    // No items should appear because the only item is incomplete.
+    []
+);
+
+// Test: All complete objects should appear normally.
+test_partial_deserializer_streaming!(
+    test_union_stream_done_list_all_complete,
+    UNION_STREAM_DONE_LIST,
+    r#"[{"name": "get_weather", "parameters": "{}"}, {"role": "assistant", "content": "hello world"}]"#,
+    {
+        let inner = {
+            let mut u = TypeIR::union(vec![
+                TypeIR::class("ToolCall"),
+                TypeIR::class("ExampleMessage"),
+            ]);
+            u.meta_mut().streaming_behavior.done = true;
+            u
+        };
+        TypeIR::List(Box::new(inner), Default::default())
+    },
+    [
+        {"name": "get_weather", "parameters": "{}"},
+        {"role": "assistant", "content": "hello world"}
+    ]
+);
+
+// Test: Classes with @@stream.done inside a list (the workaround that does work).
+const UNION_BLOCK_STREAM_DONE_LIST: &str = r#"
+class ToolCall {
+  name string
+  parameters string
+  @@stream.done
+}
+
+class ExampleMessage {
+  role string
+  content string
+  @@stream.done
+}
+
+type OutputItem = ToolCall | ExampleMessage
+"#;
+
+test_partial_deserializer_streaming!(
+    test_union_block_stream_done_list_incomplete,
+    UNION_BLOCK_STREAM_DONE_LIST,
+    r#"[{"name": "get_weather", "parameters": "{}"}, {"name": "add_reminder"#,
+    {
+        let inner = TypeIR::union(vec![
+            TypeIR::class("ToolCall"),
+            TypeIR::class("ExampleMessage"),
+        ]);
+        TypeIR::List(Box::new(inner), Default::default())
+    },
+    [{"name": "get_weather", "parameters": "{}"}]
+);

--- a/fern/01-guide/04-baml-basics/streaming.mdx
+++ b/fern/01-guide/04-baml-basics/streaming.mdx
@@ -851,6 +851,46 @@ class Person {
 }
 ```
 
+#### Atomic list items with union types
+
+A common pattern is streaming a list of items where each item can be one of
+several types (e.g. tool calls and messages). You can use `@stream.done` on
+the list element type to ensure each item only appears once it's fully complete:
+
+```baml
+class ToolCall {
+  name string
+  parameters string
+}
+
+class Message {
+  role string
+  content string
+}
+
+type OutputItem = ToolCall | Message
+
+// Each list element appears only when fully complete.
+// The list grows incrementally as items finish.
+function Run(input: string) -> (OutputItem @stream.done)[] {
+  client MyClient
+  prompt #"
+    {{ input }}
+    {{ ctx.output_format }}
+  "#
+}
+```
+
+When `@stream.done` is applied to a union type, it propagates to all variants.
+This means you don't need to add `@@stream.done` to each class individually —
+annotating the union is sufficient.
+
+<Tip>
+You can also achieve the same behavior by adding `@@stream.done` to each
+class in the union. The `(T @stream.done)[]` syntax is more concise when
+the classes are used in other contexts where you don't want `@@stream.done`.
+</Tip>
+
 ### `@stream.not_null`
 This attribute ensures a containing object is only streamed when this field has a value. It's particularly useful for discriminator fields or required metadata.
 


### PR DESCRIPTION
## Summary
- Fixes `(T @stream.done)[]` not filtering incomplete list items when `T` is a union type
- Propagates the `done` flag from Union to its variants in the streaming type converter, mirroring the existing behavior for List and Map inner types
- Adds 4 regression tests covering incomplete, all-incomplete, all-complete, and `@@stream.done` workaround scenarios

## Bug
When streaming a function returning `(OutputItem @stream.done)[]` where `OutputItem = ToolCall | ExampleMessage`, incomplete list items appeared with placeholder/null fields and updated later, instead of only appearing once fully complete.

**Root cause:** The streaming type converter (`streaming.rs`) propagated `done` from List → inner items and Map → keys/values, but did **not** propagate `done` from Union → variants. Without this, variant classes stayed in `Streaming` mode (optional fields), allowing incomplete JSON objects to be coerced successfully during streaming.

Bug report: https://discord.com/channels/1119368998161752075/1467029752606101660/1467190506990600242

## Test plan
- [x] Added `test_union_stream_done_list_incomplete_item` — incomplete 2nd item filtered out
- [x] Added `test_union_stream_done_list_all_incomplete` — all incomplete → empty list
- [x] Added `test_union_stream_done_list_all_complete` — all complete → all shown
- [x] Added `test_union_block_stream_done_list_incomplete` — `@@stream.done` workaround still works
- [x] All 471 existing jsonish tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed streaming behavior for union types annotated with `@stream.done`, ensuring incomplete union items in lists are correctly filtered out during streaming.

* **Tests**
  * Added regression and coverage tests for union-type streaming with `@stream.done` across multiple scenarios.

* **Documentation**
  * Added a "Atomic list items with union types" section explaining `@stream.done` propagation and usage examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->