### PR TITLE
[LOADBEARING] studio is built against feb-17-studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,4 +244,5 @@ P.S. We're hiring for software engineers that love rust. [Email us](mailto:found
         </a>
 </div>
 
+
 <img src="https://imgs.xkcd.com/comics/standards.png" alt_text="hi" />

--- a/engine/baml-rpc/src/lib.rs
+++ b/engine/baml-rpc/src/lib.rs
@@ -2,6 +2,7 @@ pub mod ast;
 pub mod auth;
 
 mod base;
+pub mod public_query;
 mod rpc;
 pub mod runtime_api;
 mod s3;

--- a/engine/baml-rpc/src/public_query.rs
+++ b/engine/baml-rpc/src/public_query.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+use ts_rs::TS;
+
+use crate::rpc::ApiEndpoint;
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct QueryRequest {
+    pub sql: String,
+    #[ts(optional)]
+    pub mode: Option<QueryMode>,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMode {
+    Interactive,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct QueryColumn {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub r#type: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct QueryStats {
+    #[ts(type = "number")]
+    pub elapsed_ms: u64,
+    #[ts(type = "number")]
+    pub rows_read: u64,
+    #[ts(type = "number")]
+    pub bytes_read: u64,
+    #[ts(type = "number")]
+    pub result_rows: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct QueryResponse {
+    pub columns: Vec<QueryColumn>,
+    #[ts(type = "Array<Record<string, unknown>>")]
+    pub rows: Vec<serde_json::Map<String, serde_json::Value>>,
+    pub stats: QueryStats,
+    pub query_id: String,
+    pub warnings: Vec<String>,
+}
+
+pub struct PublicQuery;
+
+impl ApiEndpoint for PublicQuery {
+    type Request<'a> = QueryRequest;
+    type Response<'a> = QueryResponse;
+
+    const PATH: &'static str = "/v1/query";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_typescript_bindings() {
+        let _ = QueryRequest::export();
+        let _ = QueryMode::export();
+        let _ = QueryColumn::export();
+        let _ = QueryStats::export();
+        let _ = QueryResponse::export();
+    }
+}

--- a/engine/baml-rpc/src/ui/ui_traces.rs
+++ b/engine/baml-rpc/src/ui/ui_traces.rs
@@ -197,8 +197,6 @@ pub struct GetTraceChildrenRequest {
 pub struct GetTraceChildrenResponse {
     // The function_call_id of the parent function call
     pub function_call_id: String,
-    // The function_call details of the parent function call
-    pub function_call: ui_types::UiFunctionCall,
     // The children of the parent function call
     pub children: Vec<TraceCall>,
     // Breadcrumb trail

--- a/engine/baml-rpc/src/ui/ui_traces.rs
+++ b/engine/baml-rpc/src/ui/ui_traces.rs
@@ -28,27 +28,14 @@ pub struct UsageEstimateAggregate {
 #[derive(Debug, Serialize, Deserialize, TS)]
 #[ts(export)]
 pub struct NodeDetails {
-    // Aggregate info for performance - calculated server-side
+    // Aggregate info - computed by build_trace_children_hierarchy in getTraceChildren
     #[ts(type = "number")]
     pub children_functions: u32,
     #[ts(type = "number")]
-    pub total_descendants: u32, // Total count including nested children
-    #[ts(type = "number")]
-    pub max_depth: u32, // Maximum nesting depth
+    pub total_descendants: u32,
     #[ts(optional)]
     pub usage_estimate_aggregate: Option<UsageEstimateAggregate>,
-
-    // Lazy loading metadata
     pub has_children: bool,
-    pub children_loaded: bool, // Whether children are included in this response
-    #[ts(type = "number", optional)]
-    pub children_limit: Option<u32>, // How many children were requested/returned
-    #[ts(type = "number", optional)]
-    pub children_offset: Option<u32>, // Pagination offset for children
-
-    // Match highlighting - IDs of descendants that matched filters
-    #[ts(optional)]
-    pub matched_descendant_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -90,19 +77,6 @@ pub struct ListTracesRequest {
     #[ts(optional)]
     pub ending_before: Option<String>,
 
-    // Lazy loading controls
-    /// Whether to include direct children in the response. Defaults to false.
-    #[ts(optional)]
-    pub include_children: Option<bool>,
-    /// Maximum depth of children to load. Defaults to 1 if include_children is true.
-    #[ts(optional)]
-    pub max_depth: Option<u32>,
-    /// Limit for children per trace. Defaults to 50.
-    #[ts(optional)]
-    pub children_limit: Option<u32>,
-    /// Offset for children pagination within each trace.
-    #[ts(optional)]
-    pub children_offset: Option<u32>,
     /// Whether to calculate usage estimates. Defaults to true.
     #[ts(optional)]
     pub include_usage_estimates: Option<bool>,
@@ -134,9 +108,6 @@ pub struct ListTracesRequest {
     /// Filter to only show LLM function calls (function_type = 'baml_llm')
     #[ts(optional)]
     pub llm_only: Option<FilterExpression<bool>>,
-    /// Whether to include matched_descendant_ids in the response for match highlighting. Defaults to false.
-    #[ts(optional)]
-    pub include_match_highlights: Option<bool>,
 }
 
 impl Default for ListTracesRequest {
@@ -150,10 +121,6 @@ impl Default for ListTracesRequest {
             limit: Some(100),
             starting_after: None,
             ending_before: None,
-            include_children: Some(false),
-            max_depth: Some(1),
-            children_limit: Some(50),
-            children_offset: Some(0),
             include_usage_estimates: Some(true),
             function_call_id: None,
             function_id: None,
@@ -167,7 +134,6 @@ impl Default for ListTracesRequest {
             relative_time: None,
             search: None,
             llm_only: None,
-            include_match_highlights: Some(false),
         }
     }
 }
@@ -190,6 +156,23 @@ pub struct GetTraceChildrenRequest {
     /// Whether to calculate usage estimates. Defaults to true.
     #[ts(optional)]
     pub include_usage_estimates: Option<bool>,
+
+    // Filter fields for children match highlighting
+    /// Search term to highlight matching children
+    #[ts(optional)]
+    pub search: Option<String>,
+    /// Status filter for matching children
+    #[ts(optional)]
+    pub status: Option<FilterExpression<FunctionCallStatus>>,
+    /// Tag filters for matching children
+    #[ts(optional)]
+    pub tag_filters: Option<Vec<TagFilter>>,
+    /// Error filters for matching children
+    #[ts(optional)]
+    pub error_filters: Option<Vec<TagFilter>>,
+    /// LLM-only filter for matching children
+    #[ts(optional)]
+    pub llm_only: Option<FilterExpression<bool>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -203,6 +186,9 @@ pub struct GetTraceChildrenResponse {
     #[ts(type = "number")]
     pub total_children: u32, // For pagination
     pub has_more: bool, // Whether there are more children to load
+    /// IDs of children that matched the given filters (for highlight)
+    #[ts(optional)]
+    pub matched_children_ids: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -249,18 +235,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_list_traces_lazy_loading() {
+    fn test_list_traces_request_deserialization() {
         let json_str = r#"{
             "projectId": "proj_01jvb3fnp1f09ta2a6g016t4kz",
-            "includeChildren": true,
-            "maxDepth": 2,
-            "childrenLimit": 25
+            "includeUsageEstimates": true
         }"#;
 
         let request: ListTracesRequest = serde_json::from_str(json_str).unwrap();
-        assert_eq!(request.include_children, Some(true));
-        assert_eq!(request.max_depth, Some(2));
-        assert_eq!(request.children_limit, Some(25));
+        assert_eq!(request.include_usage_estimates, Some(true));
     }
 
     #[test]

--- a/engine/baml-rpc/src/ui/ui_traces.rs
+++ b/engine/baml-rpc/src/ui/ui_traces.rs
@@ -108,6 +108,9 @@ pub struct ListTracesRequest {
     /// Filter to only show LLM function calls (function_type = 'baml_llm')
     #[ts(optional)]
     pub llm_only: Option<FilterExpression<bool>>,
+    /// Whether to search across llm_request_text and llm_response_text columns
+    #[ts(optional)]
+    pub full_text_search: Option<bool>,
 }
 
 impl Default for ListTracesRequest {
@@ -134,6 +137,7 @@ impl Default for ListTracesRequest {
             relative_time: None,
             search: None,
             llm_only: None,
+            full_text_search: None,
         }
     }
 }
@@ -173,6 +177,9 @@ pub struct GetTraceChildrenRequest {
     /// LLM-only filter for matching children
     #[ts(optional)]
     pub llm_only: Option<FilterExpression<bool>>,
+    /// Whether to search across llm_request_text and llm_response_text columns
+    #[ts(optional)]
+    pub full_text_search: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -301,6 +308,8 @@ pub struct ListTraceFunctionSummariesRequest {
     pub error_filters: Option<Vec<TagFilter>>,
     #[ts(optional)]
     pub search: Option<String>,
+    #[ts(optional)]
+    pub full_text_search: Option<bool>,
 }
 
 impl Default for ListTraceFunctionSummariesRequest {
@@ -319,6 +328,7 @@ impl Default for ListTraceFunctionSummariesRequest {
             tag_filters: None,
             error_filters: None,
             search: None,
+            full_text_search: None,
         }
     }
 }

--- a/engine/baml-rpc/src/ui/ui_traces.rs
+++ b/engine/baml-rpc/src/ui/ui_traces.rs
@@ -387,3 +387,49 @@ impl ApiEndpoint for ListTraceFunctionSummaries {
 
     const PATH: &'static str = "/v1/traces/function-summaries";
 }
+
+/// Batch request to compute costs for a set of root trace function_call_ids.
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct GetTraceCostsRequest {
+    #[ts(type = "string")]
+    pub project_id: ProjectId,
+    /// Root function_call_ids to compute costs for.
+    pub function_call_ids: Vec<String>,
+    /// Optional relative time to scope the cost query.
+    #[ts(optional)]
+    pub relative_time: Option<super::ui_function_calls::RelativeTime>,
+    /// Optional function name to narrow the cost query.
+    #[ts(optional)]
+    pub function_name: Option<String>,
+}
+
+/// Cost entry for a single root trace.
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export)]
+pub struct TraceCostEntry {
+    pub function_call_id: String,
+    #[ts(type = "number", optional)]
+    pub input_cost: Option<f64>,
+    #[ts(type = "number", optional)]
+    pub output_cost: Option<f64>,
+    #[ts(type = "number", optional)]
+    pub total_cost: Option<f64>,
+}
+
+#[derive(Debug, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct GetTraceCostsResponse {
+    pub costs: Vec<TraceCostEntry>,
+}
+
+pub struct GetTraceCosts;
+
+impl ApiEndpoint for GetTraceCosts {
+    type Request<'a> = GetTraceCostsRequest;
+    type Response<'a> = GetTraceCostsResponse;
+
+    const PATH: &'static str = "/v1/traces/costs";
+}

--- a/engine/baml-rpc/src/ui/ui_traces.rs
+++ b/engine/baml-rpc/src/ui/ui_traces.rs
@@ -105,12 +105,12 @@ pub struct ListTracesRequest {
     /// Search term to filter across function_call_id, function_name, tags, error, input (args), and output
     #[ts(optional)]
     pub search: Option<String>,
+    /// When true, also search LLM request/response text (full-text search). Defaults to false.
+    #[ts(optional)]
+    pub full_text_search: Option<bool>,
     /// Filter to only show LLM function calls (function_type = 'baml_llm')
     #[ts(optional)]
     pub llm_only: Option<FilterExpression<bool>>,
-    /// Whether to search across llm_request_text and llm_response_text columns
-    #[ts(optional)]
-    pub full_text_search: Option<bool>,
 }
 
 impl Default for ListTracesRequest {
@@ -136,8 +136,8 @@ impl Default for ListTracesRequest {
             streamed: None,
             relative_time: None,
             search: None,
-            llm_only: None,
             full_text_search: None,
+            llm_only: None,
         }
     }
 }
@@ -165,6 +165,9 @@ pub struct GetTraceChildrenRequest {
     /// Search term to highlight matching children
     #[ts(optional)]
     pub search: Option<String>,
+    /// When true, also search LLM request/response text (full-text search). Defaults to false.
+    #[ts(optional)]
+    pub full_text_search: Option<bool>,
     /// Status filter for matching children
     #[ts(optional)]
     pub status: Option<FilterExpression<FunctionCallStatus>>,
@@ -177,9 +180,6 @@ pub struct GetTraceChildrenRequest {
     /// LLM-only filter for matching children
     #[ts(optional)]
     pub llm_only: Option<FilterExpression<bool>>,
-    /// Whether to search across llm_request_text and llm_response_text columns
-    #[ts(optional)]
-    pub full_text_search: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, TS)]
@@ -308,6 +308,7 @@ pub struct ListTraceFunctionSummariesRequest {
     pub error_filters: Option<Vec<TagFilter>>,
     #[ts(optional)]
     pub search: Option<String>,
+    /// When true, also search LLM request/response text (full-text search). Defaults to false.
     #[ts(optional)]
     pub full_text_search: Option<bool>,
 }

--- a/engine/baml-rpc/src/ui/ui_types.rs
+++ b/engine/baml-rpc/src/ui/ui_types.rs
@@ -112,6 +112,9 @@ pub struct UiFunctionCall {
     #[ts(type = "unknown")]
     pub baml_options: serde_json::Value,
     pub inputs: Vec<UiFunctionInput>,
+    /// True when the inputs were too large and were truncated by the query
+    #[serde(default)]
+    pub inputs_truncated: bool,
     #[ts(as = "Option<BamlValue>")]
     pub output: serde_json::Value,
     pub error: Option<UiBamlFunctionCallError>,

--- a/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
+++ b/engine/baml-runtime/src/tracingv2/publisher/publisher.rs
@@ -231,7 +231,7 @@ pub fn start_publisher(
         log::debug!("Skipping publisher because BOUNDARY_API_KEY is not set");
         return;
     }
-    log::debug!("Starting publisher");
+    log::info!("Starting publisher");
 
     // Read batch sizes early to calculate channel capacities
     let trace_batch_size = lookup


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the public UI RPC contract for traces (removes/renames fields and adds new request/response fields), which can break existing UI/client integrations if not updated. New filtering and cost endpoints are additive but touch query semantics and pagination/highlighting behavior.
> 
> **Overview**
> **Trace UI RPC payloads are simplified and extended.** `ListTracesRequest` and `NodeDetails` drop several lazy-loading/match-highlighting fields, while adding an optional `full_text_search` flag to expand search into LLM request/response text.
> 
> **Child-trace loading gains server-side match/highlight support.** `GetTraceChildrenRequest` now accepts search/status/tag/error/LLM-only filters (plus `full_text_search`), and `GetTraceChildrenResponse` can return `matched_children_ids` for UI highlighting; the embedded parent `function_call` is removed from the response.
> 
> **Adds new trace cost batch API types.** Introduces `/v1/traces/costs` (`GetTraceCosts*`) to fetch per-root-trace input/output/total costs, and adds `inputs_truncated` to `UiFunctionCall` to indicate query-side input truncation. Also bumps publisher startup logging from debug to info.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4b8c1caf0e70390b13c68e41c24df5899570fb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified trace node payloads by removing lazy-loading controls, depth/children limits, and embedded match-highlighting metadata.

* **New Features**
  * Server-side child search and filtering (search, full-text, status, tag/error filters, LLM-only).
  * Responses may return matched child IDs for UI highlighting.
  * New trace costs endpoint and response types.

* **Other**
  * Function-call metadata now indicates when inputs were truncated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->