### PR TITLE
baml-language: add Type variants to assorted type expr variants

### DIFF
--- a/baml_language/crates/baml_builtins/baml/llm.baml
+++ b/baml_language/crates/baml_builtins/baml/llm.baml
@@ -78,5 +78,6 @@ function call_llm_function(function_name: string, args: map<string, unknown>) ->
     let result = http_response.text();
 
     // Parse the response
-    return primitive_client.parse(result, function_name);
+    let return_type = baml.llm.get_return_type(function_name);
+    return primitive_client.parse(result, return_type);
 }

--- a/baml_language/crates/baml_builtins/src/lib.rs
+++ b/baml_language/crates/baml_builtins/src/lib.rs
@@ -52,6 +52,9 @@ pub enum TypePattern {
     /// Maps to `Ty::BuiltinUnknown` in TIR.
     /// In builtin definitions, use the `Unknown` type annotation.
     BuiltinUnknown,
+    /// Meta-type — the type of type values.
+    /// A value of type `Type` wraps a `baml_type::Ty` at runtime.
+    Type,
 }
 
 /// How a builtin type is represented at runtime on the VM heap.
@@ -335,8 +338,7 @@ macro_rules! with_builtins {
                         /// Parse an HTTP response into a BAML value.
                         /// Interprets the provider-specific response format and parses the output.
                         #[sys_op]
-                        #[uses(engine_ctx)]
-                        fn parse(self: PrimitiveClient, http_response_body: String, function_name: String) -> Any;
+                        fn parse(self: PrimitiveClient, http_response_body: String, type_def: Type) -> Any;
                     }
 
                     /// Get the Jinja template for an LLM function.
@@ -360,6 +362,12 @@ macro_rules! with_builtins {
                     #[sys_op]
                     #[uses(engine_ctx)]
                     fn get_client_function(function_name: String) -> fn() -> PrimitiveClient;
+
+                    /// Get the return type for an LLM function.
+                    /// Returns a Type value that can be passed to parse().
+                    #[sys_op]
+                    #[uses(engine_ctx)]
+                    fn get_return_type(function_name: String) -> Type;
                 }
             }
 

