### PR TITLE
baml-language: implement baml_types::Ty::Opaque

### DIFF
--- a/baml_language/crates/baml_compiler_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler_mir/src/lower.rs
@@ -1917,7 +1917,7 @@ impl<'a, 'ctx> LoweringContext<'a, 'ctx> {
             // Works for both builtin class types and primitive types with methods
             let type_name = match &base_ty {
                 Ty::Class(tn) if !tn.module_path.is_empty() => Some(tn.display_name.to_string()),
-                Ty::PromptAst => Some("baml.llm.PromptAst".to_string()),
+                Ty::Opaque(tn) => Some(tn.display_name.to_string()),
                 Ty::List(_) => Some("baml.Array".to_string()),
                 Ty::String => Some("baml.String".to_string()),
                 Ty::Map { .. } => Some("baml.Map".to_string()),

--- a/baml_language/crates/baml_compiler_tir/src/builtins.rs
+++ b/baml_language/crates/baml_compiler_tir/src/builtins.rs
@@ -415,19 +415,27 @@ mod tests {
     #[test]
     fn test_match_opaque_types() {
         assert!(match_pattern(&TypePattern::Resource, &Ty::Resource).is_some());
+        assert!(match_pattern(&TypePattern::Type, &Ty::Type).is_some());
 
-        // Resource should not match other types
+        // Type also matches error recovery types
+        assert!(match_pattern(&TypePattern::Type, &Ty::Unknown).is_some());
+        assert!(match_pattern(&TypePattern::Type, &Ty::Error).is_some());
+
+        // Neither matches unrelated types
         assert!(match_pattern(&TypePattern::Resource, &Ty::Int).is_none());
+        assert!(match_pattern(&TypePattern::Type, &Ty::Int).is_none());
     }
 
     #[test]
     fn test_substitute_opaque_types() {
         let bindings = HashMap::new();
         assert_eq!(substitute(&TypePattern::Resource, &bindings), Ty::Resource);
+        assert_eq!(substitute(&TypePattern::Type, &bindings), Ty::Type);
     }
 
     #[test]
     fn test_substitute_unknown_opaque_types() {
         assert_eq!(substitute_unknown(&TypePattern::Resource), Ty::Resource);
+        assert_eq!(substitute_unknown(&TypePattern::Type), Ty::Type);
     }
 }

--- a/baml_language/crates/baml_type/src/convert.rs
+++ b/baml_language/crates/baml_type/src/convert.rs
@@ -83,7 +83,7 @@ pub fn convert_tir_ty(
             // Most builtins are Object::Instance, but PromptAst wraps an opaque
             // Rust ADT and has its own Object variant.
             if baml_compiler_tir::is_prompt_ast_class(fqn) {
-                return Ok(Ty::PromptAst);
+                return Ok(Ty::prompt_ast());
             }
             Ok(Ty::Class(fqn_to_type_name(fqn)))
         }
@@ -143,10 +143,10 @@ pub fn convert_tir_ty(
         baml_compiler_tir::Ty::Unknown => Ok(Ty::Null),
         baml_compiler_tir::Ty::Error => Ok(Ty::Null),
         baml_compiler_tir::Ty::Void => Ok(Ty::Void),
-        baml_compiler_tir::Ty::Resource => Ok(Ty::Resource),
+        baml_compiler_tir::Ty::Resource => Ok(Ty::resource()),
         // BuiltinUnknown is preserved for VIR type checking at call sites.
         baml_compiler_tir::Ty::BuiltinUnknown => Ok(Ty::BuiltinUnknown),
-        baml_compiler_tir::Ty::Type => Ok(Ty::Type),
+        baml_compiler_tir::Ty::Type => Ok(Ty::big_t_type()),
 
         baml_compiler_tir::Ty::WatchAccessor(inner) => Ok(Ty::WatchAccessor(Box::new(
             convert_tir_ty(inner, aliases, recursive_aliases)?,

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -95,13 +95,20 @@ pub enum Ty {
     Union(Vec<Ty>),
 
     // --- Runtime-only: present at runtime, not in user-facing type syntax ---
-    /// Opaque resource handle (file, socket, HTTP response body).
-    Resource,
-    /// Opaque structured prompt tree for LLM calls.
-    PromptAst,
-    /// Meta-type — a runtime value that wraps a `Ty`.
-    /// Used by `baml.llm.parse()` to accept a type descriptor.
-    Type,
+    /// Opaque runtime-only type, identified by its qualified name.
+    ///
+    /// Used for types that the type system treats generically (nominal equality,
+    /// no structural decomposition, infinite for exhaustiveness) but whose
+    /// *values* are concrete Rust types on the VM heap.
+    ///
+    /// Well-known opaque types:
+    /// - `baml.llm.Resource` — file/socket/HTTP response handles
+    /// - `baml.llm.PromptAst` — structured prompt trees for LLM calls
+    /// - `big_t_type` — meta-type wrapping a `Ty` for reflection
+    ///
+    /// Use the convenience constructors `Ty::resource()`, `Ty::prompt_ast()`,
+    /// `Ty::big_t_type()` instead of constructing directly.
+    Opaque(TypeName),
 
     // --- Compiler-specific: present in VIR/MIR, absent at runtime ---
     /// Only recursive aliases survive lower_ty; non-recursive are expanded.
@@ -141,6 +148,67 @@ pub enum Ty {
 //   produces `Void` directly instead of `Never`.
 
 impl Ty {
+    // --- Opaque type constructors ---
+
+    /// Helper to build a TypeName for a builtin opaque type.
+    ///
+    /// `qualified_name`: dotted path like `"baml.llm.Resource"` — the last
+    /// segment becomes `name`, everything before it becomes `module_path`.
+    ///
+    /// `display`: the user-facing display string (may differ from the
+    /// qualified name).
+    fn opaque_builtin(qualified_name: &str, display: &str) -> Self {
+        let segments: Vec<&str> = qualified_name.split('.').collect();
+        let name = Name::new(*segments.last().expect("qualified_name must be non-empty"));
+        let module_path = segments[..segments.len() - 1]
+            .iter()
+            .map(Name::new)
+            .collect();
+        Ty::Opaque(TypeName {
+            name,
+            module_path,
+            display_name: Name::new(display),
+        })
+    }
+
+    /// Opaque resource handle type (file, socket, HTTP response body).
+    pub fn resource() -> Self {
+        Self::opaque_builtin("baml.llm.Resource", "baml.llm.Resource")
+    }
+
+    /// Opaque structured prompt tree type for LLM calls.
+    pub fn prompt_ast() -> Self {
+        Self::opaque_builtin("baml.llm.PromptAst", "baml.llm.PromptAst")
+    }
+
+    /// Meta-type — a runtime value that wraps a `Ty`.
+    pub fn big_t_type() -> Self {
+        Self::opaque_builtin("baml.reflect.Type", "big_t_type")
+    }
+
+    /// Check if this is an opaque type with the given qualified name
+    /// (e.g. `"baml.llm.PromptAst"`).
+    pub fn is_opaque(&self, qualified_name: &str) -> bool {
+        match self {
+            Ty::Opaque(tn) => {
+                // Build "module.path.Name" and compare.
+                let mut parts: Vec<&str> = tn.module_path.iter().map(|n| n.as_str()).collect();
+                parts.push(tn.name.as_str());
+                let full = parts.join(".");
+                full == qualified_name
+            }
+            _ => false,
+        }
+    }
+
+    /// If this is an opaque type, return its TypeName.
+    pub fn as_opaque(&self) -> Option<&TypeName> {
+        match self {
+            Ty::Opaque(tn) => Some(tn),
+            _ => None,
+        }
+    }
+
     /// Check if this is the void type.
     pub fn is_void(&self) -> bool {
         matches!(self, Ty::Void)
@@ -263,9 +331,7 @@ impl Ty {
             | Ty::Literal(_)
             | Ty::Class(_)
             | Ty::Enum(_)
-            | Ty::Resource
-            | Ty::PromptAst
-            | Ty::Type => Ok(()),
+            | Ty::Opaque(_) => Ok(()),
         }
     }
 }
@@ -287,9 +353,7 @@ impl fmt::Display for Ty {
             },
             Ty::Class(tn) => write!(f, "{tn}"),
             Ty::Enum(tn) => write!(f, "{tn}"),
-            Ty::Resource => write!(f, "resource"),
-            Ty::PromptAst => write!(f, "prompt_ast"),
-            Ty::Type => write!(f, "type"),
+            Ty::Opaque(tn) => write!(f, "{tn}"),
             Ty::TypeAlias(tn) => write!(f, "{tn}"),
             Ty::Optional(inner) => write!(f, "{inner}?"),
             Ty::List(inner) => write!(f, "{inner}[]"),
@@ -400,14 +464,27 @@ mod tests {
 
     #[test]
     fn test_validate_runtime_accepts_opaque_types() {
-        assert!(Ty::Resource.validate_runtime().is_ok());
-        assert!(Ty::PromptAst.validate_runtime().is_ok());
+        assert!(Ty::resource().validate_runtime().is_ok());
+        assert!(Ty::prompt_ast().validate_runtime().is_ok());
+        assert!(Ty::big_t_type().validate_runtime().is_ok());
     }
 
     #[test]
     fn test_display_opaque_types() {
-        assert_eq!(Ty::Resource.to_string(), "resource");
-        assert_eq!(Ty::PromptAst.to_string(), "prompt_ast");
+        assert_eq!(Ty::resource().to_string(), "baml.llm.Resource");
+        assert_eq!(Ty::prompt_ast().to_string(), "baml.llm.PromptAst");
+        assert_eq!(Ty::big_t_type().to_string(), "big_t_type");
+    }
+
+    #[test]
+    fn test_opaque_helpers() {
+        assert!(Ty::resource().is_opaque("baml.llm.Resource"));
+        assert!(!Ty::resource().is_opaque("baml.reflect.Type"));
+        assert_eq!(
+            Ty::prompt_ast().as_opaque().map(|tn| tn.name.as_str()),
+            Some("PromptAst"),
+        );
+        assert_eq!(Ty::Int.as_opaque(), None);
     }
 
     #[test]

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -417,9 +417,17 @@ fn value_matches_type(value: &BexExternalValue, ty: &Ty) -> bool {
             enum_name.as_str() == tn.display_name.as_str()
         }
         (BexExternalValue::Adt(BexExternalAdt::Media(_)), Ty::Media(_)) => true,
-        (BexExternalValue::Adt(BexExternalAdt::PromptAst(_)), Ty::PromptAst) => true,
+        (BexExternalValue::Adt(BexExternalAdt::PromptAst(_)), ty)
+            if ty.is_opaque("baml.llm.PromptAst") =>
+        {
+            true
+        }
         (BexExternalValue::Adt(BexExternalAdt::Collector(_)), _) => false,
-        (BexExternalValue::Adt(BexExternalAdt::Type(_)), Ty::Type) => true,
+        (BexExternalValue::Adt(BexExternalAdt::Type(_)), ty)
+            if ty.is_opaque("baml.reflect.Type") =>
+        {
+            true
+        }
         (BexExternalValue::Union { value, .. }, ty) => value_matches_type(value, ty),
         // Handle nested unions/optionals in the type
         (value, Ty::Union(members)) => members.iter().any(|m| value_matches_type(value, m)),
@@ -498,7 +506,7 @@ fn find_matching_union_member<'a>(value: &Value, members: &'a [Ty]) -> Option<&'
                 }
                 Object::Map(_) => members.iter().find(|m| matches!(m, Ty::Map { .. })),
                 Object::Media(_) => members.iter().find(|m| matches!(m, Ty::Media(_))),
-                Object::PromptAst(_) => members.iter().find(|m| matches!(m, Ty::PromptAst)),
+                Object::PromptAst(_) => members.iter().find(|m| m.is_opaque("baml.llm.PromptAst")),
                 _ => None,
             }
         }

--- a/baml_language/crates/bridge_ctypes/src/value_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_encode.rs
@@ -150,8 +150,8 @@ fn ty_to_field_type(ty: &Ty) -> CffiFieldTypeHolder {
             value: Some(Box::new(ty_to_field_type(inner))),
         }))),
         Ty::Media(_) | Ty::Literal(_) => Some(FieldType::AnyType(CffiFieldTypeAny {})),
-        Ty::Resource | Ty::PromptAst | Ty::Type => {
-            unreachable!("runtime-only variant should not reach FFI type encoding")
+        Ty::Opaque(tn) => {
+            unreachable!("runtime-only {tn} should not reach FFI type encoding")
         }
         Ty::TypeAlias(_)
         | Ty::Function { .. }

--- a/baml_language/crates/sys_llm/src/types/output_format.rs
+++ b/baml_language/crates/sys_llm/src/types/output_format.rs
@@ -197,9 +197,7 @@ impl OutputFormatContent {
             Ty::Literal(lit) => Ok(Some(render_literal(lit))),
 
             // Runtime-only variants that shouldn't appear in LLM prompts
-            Ty::Resource => Err(RenderError::UnsupportedType("resource".to_string())),
-            Ty::PromptAst => Err(RenderError::UnsupportedType("prompt_ast".to_string())),
-            Ty::Type => Err(RenderError::UnsupportedType("type".to_string())),
+            Ty::Opaque(tn) => Err(RenderError::UnsupportedType(tn.to_string())),
 
             // Compiler-only variants should never reach runtime
             Ty::TypeAlias(_)
@@ -560,5 +558,12 @@ mod tests {
             rendered,
             Some("Answer using this specific value:\ntrue".to_string())
         );
+    }
+
+    #[test]
+    fn test_render_opaque_unsupported() {
+        let content = OutputFormatContent::new(Ty::big_t_type());
+        let err = content.render(&RenderOptions::default()).unwrap_err();
+        assert!(matches!(err, RenderError::UnsupportedType(s) if s == "big_t_type"));
     }
 }


### PR DESCRIPTION
Consolidating PromptAst, Resource, and Type into Opaque means that when we add new builtin types in the future, we have to make fewer code changes.

Slack discussion: https://gloo-global.slack.com/archives/C0958DV7YPL/p1771361402317269?thread_ts=1770925371.154739&cid=C0958DV7YPL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified runtime representation for opaque types, simplifying type handling and method resolution.

* **New Features**
  * Added public constructors and accessors for creating and inspecting opaque runtime types.

* **Tests**
  * Expanded tests for opaque-type matching, substitution, rendering, display, and unsupported-type errors.

* **Chores**
  * Updated codebase to use the new opaque-type APIs; error messages and rendering now report opaque type names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->