### PR TITLE
baml-cli --test in baml_language

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -361,10 +361,14 @@ dependencies = [
  "baml_lsp_server",
  "baml_project",
  "baml_workspace",
+ "bex_engine",
+ "bex_vm_types",
  "clap",
  "clap-cargo",
  "ctrlc",
  "regex",
+ "sys_native",
+ "tokio",
 ]
 
 [[package]]
@@ -437,6 +441,7 @@ dependencies = [
  "baml_compiler_parser",
  "baml_compiler_syntax",
  "baml_workspace",
+ "indexmap",
  "la-arena",
  "rowan 0.16.1",
  "rustc-hash 2.1.1",

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -356,11 +356,15 @@ name = "baml_cli"
 version = "0.0.0-beta"
 dependencies = [
  "anyhow",
+ "baml_db",
  "baml_fmt",
  "baml_lsp_server",
+ "baml_project",
+ "baml_workspace",
  "clap",
  "clap-cargo",
  "ctrlc",
+ "regex",
 ]
 
 [[package]]

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -22,11 +22,15 @@ baml_fmt = { workspace = true }
 baml_lsp_server = { workspace = true }
 baml_project = { workspace = true }
 baml_workspace = { workspace = true }
+bex_engine = { workspace = true }
+bex_vm_types = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = [ "color", "env" ] }
 clap-cargo = { workspace = true }
 ctrlc = { workspace = true }
 regex = { workspace = true }
+sys_native = { workspace = true }
+tokio = { workspace = true }
 
 [features]
 default = [ "native-tls" ]

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -24,12 +24,12 @@ baml_project = { workspace = true }
 baml_workspace = { workspace = true }
 bex_engine = { workspace = true }
 bex_vm_types = { workspace = true }
+sys_native = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = [ "color", "env" ] }
 clap-cargo = { workspace = true }
 ctrlc = { workspace = true }
 regex = { workspace = true }
-sys_native = { workspace = true }
 tokio = { workspace = true }
 
 [features]

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -17,12 +17,16 @@ doctest = false
 workspace = true
 
 [dependencies]
+baml_db = { workspace = true }
 baml_fmt = { workspace = true }
 baml_lsp_server = { workspace = true }
+baml_project = { workspace = true }
+baml_workspace = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true, features = [ "color", "env" ] }
 clap-cargo = { workspace = true }
 ctrlc = { workspace = true }
+regex = { workspace = true }
 
 [features]
 default = [ "native-tls" ]
@@ -49,4 +53,3 @@ path = "src/main.rs"
 
 [package.metadata.ci]
 wasm_support = false
