### PR TITLE
emit: add MIR/emitter invariant verifier

### DIFF
--- a/baml_language/crates/baml_compiler_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler_emit/src/analysis.rs
@@ -367,29 +367,8 @@ fn build_redirect_targets_with_classifications(
     let mut goto_targets: HashMap<BlockId, BlockId> = HashMap::new();
 
     for block in &mir.blocks {
-        let Some(Terminator::Goto { target }) = &block.terminator else {
-            continue;
-        };
-
-        let effectively_empty = block.statements.iter().all(|stmt| {
-            matches!(
-                &stmt.kind,
-                StatementKind::Assign {
-                    destination: Place::Local(local),
-                    ..
-                } if matches!(
-                    classifications.get(local),
-                    Some(
-                        LocalClassification::Virtual
-                        | LocalClassification::Dead
-                        | LocalClassification::CopyOf
-                    )
-                )
-            )
-        });
-
-        if effectively_empty {
-            goto_targets.insert(block.id, *target);
+        if let Some(target) = threadable_goto_target(block, classifications) {
+            goto_targets.insert(block.id, target);
         }
     }
 
@@ -404,6 +383,36 @@ fn build_redirect_targets_with_classifications(
     }
 
     resolved
+}
+
+/// Return the goto target if this block is threadable as an effectively-empty
+/// redirect source under the given local classifications.
+pub(crate) fn threadable_goto_target(
+    block: &baml_compiler_mir::BasicBlock,
+    classifications: &HashMap<Local, LocalClassification>,
+) -> Option<BlockId> {
+    let Some(Terminator::Goto { target }) = &block.terminator else {
+        return None;
+    };
+
+    let effectively_empty = block.statements.iter().all(|stmt| {
+        matches!(
+            &stmt.kind,
+            StatementKind::Assign {
+                destination: Place::Local(local),
+                ..
+            } if matches!(
+                classifications.get(local),
+                Some(
+                    LocalClassification::Virtual
+                    | LocalClassification::Dead
+                    | LocalClassification::CopyOf
+                )
+            )
+        )
+    });
+
+    effectively_empty.then_some(*target)
 }
 
 // ============================================================================

--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -198,6 +198,12 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
         }
     }
 
