### PR TITLE
Add int/float coercion for binary and comparison ops

### DIFF
--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1300,6 +1300,71 @@ impl BexVm {
                             })
                         }
 
+                        // Mixed int/float: promote int to float.
+                        #[allow(clippy::cast_precision_loss)]
+                        (Value::Int(left), Value::Float(right)) => {
+                            let left = left as f64;
+                            Value::Float(match op {
+                                BinOp::Div if right == 0.0 => {
+                                    return Err(RuntimeError::DivisionByZero {
+                                        left: Value::Float(left),
+                                        right: Value::Float(right),
+                                    }
+                                    .into());
+                                }
+
+                                BinOp::Add => left + right,
+                                BinOp::Sub => left - right,
+                                BinOp::Mul => left * right,
+                                BinOp::Div => left / right,
+                                BinOp::Mod => left % right,
+
+                                BinOp::BitAnd
+                                | BinOp::BitOr
+                                | BinOp::BitXor
+                                | BinOp::Shl
+                                | BinOp::Shr => {
+                                    return Err(VmError::from(InternalError::CannotApplyBinOp {
+                                        left: Type::Int,
+                                        right: Type::Float,
+                                        op,
+                                    }));
+                                }
+                            })
+                        }
+
+                        #[allow(clippy::cast_precision_loss)]
+                        (Value::Float(left), Value::Int(right)) => {
+                            let right = right as f64;
+                            Value::Float(match op {
+                                BinOp::Div if right == 0.0 => {
+                                    return Err(RuntimeError::DivisionByZero {
+                                        left: Value::Float(left),
+                                        right: Value::Float(right),
+                                    }
+                                    .into());
+                                }
+
+                                BinOp::Add => left + right,
+                                BinOp::Sub => left - right,
+                                BinOp::Mul => left * right,
+                                BinOp::Div => left / right,
+                                BinOp::Mod => left % right,
+
+                                BinOp::BitAnd
+                                | BinOp::BitOr
+                                | BinOp::BitXor
+                                | BinOp::Shl
+                                | BinOp::Shr => {
+                                    return Err(VmError::from(InternalError::CannotApplyBinOp {
+                                        left: Type::Float,
+                                        right: Type::Int,
+                                        op,
+                                    }));
+                                }
+                            })
+                        }
+
                         (Value::Object(_), Value::Object(_)) if op == BinOp::Add => {
                             let left = self.as_string(&left)?;
                             let right = self.as_string(&right)?;
@@ -1364,6 +1429,51 @@ impl BexVm {
                                 .into());
                             }
                         }),
+
+                        // Mixed int/float comparisons: promote int to float.
+                        #[allow(clippy::cast_precision_loss, clippy::float_cmp)]
+                        (Value::Int(left), Value::Float(right)) => {
+                            let left = left as f64;
+                            Value::Bool(match op {
+                                CmpOp::Eq => left == right,
+                                CmpOp::NotEq => left != right,
+                                CmpOp::Lt => left < right,
+                                CmpOp::LtEq => left <= right,
+                                CmpOp::Gt => left > right,
+                                CmpOp::GtEq => left >= right,
+
+                                CmpOp::InstanceOf => {
+                                    return Err(InternalError::CannotApplyCmpOp {
+                                        left: Type::Int,
+                                        right: Type::Float,
+                                        op,
+                                    }
+                                    .into());
+                                }
+                            })
+                        }
+
+                        #[allow(clippy::cast_precision_loss, clippy::float_cmp)]
+                        (Value::Float(left), Value::Int(right)) => {
+                            let right = right as f64;
+                            Value::Bool(match op {
+                                CmpOp::Eq => left == right,
+                                CmpOp::NotEq => left != right,
+                                CmpOp::Lt => left < right,
+                                CmpOp::LtEq => left <= right,
+                                CmpOp::Gt => left > right,
+                                CmpOp::GtEq => left >= right,
+
+                                CmpOp::InstanceOf => {
+                                    return Err(InternalError::CannotApplyCmpOp {
+                                        left: Type::Float,
+                                        right: Type::Int,
+                                        op,
+                                    }
+                                    .into());
+                                }
+                            })
+                        }
 
                         (Value::Object(left_index), Value::Object(right_index))
                             if matches!(self.get_object(left_index), Object::String(_))


### PR DESCRIPTION
## Summary
- The type checker already allows mixed int/float operations (e.g. `int * float → float`), but the VM was missing match arms for these cases, causing runtime errors
- Adds int-to-f64 promotion for `BinOp` (+, -, *, /, %) and `CmpOp` (==, !=, <, <=, >, >=) with mixed int/float operands
- Bitwise ops on mixed int/float correctly error (same as float/float)

## Test plan
- [x] All 260 existing bex_vm tests pass
- [x] Clippy clean with `-D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integer and floating-point values can now be used together in arithmetic operations, with automatic promotion to floating-point calculations.
  * Integer and floating-point values can now be directly compared, with automatic type promotion for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->