### PR TITLE
Add agent-facing BEP lookup endpoint

### DIFF
--- a/typescript/apps/beps/README.md
+++ b/typescript/apps/beps/README.md
@@ -215,6 +215,7 @@ beps-app/
 │   │   ├── layout.tsx                # Root layout with providers
 │   │   ├── page.tsx                  # Home (BEP list)
 │   │   ├── login/page.tsx            # Login page
+│   │   ├── api/agent/beps/route.ts   # Public read-only BEP context API
 │   │   └── beps/
 │   │       ├── new/page.tsx          # Create BEP
 │   │       └── [number]/
@@ -430,6 +431,19 @@ Both can be created from comments to maintain traceability.
 | Endpoint                   | Method | Description                 |
 | -------------------------- | ------ | --------------------------- |
 | `/api/ai/stream-assistant` | POST   | Stream AI responses for Q&A |
+| `/api/agent/beps`          | GET    | Public read-only BEP listing/fetch for agents |
+
+### Public Agent Endpoint
+
+`GET /api/agent/beps`
+
+- Without query params: lists all BEPs.
+- With `name=<bep-name-or-id>`: fuzzy-matches and returns a BEP markdown bundle (content, comments, issues, decisions).
+- Defaults to including all versions/history.
+- Add `omitOtherVersions=true` to omit historical versions from the returned bundle.
+- Add `format=markdown` to get raw markdown output instead of JSON.
+
+You should install the `beps` skill through our [https://github.com/BoundaryML/skills](skills) repository.
 
 ---
 

--- a/typescript/apps/beps/README.md
+++ b/typescript/apps/beps/README.md
@@ -428,9 +428,9 @@ Both can be created from comments to maintain traceability.
 
 ### HTTP Endpoints
 
-| Endpoint                   | Method | Description                 |
-| -------------------------- | ------ | --------------------------- |
-| `/api/ai/stream-assistant` | POST   | Stream AI responses for Q&A |
+| Endpoint                   | Method | Description                                   |
+| -------------------------- | ------ | --------------------------------------------- |
+| `/api/ai/stream-assistant` | POST   | Stream AI responses for Q&A                   |
 | `/api/agent/beps`          | GET    | Public read-only BEP listing/fetch for agents |
 
 ### Public Agent Endpoint
@@ -438,12 +438,119 @@ Both can be created from comments to maintain traceability.
 `GET /api/agent/beps`
 
 - Without query params: lists all BEPs.
-- With `name=<bep-name-or-id>`: fuzzy-matches and returns a BEP markdown bundle (content, comments, issues, decisions).
+- With `name=<bep-name-or-id>` (also accepts `query` or `q`): fuzzy-matches and returns a BEP bundle.
 - Defaults to including all versions/history.
 - Add `omitOtherVersions=true` to omit historical versions from the returned bundle.
 - Add `format=markdown` to get raw markdown output instead of JSON.
 
-You should install the `beps` skill through our [https://github.com/BoundaryML/skills](skills) repository.
+#### Query Parameters
+
+| Param | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | No | Fuzzy BEP matcher (preferred key). |
+| `query` | string | No | Alias for `name`. |
+| `q` | string | No | Alias for `name`. |
+| `omitOtherVersions` | boolean-ish | No | Truthy values (`1`, `true`, `yes`, `y`, `on`) omit `history/*` files. |
+| `format` | string | No | `json` (default) or `markdown`. |
+
+#### Success Responses
+
+`200` list mode (`GET /api/agent/beps` with no query):
+
+```json
+{
+  "mode": "list",
+  "total": 2,
+  "beps": [
+    {
+      "id": "BEP-001",
+      "number": 1,
+      "title": "Structured Error Payloads",
+      "status": "accepted",
+      "updatedAt": "2026-02-18T20:13:34.000Z"
+    }
+  ],
+  "usage": {
+    "list": "/api/agent/beps",
+    "fetch": "/api/agent/beps?name=<bep-name-or-id>",
+    "omitOtherVersions": "/api/agent/beps?name=<bep-name-or-id>&omitOtherVersions=true"
+  }
+}
+```
+
+`200` matched BEP JSON mode (`GET /api/agent/beps?name=<...>`):
+
+```json
+{
+  "mode": "bep",
+  "query": "structured error payloads",
+  "matched": {
+    "id": "BEP-001",
+    "number": 1,
+    "title": "Structured Error Payloads",
+    "status": "accepted",
+    "score": 1.732
+  },
+  "currentVersion": 5,
+  "omitOtherVersions": false,
+  "markdown": "<!-- FILE: README.md -->\n# BEP-001 ...",
+  "files": [
+    {
+      "path": "README.md",
+      "content": "# BEP-001 ..."
+    }
+  ]
+}
+```
+
+Schema for `mode: "bep"` JSON responses:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `mode` | string | Always `"bep"` in this response shape. |
+| `query` | string | Normalized user query used for fuzzy matching. |
+| `matched` | object | Matched BEP metadata: `id`, `number`, `title`, `status`, `score`. |
+| `currentVersion` | number | Current BEP version number. |
+| `omitOtherVersions` | boolean | Echoes resolved filter flag from query params. |
+| `markdown` | string | Flattened markdown bundle content (all selected `.md` files). |
+| `files` | array | Per-file markdown entries: `{ path, content }`. |
+
+`200` matched BEP markdown mode (`GET /api/agent/beps?name=<...>&format=markdown`):
+
+```markdown
+<!-- FILE: README.md -->
+# BEP-001 Structured Error Payloads
+...
+```
+
+#### Error Responses
+
+`404` (no fuzzy match found):
+
+```json
+{
+  "error": "Could not find a BEP that matches \"<query>\".",
+  "suggestions": [
+    { "id": "BEP-003", "title": "..." },
+    { "id": "BEP-010", "title": "..." }
+  ]
+}
+```
+
+`500` (server misconfiguration, missing Convex URL):
+
+```json
+{
+  "error": "Missing NEXT_PUBLIC_CONVEX_URL environment variable."
+}
+```
+
+#### CORS / Preflight
+
+- `OPTIONS /api/agent/beps` is supported for browser preflight and returns `204`.
+- CORS headers: `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods: GET, OPTIONS`, `Access-Control-Allow-Headers: Content-Type`.
+
+You should install the `beps` skill through our [skills](https://github.com/BoundaryML/skills) repository.
 
 ---
 

--- a/typescript/apps/beps/README.md
+++ b/typescript/apps/beps/README.md
@@ -545,6 +545,28 @@ Schema for `mode: "bep"` JSON responses:
 }
 ```
 
+`502` (upstream Convex failure, or unrecognized export payload shape):
+
+```json
+{
+  "error": "Failed to fetch BEP list.",
+  "detail": "<error message>"
+}
+```
+
+```json
+{
+  "error": "Failed to fetch BEP export data.",
+  "detail": "<error message>"
+}
+```
+
+```json
+{
+  "error": "Invalid BEP export payload shape."
+}
+```
+
 #### CORS / Preflight
 
 - `OPTIONS /api/agent/beps` is supported for browser preflight and returns `204`.

--- a/typescript/apps/beps/src/app/api/agent/beps/route.ts
+++ b/typescript/apps/beps/src/app/api/agent/beps/route.ts
@@ -122,7 +122,10 @@ function findBestMatch(query: string, beps: ListBepResult[]): {
 } {
   const normalizedQuery = normalize(query);
 
-  const byNumber = normalizedQuery.match(/(?:^|\s)bep\s*0*(\d+)(?:\s|$)|(?:^|\s)0*(\d+)(?:\s|$)/i);
+  // Match "bep 5" / "BEP-005" anywhere, or a bare integer when that is the entire query.
+  const byNumber = normalizedQuery.match(
+    /(?:^|\s)bep\s*0*(\d+)(?:\s|$)|^0*(\d+)$/
+  );
   const numberCandidate = byNumber?.[1] ?? byNumber?.[2];
   if (numberCandidate) {
     const parsedNumber = Number.parseInt(numberCandidate, 10);
@@ -147,9 +150,29 @@ function findBestMatch(query: string, beps: ListBepResult[]): {
   };
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isExportData(value: unknown): value is ExportData {
+  if (!isRecord(value)) return false;
+
+  return (
+    isRecord(value.bep) &&
+    Array.isArray(value.pages) &&
+    Array.isArray(value.comments) &&
+    Array.isArray(value.decisions) &&
+    Array.isArray(value.issues) &&
+    Array.isArray(value.versions) &&
+    Array.isArray(value.summaries) &&
+    typeof value.currentVersion === "number" &&
+    typeof value.exportedAt === "number"
+  );
+}
+
+// Callers should pass only markdown files.
 function flattenMarkdownForAgents(files: ExportFile[]): string {
   return files
-    .filter((file) => file.path.endsWith(".md"))
     .map(
       (file) =>
         `<!-- FILE: ${file.path} -->\n${file.content.trimEnd()}`
@@ -193,14 +216,33 @@ export async function GET(request: NextRequest): Promise<Response> {
   const omitOtherVersions = isTruthy(searchParams.get("omitOtherVersions"));
   const format = (searchParams.get("format") ?? "json").toLowerCase();
 
-  const bepsRaw = await convex.query(api.beps.list, { limit: 500 });
-  const beps: ListBepResult[] = bepsRaw.map((bep) => ({
-    _id: String(bep._id),
-    number: bep.number,
-    title: bep.title,
-    status: bep.status,
-    updatedAt: bep.updatedAt,
-  }));
+  let beps: ListBepResult[];
+  try {
+    const bepsRaw = await convex.query(api.beps.list, { limit: 500 });
+    beps = bepsRaw.map(
+      (bep: {
+        _id: unknown;
+        number: number;
+        title: string;
+        status: string;
+        updatedAt: number;
+      }) => ({
+        _id: String(bep._id),
+        number: bep.number,
+        title: bep.title,
+        status: bep.status,
+        updatedAt: bep.updatedAt,
+      })
+    );
+  } catch (err) {
+    return jsonResponse(
+      {
+        error: "Failed to fetch BEP list.",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      502
+    );
+  }
 
   if (!query) {
     const sorted = [...beps].sort((a, b) => a.number - b.number);
@@ -239,15 +281,31 @@ export async function GET(request: NextRequest): Promise<Response> {
     );
   }
 
-  const exportDataRaw = await convex.query(api.export.getFullBepForExport, {
-    bepId: bestMatch.bep._id as Id<"beps">,
-  });
+  let exportDataRaw: unknown;
+  try {
+    exportDataRaw = await convex.query(api.export.getFullBepForExport, {
+      bepId: bestMatch.bep._id as Id<"beps">,
+    });
+  } catch (err) {
+    return jsonResponse(
+      {
+        error: "Failed to fetch BEP export data.",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      502
+    );
+  }
 
   if (!exportDataRaw) {
     return jsonResponse({ error: "Matched BEP was not found." }, 404);
   }
 
-  const exportData = exportDataRaw as unknown as ExportData;
+  if (!isExportData(exportDataRaw)) {
+    return jsonResponse({ error: "Invalid BEP export payload shape." }, 502);
+  }
+
+  // TODO: Align getFullBepForExport's generated return type with ExportData.
+  const exportData = exportDataRaw;
   const allFiles = generateAllExportFiles(exportData).filter((file) =>
     file.path.endsWith(".md")
   );

--- a/typescript/apps/beps/src/app/api/agent/beps/route.ts
+++ b/typescript/apps/beps/src/app/api/agent/beps/route.ts
@@ -213,6 +213,7 @@ export async function GET(request: NextRequest): Promise<Response> {
     searchParams.get("query") ??
     searchParams.get("q");
   const query = rawQuery?.trim() ?? "";
+  const normalizedQuery = normalize(query);
   const omitOtherVersions = isTruthy(searchParams.get("omitOtherVersions"));
   const format = (searchParams.get("format") ?? "json").toLowerCase();
 
@@ -306,13 +307,25 @@ export async function GET(request: NextRequest): Promise<Response> {
 
   // TODO: Align getFullBepForExport's generated return type with ExportData.
   const exportData = exportDataRaw;
-  const allFiles = generateAllExportFiles(exportData).filter((file) =>
-    file.path.endsWith(".md")
-  );
-  const selectedFiles = omitOtherVersions
-    ? allFiles.filter((file) => !file.path.startsWith("history/"))
-    : allFiles;
-  const markdown = flattenMarkdownForAgents(selectedFiles);
+  let selectedFiles: ExportFile[];
+  let markdown: string;
+  try {
+    const allFiles = generateAllExportFiles(exportData).filter((file) =>
+      file.path.endsWith(".md")
+    );
+    selectedFiles = omitOtherVersions
+      ? allFiles.filter((file) => !file.path.startsWith("history/"))
+      : allFiles;
+    markdown = flattenMarkdownForAgents(selectedFiles);
+  } catch (err) {
+    return jsonResponse(
+      {
+        error: "Invalid BEP export payload shape.",
+        detail: err instanceof Error ? err.message : String(err),
+      },
+      502
+    );
+  }
 
   if (format === "markdown") {
     return new Response(markdown, {
@@ -327,7 +340,7 @@ export async function GET(request: NextRequest): Promise<Response> {
 
   return jsonResponse({
     mode: "bep",
-    query,
+    query: normalizedQuery,
     matched: {
       id: formatBepId(bestMatch.bep.number),
       number: bestMatch.bep.number,

--- a/typescript/apps/beps/src/app/api/agent/beps/route.ts
+++ b/typescript/apps/beps/src/app/api/agent/beps/route.ts
@@ -1,0 +1,288 @@
+import { NextRequest, NextResponse } from "next/server";
+import { ConvexHttpClient } from "convex/browser";
+import type { Id } from "../../../../../convex/_generated/dataModel";
+import { api } from "../../../../../convex/_generated/api";
+import {
+  type ExportData,
+  type ExportFile,
+  generateAllExportFiles,
+} from "@/lib/export-utils";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+type ListBepResult = {
+  _id: string;
+  number: number;
+  title: string;
+  status: string;
+  updatedAt: number;
+};
+
+type MatchResult = {
+  bep: ListBepResult;
+  score: number;
+};
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "y", "on"]);
+
+function isTruthy(value: string | null): boolean {
+  if (!value) return false;
+  return TRUE_VALUES.has(value.toLowerCase());
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, " ").trim();
+}
+
+function formatBepId(number: number): string {
+  return `BEP-${String(number).padStart(3, "0")}`;
+}
+
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  const prev = new Array<number>(b.length + 1);
+  const curr = new Array<number>(b.length + 1);
+
+  for (let j = 0; j <= b.length; j += 1) {
+    prev[j] = j;
+  }
+
+  for (let i = 1; i <= a.length; i += 1) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        curr[j - 1] + 1,
+        prev[j] + 1,
+        prev[j - 1] + cost
+      );
+    }
+    for (let j = 0; j <= b.length; j += 1) {
+      prev[j] = curr[j];
+    }
+  }
+
+  return prev[b.length];
+}
+
+function tokenOverlapScore(query: string, candidate: string): number {
+  const queryTokens = new Set(query.split(" ").filter(Boolean));
+  if (queryTokens.size === 0) return 0;
+
+  const candidateTokens = new Set(candidate.split(" ").filter(Boolean));
+  let overlap = 0;
+  for (const token of queryTokens) {
+    if (candidateTokens.has(token)) overlap += 1;
+  }
+
+  return overlap / queryTokens.size;
+}
+
+function scoreBepMatch(query: string, bep: ListBepResult): number {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) return 0;
+
+  const id = normalize(formatBepId(bep.number));
+  const title = normalize(bep.title);
+  const full = `${id} ${title}`.trim();
+
+  let score = 0;
+
+  if (normalizedQuery === id) score += 1.2;
+  if (normalizedQuery === title) score += 1.1;
+  if (normalizedQuery === full) score += 1.3;
+
+  if (id.includes(normalizedQuery)) score += 0.85;
+  if (title.includes(normalizedQuery)) score += 0.75;
+  if (full.includes(normalizedQuery)) score += 0.65;
+
+  score += tokenOverlapScore(normalizedQuery, full) * 0.7;
+
+  const distance = levenshteinDistance(normalizedQuery, title);
+  const maxLen = Math.max(normalizedQuery.length, title.length, 1);
+  const similarity = 1 - distance / maxLen;
+  score += Math.max(0, similarity) * 0.3;
+
+  return score;
+}
+
+function findBestMatch(query: string, beps: ListBepResult[]): {
+  bestMatch: MatchResult | null;
+  topMatches: MatchResult[];
+} {
+  const normalizedQuery = normalize(query);
+
+  const byNumber = normalizedQuery.match(/(?:^|\s)bep\s*0*(\d+)(?:\s|$)|(?:^|\s)0*(\d+)(?:\s|$)/i);
+  const numberCandidate = byNumber?.[1] ?? byNumber?.[2];
+  if (numberCandidate) {
+    const parsedNumber = Number.parseInt(numberCandidate, 10);
+    if (!Number.isNaN(parsedNumber)) {
+      const exact = beps.find((bep) => bep.number === parsedNumber);
+      if (exact) {
+        return {
+          bestMatch: { bep: exact, score: 99 },
+          topMatches: [{ bep: exact, score: 99 }],
+        };
+      }
+    }
+  }
+
+  const scored = beps
+    .map((bep) => ({ bep, score: scoreBepMatch(query, bep) }))
+    .sort((a, b) => b.score - a.score);
+
+  return {
+    bestMatch: scored.length > 0 ? scored[0] : null,
+    topMatches: scored.slice(0, 5),
+  };
+}
+
+function flattenMarkdownForAgents(files: ExportFile[]): string {
+  return files
+    .filter((file) => file.path.endsWith(".md"))
+    .map(
+      (file) =>
+        `<!-- FILE: ${file.path} -->\n${file.content.trimEnd()}`
+    )
+    .join("\n\n");
+}
+
+function jsonResponse(body: unknown, status = 200): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      ...CORS_HEADERS,
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+export async function OPTIONS(): Promise<Response> {
+  return new Response(null, {
+    status: 204,
+    headers: CORS_HEADERS,
+  });
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!convexUrl) {
+    return jsonResponse(
+      { error: "Missing NEXT_PUBLIC_CONVEX_URL environment variable." },
+      500
+    );
+  }
+
+  const convex = new ConvexHttpClient(convexUrl);
+  const searchParams = request.nextUrl.searchParams;
+  const rawQuery =
+    searchParams.get("name") ??
+    searchParams.get("query") ??
+    searchParams.get("q");
+  const query = rawQuery?.trim() ?? "";
+  const omitOtherVersions = isTruthy(searchParams.get("omitOtherVersions"));
+  const format = (searchParams.get("format") ?? "json").toLowerCase();
+
+  const bepsRaw = await convex.query(api.beps.list, { limit: 500 });
+  const beps: ListBepResult[] = bepsRaw.map((bep) => ({
+    _id: String(bep._id),
+    number: bep.number,
+    title: bep.title,
+    status: bep.status,
+    updatedAt: bep.updatedAt,
+  }));
+
+  if (!query) {
+    const sorted = [...beps].sort((a, b) => a.number - b.number);
+
+    return jsonResponse({
+      mode: "list",
+      total: sorted.length,
+      beps: sorted.map((bep) => ({
+        id: formatBepId(bep.number),
+        number: bep.number,
+        title: bep.title,
+        status: bep.status,
+        updatedAt: new Date(bep.updatedAt).toISOString(),
+      })),
+      usage: {
+        list: "/api/agent/beps",
+        fetch: "/api/agent/beps?name=<bep-name-or-id>",
+        omitOtherVersions:
+          "/api/agent/beps?name=<bep-name-or-id>&omitOtherVersions=true",
+      },
+    });
+  }
+
+  const { bestMatch, topMatches } = findBestMatch(query, beps);
+  const minimumScore = 0.6;
+  if (!bestMatch || bestMatch.score < minimumScore) {
+    return jsonResponse(
+      {
+        error: `Could not find a BEP that matches "${query}".`,
+        suggestions: topMatches.map((item) => ({
+          id: formatBepId(item.bep.number),
+          title: item.bep.title,
+        })),
+      },
+      404
+    );
+  }
+
+  const exportDataRaw = await convex.query(api.export.getFullBepForExport, {
+    bepId: bestMatch.bep._id as Id<"beps">,
+  });
+
+  if (!exportDataRaw) {
+    return jsonResponse({ error: "Matched BEP was not found." }, 404);
+  }
+
+  const exportData = exportDataRaw as unknown as ExportData;
+  const allFiles = generateAllExportFiles(exportData).filter((file) =>
+    file.path.endsWith(".md")
+  );
+  const selectedFiles = omitOtherVersions
+    ? allFiles.filter((file) => !file.path.startsWith("history/"))
+    : allFiles;
+  const markdown = flattenMarkdownForAgents(selectedFiles);
+
+  if (format === "markdown") {
+    return new Response(markdown, {
+      status: 200,
+      headers: {
+        ...CORS_HEADERS,
+        "Cache-Control": "no-store",
+        "Content-Type": "text/markdown; charset=utf-8",
+      },
+    });
+  }
+
+  return jsonResponse({
+    mode: "bep",
+    query,
+    matched: {
+      id: formatBepId(bestMatch.bep.number),
+      number: bestMatch.bep.number,
+      title: bestMatch.bep.title,
+      status: bestMatch.bep.status,
+      score: Number(bestMatch.score.toFixed(3)),
+    },
+    currentVersion: exportData.currentVersion,
+    omitOtherVersions,
+    markdown,
+    files: selectedFiles.map((file) => ({
+      path: file.path,
+      content: file.content,
+    })),
+  });
+}

--- a/typescript/apps/beps/src/app/api/agent/beps/route.ts
+++ b/typescript/apps/beps/src/app/api/agent/beps/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { ConvexHttpClient } from "convex/browser";
+import type { FunctionReturnType } from "convex/server";
 import type { Id } from "../../../../../convex/_generated/dataModel";
 import { api } from "../../../../../convex/_generated/api";
 import {
@@ -31,6 +32,10 @@ type MatchResult = {
 };
 
 const TRUE_VALUES = new Set(["1", "true", "yes", "y", "on"]);
+const BEP_LIST_LIMIT = 500;
+const BEP_LIST_PROBE_LIMIT = BEP_LIST_LIMIT + 1;
+
+type RawBepListItem = FunctionReturnType<typeof api.beps.list>[number];
 
 function isTruthy(value: string | null): boolean {
   if (!value) return false;
@@ -219,15 +224,21 @@ export async function GET(request: NextRequest): Promise<Response> {
 
   let beps: ListBepResult[];
   try {
-    const bepsRaw = await convex.query(api.beps.list, { limit: 500 });
+    const bepsRaw = await convex.query(api.beps.list, {
+      limit: BEP_LIST_PROBE_LIMIT,
+    });
+    if (bepsRaw.length > BEP_LIST_LIMIT) {
+      return jsonResponse(
+        {
+          error: `BEP list exceeds the supported search size (${BEP_LIST_LIMIT}).`,
+          detail: "Add pagination support before returning more BEPs.",
+        },
+        503
+      );
+    }
+
     beps = bepsRaw.map(
-      (bep: {
-        _id: unknown;
-        number: number;
-        title: string;
-        status: string;
-        updatedAt: number;
-      }) => ({
+      (bep: RawBepListItem) => ({
         _id: String(bep._id),
         number: bep.number,
         title: bep.title,


### PR DESCRIPTION
Summary
- document the public `/api/agent/beps` endpoint in the BEP app README so agents know how to list or request a BEP by name
- implement the Next.js API route that lists BEPs, fuzzy-matches names or numbers, and returns markdown bundles (with history filtering and format options) from Convex-exported data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public API endpoint for BEP search, listing, matching, and export via GET (JSON or Markdown).
  * Fuzzy name/ID matching with suggestions and score threshold; optional omission of historical versions.
  * CORS-enabled with preflight handling and descriptive error responses; Markdown export mode.

* **Documentation**
  * README updated with endpoint details, query parameters, example requests/responses, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->