+    fn local_slot_or_panic(&self, local: Local, context: &str) -> usize {
+        *self.local_slots.get(&local).unwrap_or_else(|| {
+            panic!("local {local} has no allocated slot while emitting {context}")
+        })
+    }
+
     /// Compile a MIR function to bytecode.
     fn compile(mut self, mir: &MirFunction) -> Function {
         // 1. Allocate stack slots only for real locals
@@ -496,17 +502,15 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                         if local_decl.is_watched && !self.watched_locals_initialized.contains(local)
                         {
                             self.watched_locals_initialized.insert(*local);
-                            if self.local_slots.contains_key(local) {
-                                if let Err(never) =
-                                    self.push_watch_channel(*local, local_decl.name.as_deref())
-                                {
-                                    match never {}
-                                }
-                                let null_const_idx = self.add_constant(ConstValue::Null);
-                                self.emit(Instruction::LoadConst(null_const_idx));
-                                if let Err(never) = self.watch_local(*local) {
-                                    match never {}
-                                }
+                            if let Err(never) =
+                                self.push_watch_channel(*local, local_decl.name.as_deref())
+                            {
+                                match never {}
+                            }
+                            let null_const_idx = self.add_constant(ConstValue::Null);
+                            self.emit(Instruction::LoadConst(null_const_idx));
+                            if let Err(never) = self.watch_local(*local) {
+                                match never {}
                             }
                         }
                     }
@@ -520,9 +524,8 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             }
             StatementKind::Unwatch(local) => {
                 // Emit unwatch for a watched local going out of scope
-                if let Some(&slot) = self.local_slots.get(local) {
-                    self.emit(Instruction::Unwatch(slot));
-                }
+                let slot = self.local_slot_or_panic(*local, "Unwatch");
+                self.emit(Instruction::Unwatch(slot));
             }
             StatementKind::NotifyBlock { name, level } => {
                 // Add block notification to the function's metadata
@@ -546,9 +549,8 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             }
             StatementKind::WatchNotify(local) => {
                 // Emit manual notify for a watched variable
-                if let Some(&slot) = self.local_slots.get(local) {
-                    self.emit(Instruction::Notify(slot));
-                }
+                let slot = self.local_slot_or_panic(*local, "WatchNotify");
+                self.emit(Instruction::Notify(slot));
             }
             StatementKind::VizEnter(node_idx) => {
                 self.emit(Instruction::VizEnter(*node_idx));
@@ -1331,10 +1333,7 @@ impl StackEffectSink for StackifyCodegen<'_, '_> {
         channel_name: Option<&str>,
     ) -> Result<(), Self::Error> {
         // Watched locals must be `Real` and therefore must have slots.
-        assert!(
-            self.local_slots.contains_key(&local),
-            "watched local {local} has no allocated slot"
-        );
+        let _slot = self.local_slot_or_panic(local, "WatchOptions/watch initialization");
         let channel = channel_name
             .unwrap_or_else(|| panic!("watched local {local} must have a user-visible name"))
             .to_string();
@@ -1347,10 +1346,7 @@ impl StackEffectSink for StackifyCodegen<'_, '_> {
     }
 
     fn watch_local(&mut self, local: Local) -> Result<(), Self::Error> {
-        let slot = *self
-            .local_slots
-            .get(&local)
-            .unwrap_or_else(|| panic!("watched local {local} has no allocated slot"));
+        let slot = self.local_slot_or_panic(local, "Watch");
         self.emit(Instruction::Watch(slot));
         Ok(())
     }

--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -41,6 +41,15 @@ const JUMP_TABLE_MIN_DENSITY: f64 = 0.5; // Minimum density for jump table
 const JUMP_TABLE_MAX_SIZE: usize = 256; // Maximum jump table size
 const BINARY_SEARCH_MIN_ARMS: usize = 4; // Minimum arms for binary search
 
+/// Unwrap a `Result` whose error type is `Infallible`.
+#[inline]
+fn unwrap_infallible<T>(result: Result<T, Infallible>) -> T {
+    match result {
+        Ok(value) => value,
+        Err(never) => match never {},
+    }
+}
+
 /// Analyze a switch's arms to determine the best emission strategy.
 ///
 /// The thresholds are tunable constants that balance code size, memory usage,
@@ -486,10 +495,12 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
 
                 // For field/index stores, push the base object first, then emit the value
                 // This sets up the stack correctly for StoreField/StoreArrayElement
-                match pull_semantics::walk_projection_store(self, destination, value) {
-                    Ok(true) => return,
-                    Ok(false) => {}
-                    Err(never) => match never {},
+                if unwrap_infallible(pull_semantics::walk_projection_store(
+                    self,
+                    destination,
+                    value,
+                )) {
+                    return;
                 }
 
                 match destination {
@@ -502,25 +513,19 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                         if local_decl.is_watched && !self.watched_locals_initialized.contains(local)
                         {
                             self.watched_locals_initialized.insert(*local);
-                            if let Err(never) =
-                                self.push_watch_channel(*local, local_decl.name.as_deref())
-                            {
-                                match never {}
-                            }
+                            unwrap_infallible(
+                                self.push_watch_channel(*local, local_decl.name.as_deref()),
+                            );
                             let null_const_idx = self.add_constant(ConstValue::Null);
                             self.emit(Instruction::LoadConst(null_const_idx));
-                            if let Err(never) = self.watch_local(*local) {
-                                match never {}
-                            }
+                            unwrap_infallible(self.watch_local(*local));
                         }
                     }
                     Place::Field { .. } | Place::Index { .. } => unreachable!(),
                 }
             }
             StatementKind::Drop(place) => {
-                if let Err(never) = pull_semantics::walk_drop_statement(self, place) {
-                    match never {}
-                }
+                unwrap_infallible(pull_semantics::walk_drop_statement(self, place));
             }
             StatementKind::Unwatch(local) => {
                 // Emit unwatch for a watched local going out of scope
@@ -541,11 +546,12 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             }
             StatementKind::WatchOptions { local, filter } => {
                 let channel_name = mir.local(*local).name.as_deref();
-                if let Err(never) =
-                    pull_semantics::walk_watch_options_statement(self, *local, channel_name, filter)
-                {
-                    match never {}
-                }
+                unwrap_infallible(pull_semantics::walk_watch_options_statement(
+                    self,
+                    *local,
+                    channel_name,
+                    filter,
+                ));
             }
             StatementKind::WatchNotify(local) => {
                 // Emit manual notify for a watched variable
@@ -560,9 +566,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             }
             StatementKind::Nop => {}
             StatementKind::Assert(operand) => {
-                if let Err(never) = pull_semantics::walk_assert_statement(self, operand) {
-                    match never {}
-                }
+                unwrap_infallible(pull_semantics::walk_assert_statement(self, operand));
             }
         }
     }