--- a/baml_language/crates/baml_builtins_macros/src/codegen_sys_ops.rs
+++ b/baml_language/crates/baml_builtins_macros/src/codegen_sys_ops.rs
@@ -261,6 +261,7 @@ fn sys_op_rust_type(
         "()" => Ok(quote!(())),
         "Media" => Ok(quote!(bex_vm_types::MediaValue)),
         "PromptAst" => Ok(quote!(bex_vm_types::PromptAst)),
+        "Type" => Ok(quote!(baml_type::Ty)),
         t if t.starts_with("Option<") && t.ends_with('>') => {
             let inner = &t[7..t.len() - 1];
             let inner_type = sys_op_rust_type(inner.trim(), builtin_types)?;
@@ -297,6 +298,7 @@ fn sys_op_extract_one(
             )
         }
         "PromptAst" => quote!(#arg_ident.as_prompt_ast_owned(&__p)?),
+        "Type" => quote!(#arg_ident.as_baml_type_owned(&__p)?),
         _ => quote!(#arg_ident.as_owned_but_very_slow(&__p)?),
     }
 }

--- a/baml_language/crates/baml_builtins_macros/src/util.rs
+++ b/baml_language/crates/baml_builtins_macros/src/util.rs
@@ -100,6 +100,7 @@ pub(crate) fn type_to_pattern(
                 "Media" => quote!(TypePattern::Media),
                 "ResourceHandle" => quote!(TypePattern::Resource),
                 "Unknown" => quote!(TypePattern::BuiltinUnknown),
+                "Type" => quote!(TypePattern::Type),
                 "Option" => {
                     if let PathArguments::AngleBracketed(args) = &segment.arguments {
                         if let Some(GenericArgument::Type(inner)) = args.args.first() {

--- a/baml_language/crates/baml_compiler_tir/src/builtins.rs
+++ b/baml_language/crates/baml_compiler_tir/src/builtins.rs
@@ -117,6 +117,9 @@ fn match_pattern_inner(pattern: &TypePattern, ty: &Ty, bindings: &mut Bindings) 
 
         // Opaque runtime types match their corresponding patterns
         (TypePattern::Resource, Ty::Resource) => true,
+        (TypePattern::Type, Ty::Type) => true,
+        (TypePattern::Type, Ty::Unknown | Ty::Error) => true,
+        (TypePattern::Type, _) => false,
 
         // Unknown in Ty matches any pattern (for error recovery)
         (_, Ty::Unknown) => true,
@@ -181,6 +184,7 @@ pub fn substitute(pattern: &TypePattern, bindings: &Bindings) -> Ty {
         },
         TypePattern::Resource => Ty::Resource,
         TypePattern::BuiltinUnknown => Ty::BuiltinUnknown,
+        TypePattern::Type => Ty::Type,
     }
 }
 
@@ -213,6 +217,7 @@ pub fn substitute_unknown(pattern: &TypePattern) -> Ty {
         },
         TypePattern::Resource => Ty::Resource,
         TypePattern::BuiltinUnknown => Ty::BuiltinUnknown,
+        TypePattern::Type => Ty::Type,
     }
 }
 

--- a/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
+++ b/baml_language/crates/baml_compiler_tir/src/exhaustiveness.rs
@@ -369,6 +369,7 @@ impl<'a> ExhaustivenessChecker<'a> {
             Ty::Float => vec![ValueSet::OfType(Name::new("float"))],
             Ty::String => vec![ValueSet::OfType(Name::new("string"))],
             Ty::Resource => vec![ValueSet::OfType(Name::new("resource"))],
+            Ty::Type => vec![ValueSet::OfType(Name::new("type"))],
             Ty::Media(kind) => vec![ValueSet::OfType(Name::new(kind.to_string()))],
 
             // User-defined class and enum types (resolved by FQN).

--- a/baml_language/crates/baml_compiler_tir/src/lib.rs
+++ b/baml_language/crates/baml_compiler_tir/src/lib.rs
@@ -90,6 +90,7 @@ fn substitute_with_fallback(pattern: &baml_builtins::TypePattern, bindings: &Bin
         },
         TypePattern::Resource => Ty::Resource,
         TypePattern::BuiltinUnknown => Ty::BuiltinUnknown,
+        TypePattern::Type => Ty::Type,
     }
 }
 

--- a/baml_language/crates/baml_compiler_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler_tir/src/normalize.rs
@@ -68,6 +68,7 @@ enum StructuralTy {
     /// Internal-only type for builtins - any type is assignable to it.
     BuiltinUnknown,
     WatchAccessor(Box<StructuralTy>),
+    Type,
 }
 
 impl StructuralTy {
@@ -291,6 +292,7 @@ fn is_valid_map_key_type(ty: &Ty, aliases: &HashMap<Name, Ty>) -> bool {
             StructuralTy::Resource => false,
             StructuralTy::BuiltinUnknown => false,
             StructuralTy::WatchAccessor(_) => false,
+            StructuralTy::Type => false,
         }
     }
     let recursive = find_recursive_aliases(aliases);
@@ -366,6 +368,7 @@ fn normalize_impl(
         Ty::Void => StructuralTy::Void,
         Ty::Resource => StructuralTy::Resource,
         Ty::BuiltinUnknown => StructuralTy::BuiltinUnknown,
+        Ty::Type => StructuralTy::Type,
         Ty::Literal(lit) => StructuralTy::Literal(lit.clone()),
         Ty::Class(fqn) => StructuralTy::Class(fqn.name.clone()),
         Ty::Enum(fqn) => StructuralTy::Enum(fqn.name.clone()),

--- a/baml_language/crates/baml_compiler_tir/src/types.rs
+++ b/baml_language/crates/baml_compiler_tir/src/types.rs
@@ -131,6 +131,10 @@ pub enum Ty {
     /// Watch accessor type: represents `x.$watch` on a watched variable.
     /// Contains the inner type being watched for method resolution.
     WatchAccessor(Box<Ty>),
+
+    /// Meta-type — the type of type values at the TIR level.
+    /// Matches `TypePattern::Type` in builtin signatures.
+    Type,
 }
 
 impl Ty {
@@ -271,6 +275,7 @@ impl fmt::Display for Ty {
             Ty::Resource => write!(f, "resource"),
             Ty::BuiltinUnknown => write!(f, "unknown"),
             Ty::WatchAccessor(inner) => write!(f, "{inner}.$watch"),
+            Ty::Type => write!(f, "type"),
         }
     }
 }

--- a/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/attribute_validation/baml_tests__attribute_validation__06_codegen.snap
@@ -1,26 +1,26 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 62
-Globals: 50
+Objects: 63
+Globals: 51
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -41,19 +41,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -82,28 +82,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/basic_types/baml_tests__basic_types__06_codegen.snap
@@ -1,35 +1,35 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 7
-Objects: 69
-Globals: 54
+Objects: 70
+Globals: 55
 
 Function GetMixedList (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetMixedList")
      2   ALLOC_MAP 0      
      3   CALL 2           
      4   RETURN           
 
 Function GetMixedMap (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetMixedMap")
      2   ALLOC_MAP 0      
      3   CALL 2           
      4   RETURN           
 
 Function GetStatus (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetStatus")
      2   ALLOC_MAP 0      
      3   CALL 2           
      4   RETURN           
 
 Function GetUser (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetUser")
      2   LOAD_VAR 1       (id)
      3   LOAD_CONST 1     ("id")
@@ -39,18 +39,18 @@ Function GetUser (arity: 1, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -71,19 +71,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -112,28 +112,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/builtin_io/baml_tests__builtin_io__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 14
-Objects: 82
-Globals: 61
+Objects: 83
+Globals: 62
 
 Function ChainCommands (arity: 0, kind: Bytecode):
      0    INIT_LOCALS 2       
@@ -188,18 +188,18 @@ Function RunCommandWithVar (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -220,19 +220,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -261,28 +261,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_after_string_in_config/baml_tests__comment_after_string_in_config__06_codegen.snap
@@ -1,20 +1,20 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 71
-Globals: 51
+Objects: 72
+Globals: 52
 
 Function OpenRouterMistralSmall3_1_24b.resolve (arity: 0, kind: Bytecode):
      0    INIT_LOCALS 1       
-     1    LOAD_GLOBAL 42      (<fn env.get_or_panic>)
+     1    LOAD_GLOBAL 43      (<fn env.get_or_panic>)
      2    LOAD_CONST 0        ("OPENROUTER_API_KEY")
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 1         (_13)
-     6    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
+     6    LOAD_GLOBAL 45      (<fn baml.llm.build_primitive_client>)
      7    LOAD_CONST 1        ("OpenRouterMistralSmall3_1_24b")
      8    LOAD_CONST 2        ("unknown")
      9    LOAD_CONST 3        ("user")
@@ -39,18 +39,18 @@ Function OpenRouterMistralSmall3_1_24b.resolve (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -71,19 +71,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -112,28 +112,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/comment_in_type/baml_tests__comment_in_type__06_codegen.snap
@@ -1,21 +1,21 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 6
-Objects: 69
-Globals: 53
+Objects: 70
+Globals: 54
 
 Function CommentAfterArrow (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("CommentAfterArrow")
      2   ALLOC_MAP 0      
      3   CALL 2           
      4   RETURN           
 
 Function FunctionWithComments (arity: 2, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("FunctionWithComments")
      2   LOAD_VAR 1       (a)
      3   LOAD_VAR 2       (b)
@@ -26,7 +26,7 @@ Function FunctionWithComments (arity: 2, kind: Bytecode):
      8   RETURN           
 
 Function TestClient.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 45      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("TestClient")
      2    LOAD_CONST 1        ("baml-openai-chat")
      3    LOAD_CONST 2        ("user")
@@ -41,18 +41,18 @@ Function TestClient.resolve (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -73,19 +73,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -114,28 +114,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/config_dictionary/baml_tests__config_dictionary__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 120
-Globals: 51
+Objects: 121
+Globals: 52
 
 Function MyClient.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 45      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("MyClient")
      2    LOAD_CONST 1        ("baml-openai-chat")
      3    LOAD_CONST 2        ("user")
@@ -101,18 +101,18 @@ Function MyClient.resolve (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -133,19 +133,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -174,28 +174,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/duplicate_class_span/baml_tests__duplicate_class_span__06_codegen.snap
@@ -1,26 +1,26 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 58
-Globals: 50
+Objects: 59
+Globals: 51
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -41,19 +41,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -82,28 +82,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_call/baml_tests__function_call__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 9
-Objects: 65
-Globals: 56
+Objects: 66
+Globals: 57
 
 Function Bar (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 53   (<fn Foo>)
+     0   LOAD_GLOBAL 54   (<fn Foo>)
      1   LOAD_CONST 0     (1)
      2   CALL 1           
      3   RETURN           
@@ -29,7 +29,7 @@ Function Foo (arity: 1, kind: Bytecode):
      3   RETURN         
 
 Function GreetBaz (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 55     (<fn Baz.Greeting>)
+     0   LOAD_GLOBAL 56     (<fn Baz.Greeting>)
      1   ALLOC_INSTANCE 6   (<class Baz>)
      2   COPY 0             
      3   LOAD_VAR 1         (n)
@@ -48,18 +48,18 @@ Function array_length (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -80,19 +80,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -121,28 +121,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/function_types/baml_tests__function_types__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 57
-Globals: 51
+Objects: 58
+Globals: 52
 
 Function GetTransform (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -13,18 +13,18 @@ Function GetTransform (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -45,19 +45,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -86,28 +86,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/generator/baml_tests__generator__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 59
-Globals: 51
+Objects: 60
+Globals: 52
 
 Function GetUser (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("GetUser")
      2   ALLOC_MAP 0      
      3   CALL 2           
@@ -16,18 +16,18 @@ Function GetUser (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -48,19 +48,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -89,28 +89,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/header_in_llm_function/baml_tests__header_in_llm_function__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 5
-Objects: 69
-Globals: 52
+Objects: 70
+Globals: 53
 
 Function FetchDatax (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("FetchDatax")
      2   LOAD_VAR 1       (user_id)
      3   LOAD_CONST 1     ("user_id")
@@ -17,7 +17,7 @@ Function FetchDatax (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function VertexGCP.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 45      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("VertexGCP")
      2    LOAD_CONST 1        ("vertex-ai")
      3    LOAD_CONST 2        ("user")
@@ -34,18 +34,18 @@ Function VertexGCP.resolve (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -66,19 +66,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -107,28 +107,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/headers_edge_cases/baml_tests__headers_edge_cases__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 13
-Objects: 76
-Globals: 60
+Objects: 77
+Globals: 61
 
 Function ConsecutiveHeaders (arity: 0, kind: Bytecode):
      0   NOTIFY_BLOCK 0   (FirstHeader)
@@ -153,18 +153,18 @@ Function VeryLongHeaderTitle (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -185,19 +185,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -226,28 +226,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/match_exhaustiveness/baml_tests__match_exhaustiveness__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 89
-Objects: 313
-Globals: 136
+Objects: 314
+Globals: 137
 
 Function BoolLiteralAfterTypedBool (arity: 1, kind: Bytecode):
      0   LOAD_VAR 1             (b)
@@ -787,7 +787,7 @@ Function MatchComplexScrutinee (arity: 1, kind: Bytecode):
      23   RETURN                 
 
 Function MatchFunctionCallScrutinee (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 91         (<fn GetStatus>)
+     0    LOAD_GLOBAL 92         (<fn GetStatus>)
      1    CALL 0                 
      2    DISCRIMINANT           
      3    COPY 0                 
@@ -1570,18 +1570,18 @@ Function WrongLiteralTypeIntWithString (arity: 1, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -1602,19 +1602,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -1643,28 +1643,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/paren_union_test/baml_tests__paren_union_test__06_codegen.snap
@@ -1,26 +1,26 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 57
-Globals: 50
+Objects: 58
+Globals: 51
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -41,19 +41,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -82,28 +82,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_constructors/baml_tests__parser_constructors__06_codegen.snap
@@ -1,26 +1,26 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 15
-Objects: 85
-Globals: 62
+Objects: 86
+Globals: 63
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -41,19 +41,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -82,28 +82,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_error_recovery/baml_tests__parser_error_recovery__06_codegen.snap
@@ -1,18 +1,18 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 7
-Objects: 73
-Globals: 54
+Objects: 74
+Globals: 55
 
 Function Foo (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (null)
      1   RETURN         
 
 Function GPT4.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 45      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("GPT4")
      2    LOAD_CONST 1        ("unknown")
      3    LOAD_CONST 2        ("user")
@@ -34,18 +34,18 @@ Function NextFunction (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -66,19 +66,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -107,28 +107,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_expressions/baml_tests__parser_expressions__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 7
-Objects: 64
-Globals: 54
+Objects: 65
+Globals: 55
 
 Function Calculate (arity: 0, kind: Bytecode):
      0    INIT_LOCALS 2   
@@ -108,18 +108,18 @@ Function TestPrecedence (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -140,19 +140,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -181,28 +181,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_speculative/baml_tests__parser_speculative__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 11
-Objects: 82
-Globals: 58
+Objects: 83
+Globals: 59
 
 Function Ambiguous (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Ambiguous")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -17,7 +17,7 @@ Function Ambiguous (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function AnotherLLM (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("AnotherLLM")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -26,7 +26,7 @@ Function AnotherLLM (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function ChainedProcess (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("ChainedProcess")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -35,7 +35,7 @@ Function ChainedProcess (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function ExtractData (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("ExtractData")
      2   LOAD_VAR 1       (text)
      3   LOAD_CONST 1     ("text")
@@ -44,7 +44,7 @@ Function ExtractData (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function LLMAnalyze (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("LLMAnalyze")
      2   LOAD_VAR 1       (text)
      3   LOAD_CONST 1     ("text")
@@ -118,18 +118,18 @@ Function SimpleCalc (arity: 2, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -150,19 +150,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -191,28 +191,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_statements/baml_tests__parser_statements__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 24
-Objects: 81
-Globals: 71
+Objects: 82
+Globals: 72
 
 Function ConditionalLogic (arity: 1, kind: Bytecode):
      0    LOAD_VAR 1             (age)
@@ -61,18 +61,18 @@ Function assign_in_loop (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -93,19 +93,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -134,28 +134,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_stress/baml_tests__parser_stress__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 106
-Objects: 1466
-Globals: 153
+Objects: 1467
+Globals: 154
 
 Function BodyTorture (arity: 0, kind: Bytecode):
      0    INIT_LOCALS 1          
@@ -54,7 +54,7 @@ Function DeepExpression (arity: 0, kind: Bytecode):
      19   RETURN         
 
 Function Process1 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process1")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -63,7 +63,7 @@ Function Process1 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process10 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process10")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -72,7 +72,7 @@ Function Process10 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process100 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process100")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -81,7 +81,7 @@ Function Process100 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process11 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process11")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -90,7 +90,7 @@ Function Process11 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process12 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process12")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -99,7 +99,7 @@ Function Process12 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process13 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process13")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -108,7 +108,7 @@ Function Process13 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process14 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process14")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -117,7 +117,7 @@ Function Process14 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process15 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process15")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -126,7 +126,7 @@ Function Process15 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process16 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process16")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -135,7 +135,7 @@ Function Process16 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process17 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process17")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -144,7 +144,7 @@ Function Process17 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process18 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process18")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -153,7 +153,7 @@ Function Process18 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process19 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process19")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -162,7 +162,7 @@ Function Process19 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process2 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process2")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -171,7 +171,7 @@ Function Process2 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process20 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process20")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -180,7 +180,7 @@ Function Process20 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process21 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process21")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -189,7 +189,7 @@ Function Process21 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process22 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process22")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -198,7 +198,7 @@ Function Process22 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process23 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process23")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -207,7 +207,7 @@ Function Process23 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process24 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process24")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -216,7 +216,7 @@ Function Process24 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process25 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process25")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -225,7 +225,7 @@ Function Process25 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process26 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process26")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -234,7 +234,7 @@ Function Process26 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process27 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process27")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -243,7 +243,7 @@ Function Process27 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process28 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process28")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -252,7 +252,7 @@ Function Process28 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process29 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process29")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -261,7 +261,7 @@ Function Process29 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process3 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process3")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -270,7 +270,7 @@ Function Process3 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process30 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process30")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -279,7 +279,7 @@ Function Process30 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process31 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process31")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -288,7 +288,7 @@ Function Process31 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process32 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process32")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -297,7 +297,7 @@ Function Process32 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process33 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process33")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -306,7 +306,7 @@ Function Process33 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process34 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process34")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -315,7 +315,7 @@ Function Process34 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process35 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process35")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -324,7 +324,7 @@ Function Process35 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process36 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process36")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -333,7 +333,7 @@ Function Process36 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process37 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process37")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -342,7 +342,7 @@ Function Process37 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process38 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process38")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -351,7 +351,7 @@ Function Process38 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process39 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process39")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -360,7 +360,7 @@ Function Process39 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process4 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process4")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -369,7 +369,7 @@ Function Process4 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process40 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process40")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -378,7 +378,7 @@ Function Process40 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process41 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process41")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -387,7 +387,7 @@ Function Process41 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process42 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process42")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -396,7 +396,7 @@ Function Process42 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process43 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process43")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -405,7 +405,7 @@ Function Process43 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process44 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process44")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -414,7 +414,7 @@ Function Process44 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process45 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process45")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -423,7 +423,7 @@ Function Process45 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process46 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process46")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -432,7 +432,7 @@ Function Process46 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process47 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process47")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -441,7 +441,7 @@ Function Process47 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process48 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process48")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -450,7 +450,7 @@ Function Process48 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process49 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process49")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -459,7 +459,7 @@ Function Process49 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process5 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process5")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -468,7 +468,7 @@ Function Process5 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process50 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process50")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -477,7 +477,7 @@ Function Process50 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process51 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process51")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -486,7 +486,7 @@ Function Process51 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process52 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process52")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -495,7 +495,7 @@ Function Process52 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process53 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process53")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -504,7 +504,7 @@ Function Process53 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process54 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process54")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -513,7 +513,7 @@ Function Process54 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process55 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process55")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -522,7 +522,7 @@ Function Process55 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process56 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process56")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -531,7 +531,7 @@ Function Process56 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process57 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process57")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -540,7 +540,7 @@ Function Process57 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process58 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process58")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -549,7 +549,7 @@ Function Process58 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process59 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process59")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -558,7 +558,7 @@ Function Process59 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process6 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process6")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -567,7 +567,7 @@ Function Process6 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process60 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process60")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -576,7 +576,7 @@ Function Process60 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process61 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process61")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -585,7 +585,7 @@ Function Process61 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process62 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process62")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -594,7 +594,7 @@ Function Process62 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process63 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process63")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -603,7 +603,7 @@ Function Process63 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process64 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process64")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -612,7 +612,7 @@ Function Process64 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process65 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process65")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -621,7 +621,7 @@ Function Process65 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process66 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process66")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -630,7 +630,7 @@ Function Process66 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process67 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process67")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -639,7 +639,7 @@ Function Process67 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process68 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process68")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -648,7 +648,7 @@ Function Process68 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process69 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process69")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -657,7 +657,7 @@ Function Process69 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process7 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process7")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -666,7 +666,7 @@ Function Process7 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process70 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process70")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -675,7 +675,7 @@ Function Process70 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process71 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process71")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -684,7 +684,7 @@ Function Process71 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process72 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process72")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -693,7 +693,7 @@ Function Process72 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process73 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process73")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -702,7 +702,7 @@ Function Process73 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process74 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process74")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -711,7 +711,7 @@ Function Process74 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process75 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process75")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -720,7 +720,7 @@ Function Process75 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process76 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process76")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -729,7 +729,7 @@ Function Process76 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process77 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process77")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -738,7 +738,7 @@ Function Process77 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process78 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process78")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -747,7 +747,7 @@ Function Process78 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process79 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process79")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -756,7 +756,7 @@ Function Process79 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process8 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process8")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -765,7 +765,7 @@ Function Process8 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process80 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process80")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -774,7 +774,7 @@ Function Process80 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process81 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process81")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -783,7 +783,7 @@ Function Process81 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process82 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process82")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -792,7 +792,7 @@ Function Process82 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process83 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process83")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -801,7 +801,7 @@ Function Process83 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process84 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process84")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -810,7 +810,7 @@ Function Process84 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process85 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process85")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -819,7 +819,7 @@ Function Process85 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process86 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process86")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -828,7 +828,7 @@ Function Process86 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process87 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process87")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -837,7 +837,7 @@ Function Process87 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process88 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process88")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -846,7 +846,7 @@ Function Process88 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process89 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process89")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -855,7 +855,7 @@ Function Process89 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process9 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process9")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -864,7 +864,7 @@ Function Process9 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process90 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process90")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -873,7 +873,7 @@ Function Process90 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process91 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process91")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -882,7 +882,7 @@ Function Process91 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process92 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process92")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -891,7 +891,7 @@ Function Process92 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process93 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process93")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -900,7 +900,7 @@ Function Process93 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process94 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process94")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -909,7 +909,7 @@ Function Process94 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process95 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process95")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -918,7 +918,7 @@ Function Process95 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process96 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process96")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -927,7 +927,7 @@ Function Process96 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process97 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process97")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -936,7 +936,7 @@ Function Process97 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process98 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process98")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -945,7 +945,7 @@ Function Process98 (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function Process99 (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Process99")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -955,18 +955,18 @@ Function Process99 (arity: 1, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -987,19 +987,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -1028,28 +1028,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/parser_strings/baml_tests__parser_strings__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 7
-Objects: 75
-Globals: 54
+Objects: 76
+Globals: 55
 
 Function FormatMessage (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("FormatMessage")
      2   LOAD_VAR 1       (name)
      3   LOAD_CONST 1     ("name")
@@ -17,7 +17,7 @@ Function FormatMessage (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function GPT4.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 45      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("GPT4")
      2    LOAD_CONST 1        ("unknown")
      3    LOAD_CONST 2        ("user")
@@ -35,7 +35,7 @@ Function GetRole (arity: 0, kind: Bytecode):
      1   RETURN         
 
 Function ProcessText (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("ProcessText")
      2   LOAD_VAR 1       (input)
      3   LOAD_CONST 1     ("input")
@@ -45,18 +45,18 @@ Function ProcessText (arity: 1, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -77,19 +77,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -118,28 +118,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/pending_greaters_fix/baml_tests__pending_greaters_fix__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 5
-Objects: 63
-Globals: 52
+Objects: 64
+Globals: 53
 
 Function BadParam (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("BadParam")
      2   LOAD_VAR 1       (x)
      3   LOAD_CONST 1     ("x")
@@ -17,7 +17,7 @@ Function BadParam (arity: 1, kind: Bytecode):
      6   RETURN           
 
 Function BadReturnType (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("BadReturnType")
      2   ALLOC_MAP 0      
      3   CALL 2           
@@ -25,18 +25,18 @@ Function BadReturnType (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -57,19 +57,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -98,28 +98,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/retry_policy/baml_tests__retry_policy__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 65
-Globals: 51
+Objects: 66
+Globals: 52
 
 Function MyClient.resolve (arity: 0, kind: Bytecode):
-     0    LOAD_GLOBAL 44      (<fn baml.llm.build_primitive_client>)
+     0    LOAD_GLOBAL 45      (<fn baml.llm.build_primitive_client>)
      1    LOAD_CONST 0        ("MyClient")
      2    LOAD_CONST 1        ("openai")
      3    LOAD_CONST 2        ("user")
@@ -25,18 +25,18 @@ Function MyClient.resolve (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -57,19 +57,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -98,28 +98,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_function/baml_tests__simple_function__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 60
-Globals: 51
+Objects: 61
+Globals: 52
 
 Function HelloWorld (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("HelloWorld")
      2   LOAD_VAR 1       (name)
      3   LOAD_CONST 1     ("name")
@@ -18,18 +18,18 @@ Function HelloWorld (arity: 1, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -50,19 +50,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -91,28 +91,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/simple_type_error/baml_tests__simple_type_error__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 58
-Globals: 51
+Objects: 59
+Globals: 52
 
 Function Foo (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -15,18 +15,18 @@ Function Foo (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -47,19 +47,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -88,28 +88,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_header_comment/baml_tests__top_level_header_comment__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 57
-Globals: 51
+Objects: 58
+Globals: 52
 
 Function Foo (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -13,18 +13,18 @@ Function Foo (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -45,19 +45,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -86,28 +86,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/top_level_let/baml_tests__top_level_let__06_codegen.snap
@@ -1,26 +1,26 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 3
-Objects: 56
-Globals: 50
+Objects: 57
+Globals: 51
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -41,19 +41,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -82,28 +82,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_aliases/baml_tests__type_aliases__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 8
-Objects: 64
-Globals: 55
+Objects: 65
+Globals: 56
 
 Function Bar (arity: 0, kind: Bytecode):
      0   LOAD_CONST 0   (true)
@@ -33,18 +33,18 @@ Function MakeJSON (arity: 1, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -65,19 +65,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -106,28 +106,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_errors/baml_tests__type_builder_errors__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 60
-Globals: 51
+Objects: 61
+Globals: 52
 
 Function TypeBuilderFn (arity: 1, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("TypeBuilderFn")
      2   LOAD_VAR 1       (from_text)
      3   LOAD_CONST 1     ("from_text")
@@ -18,18 +18,18 @@ Function TypeBuilderFn (arity: 1, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -50,19 +50,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -91,28 +91,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/type_builder_test/baml_tests__type_builder_test__06_codegen.snap
@@ -1,14 +1,14 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 4
-Objects: 60
-Globals: 51
+Objects: 61
+Globals: 52
 
 Function Fn (arity: 0, kind: Bytecode):
-     0   LOAD_GLOBAL 49   (<fn baml.llm.call_llm_function>)
+     0   LOAD_GLOBAL 50   (<fn baml.llm.call_llm_function>)
      1   LOAD_CONST 0     ("Fn")
      2   ALLOC_MAP 0      
      3   CALL 2           
@@ -16,18 +16,18 @@ Function Fn (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -48,19 +48,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -89,28 +89,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/unknown_type_error/baml_tests__unknown_type_error__06_codegen.snap
@@ -1,11 +1,11 @@
 ---
-source: target/debug/build/baml_tests-6b46971f444a527b/out/generated_tests.rs
+source: target/debug/build/baml_tests-9a8b4d484ca600e9/out/generated_tests.rs
 expression: output
 ---
 === BYTECODE ===
 Functions: 6
-Objects: 59
-Globals: 53
+Objects: 60
+Globals: 54
 
 Function Bar (arity: 1, kind: Bytecode):
      0   LOAD_CONST 0   (1)
@@ -21,18 +21,18 @@ Function Foo (arity: 0, kind: Bytecode):
 
 Function baml.llm.build_request (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 4       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -53,19 +53,19 @@ Function baml.llm.build_request (arity: 2, kind: Bytecode):
      30   RETURN              
 
 Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
-     0    INIT_LOCALS 7       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     0    INIT_LOCALS 8       
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)
@@ -94,28 +94,33 @@ Function baml.llm.call_llm_function (arity: 2, kind: Bytecode):
      38   DISPATCH_FUTURE 1   
      39   AWAIT               
      40   STORE_VAR 9         (result)
-     41   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
-     42   LOAD_VAR 4          (primitive_client)
-     43   LOAD_VAR 9          (result)
-     44   LOAD_VAR 1          (function_name)
-     45   DISPATCH_FUTURE 3   
-     46   AWAIT               
-     47   RETURN              
+     41   LOAD_GLOBAL 41      (<fn baml.llm.get_return_type>)
+     42   LOAD_VAR 1          (function_name)
+     43   DISPATCH_FUTURE 1   
+     44   AWAIT               
+     45   STORE_VAR 10        (return_type)
+     46   LOAD_GLOBAL 37      (<fn baml.llm.PrimitiveClient.parse>)
+     47   LOAD_VAR 4          (primitive_client)
+     48   LOAD_VAR 9          (result)
+     49   LOAD_VAR 10         (return_type)
+     50   DISPATCH_FUTURE 3   
+     51   AWAIT               
+     52   RETURN              
 
 Function baml.llm.render_prompt (arity: 2, kind: Bytecode):
      0    INIT_LOCALS 3       
-     1    LOAD_GLOBAL 43      (<fn baml.llm.get_jinja_template>)
+     1    LOAD_GLOBAL 44      (<fn baml.llm.get_jinja_template>)
      2    LOAD_VAR 1          (function_name)
      3    DISPATCH_FUTURE 1   
      4    AWAIT               
      5    STORE_VAR 3         (jinja_string)
-     6    LOAD_GLOBAL 46      (<fn baml.llm.get_client_function>)
+     6    LOAD_GLOBAL 47      (<fn baml.llm.get_client_function>)
      7    LOAD_VAR 1          (function_name)
      8    DISPATCH_FUTURE 1   
      9    AWAIT               
      10   CALL 0              
      11   STORE_VAR 4         (primitive_client)
-     12   LOAD_GLOBAL 45      (<fn baml.llm.PrimitiveClient.render_prompt>)
+     12   LOAD_GLOBAL 46      (<fn baml.llm.PrimitiveClient.render_prompt>)
      13   LOAD_VAR 4          (primitive_client)
      14   LOAD_VAR 3          (jinja_string)
      15   LOAD_VAR 2          (args)

--- a/baml_language/crates/baml_tests/src/vm.rs
+++ b/baml_language/crates/baml_tests/src/vm.rs
@@ -152,6 +152,7 @@ impl Object {
             VmObject::Collector(_) => {
                 anyhow::bail!("Unsupported object type for testing: {obj:?}")
             }
+            VmObject::Type(_) => anyhow::bail!("Unsupported object type for testing: {obj:?}"),
             #[cfg(feature = "heap_debug")]
             VmObject::Sentinel(_) => anyhow::bail!("Unsupported object type for testing: {obj:?}"),
         }

--- a/baml_language/crates/baml_type/src/convert.rs
+++ b/baml_language/crates/baml_type/src/convert.rs
@@ -146,6 +146,7 @@ pub fn convert_tir_ty(
         baml_compiler_tir::Ty::Resource => Ok(Ty::Resource),
         // BuiltinUnknown is preserved for VIR type checking at call sites.
         baml_compiler_tir::Ty::BuiltinUnknown => Ok(Ty::BuiltinUnknown),
+        baml_compiler_tir::Ty::Type => Ok(Ty::Type),
 
         baml_compiler_tir::Ty::WatchAccessor(inner) => Ok(Ty::WatchAccessor(Box::new(
             convert_tir_ty(inner, aliases, recursive_aliases)?,

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -99,6 +99,9 @@ pub enum Ty {
     Resource,
     /// Opaque structured prompt tree for LLM calls.
     PromptAst,
+    /// Meta-type — a runtime value that wraps a `Ty`.
+    /// Used by `baml.llm.parse()` to accept a type descriptor.
+    Type,
 
     // --- Compiler-specific: present in VIR/MIR, absent at runtime ---
     /// Only recursive aliases survive lower_ty; non-recursive are expanded.
@@ -261,7 +264,8 @@ impl Ty {
             | Ty::Class(_)
             | Ty::Enum(_)
             | Ty::Resource
-            | Ty::PromptAst => Ok(()),
+            | Ty::PromptAst
+            | Ty::Type => Ok(()),
         }
     }
 }
@@ -285,6 +289,7 @@ impl fmt::Display for Ty {
             Ty::Enum(tn) => write!(f, "{tn}"),
             Ty::Resource => write!(f, "resource"),
             Ty::PromptAst => write!(f, "prompt_ast"),
+            Ty::Type => write!(f, "type"),
             Ty::TypeAlias(tn) => write!(f, "{tn}"),
             Ty::Optional(inner) => write!(f, "{inner}?"),
             Ty::List(inner) => write!(f, "{inner}[]"),

--- a/baml_language/crates/baml_type/src/typetag.rs
+++ b/baml_language/crates/baml_type/src/typetag.rs
@@ -56,6 +56,9 @@ pub const PROMPT_AST: i64 = 12;
 /// `Collector` type tag.
 pub const COLLECTOR: i64 = 13;
 
+/// `Type` meta-type tag.
+pub const TYPE: i64 = 14;
+
 /// Base value for class type tags (classes start at 100).
 pub const CLASS_BASE: i64 = 100;
 

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -194,6 +194,7 @@ impl BexEngine {
                 ast.clone(),
             ))),
             Object::Collector(c) => Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone()))),
+            Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type(ty.clone()))),
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => Err(EngineError::CannotSnapshot {
                 type_name: "sentinel".to_string(),
@@ -274,6 +275,7 @@ impl BexEngine {
             BexExternalValue::Adt(BexExternalAdt::Media(media)) => vm.alloc_media(media),
             BexExternalValue::Adt(BexExternalAdt::PromptAst(ast)) => vm.alloc_prompt_ast(ast),
             BexExternalValue::Adt(BexExternalAdt::Collector(c)) => vm.alloc_collector(c),
+            BexExternalValue::Adt(BexExternalAdt::Type(ty)) => vm.alloc_type(ty),
             BexExternalValue::FunctionRef { global_index } => {
                 let idx = bex_vm_types::GlobalIndex::from_raw(global_index);
                 assert!(
@@ -417,6 +419,7 @@ fn value_matches_type(value: &BexExternalValue, ty: &Ty) -> bool {
         (BexExternalValue::Adt(BexExternalAdt::Media(_)), Ty::Media(_)) => true,
         (BexExternalValue::Adt(BexExternalAdt::PromptAst(_)), Ty::PromptAst) => true,
         (BexExternalValue::Adt(BexExternalAdt::Collector(_)), _) => false,
+        (BexExternalValue::Adt(BexExternalAdt::Type(_)), Ty::Type) => true,
         (BexExternalValue::Union { value, .. }, ty) => value_matches_type(value, ty),
         // Handle nested unions/optionals in the type
         (value, Ty::Union(members)) => members.iter().any(|m| value_matches_type(value, m)),

--- a/baml_language/crates/bex_events/src/serialize.rs
+++ b/baml_language/crates/bex_events/src/serialize.rs
@@ -135,6 +135,9 @@ fn bex_value_to_json(value: &BexExternalValue) -> serde_json::Value {
         BexExternalValue::Adt(BexExternalAdt::Collector(_)) => {
             serde_json::json!({"__adt": "Collector"})
         }
+        BexExternalValue::Adt(BexExternalAdt::Type(ty)) => {
+            serde_json::json!({"__adt": "Type", "value": format!("{ty}")})
+        }
     }
 }
 

--- a/baml_language/crates/bex_external_types/src/bex_external_value.rs
+++ b/baml_language/crates/bex_external_types/src/bex_external_value.rs
@@ -85,6 +85,7 @@ pub enum BexExternalAdt {
     Media(bex_vm_types::MediaValue),
     PromptAst(bex_vm_types::PromptAst),
     Collector(bex_vm_types::CollectorRef),
+    Type(baml_type::Ty),
 }
 
 /// A deep-copied value tree with no heap references.
@@ -192,6 +193,7 @@ impl BexExternalAdt {
             },
             BexExternalAdt::PromptAst(_) => "prompt_ast",
             BexExternalAdt::Collector(_) => "collector",
+            BexExternalAdt::Type(_) => "type",
         }
     }
 }
@@ -296,6 +298,12 @@ impl AsBexExternalValue for bool {
 impl AsBexExternalValue for bex_vm_types::PromptAst {
     fn into_bex_external_value(self) -> BexExternalValue {
         BexExternalValue::Adt(BexExternalAdt::PromptAst(self))
+    }
+}
+
+impl AsBexExternalValue for baml_type::Ty {
+    fn into_bex_external_value(self) -> BexExternalValue {
+        BexExternalValue::Adt(BexExternalAdt::Type(self))
     }
 }
 

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -550,6 +550,39 @@ impl<'a> BexValue<'a> {
         }
     }
 
+    pub fn as_baml_type_owned(
+        self,
+        heap: &GcProtectedHeap<'_>,
+    ) -> Result<baml_type::Ty, AccessError> {
+        fn from_ptr(ptr: &HeapPtr) -> Result<baml_type::Ty, AccessError> {
+            let obj = unsafe { ptr.get() };
+            let Object::Type(ty) = obj else {
+                return Err(AccessError::TypeMismatch {
+                    expected: "type",
+                    actual: obj.to_string(),
+                });
+            };
+            Ok(ty.clone())
+        }
+
+        match self {
+            BexValue::ExternalValue(BexExternalValue::Adt(BexExternalAdt::Type(ty))) => {
+                Ok(ty.clone())
+            }
+            BexValue::ExternalValue(BexExternalValue::Handle(handle)) => {
+                let ptr = heap
+                    .resolve_handle(handle.slab_key())
+                    .ok_or(AccessError::InvalidHandle { expected: "type" })?;
+                from_ptr(&ptr)
+            }
+            BexValue::Value(Value::Object(ptr)) | BexValue::HeapPtr(ptr) => from_ptr(ptr),
+            other => Err(AccessError::TypeMismatch {
+                expected: "type",
+                actual: other.type_name(),
+            }),
+        }
+    }
+
     /// Attempts to own as much as possible.
     /// If it can't be owned, it fails.
     pub fn as_owned_but_very_slow(
@@ -717,6 +750,7 @@ impl<'a> BexValue<'a> {
                     Object::Collector(c) => {
                         Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone())))
                     }
+                    Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type(ty.clone()))),
                     #[cfg(feature = "heap_debug")]
                     Object::Sentinel(sentinel_kind) => Err(AccessError::CannotConvertToOwned {
                         reason: format!("sentinel: {:?}", sentinel_kind),

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -320,7 +320,8 @@ impl BexHeap {
             | Object::Media(_)
             | Object::PromptAst(_)
             | Object::Resource(_)
-            | Object::Collector(_) => {}
+            | Object::Collector(_)
+            | Object::Type(_) => {}
         }
     }
 
@@ -390,7 +391,8 @@ impl BexHeap {
             | Object::Media(_)
             | Object::PromptAst(_)
             | Object::Resource(_)
-            | Object::Collector(_) => {}
+            | Object::Collector(_)
+            | Object::Type(_) => {}
         }
     }
 

--- a/baml_language/crates/bex_heap/src/heap_debugger/real.rs
+++ b/baml_language/crates/bex_heap/src/heap_debugger/real.rs
@@ -352,7 +352,8 @@ impl BexHeap {
             | Object::Media(_)
             | Object::PromptAst(_)
             | Object::Resource(_)
-            | Object::Collector(_) => {}
+            | Object::Collector(_)
+            | Object::Type(_) => {}
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => {}
         }

--- a/baml_language/crates/bex_vm/src/native.rs
+++ b/baml_language/crates/bex_vm/src/native.rs
@@ -289,6 +289,7 @@ fn deep_copy_value_recursive(
                 Object::Future(f) => vm.tlab.alloc(Object::Future(f)),
                 Object::PromptAst(ast) => vm.tlab.alloc(Object::PromptAst(ast)),
                 Object::Collector(c) => vm.tlab.alloc(Object::Collector(c)),
+                Object::Type(ty) => vm.tlab.alloc(Object::Type(ty)),
                 #[cfg(feature = "heap_debug")]
                 Object::Sentinel(kind) => vm.tlab.alloc(Object::Sentinel(kind)),
             };
@@ -528,6 +529,7 @@ fn format_value_recursive(vm: &mut BexVm, value: &Value, depth: usize) -> Result
             Object::Future(_) => Ok("<future>".to_string()),
             Object::PromptAst(_) => Ok("<prompt_ast>".to_string()),
             Object::Collector(_) => Ok("<collector>".to_string()),
+            Object::Type(ty) => Ok(format!("<type: {ty}>")),
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => Ok("<sentinel>".to_string()),
         },

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -375,6 +375,7 @@ fn value_type_tag(value: &Value) -> i64 {
                 Object::Resource(_) => type_tags::RESOURCE,
                 Object::PromptAst(_) => type_tags::PROMPT_AST,
                 Object::Collector(_) => type_tags::COLLECTOR,
+                Object::Type(_) => type_tags::TYPE,
                 Object::Class(_) => type_tags::UNKNOWN,
                 #[cfg(feature = "heap_debug")]
                 Object::Sentinel(_) => type_tags::UNKNOWN,
@@ -787,6 +788,11 @@ impl BexVm {
 
     pub fn alloc_media(&mut self, media: bex_vm_types::types::MediaValue) -> Value {
         Value::Object(self.tlab.alloc(Object::Media(media)))
+    }
+
+    /// Allocate a type descriptor object on the heap.
+    pub fn alloc_type(&mut self, ty: baml_type::Ty) -> Value {
+        Value::Object(self.tlab.alloc(Object::Type(ty)))
     }
 
     /// Builds a stack trace for the given error.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -497,6 +497,9 @@ pub enum Object {
     /// Collector object (opaque handle to `bex_events::Collector`).
     Collector(CollectorRef),
 
+    /// A type descriptor value — wraps a `baml_type::Ty`.
+    Type(baml_type::Ty),
+
     #[cfg(feature = "heap_debug")]
     Sentinel(SentinelKind),
     // TODO: Figure out how to handle this here.
@@ -518,6 +521,7 @@ impl std::fmt::Display for Object {
             Object::Media(media) => media.fmt(f),
             Object::Resource(r) => write!(f, "<{r}>"),
             Object::Collector(_) => write!(f, "<collector>"),
+            Object::Type(ty) => write!(f, "<type: {ty}>"),
             Object::PromptAst(prompt) => write!(f, "<prompt_ast {prompt:?}>"),
             Object::Future(future) => match future {
                 Future::Pending(future) => {
@@ -617,6 +621,7 @@ pub enum ObjectType {
     Resource,
     PromptAst,
     Collector,
+    Type,
 }
 
 impl ObjectType {
@@ -634,6 +639,7 @@ impl ObjectType {
             Object::Resource(_) => Self::Resource,
             Object::PromptAst(_) => Self::PromptAst,
             Object::Collector(_) => Self::Collector,
+            Object::Type(_) => Self::Type,
             Object::Future(fut) => Self::Future(fut.into()),
             #[cfg(feature = "heap_debug")]
             Object::Sentinel(_) => Self::Any,
@@ -671,6 +677,7 @@ impl std::fmt::Display for ObjectType {
             ObjectType::Resource => write!(f, "resource"),
             ObjectType::PromptAst => write!(f, "prompt_ast"),
             ObjectType::Collector => write!(f, "collector"),
+            ObjectType::Type => write!(f, "type"),
         }
     }
 }

--- a/baml_language/crates/bridge_ctypes/src/value_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_encode.rs
@@ -109,7 +109,9 @@ pub fn external_to_cffi_value(value: &BexExternalValue) -> Result<CffiValueHolde
         }
         // Runtime-only types not representable in CFFI; map to null (caller receives null value).
         BexExternalValue::Resource(_handle) => None,
-        BexExternalValue::Adt(BexExternalAdt::PromptAst(_) | BexExternalAdt::Collector(_))
+        BexExternalValue::Adt(
+            BexExternalAdt::PromptAst(_) | BexExternalAdt::Collector(_) | BexExternalAdt::Type(_),
+        )
         | BexExternalValue::FunctionRef { .. } => None,
     };
 
@@ -148,7 +150,7 @@ fn ty_to_field_type(ty: &Ty) -> CffiFieldTypeHolder {
             value: Some(Box::new(ty_to_field_type(inner))),
         }))),
         Ty::Media(_) | Ty::Literal(_) => Some(FieldType::AnyType(CffiFieldTypeAny {})),
-        Ty::Resource | Ty::PromptAst => {
+        Ty::Resource | Ty::PromptAst | Ty::Type => {
             unreachable!("runtime-only variant should not reach FFI type encoding")
         }
         Ty::TypeAlias(_)

--- a/baml_language/crates/sys_llm/src/jinja/value_conversion.rs
+++ b/baml_language/crates/sys_llm/src/jinja/value_conversion.rs
@@ -85,6 +85,10 @@ pub(crate) fn external_value_to_jinja(
             })
         }
 
+        BexExternalValue::Adt(BexExternalAdt::Type(_)) => Err(RenderPromptError::ConversionError {
+            reason: "Type values cannot be passed to Jinja templates".to_string(),
+        }),
+
         BexExternalValue::FunctionRef { .. } => Err(RenderPromptError::ConversionError {
             reason: "FunctionRef should not be passed to Jinja templates".to_string(),
         }),

--- a/baml_language/crates/sys_llm/src/types/output_format.rs
+++ b/baml_language/crates/sys_llm/src/types/output_format.rs
@@ -199,6 +199,7 @@ impl OutputFormatContent {
             // Runtime-only variants that shouldn't appear in LLM prompts
             Ty::Resource => Err(RenderError::UnsupportedType("resource".to_string())),
             Ty::PromptAst => Err(RenderError::UnsupportedType("prompt_ast".to_string())),
+            Ty::Type => Err(RenderError::UnsupportedType("type".to_string())),
 
             // Compiler-only variants should never reach runtime
             Ty::TypeAlias(_)

--- a/baml_language/crates/sys_types/src/lib.rs
+++ b/baml_language/crates/sys_types/src/lib.rs
@@ -479,23 +479,25 @@ impl<T> SysOpLlm for T {
         &self,
         primitive_client: bex_heap::builtin_types::owned::LlmPrimitiveClient,
         response: String,
+        type_def: baml_type::Ty,
+    ) -> SysOpOutput {
+        SysOpOutput::Ready(
+            sys_llm::execute_parse_response_from_owned(&primitive_client, &response, &type_def)
+                .map_err(OpErrorKind::from),
+        )
+    }
+
+    fn baml_llm_get_return_type(
+        &self,
         function_name: String,
         ctx: &SysOpContext,
-    ) -> SysOpOutput {
+    ) -> SysOpOutput<baml_type::Ty> {
         let Some(info) = ctx.llm_functions.get(&function_name) else {
             return SysOpOutput::err(OpErrorKind::Other(format!(
                 "LLM function not found: {function_name}"
             )));
         };
-
-        SysOpOutput::Ready(
-            sys_llm::execute_parse_response_from_owned(
-                &primitive_client,
-                &response,
-                &info.return_type,
-            )
-            .map_err(OpErrorKind::from),
-        )
+        SysOpOutput::ok(info.return_type.clone())
     }
 
     fn baml_llm_get_jinja_template(

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -2490,6 +2490,7 @@ fn format_vm_value(value: &bex_vm_types::Value, vm: &bex_vm::BexVm) -> String {
                 Object::Resource(r) => format!("<resource: {}>", r),
                 Object::PromptAst(_) => "<prompt_ast>".to_string(),
                 Object::Collector(_) => "<collector>".to_string(),
+                Object::Type(ty) => format!("<type: {ty}>"),
                 #[cfg(feature = "heap_debug")]
                 Object::Sentinel(_) => "<sentinel>".to_string(),
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime support for explicit "type" descriptor values and allocation/display of type objects.

* **Refactor**
  * LLM response parsing now uses explicit return-type information for more reliable deserialization.

* **Bug Fixes**
  * Rendering and template conversion hardened: type-descriptor values are formatted consistently and are blocked from being passed into Jinja templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->