-

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -56,6 +56,9 @@ pub(crate) enum Commands {
 
     // #[command(about = "Print Bytecode from BAML files", hide = true)]
     // DumpBytecode(baml_runtime::cli::dump_intermediate::DumpIntermediateArgs),
+    #[command(about = "Run BAML tests")]
+    Test(crate::test_command::TestArgs),
+
     #[command(about = "Starts a language server", name = "lsp")]
     LanguageServer(crate::lsp::LanguageServerArgs),
     // #[command(about = "Start an interactive REPL for BAML expressions", hide = true)]
@@ -108,6 +111,7 @@ impl RuntimeCli {
 
     pub fn run(&self) -> Result<crate::ExitCode> {
         match &self.command {
+            Commands::Test(args) => args.run(),
             Commands::LanguageServer(args) => match args.run() {
                 Ok(()) => Ok(crate::ExitCode::Success),
                 Err(e) => {

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -12,6 +12,8 @@
 pub(crate) mod commands;
 pub(crate) mod format;
 pub(crate) mod lsp;
+pub(crate) mod test_command;
+pub(crate) mod test_filter;
 
 // TODO: These modules are disabled for now as they depend on baml_runtime
 // pub(crate) mod api_client;

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -115,8 +115,11 @@ impl TestArgs {
             return Ok(crate::ExitCode::Other);
         }
 
-        // Compile to bytecode.
-        let bytecode = baml_compiler_emit::generate_project_bytecode(&db)
+        // Compile to bytecode (with test cases included).
+        let compile_options = baml_compiler_emit::CompileOptions {
+            emit_test_cases: true,
+        };
+        let bytecode = baml_compiler_emit::generate_project_bytecode(&db, compile_options)
             .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
 
         // Create the engine with native (tokio-based) sys ops.
@@ -131,7 +134,7 @@ impl TestArgs {
         let mut passed = 0usize;
         let mut failed = 0usize;
 
-        for ((func_name, test_name), _path) in &selected {
+        for (func_name, test_name) in selected.keys() {
             // Look up the compiled test case from the engine.
             let test_case = match engine.test_case(test_name) {
                 Some(tc) => tc,

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -1,16 +1,18 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use std::{collections::BTreeMap, path::PathBuf};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 
 use anyhow::{Context, Result, anyhow};
-use baml_db::baml_compiler_diagnostics::Severity;
-use baml_db::baml_compiler_emit;
-use baml_db::baml_compiler_hir::{ItemId, file_item_tree, project_items};
+use baml_db::{
+    baml_compiler_diagnostics::Severity,
+    baml_compiler_emit,
+    baml_compiler_hir::{ItemId, file_item_tree, project_items},
+};
 use baml_project::ProjectDatabase;
 use baml_workspace::discover_baml_files;
-use bex_engine::{BexEngine, BexExternalValue, test_arg_to_external};
+use bex_engine::{BexEngine, BexExternalValue, FunctionCallContextBuilder, test_arg_to_external};
 use clap::Args;
-use sys_native::SysOpsExt;
+use sys_native::{CallId, SysOpsExt};
 
 use crate::test_filter::TestFilter;
 
@@ -122,7 +124,7 @@ impl TestArgs {
             .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
 
         // Create the engine with native (tokio-based) sys ops.
-        let engine = BexEngine::new(bytecode, sys_native::SysOps::native())
+        let engine = BexEngine::new(bytecode, Arc::new(sys_native::SysOps::native()), None)
             .map_err(|e| anyhow!("Failed to create engine: {e:?}"))?;
 
         // Create a tokio runtime for async execution.
@@ -157,7 +159,11 @@ impl TestArgs {
             };
 
             // Execute the function.
-            match rt.block_on(engine.call_function(func_name, ordered_args, None, &[])) {
+            match rt.block_on(engine.call_function(
+                func_name,
+                ordered_args,
+                FunctionCallContextBuilder::new(CallId::next()).build(),
+            )) {
                 Ok(result) => {
                     println!("PASS {func_name}::{test_name}");
                     println!("  => {result:?}");

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -1,10 +1,14 @@
 use std::{collections::BTreeMap, path::PathBuf};
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
+use baml_db::baml_compiler_diagnostics::Severity;
+use baml_db::baml_compiler_emit;
 use baml_db::baml_compiler_hir::{ItemId, file_item_tree, project_items};
 use baml_project::ProjectDatabase;
 use baml_workspace::discover_baml_files;
+use bex_engine::{BexEngine, BexExternalValue, test_arg_to_external};
 use clap::Args;
+use sys_native::SysOpsExt;
 
 use crate::test_filter::TestFilter;
 
@@ -96,17 +100,107 @@ impl TestArgs {
             return Ok(crate::ExitCode::Success);
         }
 
-        // TODO: Actual test execution (runtime invocation) goes here.
-        println!(
-            "Would run {} test(s), but runtime execution is not yet implemented.",
-            selected.len()
-        );
-        for ((func, test), _) in &selected {
-            println!("  {func}::{test}");
+        // Check for diagnostic errors before compiling.
+        let source_files = db.get_source_files();
+        let diagnostics = baml_project::collect_diagnostics(&db, project, &source_files);
+        let errors: Vec<_> = diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .collect();
+        if !errors.is_empty() {
+            eprintln!("Compilation errors found ({}):", errors.len());
+            for diag in &errors {
+                eprintln!("  error: {}", diag.message);
+            }
+            return Ok(crate::ExitCode::Other);
         }
 
-        Ok(crate::ExitCode::Success)
+        // Compile to bytecode.
+        let bytecode = baml_compiler_emit::generate_project_bytecode(&db)
+            .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
+
+        // Create the engine with native (tokio-based) sys ops.
+        let engine = BexEngine::new(bytecode, sys_native::SysOps::native())
+            .map_err(|e| anyhow!("Failed to create engine: {e:?}"))?;
+
+        // Create a tokio runtime for async execution.
+        let rt = tokio::runtime::Runtime::new().context("Failed to create tokio runtime")?;
+
+        // Run tests sequentially.
+        let total = selected.len();
+        let mut passed = 0usize;
+        let mut failed = 0usize;
+
+        for ((func_name, test_name), _path) in &selected {
+            // Look up the compiled test case from the engine.
+            let test_case = match engine.test_case(test_name) {
+                Some(tc) => tc,
+                None => {
+                    eprintln!(
+                        "FAIL {func_name}::{test_name} - test case not found in compiled program"
+                    );
+                    failed += 1;
+                    continue;
+                }
+            };
+
+            // Convert TestArgValue -> BexExternalValue and order by function params.
+            let ordered_args = match build_ordered_args(&engine, func_name, test_case) {
+                Ok(args) => args,
+                Err(e) => {
+                    eprintln!("FAIL {func_name}::{test_name} - {e}");
+                    failed += 1;
+                    continue;
+                }
+            };
+
+            // Execute the function.
+            match rt.block_on(engine.call_function(func_name, ordered_args, None, &[])) {
+                Ok(result) => {
+                    println!("PASS {func_name}::{test_name}");
+                    println!("  => {result:?}");
+                    passed += 1;
+                }
+                Err(e) => {
+                    eprintln!("FAIL {func_name}::{test_name}");
+                    eprintln!("  => {e:?}");
+                    failed += 1;
+                }
+            }
+        }
+
+        println!("\nResults: {passed} passed, {failed} failed, {total} total");
+
+        if failed > 0 {
+            Ok(crate::ExitCode::TestFailure)
+        } else {
+            Ok(crate::ExitCode::Success)
+        }
     }
+}
+
+/// Build ordered args Vec from a test case, matching the function's parameter order.
+fn build_ordered_args(
+    engine: &BexEngine,
+    function_name: &str,
+    test_case: &bex_vm_types::TestCase,
+) -> Result<Vec<BexExternalValue>> {
+    let params = engine
+        .function_params(function_name)
+        .map_err(|e| anyhow!("failed to get params for {function_name}: {e:?}"))?;
+
+    let ordered: Vec<BexExternalValue> = params
+        .into_iter()
+        .map(|(name, _ty)| {
+            test_case
+                .args
+                .get(name)
+                .map(test_arg_to_external)
+                .ok_or_else(|| anyhow!("missing argument '{name}' for function {function_name}"))
+        })
+        .collect::<Result<_>>()?;
+
+    Ok(ordered)
 }
 
 /// Walk the HIR to discover all (function_name, test_name) pairs.

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -135,7 +135,7 @@ impl TestArgs {
 
         for (func_name, test_name) in selected.keys() {
             // Look up the compiled test case from the engine.
-            let test_case = match engine.test_case(test_name) {
+            let test_case = match engine.test_case(func_name, test_name) {
                 Some(tc) => tc,
                 None => {
                     eprintln!(

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::print_stdout, clippy::print_stderr)]
+
 use std::{collections::BTreeMap, path::PathBuf};
 
 use anyhow::{Context, Result, anyhow};
@@ -56,12 +58,10 @@ impl TestArgs {
 
         // Set up the compiler database and load all .baml files.
         let mut db = ProjectDatabase::new();
+        let project = db.set_project_root(&from);
         let baml_files = discover_baml_files(&from);
         if baml_files.is_empty() {
-            #[allow(clippy::print_stderr)]
-            {
-                eprintln!("No .baml files found in {}", from.display());
-            }
+            eprintln!("No .baml files found in {}", from.display());
             return Ok(crate::ExitCode::NoTestsRun);
         }
 
@@ -70,13 +70,12 @@ impl TestArgs {
                 .with_context(|| format!("Failed to read {}", file_path.display()))?;
             db.add_or_update_file(file_path, &content);
         }
-        let project = db.set_project_root(&from);
 
         // Discover all (function, test) pairs from the HIR.
         let discovered = discover_tests(&db, project);
 
         // Apply include/exclude filters.
-        let filter = TestFilter::from(
+        let filter = TestFilter::new(
             self.include.iter().map(|s| s.as_str()),
             self.exclude.iter().map(|s| s.as_str()),
         );
@@ -119,7 +118,7 @@ impl TestArgs {
         let compile_options = baml_compiler_emit::CompileOptions {
             emit_test_cases: true,
         };
-        let bytecode = baml_compiler_emit::generate_project_bytecode(&db, compile_options)
+        let bytecode = baml_compiler_emit::generate_project_bytecode(&db, &compile_options)
             .map_err(|e| anyhow!("Compilation failed: {e:?}"))?;
 
         // Create the engine with native (tokio-based) sys ops.

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -1,0 +1,139 @@
+use std::{collections::BTreeMap, path::PathBuf};
+
+use anyhow::{Context, Result};
+use baml_db::baml_compiler_hir::{ItemId, file_item_tree, project_items};
+use baml_project::ProjectDatabase;
+use baml_workspace::discover_baml_files;
+use clap::Args;
+
+use crate::test_filter::TestFilter;
+
+#[derive(Args, Clone, Debug)]
+pub struct TestArgs {
+    #[arg(long, help = "path/to/baml_src", default_value = ".")]
+    pub from: PathBuf,
+
+    /// Only list selected tests
+    #[arg(long, default_value_t = false)]
+    list: bool,
+
+    #[arg(long, short = 'i')]
+    /// Specific functions or tests to include. If none provided, runs all tests.
+    ///
+    /// Examples:
+    ///
+    /// -i "FunctionName::TestName" will match the specific test
+    ///
+    /// -i "FunctionName::" will run all tests in the function
+    ///
+    /// -i "::TestName" will run the test in any function
+    ///
+    /// -i "Get*::*Bar" will match with wildcards
+    pub include: Vec<String>,
+
+    #[arg(long, short = 'x')]
+    /// Specific functions or tests to exclude. Takes precedence over --include.
+    ///
+    /// Uses the same syntax as --include.
+    pub exclude: Vec<String>,
+}
+
+/// A discovered test: a (function_name, test_name) pair with its source location.
+struct DiscoveredTest {
+    function_name: String,
+    test_name: String,
+    file_path: PathBuf,
+}
+
+impl TestArgs {
+    pub fn run(&self) -> Result<crate::ExitCode> {
+        let from = std::fs::canonicalize(&self.from)
+            .with_context(|| format!("Could not resolve baml_src path: {}", self.from.display()))?;
+
+        // Set up the compiler database and load all .baml files.
+        let mut db = ProjectDatabase::new();
+        let baml_files = discover_baml_files(&from);
+        if baml_files.is_empty() {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!("No .baml files found in {}", from.display());
+            }
+            return Ok(crate::ExitCode::NoTestsRun);
+        }
+
+        for file_path in &baml_files {
+            let content = std::fs::read_to_string(file_path)
+                .with_context(|| format!("Failed to read {}", file_path.display()))?;
+            db.add_or_update_file(file_path, &content);
+        }
+        let project = db.set_project_root(&from);
+
+        // Discover all (function, test) pairs from the HIR.
+        let discovered = discover_tests(&db, project);
+
+        // Apply include/exclude filters.
+        let filter = TestFilter::from(
+            self.include.iter().map(|s| s.as_str()),
+            self.exclude.iter().map(|s| s.as_str()),
+        );
+
+        let selected: BTreeMap<(String, String), PathBuf> = discovered
+            .into_iter()
+            .filter(|t| filter.includes(&t.function_name, &t.test_name))
+            .map(|t| ((t.function_name, t.test_name), t.file_path))
+            .collect();
+
+        if selected.is_empty() {
+            println!("No tests selected.");
+            return Ok(crate::ExitCode::NoTestsRun);
+        }
+
+        if self.list {
+            println!("Selected tests ({}):\n", selected.len());
+            for ((func, test), path) in &selected {
+                println!("  {func}::{test}  ({path})", path = path.display());
+            }
+            return Ok(crate::ExitCode::Success);
+        }
+
+        // TODO: Actual test execution (runtime invocation) goes here.
+        println!(
+            "Would run {} test(s), but runtime execution is not yet implemented.",
+            selected.len()
+        );
+        for ((func, test), _) in &selected {
+            println!("  {func}::{test}");
+        }
+
+        Ok(crate::ExitCode::Success)
+    }
+}
+
+/// Walk the HIR to discover all (function_name, test_name) pairs.
+///
+/// Each test block references one or more functions via `function_refs`.
+/// We expand each test into one entry per referenced function, matching
+/// the old engine's `walk_function_test_pairs` behavior.
+fn discover_tests(db: &ProjectDatabase, project: baml_workspace::Project) -> Vec<DiscoveredTest> {
+    let items = project_items(db, project);
+    let mut tests = Vec::new();
+
+    for item in items.items(db) {
+        if let ItemId::Test(test_loc) = item {
+            let file = test_loc.file(db);
+            let item_tree = file_item_tree(db, file);
+            let test = &item_tree[test_loc.id(db)];
+            let file_path = file.path(db);
+
+            for func_ref in &test.function_refs {
+                tests.push(DiscoveredTest {
+                    function_name: func_ref.to_string(),
+                    test_name: test.name.to_string(),
+                    file_path: file_path.clone(),
+                });
+            }
+        }
+    }
+
+    tests
+}

--- a/baml_language/crates/baml_cli/src/test_filter.rs
+++ b/baml_language/crates/baml_cli/src/test_filter.rs
@@ -1,0 +1,190 @@
+use regex::Regex;
+
+pub struct TestFilter {
+    pub include: Vec<(String, String)>,
+    pub exclude: Vec<(String, String)>,
+}
+
+impl TestFilter {
+    pub fn from<'a>(
+        include: impl Iterator<Item = &'a str>,
+        exclude: impl Iterator<Item = &'a str>,
+    ) -> TestFilter {
+        TestFilter {
+            include: include
+                .flat_map(|s| match s.split_once("::") {
+                    Some((function_match, test_match)) => {
+                        vec![(function_match.to_string(), test_match.to_string())]
+                    }
+                    None => {
+                        vec![
+                            (s.to_string(), "".to_string()),
+                            ("".to_string(), s.to_string()),
+                        ]
+                    }
+                })
+                .collect(),
+            exclude: exclude
+                .flat_map(|s| match s.split_once("::") {
+                    Some((function_match, test_match)) => {
+                        vec![(function_match.to_string(), test_match.to_string())]
+                    }
+                    None => {
+                        vec![
+                            (s.to_string(), "".to_string()),
+                            ("".to_string(), s.to_string()),
+                        ]
+                    }
+                })
+                .collect(),
+        }
+    }
+
+    pub fn filter_expr_match(filter_expr: &str, subject: &str) -> bool {
+        if filter_expr.is_empty() {
+            return true;
+        }
+
+        Regex::new(&format!("^{}$", filter_expr.replace("*", ".*")))
+            .unwrap()
+            .is_match(subject)
+    }
+
+    pub fn includes(&self, function_name: &str, test_name: &str) -> bool {
+        for (func_pattern, test_pattern) in &self.exclude {
+            if TestFilter::filter_expr_match(func_pattern, function_name)
+                && TestFilter::filter_expr_match(test_pattern, test_name)
+            {
+                return false;
+            }
+        }
+        for (func_pattern, test_pattern) in &self.include {
+            if TestFilter::filter_expr_match(func_pattern, function_name)
+                && TestFilter::filter_expr_match(test_pattern, test_name)
+            {
+                return true;
+            }
+        }
+
+        // Fall-through behavior changes based on the presence of include filters:
+        //
+        // |                           | 0 exclude filters              | at least 1 exclude filter                       |
+        // |---------------------------|--------------------------------|-------------------------------------------------|
+        // | 0 include filters         | include all tests              | include all tests, except excluded              |
+        // | at least 1 include filter | include only --include matches | include only --include matches, except excluded |
+        self.include.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn does_include() {
+        assert!(test_filters(&["MyFunc::MyTest"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["MyFunc::*"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["MyFunc::"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["*::MyTest"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["::MyTest"], &[]).includes("MyFunc", "MyTest"));
+
+        assert!(test_filters(&["My*::"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["*Func::"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["My*::MyTest"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["*Func::MyTest"], &[]).includes("MyFunc", "MyTest"));
+
+        assert!(test_filters(&["::My*"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["::*Test"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["MyFunc::My*"], &[]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["MyFunc::*Test"], &[]).includes("MyFunc", "MyTest"));
+
+        assert!(!test_filters(&["My::"], &[]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&["Func::"], &[]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&["::My"], &[]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&["::Test"], &[]).includes("MyFunc", "MyTest"));
+    }
+
+    #[test]
+    fn does_not_include() {
+        assert!(!test_filters(&["MyFunc::MyTest"], &[]).includes("MyOtherFunc", "MyOtherTest"));
+        assert!(!test_filters(&["MyFunc::*"], &[]).includes("MyOtherFunc", "MyOtherTest"));
+        assert!(!test_filters(&["MyFunc::"], &[]).includes("MyOtherFunc", "MyOtherTest"));
+        assert!(!test_filters(&["*::MyTest"], &[]).includes("MyOtherFunc", "MyOtherTest"));
+        assert!(!test_filters(&["::MyTest"], &[]).includes("MyOtherFunc", "MyOtherTest"));
+    }
+
+    #[test]
+    fn does_exclude() {
+        assert!(!test_filters(&[], &["MyFunc::MyTest"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["MyFunc::*"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["MyFunc::"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["*::MyTest"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["::MyTest"]).includes("MyFunc", "MyTest"));
+
+        assert!(!test_filters(&[], &["My*::"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["*Func::"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["My*::MyTest"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["*Func::MyTest"]).includes("MyFunc", "MyTest"));
+
+        assert!(!test_filters(&[], &["::My*"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["::*Test"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["MyFunc::My*"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&[], &["MyFunc::*Test"]).includes("MyFunc", "MyTest"));
+
+        assert!(test_filters(&[], &["My::"]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&[], &["Func::"]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&[], &["::My"]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&[], &["::Test"]).includes("MyFunc", "MyTest"));
+    }
+
+    #[test]
+    fn does_not_exclude() {
+        assert!(test_filters(&[], &["MyFunc::MyTest"]).includes("MyOtherFunc", "MyOtherTest"));
+        assert!(test_filters(&[], &["MyFunc::*"]).includes("MyOtherFunc", "MyOtherTest"));
+        assert!(test_filters(&[], &["MyFunc::"]).includes("MyOtherFunc", "MyOtherTest"));
+        assert!(test_filters(&[], &["*::MyTest"]).includes("MyOtherFunc", "MyOtherTest"));
+        assert!(test_filters(&[], &["::MyTest"]).includes("MyOtherFunc", "MyOtherTest"));
+    }
+
+    #[test]
+    fn mixed_include_exclude() {
+        assert!(!test_filters(&["MyFunc"], &["MyTest"]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["MyFunc"], &["MyOtherTest"]).includes("MyFunc", "MyTest"));
+
+        assert!(!test_filters(&["MyFunc::*"], &["My*"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&["MyFunc::*"], &["MyTest"]).includes("MyFunc", "MyTest"));
+
+        assert!(!test_filters(&["*Func::*"], &["MyTest"]).includes("MyFunc", "MyTest"));
+        assert!(test_filters(&["*Func::*"], &["MyOtherTest"]).includes("MyFunc", "MyTest"));
+
+        // Case where include and exclude are the same
+        assert!(
+            !test_filters(&["MyFunc::MyTest"], &["MyFunc::MyTest"]).includes("MyFunc", "MyTest")
+        );
+    }
+
+    #[test]
+    fn mixed_include_exclude_specificities() {
+        // Excludes always take precedence over includes (no specificity scoring).
+        assert!(!test_filters(&["MyFunc::MyTest"], &["MyFunc::*"]).includes("MyFunc", "MyTest"));
+        assert!(!test_filters(&["MyFunc::*"], &["MyFunc::MyTest"]).includes("MyFunc", "MyTest"));
+
+        assert!(
+            test_filters(&["*Func::MyTest"], &["OtherFunc::MyTest"]).includes("MyFunc", "MyTest")
+        );
+        assert!(
+            !test_filters(&["*Func::MyTest"], &["MyFunc::MyTest"]).includes("MyFunc", "MyTest")
+        );
+
+        assert!(
+            test_filters(&["MyFunc::*Test"], &["MyFunc::OtherTest"]).includes("MyFunc", "MyTest")
+        );
+        assert!(
+            !test_filters(&["MyFunc::*Test"], &["MyFunc::MyTest"]).includes("MyFunc", "MyTest")
+        );
+    }
+
+    fn test_filters(include: &[&str], exclude: &[&str]) -> TestFilter {
+        TestFilter::from(include.iter().copied(), exclude.iter().copied())
+    }
+}

--- a/baml_language/crates/baml_cli/src/test_filter.rs
+++ b/baml_language/crates/baml_cli/src/test_filter.rs
@@ -6,7 +6,7 @@ pub struct TestFilter {
 }
 
 impl TestFilter {
-    pub fn from<'a>(
+    pub fn new<'a>(
         include: impl Iterator<Item = &'a str>,
         exclude: impl Iterator<Item = &'a str>,
     ) -> TestFilter {
@@ -45,9 +45,13 @@ impl TestFilter {
             return true;
         }
 
-        Regex::new(&format!("^{}$", filter_expr.replace("*", ".*")))
-            .unwrap()
-            .is_match(subject)
+        Regex::new(&format!("^{}$", filter_expr.replace("*", ".*"))).map_or_else(
+            |e| {
+                eprintln!("Failed to parse filter: {e}");
+                false
+            },
+            |r| r.is_match(subject),
+        )
     }
 
     pub fn includes(&self, function_name: &str, test_name: &str) -> bool {
@@ -185,6 +189,6 @@ mod tests {
     }
 
     fn test_filters(include: &[&str], exclude: &[&str]) -> TestFilter {
-        TestFilter::from(include.iter().copied(), exclude.iter().copied())
+        TestFilter::new(include.iter().copied(), exclude.iter().copied())
     }
 }

--- a/baml_language/crates/baml_cli/src/test_filter.rs
+++ b/baml_language/crates/baml_cli/src/test_filter.rs
@@ -6,37 +6,29 @@ pub struct TestFilter {
 }
 
 impl TestFilter {
+    fn parse_patterns<'a>(patterns: impl Iterator<Item = &'a str>) -> Vec<(String, String)> {
+        patterns
+            .flat_map(|s| match s.split_once("::") {
+                Some((function_match, test_match)) => {
+                    vec![(function_match.to_string(), test_match.to_string())]
+                }
+                None => {
+                    vec![
+                        (s.to_string(), "".to_string()),
+                        ("".to_string(), s.to_string()),
+                    ]
+                }
+            })
+            .collect()
+    }
+
     pub fn new<'a>(
         include: impl Iterator<Item = &'a str>,
         exclude: impl Iterator<Item = &'a str>,
     ) -> TestFilter {
         TestFilter {
-            include: include
-                .flat_map(|s| match s.split_once("::") {
-                    Some((function_match, test_match)) => {
-                        vec![(function_match.to_string(), test_match.to_string())]
-                    }
-                    None => {
-                        vec![
-                            (s.to_string(), "".to_string()),
-                            ("".to_string(), s.to_string()),
-                        ]
-                    }
-                })
-                .collect(),
-            exclude: exclude
-                .flat_map(|s| match s.split_once("::") {
-                    Some((function_match, test_match)) => {
-                        vec![(function_match.to_string(), test_match.to_string())]
-                    }
-                    None => {
-                        vec![
-                            (s.to_string(), "".to_string()),
-                            ("".to_string(), s.to_string()),
-                        ]
-                    }
-                })
-                .collect(),
+            include: Self::parse_patterns(include),
+            exclude: Self::parse_patterns(exclude),
         }
     }
 

--- a/baml_language/crates/baml_cli/src/test_filter.rs
+++ b/baml_language/crates/baml_cli/src/test_filter.rs
@@ -32,6 +32,7 @@ impl TestFilter {
         }
     }
 
+    #[allow(clippy::print_stderr)]
     pub fn filter_expr_match(filter_expr: &str, subject: &str) -> bool {
         if filter_expr.is_empty() {
             return true;

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -89,7 +89,10 @@ pub struct CompileOptions {
 /// lowers to MIR, and compiles to bytecode.
 ///
 /// Returns `Err` if any function contains unrecoverable errors (Missing nodes).
-pub fn generate_project_bytecode(db: &dyn baml_compiler_mir::Db, options: &CompileOptions) -> Result<Program, LoweringError> {
+pub fn generate_project_bytecode(
+    db: &dyn baml_compiler_mir::Db,
+    options: &CompileOptions,
+) -> Result<Program, LoweringError> {
     let project = db.project();
     compile_files(db, project.files(db), OptLevel::One, options)
 }
@@ -103,7 +106,7 @@ pub fn compile_files(
     db: &dyn baml_compiler_mir::Db,
     files: &[SourceFile],
     opt: OptLevel,
-    options: CompileOptions,
+    options: &CompileOptions,
 ) -> Result<Program, LoweringError> {
     // Note: Builtin BAML files (like llm.baml) are now loaded at project setup time
     // in ProjectDatabase::set_project_root(), so they're already in the files list.
@@ -662,35 +665,50 @@ pub fn compile_files(
         }
     }
 
-    // --- Pass: Emit test cases ---
-    for file in files {
-        let item_tree = baml_compiler_hir::file_item_tree(db, *file);
-        let items_struct = baml_compiler_hir::file_items(db, *file);
-        for item in items_struct.items(db) {
-            if let ItemId::Test(test_loc) = item {
-                let test = &item_tree[test_loc.id(db)];
-                let args = test
-                    .args
-                    .iter()
-                    .map(|(k, v)| (k.clone(), convert_hir_test_arg(v)))
-                    .collect();
-                program.test_cases.push(bex_vm_types::TestCase {
-                    name: test.name.to_string(),
-                    function_names: test.function_refs.iter().map(|n| n.to_string()).collect(),
-                    args,
-                });
     // --- Pass: Emit test cases (only when requested) ---
     if options.emit_test_cases {
+        // Build a map of function name -> (param_name -> Ty) so we can
+        // annotate test arg values with their declared types.
+        let mut fn_param_types: HashMap<String, HashMap<String, baml_type::Ty>> = HashMap::new();
+        for file in files {
+            let items_struct = baml_compiler_hir::file_items(db, *file);
+            for item in items_struct.items(db) {
+                if let ItemId::Function(func_loc) = item {
+                    let signature = function_signature(db, *func_loc);
+                    let (param_names, param_types, _) = compute_function_metadata(
+                        &signature,
+                        &resolution_ctx,
+                        &type_aliases,
+                        &recursive_aliases,
+                    );
+                    let param_map: HashMap<String, baml_type::Ty> =
+                        param_names.into_iter().zip(param_types).collect();
+                    fn_param_types.insert(signature.name.to_string(), param_map);
+                }
+            }
+        }
+
         for file in files {
             let item_tree = baml_compiler_hir::file_item_tree(db, *file);
             let items_struct = baml_compiler_hir::file_items(db, *file);
             for item in items_struct.items(db) {
                 if let ItemId::Test(test_loc) = item {
                     let test = &item_tree[test_loc.id(db)];
+                    // Use the first function ref to look up param types.
+                    let param_types = test
+                        .function_refs
+                        .first()
+                        .and_then(|name| fn_param_types.get(name.as_str()));
                     let args = test
                         .args
                         .iter()
-                        .map(|(k, v)| (k.clone(), convert_hir_test_arg(v)))
+                        .map(|(k, v)| {
+                            let ty = param_types
+                                .and_then(|m| m.get(k.as_str()))
+                                .cloned()
+                                .unwrap_or(baml_type::Ty::Null);
+                            (k.clone(), convert_hir_test_arg(v, &ty))
+                        })
                         .collect();
                     program.test_cases.push(bex_vm_types::TestCase {
                         name: test.name.to_string(),
@@ -732,8 +750,12 @@ where
     }
 }
 
-/// Convert an HIR `TestArgValue` to a `bex_vm_types::TestArgValue`.
-fn convert_hir_test_arg(v: &baml_compiler_hir::TestArgValue) -> bex_vm_types::TestArgValue {
+/// Convert an HIR `TestArgValue` to a `bex_vm_types::TestArgValue`,
+/// using the declared parameter type to annotate arrays and maps.
+fn convert_hir_test_arg(
+    v: &baml_compiler_hir::TestArgValue,
+    ty: &baml_type::Ty,
+) -> bex_vm_types::TestArgValue {
     match v {
         baml_compiler_hir::TestArgValue::Null => bex_vm_types::TestArgValue::Null,
         baml_compiler_hir::TestArgValue::Int(i) => bex_vm_types::TestArgValue::Int(*i),
@@ -741,13 +763,32 @@ fn convert_hir_test_arg(v: &baml_compiler_hir::TestArgValue) -> bex_vm_types::Te
         baml_compiler_hir::TestArgValue::Bool(b) => bex_vm_types::TestArgValue::Bool(*b),
         baml_compiler_hir::TestArgValue::String(s) => bex_vm_types::TestArgValue::String(s.clone()),
         baml_compiler_hir::TestArgValue::Array(arr) => {
-            bex_vm_types::TestArgValue::Array(arr.iter().map(convert_hir_test_arg).collect())
+            let element_type = match ty {
+                baml_type::Ty::List(elem) => elem.as_ref().clone(),
+                _ => baml_type::Ty::Null,
+            };
+            bex_vm_types::TestArgValue::Array {
+                element_type: element_type.clone(),
+                items: arr
+                    .iter()
+                    .map(|item| convert_hir_test_arg(item, &element_type))
+                    .collect(),
+            }
         }
-        baml_compiler_hir::TestArgValue::Map(map) => bex_vm_types::TestArgValue::Map(
-            map.iter()
-                .map(|(k, v)| (k.clone(), convert_hir_test_arg(v)))
-                .collect(),
-        ),
+        baml_compiler_hir::TestArgValue::Map(map) => {
+            let (key_type, value_type) = match ty {
+                baml_type::Ty::Map { key, value } => (key.as_ref().clone(), value.as_ref().clone()),
+                _ => (baml_type::Ty::String, baml_type::Ty::Null),
+            };
+            bex_vm_types::TestArgValue::Map {
+                key_type: key_type.clone(),
+                value_type: value_type.clone(),
+                entries: map
+                    .iter()
+                    .map(|(k, v)| (k.clone(), convert_hir_test_arg(v, &value_type)))
+                    .collect(),
+            }
+        }
     }
 }
 

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -72,6 +72,16 @@ pub use bex_vm_types::{
 #[salsa::db]
 pub trait Db: baml_compiler_mir::Db {}
 
+/// Options for controlling bytecode compilation.
+#[derive(Debug, Clone, Copy)]
+pub struct CompileOptions {
+    /// Include test cases in the compiled program.
+    ///
+    /// When true, `test { ... }` blocks are compiled into `Program::test_cases`.
+    /// Only the CLI test runner needs this; SDK runtimes can leave it off.
+    pub emit_test_cases: bool,
+}
+
 /// Generate bytecode for all functions in a project.
 ///
 /// This is the main entry point for project-wide code generation.
@@ -79,9 +89,9 @@ pub trait Db: baml_compiler_mir::Db {}
 /// lowers to MIR, and compiles to bytecode.
 ///
 /// Returns `Err` if any function contains unrecoverable errors (Missing nodes).
-pub fn generate_project_bytecode(db: &dyn Db) -> Result<Program, LoweringError> {
+pub fn generate_project_bytecode(db: &dyn baml_compiler_mir::Db, options: &CompileOptions) -> Result<Program, LoweringError> {
     let project = db.project();
-    compile_files(db, project.files(db), OptLevel::One)
+    compile_files(db, project.files(db), OptLevel::One, options)
 }
 
 /// Generate bytecode for a list of source files.
@@ -93,6 +103,7 @@ pub fn compile_files(
     db: &dyn baml_compiler_mir::Db,
     files: &[SourceFile],
     opt: OptLevel,
+    options: CompileOptions,
 ) -> Result<Program, LoweringError> {
     // Note: Builtin BAML files (like llm.baml) are now loaded at project setup time
     // in ProjectDatabase::set_project_root(), so they're already in the files list.
@@ -668,6 +679,29 @@ pub fn compile_files(
                     function_names: test.function_refs.iter().map(|n| n.to_string()).collect(),
                     args,
                 });
+    // --- Pass: Emit test cases (only when requested) ---
+    if options.emit_test_cases {
+        for file in files {
+            let item_tree = baml_compiler_hir::file_item_tree(db, *file);
+            let items_struct = baml_compiler_hir::file_items(db, *file);
+            for item in items_struct.items(db) {
+                if let ItemId::Test(test_loc) = item {
+                    let test = &item_tree[test_loc.id(db)];
+                    let args = test
+                        .args
+                        .iter()
+                        .map(|(k, v)| (k.clone(), convert_hir_test_arg(v)))
+                        .collect();
+                    program.test_cases.push(bex_vm_types::TestCase {
+                        name: test.name.to_string(),
+                        function_names: test
+                            .function_refs
+                            .iter()
+                            .map(std::string::ToString::to_string)
+                            .collect(),
+                        args,
+                    });
+                }
             }
         }
     }

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -651,6 +651,27 @@ pub fn compile_files(
         }
     }
 
+    // --- Pass: Emit test cases ---
+    for file in files {
+        let item_tree = baml_compiler_hir::file_item_tree(db, *file);
+        let items_struct = baml_compiler_hir::file_items(db, *file);
+        for item in items_struct.items(db) {
+            if let ItemId::Test(test_loc) = item {
+                let test = &item_tree[test_loc.id(db)];
+                let args = test
+                    .args
+                    .iter()
+                    .map(|(k, v)| (k.clone(), convert_hir_test_arg(v)))
+                    .collect();
+                program.test_cases.push(bex_vm_types::TestCase {
+                    name: test.name.to_string(),
+                    function_names: test.function_refs.iter().map(|n| n.to_string()).collect(),
+                    args,
+                });
+            }
+        }
+    }
+
     Ok(program)
 }
 
@@ -674,6 +695,25 @@ where
                 value: value.to_string(),
                 reason: e.to_string(),
             }),
+    }
+}
+
+/// Convert an HIR `TestArgValue` to a `bex_vm_types::TestArgValue`.
+fn convert_hir_test_arg(v: &baml_compiler_hir::TestArgValue) -> bex_vm_types::TestArgValue {
+    match v {
+        baml_compiler_hir::TestArgValue::Null => bex_vm_types::TestArgValue::Null,
+        baml_compiler_hir::TestArgValue::Int(i) => bex_vm_types::TestArgValue::Int(*i),
+        baml_compiler_hir::TestArgValue::Float(f) => bex_vm_types::TestArgValue::Float(*f),
+        baml_compiler_hir::TestArgValue::Bool(b) => bex_vm_types::TestArgValue::Bool(*b),
+        baml_compiler_hir::TestArgValue::String(s) => bex_vm_types::TestArgValue::String(s.clone()),
+        baml_compiler_hir::TestArgValue::Array(arr) => {
+            bex_vm_types::TestArgValue::Array(arr.iter().map(convert_hir_test_arg).collect())
+        }
+        baml_compiler_hir::TestArgValue::Map(map) => bex_vm_types::TestArgValue::Map(
+            map.iter()
+                .map(|(k, v)| (k.clone(), convert_hir_test_arg(v)))
+                .collect(),
+        ),
     }
 }
 

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -781,7 +781,7 @@ fn convert_hir_test_arg(
                 _ => (baml_type::Ty::String, baml_type::Ty::Null),
             };
             bex_vm_types::TestArgValue::Map {
-                key_type: key_type.clone(),
+                key_type,
                 value_type: value_type.clone(),
                 entries: map
                     .iter()

--- a/baml_language/crates/baml_compiler_emit/tests/retry_policy.rs
+++ b/baml_language/crates/baml_compiler_emit/tests/retry_policy.rs
@@ -1,4 +1,4 @@
-use baml_compiler_emit::{LoweringError, compile_files};
+use baml_compiler_emit::{CompileOptions, LoweringError, compile_files};
 use baml_tests::bytecode::setup_test_db;
 
 #[test]
@@ -18,8 +18,11 @@ retry_policy Bad {
     let db = setup_test_db(source);
     let project = db.get_project().expect("project should be initialized");
     let files = project.files(&db).clone();
+    let options = CompileOptions {
+        emit_test_cases: false,
+    };
 
-    let err = compile_files(&db, &files, baml_compiler_emit::OptLevel::One)
+    let err = compile_files(&db, &files, baml_compiler_emit::OptLevel::One, &options)
         .expect_err("invalid retry_policy should fail compile");
 
     match err {

--- a/baml_language/crates/baml_compiler_hir/Cargo.toml
+++ b/baml_language/crates/baml_compiler_hir/Cargo.toml
@@ -23,6 +23,7 @@ baml_compiler_diagnostics = { workspace = true }
 baml_compiler_parser = { workspace = true }
 baml_compiler_syntax = { workspace = true }
 baml_workspace = { workspace = true }
+indexmap = { workspace = true }
 la-arena = { workspace = true }
 rowan = { workspace = true }
 rustc-hash = { workspace = true }

--- a/baml_language/crates/baml_compiler_hir/src/item_tree.rs
+++ b/baml_language/crates/baml_compiler_hir/src/item_tree.rs
@@ -7,6 +7,7 @@
 use std::ops::Index;
 
 use baml_base::Name;
+use indexmap::IndexMap;
 use rowan::TextRange;
 use rustc_hash::FxHashMap;
 
@@ -325,6 +326,40 @@ pub struct RetryPolicy {
     pub max_delay_ms: Option<String>,
 }
 
+/// A test argument value, extracted from the CST during HIR lowering.
+///
+/// These are untyped constant values — type checking against function
+/// signatures happens at a later stage (during emission or at runtime).
+#[derive(Debug, Clone)]
+pub enum TestArgValue {
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    String(String),
+    Null,
+    Array(Vec<TestArgValue>),
+    Map(IndexMap<String, TestArgValue>),
+}
+
+// Manual PartialEq/Eq implementation to handle f64 comparison via bit pattern.
+// This satisfies ItemTree's Eq requirement (needed for salsa early cutoff).
+impl PartialEq for TestArgValue {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Int(a), Self::Int(b)) => a == b,
+            (Self::Float(a), Self::Float(b)) => a.to_bits() == b.to_bits(),
+            (Self::Bool(a), Self::Bool(b)) => a == b,
+            (Self::String(a), Self::String(b)) => a == b,
+            (Self::Null, Self::Null) => true,
+            (Self::Array(a), Self::Array(b)) => a == b,
+            (Self::Map(a), Self::Map(b)) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for TestArgValue {}
+
 /// Test definition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Test {
@@ -332,6 +367,9 @@ pub struct Test {
 
     /// Unresolved function references.
     pub function_refs: Vec<Name>,
+
+    /// Test arguments, keyed by parameter name.
+    pub args: IndexMap<String, TestArgValue>,
 
     /// Type builder block containing dynamic type definitions.
     pub type_builder: Option<TypeBuilderBlock>,

--- a/baml_language/crates/baml_compiler_hir/src/test.rs
+++ b/baml_language/crates/baml_compiler_hir/src/test.rs
@@ -7,12 +7,13 @@
 
 use baml_base::Name;
 use baml_compiler_diagnostics::HirDiagnostic;
-use baml_compiler_syntax::SyntaxNode;
+use baml_compiler_syntax::{SyntaxKind, SyntaxNode, ast::ConfigItem};
+use indexmap::IndexMap;
 use rowan::ast::AstNode;
 
 use crate::{
     Attribute, LoweringContext,
-    item_tree::{Test, TypeBuilderBlock, TypeBuilderEntry},
+    item_tree::{Test, TestArgValue, TypeBuilderBlock, TypeBuilderEntry},
     lower_class, lower_enum, lower_type_alias,
 };
 
@@ -33,6 +34,7 @@ pub(crate) fn lower_test(node: &SyntaxNode, ctx: &mut LoweringContext) -> Option
     // Track for required property check
     let mut has_functions = false;
     let mut has_args = false;
+    let mut args = IndexMap::new();
 
     // Process config block if present
     if let Some(config_block) = test.config_block() {
@@ -60,6 +62,14 @@ pub(crate) fn lower_test(node: &SyntaxNode, ctx: &mut LoweringContext) -> Option
                 }
                 "args" => {
                     has_args = true;
+                    if let Some(nested) = item.nested_block() {
+                        for arg_item in nested.items() {
+                            if let Some(arg_key) = arg_item.key() {
+                                let value = lower_config_item_to_test_arg(&arg_item);
+                                args.insert(arg_key.text().to_string(), value);
+                            }
+                        }
+                    }
                 }
                 _ => {}
             }
@@ -136,8 +146,129 @@ pub(crate) fn lower_test(node: &SyntaxNode, ctx: &mut LoweringContext) -> Option
     Some(Test {
         name,
         function_refs,
+        args,
         type_builder,
     })
+}
+
+/// Convert a CST `ConfigItem` to a `TestArgValue`.
+fn lower_config_item_to_test_arg(item: &ConfigItem) -> TestArgValue {
+    // Nested block → Map
+    if let Some(nested) = item.nested_block() {
+        let mut entries = IndexMap::new();
+        for sub_item in nested.items() {
+            if let Some(key) = sub_item.key() {
+                let value = lower_config_item_to_test_arg(&sub_item);
+                entries.insert(key.text().to_string(), value);
+            }
+        }
+        return TestArgValue::Map(entries);
+    }
+
+    // Array
+    if item.is_array() {
+        if let Some(array_node) = item.array_node() {
+            let items = array_node
+                .children()
+                .filter(|child| child.kind() == SyntaxKind::CONFIG_VALUE)
+                .map(|child| lower_config_value_node(&child))
+                .collect();
+            return TestArgValue::Array(items);
+        }
+        return TestArgValue::Array(Vec::new());
+    }
+
+    // Integer
+    if let Some(int_val) = item.value_int() {
+        let val = if item.is_negative() {
+            -int_val
+        } else {
+            int_val
+        };
+        return TestArgValue::Int(val);
+    }
+
+    // String/word value
+    if let Some(s) = item.value_str() {
+        return parse_scalar_str(&s);
+    }
+
+    TestArgValue::Null
+}
+
+/// Parse a scalar string value into the appropriate `TestArgValue`.
+fn parse_scalar_str(s: &str) -> TestArgValue {
+    if s == "null" {
+        return TestArgValue::Null;
+    }
+    if s == "true" {
+        return TestArgValue::Bool(true);
+    }
+    if s == "false" {
+        return TestArgValue::Bool(false);
+    }
+    if s.contains('.') {
+        if let Ok(f) = s.parse::<f64>() {
+            return TestArgValue::Float(f);
+        }
+    }
+    TestArgValue::String(s.to_string())
+}
+
+/// Parse a raw `CONFIG_VALUE` syntax node into a `TestArgValue`.
+fn lower_config_value_node(node: &SyntaxNode) -> TestArgValue {
+    // Nested block
+    for child in node.children() {
+        if child.kind() == SyntaxKind::CONFIG_BLOCK {
+            if let Some(block) = baml_compiler_syntax::ast::ConfigBlock::cast(child.clone()) {
+                let mut entries = IndexMap::new();
+                for sub_item in block.items() {
+                    if let Some(key) = sub_item.key() {
+                        let value = lower_config_item_to_test_arg(&sub_item);
+                        entries.insert(key.text().to_string(), value);
+                    }
+                }
+                return TestArgValue::Map(entries);
+            }
+        }
+        // Nested array
+        if child.kind() == SyntaxKind::ARRAY_LITERAL {
+            let items = child
+                .children()
+                .filter(|c| c.kind() == SyntaxKind::CONFIG_VALUE)
+                .map(|c| lower_config_value_node(&c))
+                .collect();
+            return TestArgValue::Array(items);
+        }
+    }
+
+    // Extract text, filtering whitespace/comments/quotes
+    let text: String = node
+        .descendants_with_tokens()
+        .filter_map(rowan::NodeOrToken::into_token)
+        .filter(|token| {
+            !matches!(
+                token.kind(),
+                SyntaxKind::WHITESPACE
+                    | SyntaxKind::NEWLINE
+                    | SyntaxKind::LINE_COMMENT
+                    | SyntaxKind::BLOCK_COMMENT
+                    | SyntaxKind::QUOTE
+            )
+        })
+        .map(|token| token.text().to_string())
+        .collect();
+
+    if text.is_empty() {
+        return TestArgValue::Null;
+    }
+
+    // Try parsing as integer first
+    if let Ok(i) = text.parse::<i64>() {
+        return TestArgValue::Int(i);
+    }
+
+    parse_scalar_str(&text)
 }
 
 /// Lower a `type_builder` block to HIR.

--- a/baml_language/crates/baml_compiler_hir/src/test.rs
+++ b/baml_language/crates/baml_compiler_hir/src/test.rs
@@ -242,26 +242,14 @@ fn lower_config_value_node(node: &SyntaxNode) -> TestArgValue {
         }
     }
 
-    // Extract text, filtering whitespace/comments/quotes
-    let text: String = node
-        .descendants_with_tokens()
-        .filter_map(rowan::NodeOrToken::into_token)
-        .filter(|token| {
-            !matches!(
-                token.kind(),
-                SyntaxKind::WHITESPACE
-                    | SyntaxKind::NEWLINE
-                    | SyntaxKind::LINE_COMMENT
-                    | SyntaxKind::BLOCK_COMMENT
-                    | SyntaxKind::QUOTE
-            )
-        })
-        .map(|token| token.text().to_string())
-        .collect();
-
-    if text.is_empty() {
-        return TestArgValue::Null;
-    }
+    // Extract scalar text, filtering trivia and quotes
+    let text = match baml_compiler_syntax::ast::ConfigValue::cast(node.clone()) {
+        Some(cv) => match cv.scalar_text() {
+            Some(t) => t,
+            None => return TestArgValue::Null,
+        },
+        None => return TestArgValue::Null,
+    };
 
     // Try parsing as integer first
     if let Ok(i) = text.parse::<i64>() {

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -1409,11 +1409,7 @@ impl ConfigValue {
             .filter(|token| !token.kind().is_trivia() && token.kind() != SyntaxKind::QUOTE)
             .map(|token| token.text().to_string())
             .collect();
-        if text.is_empty() {
-            None
-        } else {
-            Some(text)
-        }
+        if text.is_empty() { None } else { Some(text) }
     }
 }
 

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -97,6 +97,7 @@ ast_node!(Field, FIELD);
 ast_node!(EnumVariant, ENUM_VARIANT);
 ast_node!(ConfigBlock, CONFIG_BLOCK);
 ast_node!(ConfigItem, CONFIG_ITEM);
+ast_node!(ConfigValue, CONFIG_VALUE);
 ast_node!(ClientField, CLIENT_FIELD);
 ast_node!(PromptField, PROMPT_FIELD);
 ast_node!(RawStringLiteral, RAW_STRING_LITERAL);
@@ -1227,32 +1228,16 @@ impl ConfigItem {
             .map(|config_value| config_value.text_range())
     }
 
+    /// Get the typed `ConfigValue` child, if present.
+    pub fn config_value(&self) -> Option<ConfigValue> {
+        self.syntax.children().find_map(ConfigValue::cast)
+    }
+
     /// Get the full config item value as a string.
     /// This handles compound values like "python/pydantic" that span multiple tokens.
     /// Returns the unquoted text of the value.
     pub fn value_str(&self) -> Option<String> {
-        self.syntax
-            .children()
-            .find(|child| child.kind() == SyntaxKind::CONFIG_VALUE)
-            .map(|config_value| {
-                // Collect all non-whitespace, non-quote token text from nested tokens
-                config_value
-                    .descendants_with_tokens()
-                    .filter_map(rowan::NodeOrToken::into_token)
-                    .filter(|token| {
-                        !matches!(
-                            token.kind(),
-                            SyntaxKind::WHITESPACE
-                                | SyntaxKind::NEWLINE
-                                | SyntaxKind::LINE_COMMENT
-                                | SyntaxKind::BLOCK_COMMENT
-                                | SyntaxKind::QUOTE
-                        )
-                    })
-                    .map(|token| token.text().to_string())
-                    .collect::<String>()
-            })
-            .filter(|s| !s.is_empty())
+        self.config_value().and_then(|cv| cv.scalar_text())
     }
 
     /// Get a nested config block, if this item has one.
@@ -1409,6 +1394,26 @@ impl ConfigItem {
     /// Get attributes attached to this config item (e.g., `args { ... } @check(...)`).
     pub fn attributes(&self) -> impl Iterator<Item = Attribute> {
         self.syntax.children().filter_map(Attribute::cast)
+    }
+}
+
+impl ConfigValue {
+    /// Extract the unquoted scalar text content, filtering trivia and quotes.
+    ///
+    /// Returns `None` if the node contains no significant tokens.
+    pub fn scalar_text(&self) -> Option<String> {
+        let text: String = self
+            .syntax
+            .descendants_with_tokens()
+            .filter_map(rowan::NodeOrToken::into_token)
+            .filter(|token| !token.kind().is_trivia() && token.kind() != SyntaxKind::QUOTE)
+            .map(|token| token.text().to_string())
+            .collect();
+        if text.is_empty() {
+            None
+        } else {
+            Some(text)
+        }
     }
 }
 

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -12,6 +12,7 @@ use std::{
     sync::{Arc, atomic::AtomicU32},
 };
 
+use baml_compiler_emit::{CompileOptions, OptLevel};
 use baml_db::{FileId, SourceFile};
 use baml_workspace::Project;
 use salsa::Setter;
@@ -356,7 +357,10 @@ impl ProjectDatabase {
         {
             return Err(baml_compiler_emit::LoweringError::HasDiagnosticsErrors);
         }
-        baml_compiler_emit::generate_project_bytecode(self)
+        let opts = CompileOptions {
+            emit_test_cases: false,
+        };
+        baml_compiler_emit::generate_project_bytecode(self, &opts)
     }
 }
 

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -12,7 +12,7 @@ use std::{
     sync::{Arc, atomic::AtomicU32},
 };
 
-use baml_compiler_emit::{CompileOptions, OptLevel};
+use baml_compiler_emit::CompileOptions;
 use baml_db::{FileId, SourceFile};
 use baml_workspace::Project;
 use salsa::Setter;

--- a/baml_language/crates/baml_tests/build.rs
+++ b/baml_language/crates/baml_tests/build.rs
@@ -793,7 +793,8 @@ fn generate_codegen_test(
             let mut output = String::new();
 
             // Pass all files (builtins + user) to compile_files
-            match baml_compiler_emit::compile_files(&db, &all_files, baml_compiler_emit::OptLevel::One) {
+            let options = baml_compiler_emit::CompileOptions { emit_test_cases: false };
+            match baml_compiler_emit::compile_files(&db, &all_files, baml_compiler_emit::OptLevel::One, &options) {
                 Ok(program) => {
                     // Collect sorted functions, excluding builtins (baml.*)
                     // which are snapshotted separately in baml_std.

--- a/baml_language/crates/baml_tests/src/bytecode.rs
+++ b/baml_language/crates/baml_tests/src/bytecode.rs
@@ -86,7 +86,10 @@ pub fn compile_source(source: &str) -> VmProgram {
 
     let project = db.get_project().unwrap();
     let all_files = project.files(&db).clone();
-    baml_compiler_emit::compile_files(&db, &all_files, baml_compiler_emit::OptLevel::One)
+    let options = baml_compiler_emit::CompileOptions {
+        emit_test_cases: false,
+    };
+    baml_compiler_emit::compile_files(&db, &all_files, baml_compiler_emit::OptLevel::One, &options)
         .expect("compile_files should succeed for valid test source")
 }
 

--- a/baml_language/crates/baml_tests/src/codegen.rs
+++ b/baml_language/crates/baml_tests/src/codegen.rs
@@ -179,7 +179,10 @@ fn compile_source_with_opt(source: &str, opt: baml_compiler_emit::OptLevel) -> C
 
     let project = db.get_project().unwrap();
     let all_files = project.files(&db).clone();
-    let program = baml_compiler_emit::compile_files(&db, &all_files, opt)
+    let options = baml_compiler_emit::CompileOptions {
+        emit_test_cases: false,
+    };
+    let program = baml_compiler_emit::compile_files(&db, &all_files, opt, &options)
         .expect("compile_files should succeed for valid test source");
 
     // Extract functions from the program

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -591,3 +591,26 @@ pub(crate) fn vm_arg_to_external(vm: &BexVm, value: &Value) -> BexExternalValue 
         }
     }
 }
+
+/// Convert a compiled `TestArgValue` to a `BexExternalValue` for function calls.
+pub fn test_arg_to_external(v: &bex_vm_types::TestArgValue) -> BexExternalValue {
+    match v {
+        bex_vm_types::TestArgValue::Null => BexExternalValue::Null,
+        bex_vm_types::TestArgValue::Int(i) => BexExternalValue::Int(*i),
+        bex_vm_types::TestArgValue::Float(f) => BexExternalValue::Float(*f),
+        bex_vm_types::TestArgValue::Bool(b) => BexExternalValue::Bool(*b),
+        bex_vm_types::TestArgValue::String(s) => BexExternalValue::String(s.clone()),
+        bex_vm_types::TestArgValue::Array(arr) => BexExternalValue::Array {
+            element_type: Ty::String,
+            items: arr.iter().map(test_arg_to_external).collect(),
+        },
+        bex_vm_types::TestArgValue::Map(map) => BexExternalValue::Map {
+            key_type: Ty::String,
+            value_type: Ty::String,
+            entries: map
+                .iter()
+                .map(|(k, v)| (k.clone(), test_arg_to_external(v)))
+                .collect(),
+        },
+    }
+}

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -600,14 +600,21 @@ pub fn test_arg_to_external(v: &bex_vm_types::TestArgValue) -> BexExternalValue 
         bex_vm_types::TestArgValue::Float(f) => BexExternalValue::Float(*f),
         bex_vm_types::TestArgValue::Bool(b) => BexExternalValue::Bool(*b),
         bex_vm_types::TestArgValue::String(s) => BexExternalValue::String(s.clone()),
-        bex_vm_types::TestArgValue::Array(arr) => BexExternalValue::Array {
-            element_type: Ty::String,
-            items: arr.iter().map(test_arg_to_external).collect(),
+        bex_vm_types::TestArgValue::Array {
+            element_type,
+            items,
+        } => BexExternalValue::Array {
+            element_type: element_type.clone(),
+            items: items.iter().map(test_arg_to_external).collect(),
         },
-        bex_vm_types::TestArgValue::Map(map) => BexExternalValue::Map {
-            key_type: Ty::String,
-            value_type: Ty::String,
-            entries: map
+        bex_vm_types::TestArgValue::Map {
+            key_type,
+            value_type,
+            entries,
+        } => BexExternalValue::Map {
+            key_type: key_type.clone(),
+            value_type: value_type.clone(),
+            entries: entries
                 .iter()
                 .map(|(k, v)| (k.clone(), test_arg_to_external(v)))
                 .collect(),

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -55,6 +55,7 @@
 
 mod conversion;
 mod function_call_context;
+pub use conversion::test_arg_to_external;
 
 use std::{
     collections::HashMap,
@@ -350,6 +351,8 @@ pub struct BexEngine {
     /// Optional event sink for persisting events (JSONL file, JS callback, etc.).
     /// If `None`, events are only stored in the `CollectorStore` for in-memory queries.
     event_sink: Option<std::sync::Arc<dyn bex_events::EventSink>>,
+    /// Compiled test cases from the BAML program.
+    test_cases: Vec<bex_vm_types::TestCase>,
 
     // --- Epoch-based GC coordination ---
     /// Current epoch counter (monotonically increasing).
@@ -406,6 +409,9 @@ impl BexEngine {
     ) -> Result<Self, EngineError> {
         // Convert the pure bytecode to a VM-ready program with native functions attached
         let bytecode = bex_vm::convert_program(bytecode_program)?;
+
+        // Extract test cases before consuming other bytecode fields.
+        let test_cases = bytecode.test_cases;
 
         // Extract compile-time objects for the heap
         let compile_time_objects: Vec<Object> = bytecode.objects.into_iter().collect();
@@ -552,6 +558,7 @@ impl BexEngine {
             sys_ops,
             sys_op_ctx,
             event_sink,
+            test_cases,
             // Initialize epoch tracking
             current_epoch: AtomicU64::new(0),
             epoch_states: [EpochState::new(), EpochState::new()],
@@ -963,6 +970,16 @@ impl BexEngine {
                 message: format!("Expected Function, got {other:?}"),
             }),
         }
+    }
+
+    /// Get all compiled test cases.
+    pub fn test_cases(&self) -> &[bex_vm_types::TestCase] {
+        &self.test_cases
+    }
+
+    /// Find a test case by name.
+    pub fn test_case(&self, name: &str) -> Option<&bex_vm_types::TestCase> {
+        self.test_cases.iter().find(|t| t.name == name)
     }
 
     /// Collect roots from a yielded VM.

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -978,8 +978,18 @@ impl BexEngine {
     }
 
     /// Find a test case by name.
-    pub fn test_case(&self, name: &str) -> Option<&bex_vm_types::TestCase> {
-        self.test_cases.iter().find(|t| t.name == name)
+    pub fn test_case(
+        &self,
+        function_name: &str,
+        test_name: &str,
+    ) -> Option<&bex_vm_types::TestCase> {
+        self.test_cases.iter().find(|t| {
+            t.function_names
+                .iter()
+                .find(|n| &function_name == n)
+                .is_some()
+                && t.name == test_name
+        })
     }
 
     /// Collect roots from a yielded VM.

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -55,8 +55,6 @@
 
 mod conversion;
 mod function_call_context;
-pub use conversion::test_arg_to_external;
-
 use std::{
     collections::HashMap,
     sync::{
@@ -75,6 +73,7 @@ use bex_heap::BexHeap;
 pub use bex_heap::GcStats;
 use bex_vm::{BexVm, SpanNotification, VmExecState};
 use bex_vm_types::{FunctionMeta, GlobalPool, HeapPtr, Object, SysOp, Value};
+pub use conversion::test_arg_to_external;
 // Re-export CancellationToken for callers.
 pub use function_call_context::{FunctionCallContext, FunctionCallContextBuilder};
 use sys_types::{CallId, OpError, SysOpResult};
@@ -983,13 +982,9 @@ impl BexEngine {
         function_name: &str,
         test_name: &str,
     ) -> Option<&bex_vm_types::TestCase> {
-        self.test_cases.iter().find(|t| {
-            t.function_names
-                .iter()
-                .find(|n| &function_name == n)
-                .is_some()
-                && t.name == test_name
-        })
+        self.test_cases
+            .iter()
+            .find(|t| t.function_names.iter().any(|n| function_name == n) && t.name == test_name)
     }
 
     /// Collect roots from a yielded VM.

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -303,6 +303,8 @@ pub struct BytecodeProgram {
     pub template_strings_macros: String,
     /// Client build metadata, passed through to `SysOpContext`.
     pub client_metadata: HashMap<String, bex_vm_types::ClientBuildMeta>,
+    /// Compiled test cases.
+    pub test_cases: Vec<bex_vm_types::TestCase>,
 }
 
 /// Convert a compiled `Program` to a `BytecodeProgram` with native functions attached.
@@ -348,6 +350,7 @@ pub fn convert_program(program: bex_vm_types::Program) -> Result<BytecodeProgram
         function_global_indices: program.function_global_indices,
         template_strings_macros: program.template_strings_macros,
         client_metadata: program.client_metadata,
+        test_cases: program.test_cases,
     })
 }
 

--- a/baml_language/crates/bex_vm_types/src/lib.rs
+++ b/baml_language/crates/bex_vm_types/src/lib.rs
@@ -24,6 +24,6 @@ pub use indexable::{GlobalIndex, GlobalPool, ObjectIndex, ObjectPool, StackIndex
 pub use types::{
     Class, ClassField, ClientBuildMeta, ClientBuildType, CollectorRef, ConstValue, Enum,
     EnumVariant, Function, FunctionKind, FunctionMeta, Future, Instance, MediaValue, Object,
-    ObjectType, PendingFuture, Program, PromptAst, RetryPolicyMeta, SysOp, Value, Variant,
-    sys_op_for_path, type_tags,
+    ObjectType, PendingFuture, Program, PromptAst, RetryPolicyMeta, SysOp, TestArgValue, TestCase,
+    Value, Variant, sys_op_for_path, type_tags,
 };

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -484,8 +484,15 @@ pub enum TestArgValue {
     Float(f64),
     Bool(bool),
     String(String),
-    Array(Vec<TestArgValue>),
-    Map(IndexMap<String, TestArgValue>),
+    Array {
+        element_type: Ty,
+        items: Vec<TestArgValue>,
+    },
+    Map {
+        key_type: Ty,
+        value_type: Ty,
+        entries: IndexMap<String, TestArgValue>,
+    },
 }
 
 /// A compiled test case, ready for execution.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -48,6 +48,9 @@ pub struct Program {
     /// Client build metadata for constructing full client trees at runtime.
     /// Keyed by client name.
     pub client_metadata: HashMap<String, ClientBuildMeta>,
+
+    /// Compiled test cases.
+    pub test_cases: Vec<TestCase>,
 }
 
 /// Metadata for building a client tree at runtime.
@@ -463,6 +466,37 @@ impl std::fmt::Display for Value {
             Value::Object(ptr) => write!(f, "{ptr}"),
         }
     }
+}
+
+// ============================================================================
+// Test Cases
+// ============================================================================
+
+/// A constant value for test arguments.
+///
+/// Self-contained type with no dependency on HIR or external types.
+/// Converted from HIR's `TestArgValue` during emission, and converted
+/// to `BexExternalValue` in the engine for function calls.
+#[derive(Clone, Debug)]
+pub enum TestArgValue {
+    Null,
+    Int(i64),
+    Float(f64),
+    Bool(bool),
+    String(String),
+    Array(Vec<TestArgValue>),
+    Map(IndexMap<String, TestArgValue>),
+}
+
+/// A compiled test case, ready for execution.
+#[derive(Clone, Debug)]
+pub struct TestCase {
+    /// Test name (e.g., "TestAddOne").
+    pub name: String,
+    /// Function names this test targets.
+    pub function_names: Vec<String>,
+    /// Test arguments, keyed by parameter name.
+    pub args: IndexMap<String, TestArgValue>,
 }
 
 /// Compile-time constant values.

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -491,7 +491,7 @@ pub enum TestArgValue {
 /// A compiled test case, ready for execution.
 #[derive(Clone, Debug)]
 pub struct TestCase {
-    /// Test name (e.g., "TestAddOne").
+    /// Test name (e.g., "`TestAddOne`").
     pub name: String,
     /// Function names this test targets.
     pub function_names: Vec<String>,

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -1370,6 +1370,9 @@ impl CompilerRunner {
             &self.db,
             &files,
             baml_compiler_emit::OptLevel::One,
+            baml_compiler_emit::CompileOptions {
+                emit_test_cases: false,
+            },
         ) {
             Ok(p) => p,
             Err(err) => {
@@ -1475,6 +1478,9 @@ impl CompilerRunner {
             &self.db,
             &files,
             baml_compiler_emit::OptLevel::One,
+            baml_compiler_emit::CompileOptions {
+                emit_test_cases: false,
+            },
         ) {
             Ok(p) => p,
             Err(err) => {
@@ -1627,6 +1633,9 @@ impl CompilerRunner {
             &self.db,
             &files,
             baml_compiler_emit::OptLevel::One,
+            baml_compiler_emit::CompileOptions {
+                emit_test_cases: false,
+            },
         ) {
             Ok(p) => p,
             Err(err) => {

--- a/baml_language/crates/tools_onionskin/src/compiler.rs
+++ b/baml_language/crates/tools_onionskin/src/compiler.rs
@@ -1370,7 +1370,7 @@ impl CompilerRunner {
             &self.db,
             &files,
             baml_compiler_emit::OptLevel::One,
-            baml_compiler_emit::CompileOptions {
+            &baml_compiler_emit::CompileOptions {
                 emit_test_cases: false,
             },
         ) {
@@ -1478,7 +1478,7 @@ impl CompilerRunner {
             &self.db,
             &files,
             baml_compiler_emit::OptLevel::One,
-            baml_compiler_emit::CompileOptions {
+            &baml_compiler_emit::CompileOptions {
                 emit_test_cases: false,
             },
         ) {
@@ -1633,7 +1633,7 @@ impl CompilerRunner {
             &self.db,
             &files,
             baml_compiler_emit::OptLevel::One,
-            baml_compiler_emit::CompileOptions {
+            &baml_compiler_emit::CompileOptions {
                 emit_test_cases: false,
             },
         ) {

--- a/baml_language/stow.toml
+++ b/baml_language/stow.toml
@@ -80,12 +80,12 @@ reason = "Use baml_db or baml_project to access compiler interfaces."
 [[namespaces.dependency_rules]]
 pattern.select = "bex_*"
 pattern.exclude = ["bex_vm_types"]
-allowed_crates = ["bridge_cffi"]
+allowed_crates = ["bridge_cffi", "baml_cli"]
 reason = "baml_* crates should not depend on bex_* crates."
 
 [[namespaces.dependency_rules]]
 pattern.select = "bex_vm_types"
-allowed_crates = ["baml_compiler_emit", "baml_project"]
+allowed_crates = ["baml_compiler_emit", "baml_project", "baml_cli"]
 reason = "Only compiler_emit and baml_project crates should depend on bex_vm_types (pure data layer)."
 
 


### PR DESCRIPTION
Changes:
 - Port the `test` cli command from engine to baml_language
 - Represent tests and test args in the HIR
 - Convert tests and test args to bytecode in baml_compiler_emit
 - Run test functions through baml_sys when invoked via the CLI
 - Add `CompilerOptions { emit_test_cases: bool }` so that some compiler entrypoints (like tests) can include test data, while others (like compilation for client libraries) can omit it

For later:
 - Lower `template_string` calls and evaluate them at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new test command to run and manage BAML function tests with support for discovery, filtering, and execution.
  * Tests can be listed, included/excluded via patterns, and executed with detailed pass/fail reporting and result summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->