@@ -576,16 +580,12 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
     /// For Virtual locals, this recursively emits the definition's rvalue inline.
     /// For Real locals, this emits a `LoadVar` instruction.
     fn emit_operand_pull(&mut self, operand: &Operand) {
-        if let Err(never) = pull_semantics::walk_operand_pull(self, operand) {
-            match never {}
-        }
+        unwrap_infallible(pull_semantics::walk_operand_pull(self, operand));
     }
 
     /// Emit an rvalue using the pull model.
     fn emit_rvalue_pull(&mut self, rvalue: &Rvalue) {
-        if let Err(never) = pull_semantics::walk_rvalue_pull(self, rvalue) {
-            match never {}
-        }
+        unwrap_infallible(pull_semantics::walk_rvalue_pull(self, rvalue));
     }
 
     /// Emit a constant value.
@@ -749,9 +749,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
 
             Terminator::Return => {
                 // Use pull model for return value - if _0 is Virtual, inline it
-                if let Err(never) = pull_semantics::walk_return_value(self) {
-                    match never {}
-                }
+                unwrap_infallible(pull_semantics::walk_return_value(self));
                 self.emit(Instruction::Return);
             }
 
@@ -762,9 +760,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 target,
                 unwind: _,
             } => {
-                if let Err(never) = pull_semantics::walk_invoke_operands(self, callee, args) {
-                    match never {}
-                }
+                unwrap_infallible(pull_semantics::walk_invoke_operands(self, callee, args));
                 self.emit(Instruction::Call(args.len()));
                 self.emit_store_place(destination);
                 self.emit_jump_unless_fallthrough(*target);
@@ -784,9 +780,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 future,
                 resume,
             } => {
-                if let Err(never) = pull_semantics::walk_invoke_operands(self, callee, args) {
-                    match never {}
-                }
+                unwrap_infallible(pull_semantics::walk_invoke_operands(self, callee, args));
                 self.emit(Instruction::DispatchFuture(args.len()));
                 self.emit_store_place(future);
                 self.emit_jump_unless_fallthrough(*resume);
@@ -798,9 +792,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 target,
                 unwind: _,
             } => {
-                if let Err(never) = pull_semantics::walk_await_future(self, future) {
-                    match never {}
-                }
+                unwrap_infallible(pull_semantics::walk_await_future(self, future));
                 self.emit(Instruction::Await);
                 self.emit_store_place(destination);
                 self.emit_jump_unless_fallthrough(*target);

--- a/baml_language/crates/baml_compiler_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler_emit/src/emit.rs
@@ -1371,6 +1371,8 @@ impl StackEffectSink for StackifyCodegen<'_, '_> {
 pub(crate) fn compile_mir_function(mir: &MirFunction, ctx: MirCodegenContext<'_, '_>) -> Function {
     // Run analysis
     let analysis = AnalysisResult::analyze(mir);
+    #[cfg(debug_assertions)]
+    crate::verifier::verify_mir_emit_invariants(mir, &analysis);
 
     // Compile with stackification
     let codegen = StackifyCodegen::new(ctx, analysis);

--- a/baml_language/crates/baml_compiler_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler_emit/src/lib.rs
@@ -23,6 +23,7 @@ mod analysis;
 mod emit;
 mod pull_semantics;
 mod stack_carry;
+mod verifier;
 
 use bex_vm_types::ObjectPool;
 pub(crate) use emit::compile_mir_function;

--- a/baml_language/crates/baml_compiler_emit/src/verifier.rs
+++ b/baml_language/crates/baml_compiler_emit/src/verifier.rs
@@ -1,0 +1,287 @@
+//! MIR/emitter invariant verifier.
+//!
+//! This module validates assumptions shared by analysis and emission so
+//! regressions fail loudly during development/testing.
+
+use std::collections::{HashMap, HashSet};
+
+use baml_compiler_mir::{
+    BasicBlock, BlockId, Local, MirFunction, Place, StatementKind, Terminator,
+};
+
+use crate::analysis::{self, AnalysisResult, LocalClassification};
+
+/// Verify MIR + analysis invariants required by bytecode emission.
+///
+/// Intended for debug builds to catch invariant drift between MIR lowering,
+/// analysis, and emission.
+pub(crate) fn verify_mir_emit_invariants(mir: &MirFunction, analysis: &AnalysisResult) {
+    let block_ids: HashSet<BlockId> = mir.blocks.iter().map(|b| b.id).collect();
+
+    // Block IDs must be dense and match indexing assumptions used by MirFunction::block().
+    for (idx, block) in mir.blocks.iter().enumerate() {
+        assert!(
+            block.id == BlockId(idx),
+            "block id/index mismatch in {}: block.id={:?}, index=bb{}",
+            mir.name,
+            block.id,
+            idx
+        );
+    }
+
+    // Redirect map must only contain known blocks and must resolve to a final non-source target.
+    for (&src, &dst) in &analysis.redirect_targets {
+        assert!(
+            block_ids.contains(&src),
+            "redirect source {:?} missing in MIR function {}",
+            src,
+            mir.name
+        );
+        assert!(
+            block_ids.contains(&dst),
+            "redirect target {:?} missing in MIR function {}",
+            dst,
+            mir.name
+        );
+        assert!(
+            src != dst,
+            "self-redirect for {:?} in MIR function {}",
+            src,
+            mir.name
+        );
+
+        let src_block = mir.block(src);
+        let is_threadable = is_threadable_redirect_source(src_block, &analysis.classifications);
+        assert!(
+            is_threadable,
+            "non-threadable redirect source {:?} in MIR function {}",
+            src, mir.name
+        );
+
+        let resolved = analysis.resolve_jump_target(src);
+        assert!(
+            !analysis.redirect_targets.contains_key(&resolved),
+            "redirect chain did not converge for {:?} -> {:?} in MIR function {}",
+            src,
+            resolved,
+            mir.name
+        );
+    }
+
+    // Exhaustive switches rely on an unreachable default path. If this regresses,
+    // if-else chain emission can become unsound.
+    for block in &mir.blocks {
+        if let Some(Terminator::Switch {
+            otherwise,
+            exhaustive,
+            ..
+        }) = &block.terminator
+            && *exhaustive
+        {
+            let otherwise_block = mir.block(*otherwise);
+            assert!(
+                analysis::is_dead_unreachable_block(otherwise_block),
+                "exhaustive switch in {:?} has non-unreachable default block {:?}",
+                block.id,
+                otherwise
+            );
+        }
+    }
+
+    // Watched locals must always be real so Watch/Unwatch have stable slots.
+    for (idx, decl) in mir.locals.iter().enumerate() {
+        if decl.is_watched {
+            let local = Local(idx);
+            let class = analysis
+                .classifications
+                .get(&local)
+                .copied()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "missing classification for watched local {} in MIR function {}",
+                        local, mir.name
+                    )
+                });
+            assert!(
+                class == LocalClassification::Real,
+                "watched local {} classified as {:?} (expected Real) in MIR function {}",
+                local,
+                class,
+                mir.name
+            );
+        }
+    }
+}
+
+fn is_threadable_redirect_source(
+    block: &BasicBlock,
+    classifications: &HashMap<Local, LocalClassification>,
+) -> bool {
+    let Some(Terminator::Goto { .. }) = &block.terminator else {
+        return false;
+    };
+
+    block.statements.iter().all(|stmt| {
+        matches!(
+            &stmt.kind,
+            StatementKind::Assign {
+                destination: Place::Local(local),
+                ..
+            } if matches!(
+                classifications.get(local),
+                Some(
+                    LocalClassification::Virtual
+                    | LocalClassification::Dead
+                    | LocalClassification::CopyOf
+                )
+            )
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use baml_base::Name;
+    use baml_compiler_mir::{Constant, LocalDecl, Operand, Rvalue, Statement};
+    use baml_type::Ty;
+
+    use super::*;
+    use crate::analysis::AnalysisResult;
+
+    fn local(name: &str) -> LocalDecl {
+        LocalDecl {
+            name: Some(Name::new(name)),
+            ty: Ty::Int,
+            span: None,
+            is_watched: false,
+        }
+    }
+
+    fn local_watched(name: &str) -> LocalDecl {
+        LocalDecl {
+            name: Some(Name::new(name)),
+            ty: Ty::Int,
+            span: None,
+            is_watched: true,
+        }
+    }
+
+    fn stmt_assign(local: Local, value: i64) -> Statement {
+        Statement {
+            kind: StatementKind::Assign {
+                destination: Place::Local(local),
+                value: Rvalue::Use(Operand::Constant(Constant::Int(value))),
+            },
+            span: None,
+        }
+    }
+
+    #[test]
+    fn verifier_allows_exhaustive_switch_with_unreachable_default() {
+        let mut mir = MirFunction {
+            name: Name::new("f"),
+            arity: 0,
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: vec![],
+                    terminator: Some(Terminator::Switch {
+                        discriminant: Operand::Constant(Constant::Int(0)),
+                        arms: vec![(0, BlockId(1))],
+                        otherwise: BlockId(2),
+                        exhaustive: true,
+                    }),
+                    span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![stmt_assign(Local(0), 1)],
+                    terminator: Some(Terminator::Return),
+                    span: None,
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    statements: vec![],
+                    terminator: Some(Terminator::Unreachable),
+                    span: None,
+                },
+            ],
+            entry: BlockId(0),
+            locals: vec![local("ret")],
+            span: None,
+            viz_nodes: vec![],
+        };
+        // Ensure IDs/indexes stay coherent for this synthetic MIR.
+        for (i, block) in mir.blocks.iter_mut().enumerate() {
+            block.id = BlockId(i);
+        }
+        let analysis = AnalysisResult::analyze(&mir);
+        verify_mir_emit_invariants(&mir, &analysis);
+    }
+
+    #[test]
+    #[should_panic(expected = "exhaustive switch")]
+    fn verifier_rejects_exhaustive_switch_with_reachable_default() {
+        let mut mir = MirFunction {
+            name: Name::new("f"),
+            arity: 0,
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: vec![],
+                    terminator: Some(Terminator::Switch {
+                        discriminant: Operand::Constant(Constant::Int(0)),
+                        arms: vec![(0, BlockId(1))],
+                        otherwise: BlockId(2),
+                        exhaustive: true,
+                    }),
+                    span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![stmt_assign(Local(0), 1)],
+                    terminator: Some(Terminator::Return),
+                    span: None,
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    statements: vec![],
+                    terminator: Some(Terminator::Goto { target: BlockId(1) }),
+                    span: None,
+                },
+            ],
+            entry: BlockId(0),
+            locals: vec![local("ret")],
+            span: None,
+            viz_nodes: vec![],
+        };
+        for (i, block) in mir.blocks.iter_mut().enumerate() {
+            block.id = BlockId(i);
+        }
+        let analysis = AnalysisResult::analyze(&mir);
+        verify_mir_emit_invariants(&mir, &analysis);
+    }
+
+    #[test]
+    fn verifier_accepts_watched_locals_classified_real() {
+        let mut mir = MirFunction {
+            name: Name::new("f"),
+            arity: 0,
+            blocks: vec![BasicBlock {
+                id: BlockId(0),
+                statements: vec![],
+                terminator: Some(Terminator::Return),
+                span: None,
+            }],
+            entry: BlockId(0),
+            locals: vec![local("ret"), local_watched("x")],
+            span: None,
+            viz_nodes: vec![],
+        };
+        for (i, block) in mir.blocks.iter_mut().enumerate() {
+            block.id = BlockId(i);
+        }
+        let analysis = AnalysisResult::analyze(&mir);
+        verify_mir_emit_invariants(&mir, &analysis);
+    }
+}

