### PR TITLE
Add InitLocals instruction for bulk local initialization

### DIFF
--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -291,10 +291,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
 
         // Pre-allocate only the real locals (not virtuals)
         if slots_to_allocate > 0 {
-            let null_idx = self.add_constant(ConstValue::Null);
-            for _ in 0..slots_to_allocate {
-                self.emit(Instruction::LoadConst(null_idx));
-            }
+            self.emit(Instruction::InitLocals(slots_to_allocate));
         }
     }
 

--- a/baml_language/crates/baml_compiler_emit/tests/classes.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/classes.rs
@@ -93,7 +93,7 @@ fn class_constructor_with_spread_operator() -> anyhow::Result<()> {
             // All fields come from the spread (last assignment wins).
             // Spread is stored to temp local, then accessed for each field.
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadGlobal(Value::function("default_point")),
                 Instruction::Call(0),
                 Instruction::StoreVar("_2".to_string()),
@@ -141,7 +141,7 @@ fn nested_class_construction() -> anyhow::Result<()> {
             // Stackification with fall-through elimination:
             // o is assigned but never read (dead store)
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::AllocInstance(Value::class("Outer")),
                 Instruction::Copy(0),
                 Instruction::AllocInstance(Value::class("Inner")),
@@ -183,7 +183,7 @@ fn nested_class_with_multiple_fields() -> anyhow::Result<()> {
             // Stackification with fall-through elimination:
             // o is assigned but never read (dead store)
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::AllocInstance(Value::class("Outer")),
                 Instruction::Copy(0),
                 Instruction::AllocInstance(Value::class("Inner")),
@@ -298,7 +298,7 @@ fn class_constructor_with_spread_before_named_fields() -> anyhow::Result<()> {
             // Spread is at position 0, named fields x,y at positions 1,2.
             // x and y from named (override spread), z and w from spread.
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadGlobal(Value::function("default_point")),
                 Instruction::Call(0),
                 Instruction::StoreVar("_2".to_string()),
@@ -348,7 +348,7 @@ fn class_constructor_with_spread_after_named_fields() -> anyhow::Result<()> {
             // Spread at position 2 overrides named fields at positions 0,1.
             // All fields from spread.
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadGlobal(Value::function("default_point")),
                 Instruction::Call(0),
                 Instruction::StoreVar("_2".to_string()),
@@ -410,7 +410,7 @@ fn class_constructor_with_multiple_spread_operators() -> anyhow::Result<()> {
                 // ...x_one() at pos 0, ...xy_one() at pos 1
                 // xy_one wins for all fields; x_one called but result popped (unused)
                 vec![
-                    Instruction::LoadConst(Value::Null),
+                    Instruction::InitLocals(1),
                     Instruction::LoadGlobal(Value::function("x_one")),
                     Instruction::Call(0),
                     Instruction::Pop(1),
@@ -442,7 +442,7 @@ fn class_constructor_with_multiple_spread_operators() -> anyhow::Result<()> {
                 // ...xy_one() at pos 0, ...x_one() at pos 1
                 // x_one wins for all fields; xy_one called but result popped (unused)
                 vec![
-                    Instruction::LoadConst(Value::Null),
+                    Instruction::InitLocals(1),
                     Instruction::LoadGlobal(Value::function("xy_one")),
                     Instruction::Call(0),
                     Instruction::Pop(1),
@@ -500,8 +500,7 @@ fn class_constructor_with_spread_operator_does_not_break_locals() -> anyhow::Res
             // 'p' is assigned but never used (dead store, but still generated).
             // 'x' is a constant, inlined.
             vec![
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(2),
                 Instruction::LoadGlobal(Value::function("default_point")),
                 Instruction::Call(0),
                 Instruction::StoreVar("_2".to_string()),

--- a/baml_language/crates/baml_compiler_emit/tests/for_loops.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/for_loops.rs
@@ -31,10 +31,7 @@ fn for_loop_sum() -> anyhow::Result<()> {
             // Note: _iter is eliminated by copy propagation (uses xs directly)
             vec![
                 // Pre-allocate locals (4: result, _len, _i, x)
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(4),
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
@@ -100,10 +97,7 @@ fn for_with_break() -> anyhow::Result<()> {
             // Note: _iter is eliminated by copy propagation (uses xs directly)
             vec![
                 // Pre-allocate locals (4: result, _len, _i, x)
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(4),
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
@@ -175,10 +169,7 @@ fn for_with_continue() -> anyhow::Result<()> {
             // Note: _iter is eliminated by copy propagation (uses xs directly)
             vec![
                 // Pre-allocate locals (4: result, _len, _i, x)
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(4),
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
@@ -253,13 +244,7 @@ fn for_nested() -> anyhow::Result<()> {
             // Note: _iter and _iter1 are eliminated by copy propagation (use params directly)
             vec![
                 // Pre-allocate locals (7: result, _len, _i, a, _len1, _i1, b)
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(7),
                 // Initialize result = 0
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),

--- a/baml_language/crates/baml_compiler_emit/tests/if_else.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/if_else.rs
@@ -511,7 +511,7 @@ fn parenthesized_if_else_in_arithmetic() -> anyhow::Result<()> {
             // Phi-like optimization: second if-else result stays on stack.
             // First if-else (_1) needs Store/Load because second if-else is computed before use.
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::PopJumpIfFalse(2),
                 Instruction::Jump(4),
@@ -547,7 +547,7 @@ fn chained_if_else_in_arithmetic() -> anyhow::Result<()> {
             // Phi-like optimization: second if-else result stays on stack.
             // First if-else (_1) needs Store/Load because second if-else is computed before use.
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::PopJumpIfFalse(2),
                 Instruction::Jump(4),
@@ -616,7 +616,7 @@ fn if_without_else_statement() -> anyhow::Result<()> {
             // Stackification with fall-through elimination:
             // if-without-else is void - no temporary needed
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("x".to_string()),
                 Instruction::LoadConst(Value::Bool(true)),
@@ -650,7 +650,7 @@ fn if_without_else_with_local_var() -> anyhow::Result<()> {
             "main",
             // 'result' is Virtual (single-use, inlined as 0). 'temp' is Real (assigned but unused):
             vec![
-                Instruction::LoadConst(Value::Null), // Pre-allocate for 'temp'
+                Instruction::InitLocals(1), // Pre-allocate for 'temp'
                 Instruction::LoadConst(Value::Bool(true)),
                 Instruction::PopJumpIfFalse(2),
                 Instruction::Jump(2),
@@ -707,7 +707,7 @@ fn consecutive_if_without_else() -> anyhow::Result<()> {
             // Stackification with fall-through elimination:
             // Both if-without-else are void - no temporaries needed
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("x".to_string()),
                 Instruction::LoadConst(Value::Bool(true)),
@@ -821,8 +821,7 @@ fn if_else_normal_statement() -> anyhow::Result<()> {
             // Only unused user-named variables (x in else, y in then) need slots
             vec![
                 // Pre-allocate 2 slots for unused user-named variables
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(2),
                 // Check condition b
                 Instruction::LoadVar("b".to_string()),
                 Instruction::PopJumpIfFalse(2),
@@ -910,7 +909,7 @@ fn else_if_assignment() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate result
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 // Check condition a
                 Instruction::LoadVar("a".to_string()),
                 Instruction::PopJumpIfFalse(2),
@@ -963,7 +962,7 @@ fn else_if_assignment_with_locals() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate result
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 // Check condition a
                 Instruction::LoadVar("a".to_string()),
                 Instruction::PopJumpIfFalse(2),
@@ -1017,7 +1016,7 @@ fn nested_block_expr_with_ending_normal_if() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate a
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 // a = 1
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("a".to_string()),

--- a/baml_language/crates/baml_compiler_emit/tests/maps.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/maps.rs
@@ -114,7 +114,7 @@ fn contains() -> anyhow::Result<()> {
                 "UseMapContains",
                 vec![
                     // Init local for map (return value is PhiLike, _3 is CallResultImmediate)
-                    Instruction::LoadConst(Value::Null),
+                    Instruction::InitLocals(1),
                     // let map = CreateMapJSON();
                     Instruction::LoadGlobal(Value::function("CreateMapJSON")),
                     Instruction::Call(0),
@@ -159,7 +159,7 @@ fn modify() -> anyhow::Result<()> {
             "EditMapKey",
             vec![
                 // Init local for map (return value is ReturnPhi, no slot needed)
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 // let map = { "hi": 123 }; (values first, then keys)
                 Instruction::LoadConst(Value::Int(123)),
                 Instruction::LoadConst(Value::string("hi")),

--- a/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/match_expr.rs
@@ -180,7 +180,7 @@ fn match_typed_pattern_single_class() -> anyhow::Result<()> {
             // Wildcard elimination: _ binding is unused so eliminated
             // Scrutinee optimization: result is reused directly (no temp created)
             vec![
-                Instruction::LoadConst(Value::Null), // slot for result
+                Instruction::InitLocals(1), // slot for result
                 // let result = Success { data: "hello" }
                 Instruction::AllocInstance(Value::class("Success")),
                 Instruction::Copy(0),
@@ -231,7 +231,7 @@ fn match_typed_pattern_two_classes() -> anyhow::Result<()> {
             // because else_block is unreachable (we know it must be Failure)
             // Scrutinee optimization: result is reused directly (no temp created)
             vec![
-                Instruction::LoadConst(Value::Null), // slot for result
+                Instruction::InitLocals(1), // slot for result
                 // let result = Success { data: "ok" }
                 Instruction::AllocInstance(Value::class("Success")),
                 Instruction::Copy(0),

--- a/baml_language/crates/baml_compiler_emit/tests/operators.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/operators.rs
@@ -101,7 +101,7 @@ fn basic_assign_add() -> anyhow::Result<()> {
             // x is Real (used 3 times: init, compound assign read, return)
             // Compound assignment x += 2 expands to x = x + 2
             vec![
-                Instruction::LoadConst(Value::Null), // slot for x
+                Instruction::InitLocals(1), // slot for x
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("x".to_string()), // let x = 1
                 Instruction::LoadVar("x".to_string()),  // read x

--- a/baml_language/crates/baml_compiler_emit/tests/watch.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/watch.rs
@@ -22,7 +22,7 @@ fn watch_primitive() -> anyhow::Result<()> {
             "primitive",
             vec![
                 // Initialize locals with null (only "value" needs a slot now, _0 is ReturnPhi)
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 // Initialize watched variable
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("value".to_string()),
@@ -96,7 +96,7 @@ fn viz_header_before_while_emits_viz_enter_exit() -> anyhow::Result<()> {
         expected: vec![(
             "header_before_while",
             vec![
-                Instruction::LoadConst(Value::Null),   // local x init
+                Instruction::InitLocals(1),            // local x init
                 Instruction::LoadConst(Value::Int(0)), // x = 0
                 Instruction::StoreVar("x".to_string()),
                 Instruction::NotifyBlock(0), // //# LoopHeader

--- a/baml_language/crates/baml_compiler_emit/tests/while_loops.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/while_loops.rs
@@ -87,7 +87,7 @@ fn while_loop_with_ending_if() -> anyhow::Result<()> {
             // Stackification with dead store elimination:
             // a is user variable, dead compiler temps (_5 for if result) are eliminated
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("a".to_string()),
                 Instruction::LoadVar("a".to_string()),
@@ -134,7 +134,7 @@ fn while_loop_with_break() -> anyhow::Result<()> {
             // Stackification with dead store elimination:
             // a is user variable, dead compiler temps (_5 for if result) are eliminated
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("a".to_string()),
                 Instruction::LoadVar("a".to_string()),
@@ -181,7 +181,7 @@ fn break_factorial() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate result local
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 // Initialize result = 1
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("result".to_string()),
@@ -242,8 +242,7 @@ fn continue_factorial() -> anyhow::Result<()> {
             // MIR-based codegen with local pre-allocation
             vec![
                 // Pre-allocate locals
-                Instruction::LoadConst(Value::Null),
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(2),
                 // Initialize result = 1
                 Instruction::LoadConst(Value::Int(1)),
                 Instruction::StoreVar("result".to_string()),
@@ -347,7 +346,7 @@ fn break_nested() -> anyhow::Result<()> {
             // Stackification with dead store elimination:
             // a is user variable, dead compiler temps are eliminated
             vec![
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(5)),
                 Instruction::StoreVar("a".to_string()),
                 Instruction::LoadConst(Value::Bool(true)),
@@ -398,7 +397,7 @@ fn break_nested_with_variable_conditions() -> anyhow::Result<()> {
             "Nested",
             vec![
                 // let a = 5
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(5)),
                 Instruction::StoreVar("a".to_string()),
                 // outer while (x) - condition check
@@ -451,7 +450,7 @@ fn while_loop_with_conditional_break() -> anyhow::Result<()> {
             "CountDown",
             vec![
                 // let result = 0
-                Instruction::LoadConst(Value::Null),
+                Instruction::InitLocals(1),
                 Instruction::LoadConst(Value::Int(0)),
                 Instruction::StoreVar("result".to_string()),
                 // while (true) - condition

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
@@ -8,122 +8,111 @@ Objects: 62
 Globals: 50
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -38,122 +38,111 @@ Function GetUser (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
@@ -8,29 +8,28 @@ Objects: 82
 Globals: 61
 
 Function ChainCommands (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_GLOBAL 26      (<fn baml.sys.shell>)
-     3    LOAD_CONST 1        ("pwd")
-     4    DISPATCH_FUTURE 1   
-     5    AWAIT               
-     6    STORE_VAR 1         (result1)
-     7    LOAD_GLOBAL 26      (<fn baml.sys.shell>)
-     8    LOAD_CONST 2        ("whoami")
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 2         (result2)
-     12   LOAD_VAR 1          (result1)
-     13   LOAD_CONST 3        (" - ")
-     14   BIN_OP +            
-     15   LOAD_VAR 2          (result2)
-     16   BIN_OP +            
-     17   RETURN              
+     0    INIT_LOCALS 2       
+     1    LOAD_GLOBAL 26      (<fn baml.sys.shell>)
+     2    LOAD_CONST 0        ("pwd")
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 1         (result1)
+     6    LOAD_GLOBAL 26      (<fn baml.sys.shell>)
+     7    LOAD_CONST 1        ("whoami")
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   STORE_VAR 2         (result2)
+     11   LOAD_VAR 1          (result1)
+     12   LOAD_CONST 2        (" - ")
+     13   BIN_OP +            
+     14   LOAD_VAR 2          (result2)
+     15   BIN_OP +            
+     16   RETURN              
 
 Function ConnectAndRead (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
+     0    INIT_LOCALS 1       
      1    LOAD_GLOBAL 29      (<fn baml.net.connect>)
-     2    LOAD_CONST 1        ("127.0.0.1:8080")
+     2    LOAD_CONST 0        ("127.0.0.1:8080")
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 1         (sock)
@@ -41,9 +40,9 @@ Function ConnectAndRead (arity: 0, kind: Bytecode):
      10   RETURN              
 
 Function ConnectAndReadInline (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
+     0    INIT_LOCALS 1       
      1    LOAD_GLOBAL 29      (<fn baml.net.connect>)
-     2    LOAD_CONST 1        ("localhost:3000")
+     2    LOAD_CONST 0        ("localhost:3000")
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 1         (_1)
@@ -54,81 +53,76 @@ Function ConnectAndReadInline (arity: 0, kind: Bytecode):
      10   RETURN              
 
 Function ConnectReadAndClose (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_GLOBAL 29      (<fn baml.net.connect>)
-     3    LOAD_CONST 1        ("127.0.0.1:8080")
-     4    DISPATCH_FUTURE 1   
-     5    AWAIT               
-     6    STORE_VAR 1         (sock)
-     7    LOAD_GLOBAL 27      (<fn baml.net.Socket.read>)
-     8    LOAD_VAR 1          (sock)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 2         (data)
-     12   LOAD_GLOBAL 28      (<fn baml.net.Socket.close>)
-     13   LOAD_VAR 1          (sock)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   POP 1               
-     17   LOAD_VAR 2          (data)
-     18   RETURN              
+     0    INIT_LOCALS 2       
+     1    LOAD_GLOBAL 29      (<fn baml.net.connect>)
+     2    LOAD_CONST 0        ("127.0.0.1:8080")
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 1         (sock)
+     6    LOAD_GLOBAL 27      (<fn baml.net.Socket.read>)
+     7    LOAD_VAR 1          (sock)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   STORE_VAR 2         (data)
+     11   LOAD_GLOBAL 28      (<fn baml.net.Socket.close>)
+     12   LOAD_VAR 1          (sock)
+     13   DISPATCH_FUTURE 1   
+     14   AWAIT               
+     15   POP 1               
+     16   LOAD_VAR 2          (data)
+     17   RETURN              
 
 Function MultipleConnections (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 29      (<fn baml.net.connect>)
-     5    LOAD_CONST 1        ("server1:80")
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 1         (s1)
-     9    LOAD_GLOBAL 29      (<fn baml.net.connect>)
-     10   LOAD_CONST 2        ("server2:80")
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   STORE_VAR 2         (s2)
-     14   LOAD_GLOBAL 27      (<fn baml.net.Socket.read>)
-     15   LOAD_VAR 1          (s1)
-     16   DISPATCH_FUTURE 1   
-     17   AWAIT               
-     18   STORE_VAR 3         (data1)
-     19   LOAD_GLOBAL 27      (<fn baml.net.Socket.read>)
-     20   LOAD_VAR 2          (s2)
-     21   DISPATCH_FUTURE 1   
-     22   AWAIT               
-     23   STORE_VAR 4         (data2)
-     24   LOAD_VAR 3          (data1)
-     25   LOAD_VAR 4          (data2)
-     26   BIN_OP +            
-     27   RETURN              
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 29      (<fn baml.net.connect>)
+     2    LOAD_CONST 0        ("server1:80")
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 1         (s1)
+     6    LOAD_GLOBAL 29      (<fn baml.net.connect>)
+     7    LOAD_CONST 1        ("server2:80")
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   STORE_VAR 2         (s2)
+     11   LOAD_GLOBAL 27      (<fn baml.net.Socket.read>)
+     12   LOAD_VAR 1          (s1)
+     13   DISPATCH_FUTURE 1   
+     14   AWAIT               
+     15   STORE_VAR 3         (data1)
+     16   LOAD_GLOBAL 27      (<fn baml.net.Socket.read>)
+     17   LOAD_VAR 2          (s2)
+     18   DISPATCH_FUTURE 1   
+     19   AWAIT               
+     20   STORE_VAR 4         (data2)
+     21   LOAD_VAR 3          (data1)
+     22   LOAD_VAR 4          (data2)
+     23   BIN_OP +            
+     24   RETURN              
 
 Function ReadAndClose (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_GLOBAL 25      (<fn baml.fs.open>)
-     3    LOAD_CONST 1        ("example.txt")
-     4    DISPATCH_FUTURE 1   
-     5    AWAIT               
-     6    STORE_VAR 1         (f)
-     7    LOAD_GLOBAL 23      (<fn baml.fs.File.read>)
-     8    LOAD_VAR 1          (f)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 2         (content)
-     12   LOAD_GLOBAL 24      (<fn baml.fs.File.close>)
-     13   LOAD_VAR 1          (f)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   POP 1               
-     17   LOAD_VAR 2          (content)
-     18   RETURN              
+     0    INIT_LOCALS 2       
+     1    LOAD_GLOBAL 25      (<fn baml.fs.open>)
+     2    LOAD_CONST 0        ("example.txt")
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 1         (f)
+     6    LOAD_GLOBAL 23      (<fn baml.fs.File.read>)
+     7    LOAD_VAR 1          (f)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   STORE_VAR 2         (content)
+     11   LOAD_GLOBAL 24      (<fn baml.fs.File.close>)
+     12   LOAD_VAR 1          (f)
+     13   DISPATCH_FUTURE 1   
+     14   AWAIT               
+     15   POP 1               
+     16   LOAD_VAR 2          (content)
+     17   RETURN              
 
 Function ReadFile (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
+     0    INIT_LOCALS 1       
      1    LOAD_GLOBAL 25      (<fn baml.fs.open>)
-     2    LOAD_CONST 1        ("example.txt")
+     2    LOAD_CONST 0        ("example.txt")
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 1         (f)
@@ -139,9 +133,9 @@ Function ReadFile (arity: 0, kind: Bytecode):
      10   RETURN              
 
 Function ReadFileInline (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
+     0    INIT_LOCALS 1       
      1    LOAD_GLOBAL 25      (<fn baml.fs.open>)
-     2    LOAD_CONST 1        ("data.json")
+     2    LOAD_CONST 0        ("data.json")
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 1         (_1)
@@ -152,34 +146,31 @@ Function ReadFileInline (arity: 0, kind: Bytecode):
      10   RETURN              
 
 Function ReadMultipleFiles (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 25      (<fn baml.fs.open>)
-     5    LOAD_CONST 1        ("file1.txt")
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 1         (f1)
-     9    LOAD_GLOBAL 25      (<fn baml.fs.open>)
-     10   LOAD_CONST 2        ("file2.txt")
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   STORE_VAR 2         (f2)
-     14   LOAD_GLOBAL 23      (<fn baml.fs.File.read>)
-     15   LOAD_VAR 1          (f1)
-     16   DISPATCH_FUTURE 1   
-     17   AWAIT               
-     18   STORE_VAR 3         (content1)
-     19   LOAD_GLOBAL 23      (<fn baml.fs.File.read>)
-     20   LOAD_VAR 2          (f2)
-     21   DISPATCH_FUTURE 1   
-     22   AWAIT               
-     23   STORE_VAR 4         (content2)
-     24   LOAD_VAR 3          (content1)
-     25   LOAD_VAR 4          (content2)
-     26   BIN_OP +            
-     27   RETURN              
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 25      (<fn baml.fs.open>)
+     2    LOAD_CONST 0        ("file1.txt")
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 1         (f1)
+     6    LOAD_GLOBAL 25      (<fn baml.fs.open>)
+     7    LOAD_CONST 1        ("file2.txt")
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   STORE_VAR 2         (f2)
+     11   LOAD_GLOBAL 23      (<fn baml.fs.File.read>)
+     12   LOAD_VAR 1          (f1)
+     13   DISPATCH_FUTURE 1   
+     14   AWAIT               
+     15   STORE_VAR 3         (content1)
+     16   LOAD_GLOBAL 23      (<fn baml.fs.File.read>)
+     17   LOAD_VAR 2          (f2)
+     18   DISPATCH_FUTURE 1   
+     19   AWAIT               
+     20   STORE_VAR 4         (content2)
+     21   LOAD_VAR 3          (content1)
+     22   LOAD_VAR 4          (content2)
+     23   BIN_OP +            
+     24   RETURN              
 
 Function RunCommand (arity: 0, kind: Bytecode):
      0   LOAD_GLOBAL 26      (<fn baml.sys.shell>)
@@ -196,122 +187,111 @@ Function RunCommandWithVar (arity: 0, kind: Bytecode):
      4   RETURN              
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
@@ -8,152 +8,141 @@ Objects: 71
 Globals: 51
 
 Function OpenRouterMistralSmall3_1_24b.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
+     0    INIT_LOCALS 1       
      1    LOAD_GLOBAL 42      (<fn env.get_or_panic>)
-     2    LOAD_CONST 1        ("OPENROUTER_API_KEY")
+     2    LOAD_CONST 0        ("OPENROUTER_API_KEY")
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 1         (_13)
      6    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
-     7    LOAD_CONST 2        ("OpenRouterMistralSmall3_1_24b")
-     8    LOAD_CONST 3        ("unknown")
-     9    LOAD_CONST 4        ("user")
-     10   LOAD_CONST 5        ("user")
-     11   LOAD_CONST 6        ("assistant")
-     12   LOAD_CONST 7        ("system")
+     7    LOAD_CONST 1        ("OpenRouterMistralSmall3_1_24b")
+     8    LOAD_CONST 2        ("unknown")
+     9    LOAD_CONST 3        ("user")
+     10   LOAD_CONST 4        ("user")
+     11   LOAD_CONST 5        ("assistant")
+     12   LOAD_CONST 6        ("system")
      13   ALLOC_ARRAY 3       
-     14   LOAD_CONST 8        ("https://openrouter.ai/api/v1")
+     14   LOAD_CONST 7        ("https://openrouter.ai/api/v1")
      15   LOAD_VAR 1          (_13)
-     16   LOAD_CONST 9        ("mistralai/mistral-small-3.1-24b-instruct")
-     17   LOAD_CONST 10       (0.1)
+     16   LOAD_CONST 8        ("mistralai/mistral-small-3.1-24b-instruct")
+     17   LOAD_CONST 9        (0.1)
      18   ALLOC_MAP 0         
-     19   LOAD_CONST 11       ("base_url")
-     20   LOAD_CONST 12       ("api_key")
-     21   LOAD_CONST 13       ("model")
-     22   LOAD_CONST 14       ("temperature")
-     23   LOAD_CONST 15       ("headers")
+     19   LOAD_CONST 10       ("base_url")
+     20   LOAD_CONST 11       ("api_key")
+     21   LOAD_CONST 12       ("model")
+     22   LOAD_CONST 13       ("temperature")
+     23   LOAD_CONST 14       ("headers")
      24   ALLOC_MAP 5         
      25   DISPATCH_FUTURE 5   
      26   AWAIT               
      27   RETURN              
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -40,122 +40,111 @@ Function TestClient.resolve (arity: 0, kind: Bytecode):
      11   RETURN              
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
@@ -100,122 +100,111 @@ Function MyClient.resolve (arity: 0, kind: Bytecode):
      85   RETURN              
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
@@ -8,122 +8,111 @@ Objects: 58
 Globals: 50
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
@@ -47,125 +47,114 @@ Function array_length (arity: 0, kind: Bytecode):
      6   RETURN          
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN              
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN              
 
 Function param_in_if_statement (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1             (b)

--- a/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
@@ -12,122 +12,111 @@ Function GetTransform (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -15,122 +15,111 @@ Function GetUser (arity: 0, kind: Bytecode):
      4   RETURN           
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -33,122 +33,111 @@ Function VertexGCP.resolve (arity: 0, kind: Bytecode):
      13   RETURN              
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
@@ -48,73 +48,70 @@ Function HeadersAndComments (arity: 0, kind: Bytecode):
      4   RETURN           
 
 Function HeadersAroundExpressions (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 0           (null)
-     3    LOAD_CONST 0           (null)
-     4    NOTIFY_BLOCK 0         (BeforeLet)
-     5    NOTIFY_BLOCK 1         (AfterLet)
-     6    NOTIFY_BLOCK 2         (BeforeIf)
-     7    VIZ_ENTER 0            (BeforeIf)
-     8    LOAD_CONST 1           (5)
-     9    LOAD_CONST 2           (0)
-     10   CMP_OP >               
-     11   POP_JUMP_IF_FALSE +2   (to 13)
-     12   JUMP +3                (to 15)
-     13   NOTIFY_BLOCK 3         (InsideElse)
-     14   JUMP +2                (to 16)
-     15   NOTIFY_BLOCK 4         (InsideIf)
-     16   VIZ_EXIT 0             (BeforeIf)
-     17   NOTIFY_BLOCK 5         (AfterIf)
-     18   NOTIFY_BLOCK 6         (BeforeFor)
-     19   LOAD_CONST 3           (1)
-     20   LOAD_CONST 4           (2)
-     21   LOAD_CONST 5           (3)
-     22   ALLOC_ARRAY 3          
-     23   STORE_VAR 1            (_iter)
-     24   LOAD_GLOBAL 0          (<fn baml.Array.length>)
-     25   LOAD_VAR 1             (_iter)
-     26   CALL 1                 
-     27   STORE_VAR 2            (_len)
-     28   LOAD_CONST 2           (0)
-     29   STORE_VAR 3            (_i)
-     30   VIZ_ENTER 1            (BeforeFor)
-     31   LOAD_VAR 3             (_i)
-     32   LOAD_VAR 2             (_len)
-     33   CMP_OP <               
-     34   POP_JUMP_IF_FALSE +2   (to 36)
-     35   JUMP +6                (to 41)
-     36   VIZ_EXIT 1             (BeforeFor)
-     37   NOTIFY_BLOCK 7         (AfterFor)
-     38   NOTIFY_BLOCK 8         (FinalSection)
-     39   LOAD_CONST 1           (5)
-     40   RETURN                 
-     41   LOAD_VAR 1             (_iter)
+     0    INIT_LOCALS 4          
+     1    NOTIFY_BLOCK 0         (BeforeLet)
+     2    NOTIFY_BLOCK 1         (AfterLet)
+     3    NOTIFY_BLOCK 2         (BeforeIf)
+     4    VIZ_ENTER 0            (BeforeIf)
+     5    LOAD_CONST 0           (5)
+     6    LOAD_CONST 1           (0)
+     7    CMP_OP >               
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +3                (to 12)
+     10   NOTIFY_BLOCK 3         (InsideElse)
+     11   JUMP +2                (to 13)
+     12   NOTIFY_BLOCK 4         (InsideIf)
+     13   VIZ_EXIT 0             (BeforeIf)
+     14   NOTIFY_BLOCK 5         (AfterIf)
+     15   NOTIFY_BLOCK 6         (BeforeFor)
+     16   LOAD_CONST 2           (1)
+     17   LOAD_CONST 3           (2)
+     18   LOAD_CONST 4           (3)
+     19   ALLOC_ARRAY 3          
+     20   STORE_VAR 1            (_iter)
+     21   LOAD_GLOBAL 0          (<fn baml.Array.length>)
+     22   LOAD_VAR 1             (_iter)
+     23   CALL 1                 
+     24   STORE_VAR 2            (_len)
+     25   LOAD_CONST 1           (0)
+     26   STORE_VAR 3            (_i)
+     27   VIZ_ENTER 1            (BeforeFor)
+     28   LOAD_VAR 3             (_i)
+     29   LOAD_VAR 2             (_len)
+     30   CMP_OP <               
+     31   POP_JUMP_IF_FALSE +2   (to 33)
+     32   JUMP +6                (to 38)
+     33   VIZ_EXIT 1             (BeforeFor)
+     34   NOTIFY_BLOCK 7         (AfterFor)
+     35   NOTIFY_BLOCK 8         (FinalSection)
+     36   LOAD_CONST 0           (5)
+     37   RETURN                 
+     38   LOAD_VAR 1             (_iter)
+     39   LOAD_VAR 3             (_i)
+     40   LOAD_ARRAY_ELEMENT     
+     41   STORE_VAR 4            (i)
      42   LOAD_VAR 3             (_i)
-     43   LOAD_ARRAY_ELEMENT     
-     44   STORE_VAR 4            (i)
-     45   LOAD_VAR 3             (_i)
-     46   LOAD_CONST 3           (1)
-     47   BIN_OP +               
-     48   STORE_VAR 3            (_i)
-     49   NOTIFY_BLOCK 9         (InsideFor)
-     50   JUMP -19               (to 31)
+     43   LOAD_CONST 2           (1)
+     44   BIN_OP +               
+     45   STORE_VAR 3            (_i)
+     46   NOTIFY_BLOCK 9         (InsideFor)
+     47   JUMP -19               (to 28)
 
 Function HeadersInComplexNesting (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
+     0    INIT_LOCALS 1          
      1    NOTIFY_BLOCK 0         (MainFunction)
      2    NOTIFY_BLOCK 1         (InsideBlockExpression)
      3    VIZ_ENTER 0            (InsideBlockExpression)
-     4    LOAD_CONST 1           (true)
+     4    LOAD_CONST 0           (true)
      5    POP_JUMP_IF_FALSE +2   (to 7)
      6    JUMP +4                (to 10)
      7    NOTIFY_BLOCK 2         (InsideElse)
-     8    LOAD_CONST 2           ("else value")
+     8    LOAD_CONST 1           ("else value")
      9    JUMP +5                (to 14)
      10   NOTIFY_BLOCK 3         (InsideIfTrue)
      11   NOTIFY_BLOCK 4         (VeryDeepBlock)
      12   NOTIFY_BLOCK 5         (BacktoIfLevel)
-     13   LOAD_CONST 3           ("deep value")
+     13   LOAD_CONST 2           ("deep value")
      14   VIZ_EXIT 0             (InsideBlockExpression)
      15   NOTIFY_BLOCK 6         (BacktoBlockLevel)
      16   STORE_VAR 1            (result)
@@ -155,122 +152,111 @@ Function VeryLongHeaderTitle (arity: 0, kind: Bytecode):
      3   RETURN           
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1569,122 +1569,111 @@ Function WrongLiteralTypeIntWithString (arity: 1, kind: Bytecode):
      7   RETURN                 
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
@@ -8,122 +8,111 @@ Objects: 57
 Globals: 50
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
@@ -8,125 +8,114 @@ Objects: 85
 Globals: 62
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN              
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN              
 
 Function boolArray (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0    (true)

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
@@ -33,122 +33,111 @@ Function NextFunction (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
@@ -8,228 +8,210 @@ Objects: 64
 Globals: 54
 
 Function Calculate (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0   (null)
-     1    LOAD_CONST 0   (null)
-     2    LOAD_CONST 1   (1)
-     3    LOAD_CONST 2   (2)
-     4    BIN_OP +       
-     5    STORE_VAR 1    (a)
-     6    LOAD_VAR 1     (a)
-     7    LOAD_CONST 3   (3)
-     8    BIN_OP *       
-     9    STORE_VAR 2    (b)
-     10   LOAD_VAR 1     (a)
-     11   LOAD_VAR 2     (b)
-     12   BIN_OP +       
-     13   LOAD_VAR 2     (b)
-     14   LOAD_CONST 2   (2)
-     15   BIN_OP /       
-     16   LOAD_CONST 1   (1)
-     17   BIN_OP -       
-     18   BIN_OP *       
-     19   RETURN         
+     0    INIT_LOCALS 2   
+     1    LOAD_CONST 0    (1)
+     2    LOAD_CONST 1    (2)
+     3    BIN_OP +        
+     4    STORE_VAR 1     (a)
+     5    LOAD_VAR 1      (a)
+     6    LOAD_CONST 2    (3)
+     7    BIN_OP *        
+     8    STORE_VAR 2     (b)
+     9    LOAD_VAR 1      (a)
+     10   LOAD_VAR 2      (b)
+     11   BIN_OP +        
+     12   LOAD_VAR 2      (b)
+     13   LOAD_CONST 1    (2)
+     14   BIN_OP /        
+     15   LOAD_CONST 0    (1)
+     16   BIN_OP -        
+     17   BIN_OP *        
+     18   RETURN          
 
 Function FieldAccess (arity: 1, kind: Bytecode):
-     0    LOAD_CONST 0         (null)
-     1    LOAD_CONST 0         (null)
-     2    LOAD_CONST 0         (null)
-     3    LOAD_VAR 1           (user)
-     4    LOAD_FIELD 0         
-     5    STORE_VAR 2          (name)
-     6    LOAD_VAR 1           (user)
-     7    LOAD_FIELD 1         
-     8    LOAD_FIELD 0         
-     9    STORE_VAR 3          (bio)
-     10   LOAD_VAR 1           (user)
-     11   LOAD_FIELD 2         
-     12   LOAD_CONST 1         (0)
-     13   LOAD_ARRAY_ELEMENT   
-     14   STORE_VAR 4          (firstTag)
-     15   LOAD_VAR 1           (user)
-     16   LOAD_FIELD 1         
-     17   LOAD_FIELD 1         
-     18   LOAD_FIELD 0         
-     19   RETURN               
+     0    INIT_LOCALS 3        
+     1    LOAD_VAR 1           (user)
+     2    LOAD_FIELD 0         
+     3    STORE_VAR 2          (name)
+     4    LOAD_VAR 1           (user)
+     5    LOAD_FIELD 1         
+     6    LOAD_FIELD 0         
+     7    STORE_VAR 3          (bio)
+     8    LOAD_VAR 1           (user)
+     9    LOAD_FIELD 2         
+     10   LOAD_CONST 0         (0)
+     11   LOAD_ARRAY_ELEMENT   
+     12   STORE_VAR 4          (firstTag)
+     13   LOAD_VAR 1           (user)
+     14   LOAD_FIELD 1         
+     15   LOAD_FIELD 1         
+     16   LOAD_FIELD 0         
+     17   RETURN               
 
 Function IndexAccess (arity: 1, kind: Bytecode):
-     0    LOAD_CONST 0         (null)
-     1    LOAD_CONST 0         (null)
-     2    LOAD_CONST 0         (null)
-     3    LOAD_VAR 1           (users)
-     4    LOAD_CONST 1         (0)
-     5    LOAD_ARRAY_ELEMENT   
-     6    STORE_VAR 2          (first)
-     7    LOAD_VAR 1           (users)
-     8    LOAD_CONST 2         (1)
-     9    LOAD_ARRAY_ELEMENT   
-     10   STORE_VAR 3          (second)
-     11   LOAD_VAR 1           (users)
-     12   LOAD_CONST 1         (0)
-     13   LOAD_ARRAY_ELEMENT   
-     14   LOAD_FIELD 2         
-     15   LOAD_CONST 1         (0)
-     16   LOAD_ARRAY_ELEMENT   
-     17   STORE_VAR 4          (tag)
-     18   LOAD_VAR 1           (users)
-     19   LOAD_CONST 1         (0)
-     20   LOAD_ARRAY_ELEMENT   
-     21   LOAD_FIELD 0         
-     22   RETURN               
+     0    INIT_LOCALS 3        
+     1    LOAD_VAR 1           (users)
+     2    LOAD_CONST 0         (0)
+     3    LOAD_ARRAY_ELEMENT   
+     4    STORE_VAR 2          (first)
+     5    LOAD_VAR 1           (users)
+     6    LOAD_CONST 1         (1)
+     7    LOAD_ARRAY_ELEMENT   
+     8    STORE_VAR 3          (second)
+     9    LOAD_VAR 1           (users)
+     10   LOAD_CONST 0         (0)
+     11   LOAD_ARRAY_ELEMENT   
+     12   LOAD_FIELD 2         
+     13   LOAD_CONST 0         (0)
+     14   LOAD_ARRAY_ELEMENT   
+     15   STORE_VAR 4          (tag)
+     16   LOAD_VAR 1           (users)
+     17   LOAD_CONST 0         (0)
+     18   LOAD_ARRAY_ELEMENT   
+     19   LOAD_FIELD 0         
+     20   RETURN               
 
 Function TestPrecedence (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 0           (null)
-     3    LOAD_CONST 1           (2)
-     4    LOAD_CONST 2           (3)
-     5    BIN_OP *               
-     6    LOAD_CONST 3           (4)
-     7    BIN_OP +               
-     8    STORE_VAR 1            (c)
-     9    LOAD_CONST 1           (2)
-     10   LOAD_CONST 2           (3)
-     11   LOAD_CONST 3           (4)
-     12   BIN_OP *               
-     13   BIN_OP +               
-     14   LOAD_CONST 4           (10)
-     15   LOAD_CONST 1           (2)
-     16   BIN_OP +               
-     17   CMP_OP >               
-     18   STORE_VAR 2            (b)
-     19   LOAD_CONST 5           (true)
-     20   POP_JUMP_IF_FALSE +2   (to 22)
-     21   JUMP +10               (to 31)
-     22   LOAD_CONST 6           (false)
-     23   POP_JUMP_IF_FALSE +2   (to 25)
-     24   JUMP +4                (to 28)
-     25   LOAD_CONST 6           (false)
-     26   STORE_VAR 3            (d)
-     27   JUMP +6                (to 33)
-     28   LOAD_CONST 6           (false)
-     29   STORE_VAR 3            (d)
-     30   JUMP +3                (to 33)
-     31   LOAD_CONST 5           (true)
-     32   STORE_VAR 3            (d)
-     33   LOAD_VAR 3             (d)
-     34   RETURN                 
+     0    INIT_LOCALS 3          
+     1    LOAD_CONST 0           (2)
+     2    LOAD_CONST 1           (3)
+     3    BIN_OP *               
+     4    LOAD_CONST 2           (4)
+     5    BIN_OP +               
+     6    STORE_VAR 1            (c)
+     7    LOAD_CONST 0           (2)
+     8    LOAD_CONST 1           (3)
+     9    LOAD_CONST 2           (4)
+     10   BIN_OP *               
+     11   BIN_OP +               
+     12   LOAD_CONST 3           (10)
+     13   LOAD_CONST 0           (2)
+     14   BIN_OP +               
+     15   CMP_OP >               
+     16   STORE_VAR 2            (b)
+     17   LOAD_CONST 4           (true)
+     18   POP_JUMP_IF_FALSE +2   (to 20)
+     19   JUMP +10               (to 29)
+     20   LOAD_CONST 5           (false)
+     21   POP_JUMP_IF_FALSE +2   (to 23)
+     22   JUMP +4                (to 26)
+     23   LOAD_CONST 5           (false)
+     24   STORE_VAR 3            (d)
+     25   JUMP +6                (to 31)
+     26   LOAD_CONST 5           (false)
+     27   STORE_VAR 3            (d)
+     28   JUMP +3                (to 31)
+     29   LOAD_CONST 4           (true)
+     30   STORE_VAR 3            (d)
+     31   LOAD_VAR 3             (d)
+     32   RETURN                 
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -53,41 +53,41 @@ Function LLMAnalyze (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function ProcessAnalysis (arity: 1, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
+     0    INIT_LOCALS 1          
      1    LOAD_VAR 1             (analysis)
      2    LOAD_FIELD 2           
      3    STORE_VAR 2            (score)
      4    LOAD_VAR 2             (score)
-     5    LOAD_CONST 1           (0.8)
+     5    LOAD_CONST 0           (0.8)
      6    CMP_OP >               
      7    POP_JUMP_IF_FALSE +2   (to 9)
      8    JUMP +26               (to 34)
      9    LOAD_VAR 2             (score)
-     10   LOAD_CONST 2           (0.5)
+     10   LOAD_CONST 1           (0.5)
      11   CMP_OP >               
      12   POP_JUMP_IF_FALSE +2   (to 14)
      13   JUMP +16               (to 29)
      14   LOAD_VAR 2             (score)
-     15   LOAD_CONST 3           (0.2)
+     15   LOAD_CONST 2           (0.2)
      16   CMP_OP >               
      17   POP_JUMP_IF_FALSE +2   (to 19)
      18   JUMP +6                (to 24)
-     19   LOAD_CONST 4           ("Negative: ")
+     19   LOAD_CONST 3           ("Negative: ")
      20   LOAD_VAR 1             (analysis)
      21   LOAD_FIELD 0           
      22   BIN_OP +               
      23   RETURN                 
-     24   LOAD_CONST 5           ("Neutral: ")
+     24   LOAD_CONST 4           ("Neutral: ")
      25   LOAD_VAR 1             (analysis)
      26   LOAD_FIELD 0           
      27   BIN_OP +               
      28   RETURN                 
-     29   LOAD_CONST 6           ("Positive: ")
+     29   LOAD_CONST 5           ("Positive: ")
      30   LOAD_VAR 1             (analysis)
      31   LOAD_FIELD 0           
      32   BIN_OP +               
      33   RETURN                 
-     34   LOAD_CONST 7           ("Very positive: ")
+     34   LOAD_CONST 6           ("Very positive: ")
      35   LOAD_VAR 1             (analysis)
      36   LOAD_FIELD 0           
      37   BIN_OP +               
@@ -117,122 +117,111 @@ Function SimpleCalc (arity: 2, kind: Bytecode):
      5   RETURN         
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
@@ -26,160 +26,148 @@ Function ConditionalLogic (arity: 1, kind: Bytecode):
      15   RETURN                 
 
 Function add_assign (arity: 0, kind: Bytecode):
-     0   LOAD_CONST 0   (null)
-     1   LOAD_CONST 1   (10)
-     2   STORE_VAR 1    (x)
-     3   LOAD_VAR 1     (x)
-     4   LOAD_CONST 2   (5)
-     5   BIN_OP +       
-     6   STORE_VAR 1    (x)
-     7   LOAD_VAR 1     (x)
-     8   RETURN         
+     0   INIT_LOCALS 1   
+     1   LOAD_CONST 0    (10)
+     2   STORE_VAR 1     (x)
+     3   LOAD_VAR 1      (x)
+     4   LOAD_CONST 1    (5)
+     5   BIN_OP +        
+     6   STORE_VAR 1     (x)
+     7   LOAD_VAR 1      (x)
+     8   RETURN          
 
 Function assign_in_loop (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 1           (0)
-     3    STORE_VAR 1            (sum)
-     4    LOAD_CONST 1           (0)
-     5    STORE_VAR 2            (i)
-     6    LOAD_VAR 2             (i)
-     7    LOAD_CONST 2           (5)
-     8    CMP_OP <               
-     9    POP_JUMP_IF_FALSE +2   (to 11)
-     10   JUMP +3                (to 13)
-     11   LOAD_VAR 1             (sum)
-     12   RETURN                 
-     13   LOAD_VAR 1             (sum)
-     14   LOAD_VAR 2             (i)
-     15   BIN_OP +               
-     16   STORE_VAR 1            (sum)
-     17   LOAD_VAR 2             (i)
-     18   LOAD_CONST 3           (1)
-     19   BIN_OP +               
-     20   STORE_VAR 2            (i)
-     21   JUMP -15               (to 6)
+     0    INIT_LOCALS 2          
+     1    LOAD_CONST 0           (0)
+     2    STORE_VAR 1            (sum)
+     3    LOAD_CONST 0           (0)
+     4    STORE_VAR 2            (i)
+     5    LOAD_VAR 2             (i)
+     6    LOAD_CONST 1           (5)
+     7    CMP_OP <               
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +3                (to 12)
+     10   LOAD_VAR 1             (sum)
+     11   RETURN                 
+     12   LOAD_VAR 1             (sum)
+     13   LOAD_VAR 2             (i)
+     14   BIN_OP +               
+     15   STORE_VAR 1            (sum)
+     16   LOAD_VAR 2             (i)
+     17   LOAD_CONST 2           (1)
+     18   BIN_OP +               
+     19   STORE_VAR 2            (i)
+     20   JUMP -15               (to 5)
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN              
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN              
 
 Function block_with_tail (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -196,159 +184,149 @@ Function break_in_for (arity: 0, kind: Bytecode):
      5   RETURN                 
 
 Function break_with_locals (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 1           (true)
-     3    POP_JUMP_IF_FALSE +9   (to 12)
-     4    LOAD_CONST 2           (1)
-     5    STORE_VAR 1            (x)
-     6    LOAD_CONST 1           (true)
-     7    POP_JUMP_IF_FALSE +2   (to 9)
-     8    JUMP +2                (to 10)
-     9    JUMP -7                (to 2)
-     10   LOAD_CONST 3           (2)
-     11   STORE_VAR 2            (y)
-     12   LOAD_CONST 4           (4)
-     13   RETURN                 
+     0    INIT_LOCALS 2          
+     1    LOAD_CONST 0           (true)
+     2    POP_JUMP_IF_FALSE +9   (to 11)
+     3    LOAD_CONST 1           (1)
+     4    STORE_VAR 1            (x)
+     5    LOAD_CONST 0           (true)
+     6    POP_JUMP_IF_FALSE +2   (to 8)
+     7    JUMP +2                (to 9)
+     8    JUMP -7                (to 1)
+     9    LOAD_CONST 2           (2)
+     10   STORE_VAR 2            (y)
+     11   LOAD_CONST 3           (4)
+     12   RETURN                 
 
 Function c_style_for_loop (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 1           (0)
-     3    STORE_VAR 1            (result)
-     4    LOAD_CONST 1           (0)
-     5    STORE_VAR 2            (i)
-     6    LOAD_VAR 2             (i)
-     7    LOAD_CONST 2           (10)
-     8    CMP_OP <               
-     9    POP_JUMP_IF_FALSE +2   (to 11)
-     10   JUMP +3                (to 13)
-     11   LOAD_VAR 1             (result)
-     12   RETURN                 
-     13   LOAD_VAR 1             (result)
-     14   LOAD_VAR 2             (i)
-     15   BIN_OP +               
-     16   STORE_VAR 1            (result)
-     17   LOAD_VAR 2             (i)
-     18   LOAD_CONST 3           (1)
-     19   BIN_OP +               
-     20   STORE_VAR 2            (i)
-     21   JUMP -15               (to 6)
+     0    INIT_LOCALS 2          
+     1    LOAD_CONST 0           (0)
+     2    STORE_VAR 1            (result)
+     3    LOAD_CONST 0           (0)
+     4    STORE_VAR 2            (i)
+     5    LOAD_VAR 2             (i)
+     6    LOAD_CONST 1           (10)
+     7    CMP_OP <               
+     8    POP_JUMP_IF_FALSE +2   (to 10)
+     9    JUMP +3                (to 12)
+     10   LOAD_VAR 1             (result)
+     11   RETURN                 
+     12   LOAD_VAR 1             (result)
+     13   LOAD_VAR 2             (i)
+     14   BIN_OP +               
+     15   STORE_VAR 1            (result)
+     16   LOAD_VAR 2             (i)
+     17   LOAD_CONST 2           (1)
+     18   BIN_OP +               
+     19   STORE_VAR 2            (i)
+     20   JUMP -15               (to 5)
 
 Function continue_in_for (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 1           (0)
+     0    INIT_LOCALS 1          
+     1    LOAD_CONST 0           (0)
      2    STORE_VAR 1            (i)
      3    LOAD_VAR 1             (i)
-     4    LOAD_CONST 2           (10)
+     4    LOAD_CONST 1           (10)
      5    CMP_OP <               
      6    POP_JUMP_IF_FALSE +2   (to 8)
      7    JUMP +3                (to 10)
-     8    LOAD_CONST 3           (2)
+     8    LOAD_CONST 2           (2)
      9    RETURN                 
      10   LOAD_VAR 1             (i)
-     11   LOAD_CONST 4           (1)
+     11   LOAD_CONST 3           (1)
      12   BIN_OP +               
      13   STORE_VAR 1            (i)
      14   JUMP -11               (to 3)
 
 Function continue_with_locals (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 1           (true)
-     3    POP_JUMP_IF_FALSE +2   (to 5)
-     4    JUMP +3                (to 7)
-     5    LOAD_CONST 2           (5)
-     6    RETURN                 
-     7    LOAD_CONST 3           (1)
-     8    STORE_VAR 1            (x)
-     9    LOAD_CONST 1           (true)
-     10   POP_JUMP_IF_FALSE +2   (to 12)
-     11   JUMP +2                (to 13)
-     12   JUMP -10               (to 2)
-     13   LOAD_CONST 4           (2)
-     14   STORE_VAR 2            (y)
-     15   JUMP -13               (to 2)
+     0    INIT_LOCALS 2          
+     1    LOAD_CONST 0           (true)
+     2    POP_JUMP_IF_FALSE +2   (to 4)
+     3    JUMP +3                (to 6)
+     4    LOAD_CONST 1           (5)
+     5    RETURN                 
+     6    LOAD_CONST 2           (1)
+     7    STORE_VAR 1            (x)
+     8    LOAD_CONST 0           (true)
+     9    POP_JUMP_IF_FALSE +2   (to 11)
+     10   JUMP +2                (to 12)
+     11   JUMP -10               (to 1)
+     12   LOAD_CONST 3           (2)
+     13   STORE_VAR 2            (y)
+     14   JUMP -13               (to 1)
 
 Function iterator_style_for_loop (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 0           (null)
-     3    LOAD_CONST 0           (null)
-     4    LOAD_CONST 0           (null)
-     5    LOAD_CONST 1           (0)
-     6    STORE_VAR 1            (result)
-     7    LOAD_CONST 2           (1)
-     8    LOAD_CONST 3           (2)
-     9    LOAD_CONST 4           (3)
-     10   ALLOC_ARRAY 3          
-     11   STORE_VAR 2            (_iter)
-     12   LOAD_GLOBAL 0          (<fn baml.Array.length>)
-     13   LOAD_VAR 2             (_iter)
-     14   CALL 1                 
-     15   STORE_VAR 3            (_len)
-     16   LOAD_CONST 1           (0)
-     17   STORE_VAR 4            (_i)
-     18   LOAD_VAR 4             (_i)
-     19   LOAD_VAR 3             (_len)
-     20   CMP_OP <               
-     21   POP_JUMP_IF_FALSE +2   (to 23)
-     22   JUMP +3                (to 25)
-     23   LOAD_VAR 1             (result)
-     24   RETURN                 
-     25   LOAD_VAR 2             (_iter)
-     26   LOAD_VAR 4             (_i)
-     27   LOAD_ARRAY_ELEMENT     
-     28   STORE_VAR 5            (i)
-     29   LOAD_VAR 4             (_i)
-     30   LOAD_CONST 2           (1)
+     0    INIT_LOCALS 5          
+     1    LOAD_CONST 0           (0)
+     2    STORE_VAR 1            (result)
+     3    LOAD_CONST 1           (1)
+     4    LOAD_CONST 2           (2)
+     5    LOAD_CONST 3           (3)
+     6    ALLOC_ARRAY 3          
+     7    STORE_VAR 2            (_iter)
+     8    LOAD_GLOBAL 0          (<fn baml.Array.length>)
+     9    LOAD_VAR 2             (_iter)
+     10   CALL 1                 
+     11   STORE_VAR 3            (_len)
+     12   LOAD_CONST 0           (0)
+     13   STORE_VAR 4            (_i)
+     14   LOAD_VAR 4             (_i)
+     15   LOAD_VAR 3             (_len)
+     16   CMP_OP <               
+     17   POP_JUMP_IF_FALSE +2   (to 19)
+     18   JUMP +3                (to 21)
+     19   LOAD_VAR 1             (result)
+     20   RETURN                 
+     21   LOAD_VAR 2             (_iter)
+     22   LOAD_VAR 4             (_i)
+     23   LOAD_ARRAY_ELEMENT     
+     24   STORE_VAR 5            (i)
+     25   LOAD_VAR 4             (_i)
+     26   LOAD_CONST 1           (1)
+     27   BIN_OP +               
+     28   STORE_VAR 4            (_i)
+     29   LOAD_VAR 1             (result)
+     30   LOAD_VAR 5             (i)
      31   BIN_OP +               
-     32   STORE_VAR 4            (_i)
-     33   LOAD_VAR 1             (result)
-     34   LOAD_VAR 5             (i)
-     35   BIN_OP +               
-     36   STORE_VAR 1            (result)
-     37   JUMP -19               (to 18)
+     32   STORE_VAR 1            (result)
+     33   JUMP -19               (to 14)
 
 Function let_statements (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0       (null)
-     1    LOAD_CONST 0       (null)
-     2    LOAD_CONST 0       (null)
-     3    LOAD_CONST 0       (null)
-     4    LOAD_CONST 1       (1)
-     5    STORE_VAR 1        (x)
-     6    LOAD_CONST 2       (2)
-     7    STORE_VAR 2        (y)
-     8    LOAD_CONST 1       (1)
-     9    LOAD_CONST 2       (2)
-     10   LOAD_CONST 3       (3)
-     11   ALLOC_ARRAY 3      
-     12   STORE_VAR 3        (z)
-     13   ALLOC_INSTANCE 6   (<class Point>)
+     0    INIT_LOCALS 4      
+     1    LOAD_CONST 0       (1)
+     2    STORE_VAR 1        (x)
+     3    LOAD_CONST 1       (2)
+     4    STORE_VAR 2        (y)
+     5    LOAD_CONST 0       (1)
+     6    LOAD_CONST 1       (2)
+     7    LOAD_CONST 2       (3)
+     8    ALLOC_ARRAY 3      
+     9    STORE_VAR 3        (z)
+     10   ALLOC_INSTANCE 6   (<class Point>)
+     11   COPY 0             
+     12   LOAD_CONST 0       (1)
+     13   STORE_FIELD 0      
      14   COPY 0             
-     15   LOAD_CONST 1       (1)
-     16   STORE_FIELD 0      
-     17   COPY 0             
-     18   LOAD_CONST 2       (2)
-     19   STORE_FIELD 1      
-     20   STORE_VAR 4        (point)
-     21   LOAD_VAR 4         (point)
-     22   LOAD_FIELD 0       
-     23   LOAD_VAR 4         (point)
-     24   LOAD_FIELD 1       
-     25   BIN_OP +           
-     26   RETURN             
+     15   LOAD_CONST 1       (2)
+     16   STORE_FIELD 1      
+     17   STORE_VAR 4        (point)
+     18   LOAD_VAR 4         (point)
+     19   LOAD_FIELD 0       
+     20   LOAD_VAR 4         (point)
+     21   LOAD_FIELD 1       
+     22   BIN_OP +           
+     23   RETURN             
 
 Function mul_assign (arity: 0, kind: Bytecode):
-     0   LOAD_CONST 0   (null)
-     1   LOAD_CONST 1   (3)
-     2   STORE_VAR 1    (x)
-     3   LOAD_VAR 1     (x)
-     4   LOAD_CONST 2   (4)
-     5   BIN_OP *       
-     6   STORE_VAR 1    (x)
-     7   LOAD_VAR 1     (x)
-     8   RETURN         
+     0   INIT_LOCALS 1   
+     1   LOAD_CONST 0    (3)
+     2   STORE_VAR 1     (x)
+     3   LOAD_VAR 1      (x)
+     4   LOAD_CONST 1    (4)
+     5   BIN_OP *        
+     6   STORE_VAR 1     (x)
+     7   LOAD_VAR 1      (x)
+     8   RETURN          
 
 Function multi_assign (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (10)
@@ -365,95 +343,87 @@ Function nested_break (arity: 0, kind: Bytecode):
      5   RETURN                 
 
 Function nested_for_loop (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 0           (null)
-     2    LOAD_CONST 0           (null)
-     3    LOAD_CONST 0           (null)
-     4    LOAD_CONST 0           (null)
-     5    LOAD_CONST 0           (null)
-     6    LOAD_CONST 0           (null)
-     7    LOAD_CONST 0           (null)
-     8    LOAD_CONST 0           (null)
-     9    LOAD_CONST 1           (0)
-     10   STORE_VAR 1            (result)
-     11   LOAD_CONST 2           (1)
-     12   LOAD_CONST 3           (2)
-     13   LOAD_CONST 4           (3)
-     14   ALLOC_ARRAY 3          
-     15   STORE_VAR 2            (_iter)
-     16   LOAD_GLOBAL 0          (<fn baml.Array.length>)
-     17   LOAD_VAR 2             (_iter)
-     18   CALL 1                 
-     19   STORE_VAR 3            (_len)
-     20   LOAD_CONST 1           (0)
-     21   STORE_VAR 4            (_i)
+     0    INIT_LOCALS 9          
+     1    LOAD_CONST 0           (0)
+     2    STORE_VAR 1            (result)
+     3    LOAD_CONST 1           (1)
+     4    LOAD_CONST 2           (2)
+     5    LOAD_CONST 3           (3)
+     6    ALLOC_ARRAY 3          
+     7    STORE_VAR 2            (_iter)
+     8    LOAD_GLOBAL 0          (<fn baml.Array.length>)
+     9    LOAD_VAR 2             (_iter)
+     10   CALL 1                 
+     11   STORE_VAR 3            (_len)
+     12   LOAD_CONST 0           (0)
+     13   STORE_VAR 4            (_i)
+     14   LOAD_VAR 4             (_i)
+     15   LOAD_VAR 3             (_len)
+     16   CMP_OP <               
+     17   POP_JUMP_IF_FALSE +2   (to 19)
+     18   JUMP +3                (to 21)
+     19   LOAD_VAR 1             (result)
+     20   RETURN                 
+     21   LOAD_VAR 2             (_iter)
      22   LOAD_VAR 4             (_i)
-     23   LOAD_VAR 3             (_len)
-     24   CMP_OP <               
-     25   POP_JUMP_IF_FALSE +2   (to 27)
-     26   JUMP +3                (to 29)
-     27   LOAD_VAR 1             (result)
-     28   RETURN                 
-     29   LOAD_VAR 2             (_iter)
-     30   LOAD_VAR 4             (_i)
-     31   LOAD_ARRAY_ELEMENT     
-     32   STORE_VAR 5            (i)
-     33   LOAD_VAR 4             (_i)
-     34   LOAD_CONST 2           (1)
-     35   BIN_OP +               
-     36   STORE_VAR 4            (_i)
-     37   LOAD_CONST 5           (4)
-     38   LOAD_CONST 6           (5)
-     39   LOAD_CONST 7           (6)
-     40   ALLOC_ARRAY 3          
-     41   STORE_VAR 6            (_iter1)
-     42   LOAD_GLOBAL 0          (<fn baml.Array.length>)
-     43   LOAD_VAR 6             (_iter1)
-     44   CALL 1                 
-     45   STORE_VAR 7            (_len1)
-     46   LOAD_CONST 1           (0)
-     47   STORE_VAR 8            (_i1)
-     48   LOAD_VAR 8             (_i1)
-     49   LOAD_VAR 7             (_len1)
-     50   CMP_OP <               
-     51   POP_JUMP_IF_FALSE +2   (to 53)
-     52   JUMP +2                (to 54)
-     53   JUMP -31               (to 22)
-     54   LOAD_VAR 6             (_iter1)
-     55   LOAD_VAR 8             (_i1)
-     56   LOAD_ARRAY_ELEMENT     
-     57   STORE_VAR 9            (j)
-     58   LOAD_VAR 8             (_i1)
-     59   LOAD_CONST 2           (1)
-     60   BIN_OP +               
-     61   STORE_VAR 8            (_i1)
-     62   LOAD_VAR 1             (result)
-     63   LOAD_VAR 5             (i)
-     64   LOAD_VAR 9             (j)
-     65   BIN_OP *               
-     66   BIN_OP +               
-     67   STORE_VAR 1            (result)
-     68   JUMP -20               (to 48)
+     23   LOAD_ARRAY_ELEMENT     
+     24   STORE_VAR 5            (i)
+     25   LOAD_VAR 4             (_i)
+     26   LOAD_CONST 1           (1)
+     27   BIN_OP +               
+     28   STORE_VAR 4            (_i)
+     29   LOAD_CONST 4           (4)
+     30   LOAD_CONST 5           (5)
+     31   LOAD_CONST 6           (6)
+     32   ALLOC_ARRAY 3          
+     33   STORE_VAR 6            (_iter1)
+     34   LOAD_GLOBAL 0          (<fn baml.Array.length>)
+     35   LOAD_VAR 6             (_iter1)
+     36   CALL 1                 
+     37   STORE_VAR 7            (_len1)
+     38   LOAD_CONST 0           (0)
+     39   STORE_VAR 8            (_i1)
+     40   LOAD_VAR 8             (_i1)
+     41   LOAD_VAR 7             (_len1)
+     42   CMP_OP <               
+     43   POP_JUMP_IF_FALSE +2   (to 45)
+     44   JUMP +2                (to 46)
+     45   JUMP -31               (to 14)
+     46   LOAD_VAR 6             (_iter1)
+     47   LOAD_VAR 8             (_i1)
+     48   LOAD_ARRAY_ELEMENT     
+     49   STORE_VAR 9            (j)
+     50   LOAD_VAR 8             (_i1)
+     51   LOAD_CONST 1           (1)
+     52   BIN_OP +               
+     53   STORE_VAR 8            (_i1)
+     54   LOAD_VAR 1             (result)
+     55   LOAD_VAR 5             (i)
+     56   LOAD_VAR 9             (j)
+     57   BIN_OP *               
+     58   BIN_OP +               
+     59   STORE_VAR 1            (result)
+     60   JUMP -20               (to 40)
 
 Function nested_while_loop (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 1           (0)
-     2    LOAD_CONST 2           (10)
+     0    INIT_LOCALS 1          
+     1    LOAD_CONST 0           (0)
+     2    LOAD_CONST 1           (10)
      3    CMP_OP <               
      4    POP_JUMP_IF_FALSE +2   (to 6)
      5    JUMP +3                (to 8)
-     6    LOAD_CONST 1           (0)
+     6    LOAD_CONST 0           (0)
      7    RETURN                 
-     8    LOAD_CONST 1           (0)
+     8    LOAD_CONST 0           (0)
      9    STORE_VAR 1            (j)
      10   LOAD_VAR 1             (j)
-     11   LOAD_CONST 2           (10)
+     11   LOAD_CONST 1           (10)
      12   CMP_OP <               
      13   POP_JUMP_IF_FALSE +2   (to 15)
      14   JUMP +2                (to 16)
      15   JUMP -14               (to 1)
      16   LOAD_VAR 1             (j)
-     17   LOAD_CONST 3           (1)
+     17   LOAD_CONST 2           (1)
      18   BIN_OP +               
      19   STORE_VAR 1            (j)
      20   JUMP -10               (to 10)
@@ -477,29 +447,29 @@ Function simple_continue (arity: 0, kind: Bytecode):
      5   JUMP -5                (to 0)
 
 Function simple_while_loop (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
-     1    LOAD_CONST 1           (0)
+     0    INIT_LOCALS 1          
+     1    LOAD_CONST 0           (0)
      2    STORE_VAR 1            (i)
      3    LOAD_VAR 1             (i)
-     4    LOAD_CONST 2           (10)
+     4    LOAD_CONST 1           (10)
      5    CMP_OP <               
      6    POP_JUMP_IF_FALSE +2   (to 8)
      7    JUMP +3                (to 10)
      8    LOAD_VAR 1             (i)
      9    RETURN                 
      10   LOAD_VAR 1             (i)
-     11   LOAD_CONST 3           (1)
+     11   LOAD_CONST 2           (1)
      12   BIN_OP +               
      13   STORE_VAR 1            (i)
      14   JUMP -11               (to 3)
 
 Function sub_assign (arity: 0, kind: Bytecode):
-     0   LOAD_CONST 0   (null)
-     1   LOAD_CONST 1   (10)
-     2   STORE_VAR 1    (x)
-     3   LOAD_VAR 1     (x)
-     4   LOAD_CONST 2   (3)
-     5   BIN_OP -       
-     6   STORE_VAR 1    (x)
-     7   LOAD_VAR 1     (x)
+     0   INIT_LOCALS 1   
+     1   LOAD_CONST 0    (10)
+     2   STORE_VAR 1     (x)
+     3   LOAD_VAR 1      (x)
+     4   LOAD_CONST 1    (3)
+     5   BIN_OP -        
+     6   STORE_VAR 1     (x)
+     7   LOAD_VAR 1      (x)
      8   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
@@ -8,7 +8,7 @@ Objects: 1466
 Globals: 153
 
 Function BodyTorture (arity: 0, kind: Bytecode):
-     0    LOAD_CONST 0           (null)
+     0    INIT_LOCALS 1          
      1    LOAD_CONST 0           (null)
      2    STORE_VAR 1            (x)
      3    LOAD_VAR 1             (x)
@@ -27,9 +27,9 @@ Function BodyTorture (arity: 0, kind: Bytecode):
      16   JUMP -13               (to 3)
 
 Function ComplexType (arity: 0, kind: Bytecode):
-     0   LOAD_CONST 0   (null)
-     1   LOAD_VAR 1     (_0)
-     2   RETURN         
+     0   INIT_LOCALS 1   
+     1   LOAD_VAR 1      (_0)
+     2   RETURN          
 
 Function DeepExpression (arity: 0, kind: Bytecode):
      0    LOAD_CONST 0   (1)
@@ -954,122 +954,111 @@ Function Process99 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -44,122 +44,111 @@ Function ProcessText (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -24,122 +24,111 @@ Function BadReturnType (arity: 0, kind: Bytecode):
      4   RETURN           
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
@@ -24,122 +24,111 @@ Function MyClient.resolve (arity: 0, kind: Bytecode):
      13   RETURN              
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -17,122 +17,111 @@ Function HelloWorld (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
@@ -14,122 +14,111 @@ Function Foo (arity: 0, kind: Bytecode):
      3   RETURN         
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
@@ -12,122 +12,111 @@ Function Foo (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
@@ -8,122 +8,111 @@ Objects: 56
 Globals: 50
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
@@ -32,122 +32,111 @@ Function MakeJSON (arity: 1, kind: Bytecode):
      2   RETURN         
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -17,122 +17,111 @@ Function TypeBuilderFn (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -15,122 +15,111 @@ Function Fn (arity: 0, kind: Bytecode):
      4   RETURN           
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
@@ -20,122 +20,111 @@ Function Foo (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     5    LOAD_VAR 1          (function_name)
-     6    DISPATCH_FUTURE 1   
-     7    AWAIT               
-     8    STORE_VAR 3         (jinja_string)
-     9    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     10   LOAD_VAR 1          (function_name)
-     11   DISPATCH_FUTURE 1   
-     12   AWAIT               
-     13   CALL 0              
-     14   STORE_VAR 4         (primitive_client)
-     15   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     16   LOAD_VAR 4          (primitive_client)
-     17   LOAD_VAR 3          (jinja_string)
-     18   LOAD_VAR 2          (args)
-     19   DISPATCH_FUTURE 3   
-     20   AWAIT               
-     21   STORE_VAR 5         (prompt)
-     22   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     23   LOAD_VAR 4          (primitive_client)
-     24   LOAD_VAR 5          (prompt)
-     25   DISPATCH_FUTURE 2   
-     26   AWAIT               
-     27   STORE_VAR 6         (specialized_prompt)
-     28   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     29   LOAD_VAR 4          (primitive_client)
-     30   LOAD_VAR 6          (specialized_prompt)
-     31   DISPATCH_FUTURE 2   
-     32   AWAIT               
-     33   RETURN              
-
-Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_CONST 0        (null)
-     4    LOAD_CONST 0        (null)
-     5    LOAD_CONST 0        (null)
-     6    LOAD_CONST 0        (null)
-     7    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     8    LOAD_VAR 1          (function_name)
-     9    DISPATCH_FUTURE 1   
-     10   AWAIT               
-     11   STORE_VAR 3         (jinja_string)
-     12   LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     13   LOAD_VAR 1          (function_name)
-     14   DISPATCH_FUTURE 1   
-     15   AWAIT               
-     16   CALL 0              
-     17   STORE_VAR 4         (primitive_client)
-     18   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     19   LOAD_VAR 4          (primitive_client)
-     20   LOAD_VAR 3          (jinja_string)
-     21   LOAD_VAR 2          (args)
-     22   DISPATCH_FUTURE 3   
+     0    INIT_LOCALS 4       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
      23   AWAIT               
-     24   STORE_VAR 5         (prompt)
-     25   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
      26   LOAD_VAR 4          (primitive_client)
-     27   LOAD_VAR 5          (prompt)
+     27   LOAD_VAR 6          (specialized_prompt)
      28   DISPATCH_FUTURE 2   
      29   AWAIT               
-     30   STORE_VAR 6         (specialized_prompt)
-     31   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
-     32   LOAD_VAR 4          (primitive_client)
-     33   LOAD_VAR 6          (specialized_prompt)
-     34   DISPATCH_FUTURE 2   
-     35   AWAIT               
-     36   STORE_VAR 7         (http_request)
-     37   LOAD_GLOBAL 33      (<fn baml.http.send>)
-     38   LOAD_VAR 7          (http_request)
-     39   DISPATCH_FUTURE 1   
-     40   AWAIT               
-     41   STORE_VAR 8         (http_response)
-     42   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
-     43   LOAD_VAR 8          (http_response)
-     44   DISPATCH_FUTURE 1   
-     45   AWAIT               
-     46   STORE_VAR 9         (result)
-     47   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     48   LOAD_VAR 4          (primitive_client)
-     49   LOAD_VAR 9          (result)
-     50   LOAD_VAR 1          (function_name)
-     51   DISPATCH_FUTURE 3   
-     52   AWAIT               
-     53   RETURN              
+     30   RETURN              
+
+Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
+     0    INIT_LOCALS 7       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   STORE_VAR 6         (specialized_prompt)
+     25   LOAD_GLOBAL 36      (<fn baml.llm.PrimitiveClient.build_request>)
+     26   LOAD_VAR 4          (primitive_client)
+     27   LOAD_VAR 6          (specialized_prompt)
+     28   DISPATCH_FUTURE 2   
+     29   AWAIT               
+     30   STORE_VAR 7         (http_request)
+     31   LOAD_GLOBAL 33      (<fn baml.http.send>)
+     32   LOAD_VAR 7          (http_request)
+     33   DISPATCH_FUTURE 1   
+     34   AWAIT               
+     35   STORE_VAR 8         (http_response)
+     36   LOAD_GLOBAL 30      (<fn baml.http.Response.text>)
+     37   LOAD_VAR 8          (http_response)
+     38   DISPATCH_FUTURE 1   
+     39   AWAIT               
+     40   STORE_VAR 9         (result)
+     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     42   LOAD_VAR 4          (primitive_client)
+     43   LOAD_VAR 9          (result)
+     44   LOAD_VAR 1          (function_name)
+     45   DISPATCH_FUTURE 3   
+     46   AWAIT               
+     47   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
-     0    LOAD_CONST 0        (null)
-     1    LOAD_CONST 0        (null)
-     2    LOAD_CONST 0        (null)
-     3    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
-     4    LOAD_VAR 1          (function_name)
-     5    DISPATCH_FUTURE 1   
-     6    AWAIT               
-     7    STORE_VAR 3         (jinja_string)
-     8    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
-     9    LOAD_VAR 1          (function_name)
-     10   DISPATCH_FUTURE 1   
-     11   AWAIT               
-     12   CALL 0              
-     13   STORE_VAR 4         (primitive_client)
-     14   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
-     15   LOAD_VAR 4          (primitive_client)
-     16   LOAD_VAR 3          (jinja_string)
-     17   LOAD_VAR 2          (args)
-     18   DISPATCH_FUTURE 3   
-     19   AWAIT               
-     20   STORE_VAR 5         (prompt)
-     21   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
-     22   LOAD_VAR 4          (primitive_client)
-     23   LOAD_VAR 5          (prompt)
-     24   DISPATCH_FUTURE 2   
-     25   AWAIT               
-     26   RETURN
+     0    INIT_LOCALS 3       
+     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     2    LOAD_VAR 1          (function_name)
+     3    DISPATCH_FUTURE 1   
+     4    AWAIT               
+     5    STORE_VAR 3         (jinja_string)
+     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     7    LOAD_VAR 1          (function_name)
+     8    DISPATCH_FUTURE 1   
+     9    AWAIT               
+     10   CALL 0              
+     11   STORE_VAR 4         (primitive_client)
+     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     13   LOAD_VAR 4          (primitive_client)
+     14   LOAD_VAR 3          (jinja_string)
+     15   LOAD_VAR 2          (args)
+     16   DISPATCH_FUTURE 3   
+     17   AWAIT               
+     18   STORE_VAR 5         (prompt)
+     19   LOAD_GLOBAL 35      (<fn baml.llm.PrimitiveClient.specialize_prompt>)
+     20   LOAD_VAR 4          (primitive_client)
+     21   LOAD_VAR 5          (prompt)
+     22   DISPATCH_FUTURE 2   
+     23   AWAIT               
+     24   RETURN

--- a/baml_language/crates/baml_tests/src/codegen.rs
+++ b/baml_language/crates/baml_tests/src/codegen.rs
@@ -138,6 +138,7 @@ fn convert_instruction(
         bex_vm_types::Instruction::NotifyBlock(idx) => Instruction::NotifyBlock(*idx),
         bex_vm_types::Instruction::VizEnter(idx) => Instruction::VizEnter(*idx),
         bex_vm_types::Instruction::VizExit(idx) => Instruction::VizExit(*idx),
+        bex_vm_types::Instruction::InitLocals(n) => Instruction::InitLocals(*n),
         bex_vm_types::Instruction::JumpTable { table_idx, default } => Instruction::JumpTable {
             table_idx: *table_idx,
             default: *default,

--- a/baml_language/crates/baml_tests/src/vm.rs
+++ b/baml_language/crates/baml_tests/src/vm.rs
@@ -362,6 +362,7 @@ pub enum Instruction {
     NotifyBlock(usize),
     VizEnter(usize),
     VizExit(usize),
+    InitLocals(usize),
     JumpTable { table_idx: usize, default: isize },
     Discriminant,
     TypeTag,

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -177,6 +177,7 @@ pub fn display_instruction(
         | Instruction::Await
         | Instruction::Call(_)
         | Instruction::Assert
+        | Instruction::InitLocals(_)
         | Instruction::Discriminant
         | Instruction::TypeTag
         | Instruction::Unreachable
@@ -301,6 +302,7 @@ fn instruction_color(instruction: &Instruction) -> Color {
             Color::BrightRed
         }
         Instruction::VizEnter(_) | Instruction::VizExit(_) => Color::BrightYellow,
+        Instruction::InitLocals(_) => Color::Green,
         Instruction::Discriminant | Instruction::TypeTag => Color::BrightBlue,
         Instruction::Unreachable => Color::BrightRed,
     }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -1110,6 +1110,11 @@ impl BexVm {
                     self.stack.push(value);
                 }
 
+                Instruction::InitLocals(count) => {
+                    let new_len = self.stack.len() + count;
+                    self.stack.resize(new_len, Value::Null);
+                }
+
                 Instruction::LoadVar(index) => {
                     let value = self.stack[self.frames[frame_idx].locals_offset + index];
                     self.stack.push(value);

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -340,7 +340,7 @@ pub enum Instruction {
     /// Initialize local variable slots by pushing `n` null values onto the stack.
     ///
     /// Format: `INIT_LOCALS n` where `n` is the number of local variable slots
-    /// to allocate. Each slot is initialized to [`Value::Null`].
+    /// to allocate. Each slot is initialized to null.
     ///
     /// This is emitted once at the start of a function's bytecode to reserve
     /// stack space for all "Real" local variables (i.e., those that aren't

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -337,6 +337,17 @@ pub enum Instruction {
     /// - Classes: assigned unique IDs starting at 100
     TypeTag,
 
+    /// Initialize local variable slots by pushing `n` null values onto the stack.
+    ///
+    /// Format: `INIT_LOCALS n` where `n` is the number of local variable slots
+    /// to allocate. Each slot is initialized to [`Value::Null`].
+    ///
+    /// This is emitted once at the start of a function's bytecode to reserve
+    /// stack space for all "Real" local variables (i.e., those that aren't
+    /// virtual, phi-like, or dead). Parameters are not included since they
+    /// are already on the stack after [`Instruction::Call`].
+    InitLocals(usize),
+
     /// Halt execution with an unreachable code error.
     ///
     /// This instruction should never be executed at runtime. If it is,
@@ -542,6 +553,7 @@ impl std::fmt::Display for Instruction {
             }
             Instruction::Discriminant => f.write_str("DISCRIMINANT"),
             Instruction::TypeTag => f.write_str("TYPE_TAG"),
+            Instruction::InitLocals(n) => write!(f, "INIT_LOCALS {n}"),
             Instruction::Unreachable => f.write_str("UNREACHABLE"),
         }
     }


### PR DESCRIPTION
## Summary
- Adds a new `InitLocals(n)` bytecode instruction that pushes `n` null values onto the stack in one shot, replacing N consecutive `LoadConst(null)` instructions emitted at the start of every function for local variable pre-allocation.
- Uses `Vec::resize` for the VM handler instead of per-element push, avoiding N dispatch cycles through the main match loop.
- Reduces bytecode size across all 33 codegen snapshots (e.g., 7 instructions → 1 for the common `baml.llm.call_llm_function` prologue).

## Test plan
- [x] All 139 `baml_compiler_emit` tests pass
- [x] All 375 `baml_tests` pass (33 codegen snapshots auto-updated)
- [x] All 24 `bex_vm` tests pass
- [x] `cargo fmt --check` clean
- [x] `cargo clippy` clean on affected crates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated local variable pre-allocation into a single bytecode initialization step instead of multiple per-slot null pushes.
* **New Features**
  * VM and bytecode now recognize an explicit local-initialization instruction; debugger output and coloring updated accordingly.
* **Tests**
  * Updated emitted-code expectations and test harness to reflect the consolidated local initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->