--- a/baml_language/crates/baml_compiler_emit/src/verifier.rs
+++ b/baml_language/crates/baml_compiler_emit/src/verifier.rs
@@ -3,11 +3,9 @@
 //! This module validates assumptions shared by analysis and emission so
 //! regressions fail loudly during development/testing.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
-use baml_compiler_mir::{
-    BasicBlock, BlockId, Local, MirFunction, Place, StatementKind, Terminator,
-};
+use baml_compiler_mir::{BlockId, Local, MirFunction, StatementKind, Terminator};
 
 use crate::analysis::{self, AnalysisResult, LocalClassification};
 
@@ -51,7 +49,8 @@ pub(crate) fn verify_mir_emit_invariants(mir: &MirFunction, analysis: &AnalysisR
         );
 
         let src_block = mir.block(src);
-        let is_threadable = is_threadable_redirect_source(src_block, &analysis.classifications);
+        let is_threadable =
+            analysis::threadable_goto_target(src_block, &analysis.classifications).is_some();
         assert!(
             is_threadable,
             "non-threadable redirect source {:?} in MIR function {}",
@@ -92,6 +91,12 @@ pub(crate) fn verify_mir_emit_invariants(mir: &MirFunction, analysis: &AnalysisR
     for (idx, decl) in mir.locals.iter().enumerate() {
         if decl.is_watched {
             let local = Local(idx);
+            assert!(
+                decl.name.is_some(),
+                "watched local {} must have a user-visible name in MIR function {}",
+                local,
+                mir.name
+            );
             let class = analysis
                 .classifications
                 .get(&local)
@@ -111,38 +116,39 @@ pub(crate) fn verify_mir_emit_invariants(mir: &MirFunction, analysis: &AnalysisR
             );
         }
     }
-}
 
-fn is_threadable_redirect_source(
-    block: &BasicBlock,
-    classifications: &HashMap<Local, LocalClassification>,
-) -> bool {
-    let Some(Terminator::Goto { .. }) = &block.terminator else {
-        return false;
-    };
+    // Watch-manipulation statements must only reference watched locals.
+    for block in &mir.blocks {
+        for stmt in &block.statements {
+            let Some(local) = (match &stmt.kind {
+                StatementKind::Unwatch(local)
+                | StatementKind::WatchNotify(local)
+                | StatementKind::WatchOptions { local, .. } => Some(*local),
+                _ => None,
+            }) else {
+                continue;
+            };
 
-    block.statements.iter().all(|stmt| {
-        matches!(
-            &stmt.kind,
-            StatementKind::Assign {
-                destination: Place::Local(local),
-                ..
-            } if matches!(
-                classifications.get(local),
-                Some(
-                    LocalClassification::Virtual
-                    | LocalClassification::Dead
-                    | LocalClassification::CopyOf
-                )
-            )
-        )
-    })
+            let decl = mir.local(local);
+            assert!(
+                decl.is_watched,
+                "watch statement references non-watched local {} in MIR function {}",
+                local, mir.name
+            );
+            assert!(
+                decl.name.is_some(),
+                "watch statement references unnamed watched local {} in MIR function {}",
+                local,
+                mir.name
+            );
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use baml_base::Name;
-    use baml_compiler_mir::{Constant, LocalDecl, Operand, Rvalue, Statement};
+    use baml_compiler_mir::{BasicBlock, Constant, LocalDecl, Operand, Place, Rvalue, Statement};
     use baml_type::Ty;
 
     use super::*;


### PR DESCRIPTION
Summary
- add verifier module in baml_compiler_emit for MIR/emitter invariants
- run verifier in compile_mir_function under debug_assertions
- validate redirect/threading target shape, exhaustive-switch default shape, watched-local classification, and block-id density
- add focused unit tests for verifier behavior

Why
This makes analysis/emitter contracts explicit and catches invariant drift early during development/testing.

Validation
- cargo test -p baml_compiler_emit --lib
- cargo clippy -p baml_compiler_emit --all-targets --all-features -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal block analysis logic for improved maintainability.
  * Simplified error handling and control flow in code emission.

* **Tests**
  * Added compiler invariant verification framework with validation tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->